### PR TITLE
ci: enforce main only accepts PRs from develop

### DIFF
--- a/.github/workflows/enforce-branch-policy.yml
+++ b/.github/workflows/enforce-branch-policy.yml
@@ -1,0 +1,18 @@
+name: Enforce branch policy
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source branch is develop
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "::error::PRs targeting main must come from the develop branch. Got: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "Source branch is develop — OK"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that checks PRs targeting `main` must originate from `develop`
- Any PR from other branches to `main` will fail the check and cannot be merged

## Context
Branch policy: `feature/*` → PR → `develop` → PR → `main`