### PR TITLE
ci: sync enforce-branch-policy workflow to main

### DIFF
--- a/.github/workflows/enforce-branch-policy.yml
+++ b/.github/workflows/enforce-branch-policy.yml
@@ -1,0 +1,18 @@
+name: Enforce branch policy
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source branch is develop
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "::error::PRs targeting main must come from the develop branch. Got: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "Source branch is develop — OK"


### PR DESCRIPTION
## Summary
- Sync the branch policy enforcement workflow from develop to main
- After merge, the `check-source-branch` status check will be available as a required check

## Context
This PR itself will trigger the workflow, confirming it works (source is develop → should pass).