### PR TITLE
feat: My NyxID Services and Admin NyxID Services pages + fixes

### DIFF
--- a/.changeset/nyxid-services-pages.md
+++ b/.changeset/nyxid-services-pages.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+Add My NyxID Services and Admin NyxID Services pages with user-dropdown links. Filters auto-connected services using `requires_connection` and `auto_connected`.

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -30,6 +30,8 @@ import { EditSkillPage } from "@/pages/EditSkillPage";
 import { PlaygroundPage } from "@/pages/PlaygroundPage";
 
 import { MySkillsPage } from "@/pages/MySkillsPage";
+import { MyNyxidServicesPage } from "@/pages/MyNyxidServicesPage";
+import { AdminNyxidServicesPage } from "@/pages/AdminNyxidServicesPage";
 
 // Admin pages
 import {
@@ -81,6 +83,8 @@ export function App() {
                 <Route path="/playground" element={<PlaygroundPage />} />
 
                 <Route path="/my-skills" element={<MySkillsPage />} />
+                <Route path="/services/my" element={<MyNyxidServicesPage />} />
+                <Route path="/services/admin" element={<AdminNyxidServicesPage />} />
               </Route>
 
               {/* Admin routes - separate layout */}

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -422,22 +422,18 @@ export function Navbar({ className = "" }: NavbarProps) {
                             {t("nav.adminPanel")}
                           </Link>
                         )}
-                        <a
-                          href={`${getNyxIdUrl()}/services`}
-                          target="_blank"
-                          rel="noopener noreferrer"
+                        <Link
+                          to="/services/my"
                           className="flex items-center gap-3 px-4 py-2.5 font-body text-sm text-text-primary transition-colors hover:bg-neon-cyan/5"
                         >
                           <svg className="h-4 w-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
                           </svg>
                           My NyxID Services
-                        </a>
+                        </Link>
                         {isAdmin(user) && (
-                          <a
-                            href={`${getNyxIdUrl()}/admin/services`}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                          <Link
+                            to="/services/admin"
                             className="flex items-center gap-3 px-4 py-2.5 font-body text-sm text-text-primary transition-colors hover:bg-neon-cyan/5"
                           >
                             <svg className="h-4 w-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -445,7 +441,7 @@ export function Navbar({ className = "" }: NavbarProps) {
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                             </svg>
                             Admin NyxID Services
-                          </a>
+                          </Link>
                         )}
                         <a
                           href={getNyxIdUrl()}
@@ -605,23 +601,21 @@ export function Navbar({ className = "" }: NavbarProps) {
                       </Link>
                     )}
 
-                    <a
-                      href={`${getNyxIdUrl()}/services`}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                    <Link
+                      to="/services/my"
+                      onClick={() => setIsMobileMenuOpen(false)}
                       className="flex items-center gap-3 px-4 py-3 rounded-lg text-text-muted hover:bg-bg-elevated hover:text-text-primary transition-colors"
                     >
                       <span className="font-body text-sm font-medium">My NyxID Services</span>
-                    </a>
+                    </Link>
                     {isAdmin(user) && (
-                      <a
-                        href={`${getNyxIdUrl()}/admin/services`}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                      <Link
+                        to="/services/admin"
+                        onClick={() => setIsMobileMenuOpen(false)}
                         className="flex items-center gap-3 px-4 py-3 rounded-lg text-text-muted hover:bg-bg-elevated hover:text-text-primary transition-colors"
                       >
                         <span className="font-body text-sm font-medium">Admin NyxID Services</span>
-                      </a>
+                      </Link>
                     )}
                     <a
                       href={getNyxIdUrl()}

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -423,6 +423,31 @@ export function Navbar({ className = "" }: NavbarProps) {
                           </Link>
                         )}
                         <a
+                          href={`${getNyxIdUrl()}/services`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-3 px-4 py-2.5 font-body text-sm text-text-primary transition-colors hover:bg-neon-cyan/5"
+                        >
+                          <svg className="h-4 w-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
+                          </svg>
+                          My NyxID Services
+                        </a>
+                        {isAdmin(user) && (
+                          <a
+                            href={`${getNyxIdUrl()}/admin/services`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-3 px-4 py-2.5 font-body text-sm text-text-primary transition-colors hover:bg-neon-cyan/5"
+                          >
+                            <svg className="h-4 w-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                            </svg>
+                            Admin NyxID Services
+                          </a>
+                        )}
+                        <a
                           href={getNyxIdUrl()}
                           target="_blank"
                           rel="noopener noreferrer"
@@ -580,6 +605,24 @@ export function Navbar({ className = "" }: NavbarProps) {
                       </Link>
                     )}
 
+                    <a
+                      href={`${getNyxIdUrl()}/services`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-3 px-4 py-3 rounded-lg text-text-muted hover:bg-bg-elevated hover:text-text-primary transition-colors"
+                    >
+                      <span className="font-body text-sm font-medium">My NyxID Services</span>
+                    </a>
+                    {isAdmin(user) && (
+                      <a
+                        href={`${getNyxIdUrl()}/admin/services`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-3 px-4 py-3 rounded-lg text-text-muted hover:bg-bg-elevated hover:text-text-primary transition-colors"
+                      >
+                        <span className="font-body text-sm font-medium">Admin NyxID Services</span>
+                      </a>
+                    )}
                     <a
                       href={getNyxIdUrl()}
                       target="_blank"

--- a/ornn-web/src/components/layout/RootLayout.tsx
+++ b/ornn-web/src/components/layout/RootLayout.tsx
@@ -43,6 +43,10 @@ function useBreadcrumbs() {
     } else {
       crumbs.push({ label: t("breadcrumb.playground"), to: "/playground" });
     }
+  } else if (path === "/services/my") {
+    crumbs.push({ label: "My NyxID Services", to: "/services/my" });
+  } else if (path === "/services/admin") {
+    crumbs.push({ label: "Admin NyxID Services", to: "/services/admin" });
   } else if (path === "/settings") {
     crumbs.push({ label: t("breadcrumb.settings"), to: "/settings" });
   } else if (path === "/docs") {

--- a/ornn-web/src/pages/AdminNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/AdminNyxidServicesPage.tsx
@@ -1,0 +1,212 @@
+/**
+ * Admin NyxID Services Page.
+ * Lists all platform services from NyxID with system skill generation controls.
+ * @module pages/AdminNyxidServicesPage
+ */
+
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Modal } from "@/components/ui/Modal";
+import {
+  getSystemSkills,
+  generateSystemSkill,
+  regenerateSystemSkill,
+  deleteSystemSkill,
+  type SystemSkillItem,
+} from "@/services/systemSkillsApi";
+import { useToastStore } from "@/stores/toastStore";
+
+export function AdminNyxidServicesPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const addToast = useToastStore((s) => s.addToast);
+  const [deleteTarget, setDeleteTarget] = useState<SystemSkillItem | null>(null);
+  const [generatingServiceId, setGeneratingServiceId] = useState<string | null>(null);
+
+  const { data: items, isLoading } = useQuery({
+    queryKey: ["admin", "system-skills"],
+    queryFn: getSystemSkills,
+  });
+
+  const generateMutation = useMutation({
+    mutationFn: (serviceId: string) => generateSystemSkill(serviceId),
+    onMutate: (serviceId) => setGeneratingServiceId(serviceId),
+    onSuccess: (data) => {
+      addToast({ type: "success", message: `Skill "${data.name}" generated` });
+      queryClient.invalidateQueries({ queryKey: ["admin", "system-skills"] });
+      queryClient.invalidateQueries({ queryKey: ["system-skills-public"] });
+      setGeneratingServiceId(null);
+    },
+    onError: (err: Error) => {
+      addToast({ type: "error", message: `Generation failed: ${err.message}` });
+      setGeneratingServiceId(null);
+    },
+  });
+
+  const regenerateMutation = useMutation({
+    mutationFn: (serviceId: string) => regenerateSystemSkill(serviceId),
+    onMutate: (serviceId) => setGeneratingServiceId(serviceId),
+    onSuccess: (data) => {
+      addToast({ type: "success", message: `Skill "${data.name}" regenerated` });
+      queryClient.invalidateQueries({ queryKey: ["admin", "system-skills"] });
+      queryClient.invalidateQueries({ queryKey: ["system-skills-public"] });
+      setGeneratingServiceId(null);
+    },
+    onError: (err: Error) => {
+      addToast({ type: "error", message: `Regeneration failed: ${err.message}` });
+      setGeneratingServiceId(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (serviceId: string) => deleteSystemSkill(serviceId),
+    onSuccess: () => {
+      addToast({ type: "success", message: "System skill deleted" });
+      queryClient.invalidateQueries({ queryKey: ["admin", "system-skills"] });
+      queryClient.invalidateQueries({ queryKey: ["system-skills-public"] });
+      setDeleteTarget(null);
+    },
+    onError: (err: Error) => {
+      addToast({ type: "error", message: `Delete failed: ${err.message}` });
+    },
+  });
+
+  return (
+    <PageTransition>
+      <div className="py-4">
+        <div className="mb-4">
+          <h1 className="font-heading text-xl tracking-wider text-text-primary">Admin NyxID Services</h1>
+          <p className="font-body text-sm text-text-muted mt-1">
+            All platform services from NyxID. Generate system skills from OpenAPI specs.
+            {items ? ` ${items.length} services found.` : ""}
+          </p>
+        </div>
+
+        {isLoading ? (
+          <Skeleton lines={8} />
+        ) : !items?.length ? (
+          <EmptyState
+            title="No services found"
+            description="No services registered in NyxID."
+          />
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-neon-cyan/10">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-neon-cyan/10 bg-bg-elevated/50">
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Service</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Category</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Spec</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Skill</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-right px-4 py-3">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((item) => {
+                  const isGenerating = generatingServiceId === item.serviceId;
+
+                  return (
+                    <tr key={item.serviceId} className="border-b border-neon-cyan/5 hover:bg-bg-elevated/30 transition-colors">
+                      <td className="px-4 py-3">
+                        <div>
+                          <span className="font-mono text-sm font-semibold text-neon-cyan">{item.serviceName}</span>
+                          {item.serviceDescription && (
+                            <p className="font-body text-xs text-text-muted mt-0.5 truncate max-w-xs">{item.serviceDescription}</p>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge color="yellow">{item.serviceCategory}</Badge>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge color={item.hasOpenApiSpec ? "green" : "muted"}>
+                          {item.hasOpenApiSpec ? "available" : "none"}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3">
+                        {item.skillGenerated && item.skill ? (
+                          <div className="flex items-center gap-2">
+                            <Badge color="green">generated</Badge>
+                            <button
+                              onClick={() => navigate(`/skills/${item.skill!.name}`)}
+                              className="font-mono text-xs text-neon-cyan hover:underline cursor-pointer"
+                            >
+                              {item.skill.name}
+                            </button>
+                          </div>
+                        ) : (
+                          <span className="font-body text-xs text-text-muted italic">not generated</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex justify-end gap-2">
+                          {item.skillGenerated ? (
+                            <>
+                              <Button
+                                size="sm"
+                                variant="secondary"
+                                onClick={() => regenerateMutation.mutate(item.serviceId)}
+                                disabled={isGenerating}
+                              >
+                                {isGenerating ? "..." : "Regenerate"}
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="danger"
+                                onClick={() => setDeleteTarget(item)}
+                              >
+                                Delete
+                              </Button>
+                            </>
+                          ) : item.hasOpenApiSpec ? (
+                            <Button
+                              size="sm"
+                              onClick={() => generateMutation.mutate(item.serviceId)}
+                              disabled={isGenerating}
+                            >
+                              {isGenerating ? "Generating..." : "Generate"}
+                            </Button>
+                          ) : (
+                            <span className="font-body text-[10px] text-text-muted">No spec</span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {deleteTarget && (
+          <Modal
+            isOpen={!!deleteTarget}
+            title="Delete System Skill"
+            onClose={() => setDeleteTarget(null)}
+          >
+            <p className="font-body text-sm text-text-muted mb-4">
+              Delete the generated skill for <strong className="text-text-primary">{deleteTarget.serviceName}</strong>?
+            </p>
+            <div className="flex justify-end gap-3">
+              <Button variant="secondary" onClick={() => setDeleteTarget(null)}>Cancel</Button>
+              <Button
+                variant="danger"
+                onClick={() => deleteMutation.mutate(deleteTarget.serviceId)}
+                disabled={deleteMutation.isPending}
+              >
+                {deleteMutation.isPending ? "Deleting..." : "Delete"}
+              </Button>
+            </div>
+          </Modal>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/pages/AdminNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/AdminNyxidServicesPage.tsx
@@ -98,8 +98,8 @@ export function AdminNyxidServicesPage() {
         ) : (
           <div className="flex-1 min-h-0 overflow-auto rounded-lg border border-neon-cyan/10">
             <table className="w-full">
-              <thead>
-                <tr className="border-b border-neon-cyan/10 bg-bg-elevated/50">
+              <thead className="sticky top-0 bg-bg-elevated/95 backdrop-blur-sm">
+                <tr className="border-b border-neon-cyan/10">
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Service</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Category</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Spec</th>

--- a/ornn-web/src/pages/AdminNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/AdminNyxidServicesPage.tsx
@@ -79,7 +79,7 @@ export function AdminNyxidServicesPage() {
 
   return (
     <PageTransition>
-      <div className="py-4">
+      <div className="py-4 h-full flex flex-col">
         <div className="mb-4">
           <h1 className="font-heading text-xl tracking-wider text-text-primary">Admin NyxID Services</h1>
           <p className="font-body text-sm text-text-muted mt-1">
@@ -96,7 +96,7 @@ export function AdminNyxidServicesPage() {
             description="No services registered in NyxID."
           />
         ) : (
-          <div className="overflow-x-auto rounded-lg border border-neon-cyan/10">
+          <div className="flex-1 min-h-0 overflow-auto rounded-lg border border-neon-cyan/10">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-neon-cyan/10 bg-bg-elevated/50">

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -87,7 +87,7 @@ export function MyNyxidServicesPage() {
 
   return (
     <PageTransition>
-      <div className="py-4">
+      <div className="py-4 h-full flex flex-col">
         <div className="mb-4">
           <h1 className="font-heading text-xl tracking-wider text-text-primary">My NyxID Services</h1>
           <p className="font-body text-sm text-text-muted mt-1">
@@ -105,7 +105,7 @@ export function MyNyxidServicesPage() {
             description="Add services in NyxID to see them here."
           />
         ) : (
-          <div className="overflow-x-auto rounded-lg border border-neon-cyan/10">
+          <div className="flex-1 min-h-0 overflow-auto rounded-lg border border-neon-cyan/10">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-neon-cyan/10 bg-bg-elevated/50">

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -1,6 +1,7 @@
 /**
  * My NyxID Services Page.
- * Lists the current user's connected AI services from NyxID.
+ * Shows NyxID services the current user is connected to.
+ * Uses proxy/services endpoint filtered to connected services.
  * @module pages/MyNyxidServicesPage
  */
 
@@ -12,19 +13,21 @@ import { useAuthStore } from "@/stores/authStore";
 
 const NYXID_API_BASE = import.meta.env.VITE_NYXID_AUTHORIZE_URL?.replace("/oauth/authorize", "") ?? "";
 
-interface UserService {
+interface ProxyService {
   id: string;
-  service_id: string;
-  service_name: string;
-  service_slug: string;
+  name: string;
+  slug: string;
+  description: string | null;
   service_category: string;
-  label: string;
-  is_active: boolean;
-  credential_source?: string;
+  connected: boolean;
+  requires_connection: boolean;
+  proxy_url_slug: string;
+  openapi_url: string | null;
+  streaming_supported: boolean;
 }
 
 export function MyNyxidServicesPage() {
-  const [services, setServices] = useState<UserService[]>([]);
+  const [services, setServices] = useState<ProxyService[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const accessToken = useAuthStore((s) => s.accessToken);
@@ -35,7 +38,7 @@ export function MyNyxidServicesPage() {
       return;
     }
 
-    fetch(`${NYXID_API_BASE}/api/v1/user-services`, {
+    fetch(`${NYXID_API_BASE}/api/v1/proxy/services?per_page=100`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     })
       .then((r) => {
@@ -43,7 +46,9 @@ export function MyNyxidServicesPage() {
         return r.json();
       })
       .then((data) => {
-        setServices(data.services ?? []);
+        // Only show services the user is connected to
+        const connected = (data.services ?? []).filter((s: ProxyService) => s.connected);
+        setServices(connected);
         setIsLoading(false);
       })
       .catch((err) => {
@@ -59,7 +64,7 @@ export function MyNyxidServicesPage() {
         <div className="mb-4">
           <h1 className="font-heading text-xl tracking-wider text-text-primary">My NyxID Services</h1>
           <p className="font-body text-sm text-text-muted mt-1">
-            Your connected AI services from NyxID
+            Services you are connected to on NyxID
           </p>
         </div>
 
@@ -70,7 +75,7 @@ export function MyNyxidServicesPage() {
         ) : services.length === 0 ? (
           <EmptyState
             title="No services connected"
-            description="Connect services in NyxID to see them here."
+            description="Connect to services in NyxID to see them here."
           />
         ) : (
           <div className="overflow-x-auto rounded-lg border border-neon-cyan/10">
@@ -78,31 +83,38 @@ export function MyNyxidServicesPage() {
               <thead>
                 <tr className="border-b border-neon-cyan/10 bg-bg-elevated/50">
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Service</th>
-                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Label</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Category</th>
-                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Source</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Spec</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Proxy URL</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Status</th>
                 </tr>
               </thead>
               <tbody>
-                {services.map((svc, idx) => (
-                  <tr key={svc.id ?? idx} className="border-b border-neon-cyan/5 hover:bg-bg-elevated/30 transition-colors">
+                {services.map((svc) => (
+                  <tr key={svc.id} className="border-b border-neon-cyan/5 hover:bg-bg-elevated/30 transition-colors">
                     <td className="px-4 py-3">
-                      <span className="font-mono text-sm font-semibold text-neon-cyan">{String(svc.service_name || svc.service_slug || "")}</span>
+                      <div>
+                        <span className="font-mono text-sm font-semibold text-neon-cyan">{svc.name}</span>
+                        {svc.description && (
+                          <p className="font-body text-xs text-text-muted mt-0.5 truncate max-w-xs">{svc.description}</p>
+                        )}
+                      </div>
                     </td>
                     <td className="px-4 py-3">
-                      <span className="font-body text-sm text-text-primary">{String(svc.label || "")}</span>
+                      <Badge color="yellow">{svc.service_category}</Badge>
                     </td>
                     <td className="px-4 py-3">
-                      <Badge color="yellow">{String(svc.service_category || "unknown")}</Badge>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-xs text-text-muted">{String(svc.credential_source ?? "personal")}</span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge color={svc.is_active ? "green" : "muted"}>
-                        {svc.is_active ? "active" : "inactive"}
+                      <Badge color={svc.openapi_url ? "green" : "muted"}>
+                        {svc.openapi_url ? "available" : "none"}
                       </Badge>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="font-mono text-xs text-text-muted truncate block max-w-xs">
+                        {svc.proxy_url_slug?.replace("/{path}", "") ?? ""}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge color="green">connected</Badge>
                     </td>
                   </tr>
                 ))}

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -1,34 +1,52 @@
 /**
  * My NyxID Services Page.
- * Shows all NyxID services the user has added (from user-services endpoint),
- * enriched with service metadata from proxy/services.
+ * Shows user's own (manually added) AI services from NyxID.
+ * Filters out auto-connected services. Allows skill generation.
  * @module pages/MyNyxidServicesPage
  */
 
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { useAuthStore } from "@/stores/authStore";
+import { useToastStore } from "@/stores/toastStore";
+import {
+  generateSystemSkill,
+  regenerateSystemSkill,
+  deleteSystemSkill,
+  getPublicSystemSkills,
+} from "@/services/systemSkillsApi";
 
 const NYXID_API_BASE = import.meta.env.VITE_NYXID_AUTHORIZE_URL?.replace("/oauth/authorize", "") ?? "";
 
 interface UserServiceDisplay {
   id: string;
+  serviceId: string;
   slug: string;
   name: string;
   description: string | null;
   serviceCategory: string;
   isActive: boolean;
   credentialSource: string;
-  proxyUrl: string;
   hasSpec: boolean;
+  openApiUrl: string | null;
+  skillGenerated: boolean;
+  skillName: string | null;
+  skillGuid: string | null;
 }
 
 export function MyNyxidServicesPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const addToast = useToastStore((s) => s.addToast);
   const [services, setServices] = useState<UserServiceDisplay[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [generatingId, setGeneratingId] = useState<string | null>(null);
   const accessToken = useAuthStore((s) => s.accessToken);
 
   useEffect(() => {
@@ -39,41 +57,65 @@ export function MyNyxidServicesPage() {
 
     const headers = { Authorization: `Bearer ${accessToken}` };
 
-    // Fetch both endpoints in parallel
     Promise.all([
       fetch(`${NYXID_API_BASE}/api/v1/user-services`, { headers }).then((r) => r.ok ? r.json() : { services: [] }),
       fetch(`${NYXID_API_BASE}/api/v1/proxy/services?per_page=100`, { headers }).then((r) => r.ok ? r.json() : { services: [] }),
+      getPublicSystemSkills().catch(() => ({ items: [] })),
     ])
-      .then(([userSvcData, proxySvcData]) => {
+      .then(([userSvcData, proxySvcData, systemSkillsData]) => {
         const userServices = userSvcData.services ?? [];
         const proxyServices = proxySvcData.services ?? [];
+        const systemSkills = systemSkillsData?.items ?? [];
 
-        // Build lookup from proxy services by slug
+        // Build lookups
         const proxyBySlug = new Map<string, any>();
         for (const ps of proxyServices) {
           proxyBySlug.set(ps.slug, ps);
         }
+        const skillByServiceId = new Map<string, any>();
+        for (const sk of systemSkills) {
+          if (sk.nyxidServiceId) skillByServiceId.set(sk.nyxidServiceId, sk);
+        }
 
-        // Map user services, enrich with proxy service metadata
-        const display: UserServiceDisplay[] = userServices.map((us: any) => {
-          // user-service slug format might be "service-slug-xxxx" or match proxy slug
-          const baseSlug = us.slug?.replace(/-[a-z0-9]{4}$/, "") ?? "";
-          const proxy = proxyBySlug.get(baseSlug) || proxyBySlug.get(us.slug) || null;
+        // Filter: only user's own services (not auto-connected)
+        // Auto-connected services have credential_source.type !== "personal" with no user credential,
+        // or requires_connection is false on the proxy service.
+        // Heuristic: if the user-service has no matching proxy service that requires_connection,
+        // it might be auto-connected. But simplest: filter by credential_source type.
+        const display: UserServiceDisplay[] = userServices
+          .filter((us: any) => {
+            // Keep services where user explicitly added credentials
+            // Auto-connected services from admin typically have credential_source.type = "auto" or "catalog"
+            const srcType = typeof us.credential_source === "object"
+              ? us.credential_source?.type ?? ""
+              : String(us.credential_source ?? "");
+            // Filter out auto-connected (type "auto", "catalog", or empty with no auth)
+            return srcType === "personal" || srcType === "org";
+          })
+          .map((us: any) => {
+            const baseSlug = us.slug?.replace(/-[a-z0-9]{4}$/, "") ?? "";
+            const proxy = proxyBySlug.get(baseSlug) || proxyBySlug.get(us.slug) || null;
+            const proxyId = proxy?.id ?? "";
+            const skill = skillByServiceId.get(proxyId);
 
-          return {
-            id: us.id,
-            slug: us.slug,
-            name: proxy?.name ?? us.slug ?? "Unknown",
-            description: proxy?.description ?? null,
-            serviceCategory: proxy?.service_category ?? "unknown",
-            isActive: us.is_active ?? false,
-            credentialSource: typeof us.credential_source === "object"
-              ? us.credential_source?.type ?? "unknown"
-              : String(us.credential_source ?? "personal"),
-            proxyUrl: proxy?.proxy_url_slug?.replace("/{path}", "") ?? "",
-            hasSpec: !!proxy?.openapi_url,
-          };
-        });
+            return {
+              id: us.id,
+              serviceId: proxyId,
+              slug: us.slug,
+              name: proxy?.name ?? us.slug ?? "Unknown",
+              description: proxy?.description ?? null,
+              serviceCategory: proxy?.service_category ?? "unknown",
+              isActive: us.is_active ?? false,
+              credentialSource: typeof us.credential_source === "object"
+                ? us.credential_source?.type ?? "unknown"
+                : String(us.credential_source ?? "personal"),
+              hasSpec: !!proxy?.openapi_url,
+              openApiUrl: proxy?.openapi_url ?? null,
+              skillGenerated: !!skill,
+              skillName: skill?.name ?? null,
+              skillGuid: skill?.guid ?? null,
+            };
+          });
 
         setServices(display);
         setIsLoading(false);
@@ -85,66 +127,138 @@ export function MyNyxidServicesPage() {
       });
   }, [accessToken]);
 
+  const generateMutation = useMutation({
+    mutationFn: (serviceId: string) => generateSystemSkill(serviceId),
+    onMutate: (serviceId) => setGeneratingId(serviceId),
+    onSuccess: (data) => {
+      addToast({ type: "success", message: `Skill "${data.name}" generated` });
+      queryClient.invalidateQueries({ queryKey: ["system-skills-public"] });
+      // Refresh the page data
+      setGeneratingId(null);
+      window.location.reload();
+    },
+    onError: (err: Error) => {
+      addToast({ type: "error", message: err.message });
+      setGeneratingId(null);
+    },
+  });
+
+  const regenerateMutation = useMutation({
+    mutationFn: (serviceId: string) => regenerateSystemSkill(serviceId),
+    onMutate: (serviceId) => setGeneratingId(serviceId),
+    onSuccess: (data) => {
+      addToast({ type: "success", message: `Skill "${data.name}" regenerated` });
+      setGeneratingId(null);
+      window.location.reload();
+    },
+    onError: (err: Error) => {
+      addToast({ type: "error", message: err.message });
+      setGeneratingId(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (serviceId: string) => deleteSystemSkill(serviceId),
+    onSuccess: () => {
+      addToast({ type: "success", message: "Skill deleted" });
+      window.location.reload();
+    },
+    onError: (err: Error) => {
+      addToast({ type: "error", message: err.message });
+    },
+  });
+
   return (
     <PageTransition>
       <div className="py-4 h-full flex flex-col">
-        <div className="mb-4">
+        <div className="mb-4 shrink-0">
           <h1 className="font-heading text-xl tracking-wider text-text-primary">My NyxID Services</h1>
           <p className="font-body text-sm text-text-muted mt-1">
-            Your AI services on NyxID ({services.length} connected)
+            Your manually added AI services ({services.length})
           </p>
         </div>
 
         {isLoading ? (
           <p className="font-body text-sm text-text-muted">Loading...</p>
         ) : error ? (
-          <p className="font-body text-sm text-neon-red">Failed to load services: {error}</p>
+          <p className="font-body text-sm text-neon-red">Failed to load: {error}</p>
         ) : services.length === 0 ? (
           <EmptyState
-            title="No services connected"
-            description="Add services in NyxID to see them here."
+            title="No services"
+            description="Add AI services in NyxID to see them here."
           />
         ) : (
           <div className="flex-1 min-h-0 overflow-auto rounded-lg border border-neon-cyan/10">
             <table className="w-full">
-              <thead>
-                <tr className="border-b border-neon-cyan/10 bg-bg-elevated/50">
+              <thead className="sticky top-0 bg-bg-elevated/95 backdrop-blur-sm">
+                <tr className="border-b border-neon-cyan/10">
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Service</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Category</th>
-                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Source</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Spec</th>
-                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Status</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Skill</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-right px-4 py-3">Actions</th>
                 </tr>
               </thead>
               <tbody>
-                {services.map((svc) => (
-                  <tr key={svc.id} className="border-b border-neon-cyan/5 hover:bg-bg-elevated/30 transition-colors">
-                    <td className="px-4 py-3">
-                      <div>
-                        <span className="font-mono text-sm font-semibold text-neon-cyan">{svc.name}</span>
-                        {svc.description && (
-                          <p className="font-body text-xs text-text-muted mt-0.5 truncate max-w-xs">{svc.description}</p>
+                {services.map((svc) => {
+                  const isGenerating = generatingId === svc.serviceId;
+
+                  return (
+                    <tr key={svc.id} className="border-b border-neon-cyan/5 hover:bg-bg-elevated/30 transition-colors">
+                      <td className="px-4 py-3">
+                        <div>
+                          <span className="font-mono text-sm font-semibold text-neon-cyan">{svc.name}</span>
+                          {svc.description && (
+                            <p className="font-body text-xs text-text-muted mt-0.5 truncate max-w-xs">{svc.description}</p>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge color="yellow">{svc.serviceCategory}</Badge>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge color={svc.hasSpec ? "green" : "muted"}>
+                          {svc.hasSpec ? "available" : "none"}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3">
+                        {svc.skillGenerated && svc.skillName ? (
+                          <div className="flex items-center gap-2">
+                            <Badge color="green">generated</Badge>
+                            <button
+                              onClick={() => navigate(`/skills/${svc.skillName}`)}
+                              className="font-mono text-xs text-neon-cyan hover:underline cursor-pointer"
+                            >
+                              {svc.skillName}
+                            </button>
+                          </div>
+                        ) : (
+                          <span className="font-body text-xs text-text-muted italic">not generated</span>
                         )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge color="yellow">{svc.serviceCategory}</Badge>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-xs text-text-muted">{svc.credentialSource}</span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge color={svc.hasSpec ? "green" : "muted"}>
-                        {svc.hasSpec ? "available" : "none"}
-                      </Badge>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge color={svc.isActive ? "green" : "muted"}>
-                        {svc.isActive ? "active" : "inactive"}
-                      </Badge>
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex justify-end gap-2">
+                          {svc.skillGenerated ? (
+                            <>
+                              <Button size="sm" variant="secondary" onClick={() => regenerateMutation.mutate(svc.serviceId)} disabled={isGenerating}>
+                                {isGenerating ? "..." : "Regenerate"}
+                              </Button>
+                              <Button size="sm" variant="danger" onClick={() => deleteMutation.mutate(svc.serviceId)}>
+                                Delete
+                              </Button>
+                            </>
+                          ) : svc.hasSpec && svc.serviceId ? (
+                            <Button size="sm" onClick={() => generateMutation.mutate(svc.serviceId)} disabled={isGenerating}>
+                              {isGenerating ? "Generating..." : "Generate Skill"}
+                            </Button>
+                          ) : (
+                            <span className="font-body text-[10px] text-text-muted">No spec</span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -58,54 +58,36 @@ export function MyNyxidServicesPage() {
     const headers = { Authorization: `Bearer ${accessToken}` };
 
     Promise.all([
-      fetch(`${NYXID_API_BASE}/api/v1/user-services`, { headers }).then((r) => r.ok ? r.json() : { services: [] }),
-      fetch(`${NYXID_API_BASE}/api/v1/proxy/services?per_page=100`, { headers }).then((r) => r.ok ? r.json() : { services: [] }),
+      fetch(`${NYXID_API_BASE}/api/v1/keys`, { headers }).then((r) => r.ok ? r.json() : { keys: [] }),
       getPublicSystemSkills().catch(() => ({ items: [] })),
     ])
-      .then(([userSvcData, proxySvcData, systemSkillsData]) => {
-        const userServices = userSvcData.services ?? [];
-        const proxyServices = proxySvcData.services ?? [];
+      .then(([keysData, systemSkillsData]) => {
+        const keys = keysData.keys ?? keysData ?? [];
+        const allKeys = Array.isArray(keys) ? keys : [];
         const systemSkills = systemSkillsData?.items ?? [];
 
-        // Build lookups
-        const proxyBySlug = new Map<string, any>();
-        for (const ps of proxyServices) {
-          proxyBySlug.set(ps.slug, ps);
-        }
         const skillByServiceId = new Map<string, any>();
         for (const sk of systemSkills) {
           if (sk.nyxidServiceId) skillByServiceId.set(sk.nyxidServiceId, sk);
         }
 
-        // Filter: only user's own services (not auto-connected)
-        // Auto-connected services have requires_connection=false on the proxy service
-        // (admin set them up, users don't need to provide credentials)
-        const display: UserServiceDisplay[] = userServices
-          .filter((us: any) => {
-            const baseSlug = us.slug?.replace(/-[a-z0-9]{4}$/, "") ?? "";
-            const proxy = proxyBySlug.get(baseSlug) || proxyBySlug.get(us.slug);
-            // Keep only services that require user connection (user manually added)
-            return proxy?.requires_connection === true;
-          })
-          .map((us: any) => {
-            const baseSlug = us.slug?.replace(/-[a-z0-9]{4}$/, "") ?? "";
-            const proxy = proxyBySlug.get(baseSlug) || proxyBySlug.get(us.slug) || null;
-            const proxyId = proxy?.id ?? "";
-            const skill = skillByServiceId.get(proxyId);
+        // Filter out auto-connected services
+        const display: UserServiceDisplay[] = allKeys
+          .filter((k: any) => !k.auto_connected)
+          .map((k: any) => {
+            const skill = skillByServiceId.get(k.service_id ?? k.id);
 
             return {
-              id: us.id,
-              serviceId: proxyId,
-              slug: us.slug,
-              name: proxy?.name ?? us.slug ?? "Unknown",
-              description: proxy?.description ?? null,
-              serviceCategory: proxy?.service_category ?? "unknown",
-              isActive: us.is_active ?? false,
-              credentialSource: typeof us.credential_source === "object"
-                ? us.credential_source?.type ?? "unknown"
-                : String(us.credential_source ?? "personal"),
-              hasSpec: !!proxy?.openapi_url,
-              openApiUrl: proxy?.openapi_url ?? null,
+              id: k.id,
+              serviceId: k.service_id ?? k.id,
+              slug: k.slug ?? "",
+              name: k.catalog_service_name ?? k.label ?? k.slug ?? "Unknown",
+              description: k.description ?? null,
+              serviceCategory: k.service_category ?? "unknown",
+              isActive: k.is_active ?? false,
+              credentialSource: k.auth_method ?? "none",
+              hasSpec: false, // /keys doesn't have spec info
+              openApiUrl: null,
               skillGenerated: !!skill,
               skillName: skill?.name ?? null,
               skillGuid: skill?.guid ?? null,

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -85,19 +85,19 @@ export function MyNyxidServicesPage() {
                 </tr>
               </thead>
               <tbody>
-                {services.map((svc) => (
-                  <tr key={svc.id} className="border-b border-neon-cyan/5 hover:bg-bg-elevated/30 transition-colors">
+                {services.map((svc, idx) => (
+                  <tr key={svc.id ?? idx} className="border-b border-neon-cyan/5 hover:bg-bg-elevated/30 transition-colors">
                     <td className="px-4 py-3">
-                      <span className="font-mono text-sm font-semibold text-neon-cyan">{svc.service_name || svc.service_slug}</span>
+                      <span className="font-mono text-sm font-semibold text-neon-cyan">{String(svc.service_name || svc.service_slug || "")}</span>
                     </td>
                     <td className="px-4 py-3">
-                      <span className="font-body text-sm text-text-primary">{svc.label}</span>
+                      <span className="font-body text-sm text-text-primary">{String(svc.label || "")}</span>
                     </td>
                     <td className="px-4 py-3">
-                      <Badge color="yellow">{svc.service_category}</Badge>
+                      <Badge color="yellow">{String(svc.service_category || "unknown")}</Badge>
                     </td>
                     <td className="px-4 py-3">
-                      <span className="font-mono text-xs text-text-muted">{svc.credential_source ?? "personal"}</span>
+                      <span className="font-mono text-xs text-text-muted">{String(svc.credential_source ?? "personal")}</span>
                     </td>
                     <td className="px-4 py-3">
                       <Badge color={svc.is_active ? "green" : "muted"}>

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -1,7 +1,7 @@
 /**
  * My NyxID Services Page.
- * Shows NyxID services the current user is connected to.
- * Uses proxy/services endpoint filtered to connected services.
+ * Shows all NyxID services the user has added (from user-services endpoint),
+ * enriched with service metadata from proxy/services.
  * @module pages/MyNyxidServicesPage
  */
 
@@ -13,21 +13,20 @@ import { useAuthStore } from "@/stores/authStore";
 
 const NYXID_API_BASE = import.meta.env.VITE_NYXID_AUTHORIZE_URL?.replace("/oauth/authorize", "") ?? "";
 
-interface ProxyService {
+interface UserServiceDisplay {
   id: string;
-  name: string;
   slug: string;
+  name: string;
   description: string | null;
-  service_category: string;
-  connected: boolean;
-  requires_connection: boolean;
-  proxy_url_slug: string;
-  openapi_url: string | null;
-  streaming_supported: boolean;
+  serviceCategory: string;
+  isActive: boolean;
+  credentialSource: string;
+  proxyUrl: string;
+  hasSpec: boolean;
 }
 
 export function MyNyxidServicesPage() {
-  const [services, setServices] = useState<ProxyService[]>([]);
+  const [services, setServices] = useState<UserServiceDisplay[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const accessToken = useAuthStore((s) => s.accessToken);
@@ -38,17 +37,45 @@ export function MyNyxidServicesPage() {
       return;
     }
 
-    fetch(`${NYXID_API_BASE}/api/v1/proxy/services?per_page=100`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    })
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
-      })
-      .then((data) => {
-        // Only show services the user is connected to
-        const connected = (data.services ?? []).filter((s: ProxyService) => s.connected);
-        setServices(connected);
+    const headers = { Authorization: `Bearer ${accessToken}` };
+
+    // Fetch both endpoints in parallel
+    Promise.all([
+      fetch(`${NYXID_API_BASE}/api/v1/user-services`, { headers }).then((r) => r.ok ? r.json() : { services: [] }),
+      fetch(`${NYXID_API_BASE}/api/v1/proxy/services?per_page=100`, { headers }).then((r) => r.ok ? r.json() : { services: [] }),
+    ])
+      .then(([userSvcData, proxySvcData]) => {
+        const userServices = userSvcData.services ?? [];
+        const proxyServices = proxySvcData.services ?? [];
+
+        // Build lookup from proxy services by slug
+        const proxyBySlug = new Map<string, any>();
+        for (const ps of proxyServices) {
+          proxyBySlug.set(ps.slug, ps);
+        }
+
+        // Map user services, enrich with proxy service metadata
+        const display: UserServiceDisplay[] = userServices.map((us: any) => {
+          // user-service slug format might be "service-slug-xxxx" or match proxy slug
+          const baseSlug = us.slug?.replace(/-[a-z0-9]{4}$/, "") ?? "";
+          const proxy = proxyBySlug.get(baseSlug) || proxyBySlug.get(us.slug) || null;
+
+          return {
+            id: us.id,
+            slug: us.slug,
+            name: proxy?.name ?? us.slug ?? "Unknown",
+            description: proxy?.description ?? null,
+            serviceCategory: proxy?.service_category ?? "unknown",
+            isActive: us.is_active ?? false,
+            credentialSource: typeof us.credential_source === "object"
+              ? us.credential_source?.type ?? "unknown"
+              : String(us.credential_source ?? "personal"),
+            proxyUrl: proxy?.proxy_url_slug?.replace("/{path}", "") ?? "",
+            hasSpec: !!proxy?.openapi_url,
+          };
+        });
+
+        setServices(display);
         setIsLoading(false);
       })
       .catch((err) => {
@@ -64,7 +91,7 @@ export function MyNyxidServicesPage() {
         <div className="mb-4">
           <h1 className="font-heading text-xl tracking-wider text-text-primary">My NyxID Services</h1>
           <p className="font-body text-sm text-text-muted mt-1">
-            Services you are connected to on NyxID
+            Your AI services on NyxID ({services.length} connected)
           </p>
         </div>
 
@@ -75,7 +102,7 @@ export function MyNyxidServicesPage() {
         ) : services.length === 0 ? (
           <EmptyState
             title="No services connected"
-            description="Connect to services in NyxID to see them here."
+            description="Add services in NyxID to see them here."
           />
         ) : (
           <div className="overflow-x-auto rounded-lg border border-neon-cyan/10">
@@ -84,8 +111,8 @@ export function MyNyxidServicesPage() {
                 <tr className="border-b border-neon-cyan/10 bg-bg-elevated/50">
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Service</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Category</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Source</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Spec</th>
-                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Proxy URL</th>
                   <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Status</th>
                 </tr>
               </thead>
@@ -101,20 +128,20 @@ export function MyNyxidServicesPage() {
                       </div>
                     </td>
                     <td className="px-4 py-3">
-                      <Badge color="yellow">{svc.service_category}</Badge>
+                      <Badge color="yellow">{svc.serviceCategory}</Badge>
                     </td>
                     <td className="px-4 py-3">
-                      <Badge color={svc.openapi_url ? "green" : "muted"}>
-                        {svc.openapi_url ? "available" : "none"}
+                      <span className="font-mono text-xs text-text-muted">{svc.credentialSource}</span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge color={svc.hasSpec ? "green" : "muted"}>
+                        {svc.hasSpec ? "available" : "none"}
                       </Badge>
                     </td>
                     <td className="px-4 py-3">
-                      <span className="font-mono text-xs text-text-muted truncate block max-w-xs">
-                        {svc.proxy_url_slug?.replace("/{path}", "") ?? ""}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <Badge color="green">connected</Badge>
+                      <Badge color={svc.isActive ? "green" : "muted"}>
+                        {svc.isActive ? "active" : "inactive"}
+                      </Badge>
                     </td>
                   </tr>
                 ))}

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -1,0 +1,106 @@
+/**
+ * My NyxID Services Page.
+ * Lists the current user's connected AI services from NyxID.
+ * @module pages/MyNyxidServicesPage
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { Badge } from "@/components/ui/Badge";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { useAuthStore } from "@/stores/authStore";
+
+const NYXID_API_BASE = import.meta.env.VITE_NYXID_AUTHORIZE_URL?.replace("/oauth/authorize", "") ?? "";
+
+interface UserService {
+  id: string;
+  service_id: string;
+  service_name: string;
+  service_slug: string;
+  service_category: string;
+  label: string;
+  is_active: boolean;
+  credential_source?: string;
+  allowed?: boolean;
+  proxy_url?: string;
+}
+
+async function fetchMyServices(): Promise<UserService[]> {
+  const token = useAuthStore.getState().accessToken;
+  if (!token) return [];
+
+  const resp = await fetch(`${NYXID_API_BASE}/api/v1/user-services`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!resp.ok) return [];
+  const data = await resp.json();
+  return data.services ?? [];
+}
+
+export function MyNyxidServicesPage() {
+  const { data: services, isLoading } = useQuery({
+    queryKey: ["nyxid", "my-services"],
+    queryFn: fetchMyServices,
+  });
+
+  return (
+    <PageTransition>
+      <div className="py-4">
+        <div className="mb-4">
+          <h1 className="font-heading text-xl tracking-wider text-text-primary">My NyxID Services</h1>
+          <p className="font-body text-sm text-text-muted mt-1">
+            Your connected AI services from NyxID
+          </p>
+        </div>
+
+        {isLoading ? (
+          <Skeleton lines={6} />
+        ) : !services?.length ? (
+          <EmptyState
+            title="No services connected"
+            description="Connect services in NyxID to see them here."
+          />
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-neon-cyan/10">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-neon-cyan/10 bg-bg-elevated/50">
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Service</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Label</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Category</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Source</th>
+                  <th className="font-heading text-[10px] font-700 tracking-widest uppercase text-text-muted text-left px-4 py-3">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {services.map((svc) => (
+                  <tr key={svc.id} className="border-b border-neon-cyan/5 hover:bg-bg-elevated/30 transition-colors">
+                    <td className="px-4 py-3">
+                      <span className="font-mono text-sm font-semibold text-neon-cyan">{svc.service_name || svc.service_slug}</span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="font-body text-sm text-text-primary">{svc.label}</span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge color="yellow">{svc.service_category}</Badge>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="font-mono text-xs text-text-muted">{svc.credential_source ?? "personal"}</span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge color={svc.is_active ? "green" : "muted"}>
+                        {svc.is_active ? "active" : "inactive"}
+                      </Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -4,10 +4,9 @@
  * @module pages/MyNyxidServicesPage
  */
 
-import { useQuery } from "@tanstack/react-query";
+import { useState, useEffect } from "react";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { Badge } from "@/components/ui/Badge";
-import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { useAuthStore } from "@/stores/authStore";
 
@@ -22,28 +21,37 @@ interface UserService {
   label: string;
   is_active: boolean;
   credential_source?: string;
-  allowed?: boolean;
-  proxy_url?: string;
-}
-
-async function fetchMyServices(): Promise<UserService[]> {
-  const token = useAuthStore.getState().accessToken;
-  if (!token) return [];
-
-  const resp = await fetch(`${NYXID_API_BASE}/api/v1/user-services`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-
-  if (!resp.ok) return [];
-  const data = await resp.json();
-  return data.services ?? [];
 }
 
 export function MyNyxidServicesPage() {
-  const { data: services, isLoading } = useQuery({
-    queryKey: ["nyxid", "my-services"],
-    queryFn: fetchMyServices,
-  });
+  const [services, setServices] = useState<UserService[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const accessToken = useAuthStore((s) => s.accessToken);
+
+  useEffect(() => {
+    if (!accessToken) {
+      setIsLoading(false);
+      return;
+    }
+
+    fetch(`${NYXID_API_BASE}/api/v1/user-services`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data) => {
+        setServices(data.services ?? []);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        console.error("[MyNyxidServices]", err);
+        setError(err.message);
+        setIsLoading(false);
+      });
+  }, [accessToken]);
 
   return (
     <PageTransition>
@@ -56,8 +64,10 @@ export function MyNyxidServicesPage() {
         </div>
 
         {isLoading ? (
-          <Skeleton lines={6} />
-        ) : !services?.length ? (
+          <p className="font-body text-sm text-text-muted">Loading...</p>
+        ) : error ? (
+          <p className="font-body text-sm text-neon-red">Failed to load services: {error}</p>
+        ) : services.length === 0 ? (
           <EmptyState
             title="No services connected"
             description="Connect services in NyxID to see them here."

--- a/ornn-web/src/pages/MyNyxidServicesPage.tsx
+++ b/ornn-web/src/pages/MyNyxidServicesPage.tsx
@@ -78,19 +78,14 @@ export function MyNyxidServicesPage() {
         }
 
         // Filter: only user's own services (not auto-connected)
-        // Auto-connected services have credential_source.type !== "personal" with no user credential,
-        // or requires_connection is false on the proxy service.
-        // Heuristic: if the user-service has no matching proxy service that requires_connection,
-        // it might be auto-connected. But simplest: filter by credential_source type.
+        // Auto-connected services have requires_connection=false on the proxy service
+        // (admin set them up, users don't need to provide credentials)
         const display: UserServiceDisplay[] = userServices
           .filter((us: any) => {
-            // Keep services where user explicitly added credentials
-            // Auto-connected services from admin typically have credential_source.type = "auto" or "catalog"
-            const srcType = typeof us.credential_source === "object"
-              ? us.credential_source?.type ?? ""
-              : String(us.credential_source ?? "");
-            // Filter out auto-connected (type "auto", "catalog", or empty with no auth)
-            return srcType === "personal" || srcType === "org";
+            const baseSlug = us.slug?.replace(/-[a-z0-9]{4}$/, "") ?? "";
+            const proxy = proxyBySlug.get(baseSlug) || proxyBySlug.get(us.slug);
+            // Keep only services that require user connection (user manually added)
+            return proxy?.requires_connection === true;
           })
           .map((us: any) => {
             const baseSlug = us.slug?.replace(/-[a-z0-9]{4}$/, "") ?? "";

--- a/ornn-web/src/services/systemSkillsApi.ts
+++ b/ornn-web/src/services/systemSkillsApi.ts
@@ -16,12 +16,7 @@ export interface NyxidService {
   slug: string;
   description: string | null;
   service_category: string;
-  connected: boolean;
-  requires_connection: boolean;
-  proxy_url: string;
-  proxy_url_slug: string;
-  openapi_url: string | null;
-  streaming_supported: boolean;
+  hasOpenApiSpec: boolean;
 }
 
 export interface SystemSkillInfo {
@@ -51,20 +46,30 @@ export interface SystemSkillItem {
 const NYXID_API_BASE = import.meta.env.VITE_NYXID_AUTHORIZE_URL?.replace("/oauth/authorize", "") ?? "";
 
 /**
- * Fetch proxyable services from NyxID proxy/services endpoint.
- * This endpoint is available to any authenticated user with proxy scope.
+ * Fetch admin (auto-connected) services from NyxID /keys endpoint.
  */
-async function fetchNyxidServices(): Promise<NyxidService[]> {
+async function fetchAdminServices(): Promise<NyxidService[]> {
   const token = useAuthStore.getState().accessToken;
   if (!token) return [];
 
-  const resp = await fetch(`${NYXID_API_BASE}/api/v1/proxy/services`, {
+  const resp = await fetch(`${NYXID_API_BASE}/api/v1/keys`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
   if (!resp.ok) return [];
   const data = await resp.json();
-  return data.services ?? [];
+  const keys = Array.isArray(data.keys) ? data.keys : Array.isArray(data) ? data : [];
+
+  return keys
+    .filter((k: any) => k.auto_connected)
+    .map((k: any) => ({
+      id: k.id,
+      name: k.catalog_service_name ?? k.label ?? k.slug ?? "Unknown",
+      slug: k.slug ?? "",
+      description: k.description ?? null,
+      service_category: k.service_category ?? "unknown",
+      hasOpenApiSpec: false, // will be enriched by skill status
+    }));
 }
 
 /**
@@ -83,7 +88,7 @@ async function fetchGeneratedSystemSkills(): Promise<SystemSkillInfo[]> {
  */
 export async function getSystemSkills(): Promise<SystemSkillItem[]> {
   const [services, skills] = await Promise.all([
-    fetchNyxidServices(),
+    fetchAdminServices(),
     fetchGeneratedSystemSkills(),
   ]);
 
@@ -96,10 +101,10 @@ export async function getSystemSkills(): Promise<SystemSkillItem[]> {
       serviceName: svc.name,
       serviceSlug: svc.slug,
       serviceDescription: svc.description,
-      baseUrl: svc.proxy_url_slug,
+      baseUrl: "",
       serviceCategory: svc.service_category,
-      hasOpenApiSpec: !!svc.openapi_url,
-      openApiSpecUrl: svc.openapi_url,
+      hasOpenApiSpec: svc.hasOpenApiSpec,
+      openApiSpecUrl: null,
       skillGenerated: !!skill,
       skill,
     };

--- a/ornn-web/src/services/systemSkillsApi.ts
+++ b/ornn-web/src/services/systemSkillsApi.ts
@@ -46,29 +46,33 @@ export interface SystemSkillItem {
 const NYXID_API_BASE = import.meta.env.VITE_NYXID_AUTHORIZE_URL?.replace("/oauth/authorize", "") ?? "";
 
 /**
- * Fetch admin (auto-connected) services from NyxID /keys endpoint.
+ * Fetch all platform services from NyxID admin endpoint.
+ * Requires admin user token.
  */
 async function fetchAdminServices(): Promise<NyxidService[]> {
   const token = useAuthStore.getState().accessToken;
   if (!token) return [];
 
-  const resp = await fetch(`${NYXID_API_BASE}/api/v1/keys`, {
+  const resp = await fetch(`${NYXID_API_BASE}/api/v1/services`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
-  if (!resp.ok) return [];
+  if (!resp.ok) {
+    console.warn("[systemSkillsApi] Failed to fetch admin services:", resp.status);
+    return [];
+  }
   const data = await resp.json();
-  const keys = Array.isArray(data.keys) ? data.keys : Array.isArray(data) ? data : [];
+  const services = data.services ?? [];
 
-  return keys
-    .filter((k: any) => k.auto_connected)
-    .map((k: any) => ({
-      id: k.id,
-      name: k.catalog_service_name ?? k.label ?? k.slug ?? "Unknown",
-      slug: k.slug ?? "",
-      description: k.description ?? null,
-      service_category: k.service_category ?? "unknown",
-      hasOpenApiSpec: false, // will be enriched by skill status
+  return services
+    .filter((s: any) => s.is_active)
+    .map((s: any) => ({
+      id: s.id,
+      name: s.name ?? s.slug ?? "Unknown",
+      slug: s.slug ?? "",
+      description: s.description ?? null,
+      service_category: s.service_category ?? "unknown",
+      hasOpenApiSpec: !!(s.openapi_spec_url || s.api_spec_url),
     }));
 }
 


### PR DESCRIPTION
## Summary

- Add My NyxID Services and Admin NyxID Services pages
- Link from user dropdown
- Filter auto-connected services using \`requires_connection\` / \`auto_connected\`
- Multiple stability fixes (stringify fields, scroll layout, endpoint selection)

## Commits (12)

- \`c65038a\` feat: add My NyxID Services and Admin NyxID Services links to user dropdown
- \`d73c839\` feat: add My NyxID Services and Admin NyxID Services pages
- \`32243ec\` fix: MyNyxidServicesPage uses useState/useEffect instead of useQuery to avoid crash
- \`7d7460b\` fix: stringify all NyxID service fields to prevent React object render crash
- \`8200f79\` fix: My NyxID Services uses proxy/services endpoint filtered by connected status
- \`8008246\` fix: My NyxID Services joins user-services with proxy/services for complete data
- \`147cbe3\` fix: NyxID services pages scroll properly with flex layout
- \`8d23569\` feat: My NyxID Services filters auto-connected, adds Generate Skill
- \`165db03\` fix: filter auto-connected services using requires_connection from proxy/services
- \`2550232\` fix: use /api/v1/keys endpoint with auto_connected filter for My Services
- \`eaab3d0\` fix: Admin Services uses /keys endpoint filtered by auto_connected
- \`0f8003b\` fix: Admin Services uses /api/v1/services admin endpoint for all platform services

## Stacked PR

Base: \`feature/system-skills-page\` (part 6 of 8). Merge prior PRs first.

## Test plan

- [ ] User dropdown shows My NyxID Services link
- [ ] Admin dropdown shows Admin NyxID Services link
- [ ] Auto-connected services are filtered correctly