### PR TITLE
feat: skill versioning — semver, history, deprecation, breaking-change detection

### DIFF
--- a/.changeset/skill-versioning.md
+++ b/.changeset/skill-versioning.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+Skill versioning (#25): SKILL.md requires a 2-digit `version` field; each publish snapshots an immutable row in the new `skill_versions` collection with its own storage key. New endpoints `GET /api/skills/:idOrName?version=X.Y`, `GET /api/skills/:idOrName/versions`, and `PATCH /api/skills/:idOrName/versions/:version` (deprecation toggle). Package updates enforce a strictly-greater version and reject interface-breaking changes without a major bump (409 `BREAKING_CHANGE_WITHOUT_MAJOR_BUMP`). Skill detail page adds a version picker, history list, and deprecation banner with owner/admin deprecation controls. **Requires running `bun run migrate:versions` in `ornn-api` against any pre-existing database** — see `docs/migrations.md`.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -4,29 +4,39 @@ Operational notes for data migrations that accompany specific features. Scripts 
 
 ## `migrate:versions` — Skill versioning foundation
 
-Backfills the `skill_versions` collection for every existing skill. Required when deploying the skill-versioning feature (Phase 1 of GitHub issue #25) to a database that pre-dates it.
+For every existing skill that pre-dates the versioning feature, patches its `SKILL.md` frontmatter to carry a top-level `version` field and republishes through the API so the full versioning machinery (storage upload, hash recompute, `skill_versions` row insert, `latestVersion` pointer) runs through the same code path a normal publish uses.
 
-Behaviour:
+### Why HTTP instead of direct DB + storage
 
-1. Scans every document in `skills`.
-2. Picks a version string: uses `skill.latestVersion` when valid, else `skill.metadata.version`, else defaults to `0.1`.
-3. If a row already exists in `skill_versions` for that `(skillGuid, version)`, skips.
-4. Otherwise inserts a row pointing at the skill's current `storageKey` — the legacy package stays reachable through the versioned read path without re-uploading.
-5. Backfills `latestVersion` on the skill document when absent or malformed.
+The storage service hands out presigned URLs pointing at an internal MinIO hostname that isn't reachable from outside the cluster. Going through the API avoids that entirely — the script can run from any host with network access to `ornn-api` and an admin access token.
 
-Idempotent. Re-running on an already-migrated database makes no changes.
+### Flow per skill
+
+1. `GET /api/skills/:guid/versions` — if the list is non-empty the skill already has at least one version row and we skip.
+2. `GET /api/skills/:guid/json` — returns the unpacked package (SKILL.md body + every scripts/ / references/ / assets/ file).
+3. Patch `SKILL.md`: insert a top-level `version: "<resolved>"` line if missing, or rewrite an existing `version:` line to the canonical quoted form. Resolution order for the version string: `skill.latestVersion` → `skill.metadata.version` → `"0.1"`.
+4. Re-pack into a ZIP wrapped in a `<skill-name>/` root folder (matches the validator's expectations).
+5. `PUT /api/skills/:guid?skip_validation=true` — the API's update flow inserts the `skill_versions` row, advances the skill doc's `latestVersion`, and writes the new storage key + hash. `skip_validation` is on because some legacy skills pre-date current schema requirements beyond just the version field.
+
+Idempotent: skills with an existing version row are skipped on re-run.
 
 ```bash
-# From the repo root, in a shell with MONGODB_URI/MONGODB_DB set the same way
-# the API runs.
+# From the repo root.
 cd ornn-api
+MONGODB_URI=... MONGODB_DB=... \
+ORNN_API_URL=http://localhost:3802 \
+ORNN_ADMIN_TOKEN=<NyxID access token with ornn:admin:skill> \
 bun run migrate:versions
 ```
 
-Expected end-of-run line:
+Expected end-of-run summary:
 
 ```
-Skill versions migration complete — scanned=N, inserted=M, skipped=K, backfilledLatestVersion=L
+Skill versions migration complete:
+  scanned=N
+  migrated=M
+  alreadyMigrated=K
+  missingSkillMd=Z
 ```
 
-On a fresh deploy `inserted == scanned`; on re-runs `skipped == scanned`.
+On a fresh deploy `migrated == scanned`. On re-runs `alreadyMigrated == scanned`. Any per-skill errors are listed at the end and the process exits non-zero so the run fails loudly.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,32 @@
+# Data migrations
+
+Operational notes for data migrations that accompany specific features. Scripts live under `ornn-api/scripts/` and are wired into `ornn-api/package.json`.
+
+## `migrate:versions` — Skill versioning foundation
+
+Backfills the `skill_versions` collection for every existing skill. Required when deploying the skill-versioning feature (Phase 1 of GitHub issue #25) to a database that pre-dates it.
+
+Behaviour:
+
+1. Scans every document in `skills`.
+2. Picks a version string: uses `skill.latestVersion` when valid, else `skill.metadata.version`, else defaults to `0.1`.
+3. If a row already exists in `skill_versions` for that `(skillGuid, version)`, skips.
+4. Otherwise inserts a row pointing at the skill's current `storageKey` — the legacy package stays reachable through the versioned read path without re-uploading.
+5. Backfills `latestVersion` on the skill document when absent or malformed.
+
+Idempotent. Re-running on an already-migrated database makes no changes.
+
+```bash
+# From the repo root, in a shell with MONGODB_URI/MONGODB_DB set the same way
+# the API runs.
+cd ornn-api
+bun run migrate:versions
+```
+
+Expected end-of-run line:
+
+```
+Skill versions migration complete — scanned=N, inserted=M, skipped=K, backfilledLatestVersion=L
+```
+
+On a fresh deploy `inserted == scanned`; on re-runs `skipped == scanned`.

--- a/ornn-api/package.json
+++ b/ornn-api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",
-    "test": "bun test"
+    "test": "bun test",
+    "migrate:versions": "bun run scripts/migrate-skill-versions.ts"
   },
   "dependencies": {
     "@xenova/transformers": "^2.17.0",

--- a/ornn-api/scripts/migrate-skill-versions.ts
+++ b/ornn-api/scripts/migrate-skill-versions.ts
@@ -1,38 +1,66 @@
 /**
- * One-shot migration: backfill the `skill_versions` collection for every
- * existing skill in `skills` that predates the versioning feature.
+ * One-shot migration: for every existing skill that pre-dates the
+ * versioning feature, patch its `SKILL.md` frontmatter to carry
+ * `version: "0.1"` (or whatever `metadata.version` says, when valid) and
+ * republish through the API so the full versioning machinery — storage
+ * upload, hash recompute, `skill_versions` row insert, `latestVersion`
+ * pointer — runs through the same code path a normal publish uses.
  *
- * Behaviour:
- *   - If the skill doc has a valid `latestVersion` field, use it. Otherwise
- *     inspect `metadata.version` (legacy location); otherwise default to "0.1".
- *   - If a matching row (skillGuid + version) already exists in
- *     `skill_versions`, skip.
- *   - Otherwise insert one, referencing the skill's current `storageKey` so
- *     the pre-existing package is reachable through the versioned read path
- *     without re-uploading.
- *   - Ensure the skill doc itself carries `latestVersion` for the fast
- *     default-read path.
+ * Why HTTP instead of direct DB + storage: the storage service hands out
+ * presigned URLs pointing at an internal MinIO hostname that isn't
+ * reachable from outside the cluster. Going through the API sidesteps
+ * that entirely — this script can run from any host with network access
+ * to `ornn-api` and an admin access token.
  *
- * Idempotent: running twice on a migrated DB is a no-op.
+ * Flow per skill:
+ *   1. `GET /api/skills/:guid/versions` — if the list is non-empty, the
+ *      skill already has at least one version row and we skip.
+ *   2. `GET /api/skills/:guid/json` — returns the unpacked package
+ *      (SKILL.md body + every scripts/ / references/ / assets/ file).
+ *   3. Patch the SKILL.md string: insert a top-level
+ *      `version: "<resolved>"` line if missing, or rewrite an existing
+ *      `version:` line to the canonical quoted form.
+ *   4. Re-pack into a ZIP wrapped in a `<name>/` root folder (matches
+ *      the validator's expectations).
+ *   5. `PUT /api/skills/:guid` with the new ZIP. The API's update flow
+ *      inserts the `skill_versions` row, advances the skill doc's
+ *      `latestVersion`, and writes the new storage key + hash.
  *
- * Run with:
- *     bun run migrate:versions
+ * Idempotent: skills with an existing version row are skipped.
  *
- * Reads the same MongoDB config as the API (`MONGODB_URI`, `MONGODB_DB`).
+ * Run with (from ornn-api/):
+ *   MONGODB_URI=... MONGODB_DB=... \
+ *   ORNN_API_URL=http://localhost:3802 \
+ *   ORNN_ADMIN_TOKEN=<NyxID access token with ornn:admin:skill> \
+ *   bun run migrate:versions
  */
 
+import JSZip from "jszip";
 import { MongoClient } from "mongodb";
 import { SKILL_VERSION_REGEX } from "../src/shared/schemas/skillFrontmatter";
 
-function readMongoConfig(): { uri: string; dbName: string } {
-  const uri = process.env.MONGODB_URI;
-  if (!uri) {
-    throw new Error("MONGODB_URI is required");
-  }
-  return { uri, dbName: process.env.MONGODB_DB ?? "ornn" };
-}
-
 const DEFAULT_VERSION = "0.1";
+const FRONTMATTER_REGEX = /^(---\s*\n)([\s\S]*?)(\n---)/;
+
+function readConfig(): {
+  mongoUri: string;
+  mongoDb: string;
+  apiBaseUrl: string;
+  adminToken: string;
+} {
+  const mongoUri = process.env.MONGODB_URI;
+  if (!mongoUri) throw new Error("MONGODB_URI is required");
+  const apiBaseUrl = process.env.ORNN_API_URL;
+  if (!apiBaseUrl) throw new Error("ORNN_API_URL is required");
+  const adminToken = process.env.ORNN_ADMIN_TOKEN;
+  if (!adminToken) throw new Error("ORNN_ADMIN_TOKEN is required (must have ornn:admin:skill)");
+  return {
+    mongoUri,
+    mongoDb: process.env.MONGODB_DB ?? "ornn",
+    apiBaseUrl: apiBaseUrl.replace(/\/+$/, ""),
+    adminToken,
+  };
+}
 
 function resolveVersion(skillDoc: Record<string, unknown>): string {
   const candidates: unknown[] = [
@@ -41,86 +69,194 @@ function resolveVersion(skillDoc: Record<string, unknown>): string {
     (skillDoc as { version?: unknown }).version,
   ];
   for (const raw of candidates) {
-    if (typeof raw === "string" && SKILL_VERSION_REGEX.test(raw)) {
-      return raw;
-    }
+    if (typeof raw === "string" && SKILL_VERSION_REGEX.test(raw)) return raw;
   }
   return DEFAULT_VERSION;
 }
 
-function parseMajorMinor(version: string): { major: number; minor: number } {
-  const match = version.match(SKILL_VERSION_REGEX);
-  if (!match) {
-    throw new Error(`Unreachable — resolveVersion already validated: ${version}`);
+/**
+ * Patch a SKILL.md string so its YAML frontmatter carries
+ * `version: "<resolvedVersion>"`.
+ *
+ * Surgical text edit — preserves author formatting, comments, and
+ * unrelated keys. Returns `{ patched: false }` when the file already has
+ * the matching line or has no frontmatter block at all.
+ */
+export function patchSkillMdFrontmatter(
+  content: string,
+  resolvedVersion: string,
+): { patched: boolean; newContent: string } {
+  const fmMatch = content.match(FRONTMATTER_REGEX);
+  if (!fmMatch) return { patched: false, newContent: content };
+
+  const fmBody = fmMatch[2];
+  const desired = `"${resolvedVersion}"`;
+
+  const versionLineRe = /^(version:\s*)(.*)$/m;
+  const existing = fmBody.match(versionLineRe);
+  if (existing) {
+    if (existing[2].trim() === desired) return { patched: false, newContent: content };
+    const newFmBody = fmBody.replace(versionLineRe, `version: ${desired}`);
+    return { patched: true, newContent: rebuildWithFmBody(content, fmMatch, newFmBody) };
   }
-  return { major: Number(match[1]), minor: Number(match[2]) };
+
+  let newFmBody: string;
+  const insertAfter = (re: RegExp) => fmBody.replace(re, (m) => `${m}\nversion: ${desired}`);
+  if (/^description:[^\n]*$/m.test(fmBody)) {
+    newFmBody = insertAfter(/^description:[^\n]*$/m);
+  } else if (/^name:[^\n]*$/m.test(fmBody)) {
+    newFmBody = insertAfter(/^name:[^\n]*$/m);
+  } else {
+    newFmBody = `${fmBody.replace(/\s+$/, "")}\nversion: ${desired}`;
+  }
+  return { patched: true, newContent: rebuildWithFmBody(content, fmMatch, newFmBody) };
+}
+
+function rebuildWithFmBody(original: string, fmMatch: RegExpMatchArray, newFmBody: string): string {
+  const start = fmMatch.index ?? 0;
+  const [, openDelim, , closeDelim] = fmMatch;
+  return (
+    original.slice(0, start) +
+    openDelim +
+    newFmBody +
+    closeDelim +
+    original.slice(start + fmMatch[0].length)
+  );
+}
+
+async function apiRequest<T>(
+  method: string,
+  url: string,
+  token: string,
+  body?: BodyInit,
+  contentType?: string,
+): Promise<T> {
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+  if (contentType) headers["Content-Type"] = contentType;
+  const res = await fetch(url, { method, headers, body });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`${method} ${url} → ${res.status}: ${text.slice(0, 300)}`);
+  }
+  return (await res.json()) as T;
+}
+
+interface VersionsResponse {
+  data: { items: Array<{ version: string }> } | null;
+}
+
+interface SkillJsonResponse {
+  data: {
+    name: string;
+    description: string;
+    metadata: Record<string, unknown>;
+    files: Record<string, string>;
+  } | null;
+}
+
+/**
+ * Re-pack the /json response into a ZIP wrapped in a `<name>/` root folder
+ * so the backend validator accepts it (it enforces a kebab-case root
+ * folder that matches the skill name).
+ */
+async function buildZipFromJson(skillName: string, files: Record<string, string>): Promise<Uint8Array> {
+  const zip = new JSZip();
+  const folder = zip.folder(skillName);
+  if (!folder) throw new Error("failed to create root folder in zip");
+  for (const [relativePath, content] of Object.entries(files)) {
+    folder.file(relativePath, content);
+  }
+  return zip.generateAsync({ type: "uint8array" });
 }
 
 async function main(): Promise<void> {
-  const { uri, dbName } = readMongoConfig();
-  const client = new MongoClient(uri);
-  await client.connect();
-  const db = client.db(dbName);
-
+  const config = readConfig();
+  const mongo = new MongoClient(config.mongoUri);
+  await mongo.connect();
+  const db = mongo.db(config.mongoDb);
   const skills = db.collection("skills");
-  const skillVersions = db.collection("skill_versions");
-
-  // Make sure the same index the app relies on exists before we write.
-  await skillVersions.createIndex(
-    { skillGuid: 1, majorVersion: -1, minorVersion: -1 },
-    { name: "skill_versions_latest_lookup" },
-  );
 
   const cursor = skills.find({});
   let scanned = 0;
-  let inserted = 0;
-  let skipped = 0;
-  let backfilledLatestVersion = 0;
+  let alreadyMigrated = 0;
+  let migrated = 0;
+  let missingFrontmatter = 0;
+  const errors: Array<{ skill: string; error: string }> = [];
 
   for await (const skill of cursor) {
     scanned += 1;
     const guid = skill._id as unknown as string;
-    const version = resolveVersion(skill);
+    const name = (skill.name as string | undefined) ?? guid;
+    const resolved = resolveVersion(skill);
 
-    // Backfill `latestVersion` on the skill doc when absent/invalid.
-    if (typeof skill.latestVersion !== "string" || !SKILL_VERSION_REGEX.test(skill.latestVersion)) {
-      await skills.updateOne({ _id: skill._id }, { $set: { latestVersion: version } });
-      backfilledLatestVersion += 1;
+    try {
+      // Skip if the skill already has at least one version row.
+      const versionsResp = await apiRequest<VersionsResponse>(
+        "GET",
+        `${config.apiBaseUrl}/api/skills/${encodeURIComponent(guid)}/versions`,
+        config.adminToken,
+      );
+      if ((versionsResp.data?.items.length ?? 0) > 0) {
+        alreadyMigrated += 1;
+        continue;
+      }
+
+      // Fetch the full package as JSON.
+      const jsonResp = await apiRequest<SkillJsonResponse>(
+        "GET",
+        `${config.apiBaseUrl}/api/skills/${encodeURIComponent(guid)}/json`,
+        config.adminToken,
+      );
+      const bundle = jsonResp.data;
+      if (!bundle) throw new Error("empty /json response");
+      const skillMd = bundle.files["SKILL.md"];
+      if (typeof skillMd !== "string") {
+        missingFrontmatter += 1;
+        continue;
+      }
+
+      const { patched, newContent } = patchSkillMdFrontmatter(skillMd, resolved);
+      if (!patched) {
+        // Frontmatter already has the desired version yet no DB row exists —
+        // rare, but republish anyway so the DB catches up.
+      }
+
+      const nextFiles = { ...bundle.files, "SKILL.md": newContent };
+      const zipBuf = await buildZipFromJson(bundle.name, nextFiles);
+
+      // Republish through the API so the version row + hash are owned by
+      // the normal update path. skip_validation is on: some legacy skills
+      // may have pre-schema content that would otherwise be rejected.
+      await apiRequest(
+        "PUT",
+        `${config.apiBaseUrl}/api/skills/${encodeURIComponent(guid)}?skip_validation=true`,
+        config.adminToken,
+        zipBuf as unknown as BodyInit,
+        "application/zip",
+      );
+      migrated += 1;
+    } catch (err) {
+      errors.push({ skill: `${name} (${guid})`, error: err instanceof Error ? err.message : String(err) });
     }
-
-    const versionId = `${guid}@${version}`;
-    const existing = await skillVersions.findOne({ _id: versionId as never });
-    if (existing) {
-      skipped += 1;
-      continue;
-    }
-
-    const { major, minor } = parseMajorMinor(version);
-
-    await skillVersions.insertOne({
-      _id: versionId as never,
-      skillGuid: guid,
-      version,
-      majorVersion: major,
-      minorVersion: minor,
-      storageKey: skill.storageKey ?? skill.s3Url ?? "",
-      skillHash: skill.skillHash ?? "",
-      metadata: skill.metadata ?? { category: "plain" },
-      license: skill.license ?? null,
-      compatibility: skill.compatibility ?? null,
-      createdBy: skill.createdBy ?? "",
-      createdByEmail: skill.createdByEmail ?? null,
-      createdByDisplayName: skill.createdByDisplayName ?? null,
-      createdOn: skill.createdOn ?? new Date(),
-    });
-    inserted += 1;
   }
 
   console.log(
-    `Skill versions migration complete — scanned=${scanned}, inserted=${inserted}, skipped=${skipped}, backfilledLatestVersion=${backfilledLatestVersion}`,
+    [
+      `Skill versions migration complete:`,
+      `  scanned=${scanned}`,
+      `  migrated=${migrated}`,
+      `  alreadyMigrated=${alreadyMigrated}`,
+      `  missingSkillMd=${missingFrontmatter}`,
+    ].join("\n"),
   );
 
-  await client.close();
+  if (errors.length > 0) {
+    console.warn(`\n${errors.length} skill(s) had errors:`);
+    for (const e of errors) console.warn(`  - ${e.skill}: ${e.error}`);
+    process.exitCode = 1;
+  }
+
+  await mongo.close();
 }
 
 main().catch((err) => {

--- a/ornn-api/scripts/migrate-skill-versions.ts
+++ b/ornn-api/scripts/migrate-skill-versions.ts
@@ -1,0 +1,129 @@
+/**
+ * One-shot migration: backfill the `skill_versions` collection for every
+ * existing skill in `skills` that predates the versioning feature.
+ *
+ * Behaviour:
+ *   - If the skill doc has a valid `latestVersion` field, use it. Otherwise
+ *     inspect `metadata.version` (legacy location); otherwise default to "0.1".
+ *   - If a matching row (skillGuid + version) already exists in
+ *     `skill_versions`, skip.
+ *   - Otherwise insert one, referencing the skill's current `storageKey` so
+ *     the pre-existing package is reachable through the versioned read path
+ *     without re-uploading.
+ *   - Ensure the skill doc itself carries `latestVersion` for the fast
+ *     default-read path.
+ *
+ * Idempotent: running twice on a migrated DB is a no-op.
+ *
+ * Run with:
+ *     bun run migrate:versions
+ *
+ * Reads the same MongoDB config as the API (`MONGODB_URI`, `MONGODB_DB`).
+ */
+
+import { MongoClient } from "mongodb";
+import { SKILL_VERSION_REGEX } from "../src/shared/schemas/skillFrontmatter";
+
+function readMongoConfig(): { uri: string; dbName: string } {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error("MONGODB_URI is required");
+  }
+  return { uri, dbName: process.env.MONGODB_DB ?? "ornn" };
+}
+
+const DEFAULT_VERSION = "0.1";
+
+function resolveVersion(skillDoc: Record<string, unknown>): string {
+  const candidates: unknown[] = [
+    skillDoc.latestVersion,
+    (skillDoc.metadata as Record<string, unknown> | undefined)?.version,
+    (skillDoc as { version?: unknown }).version,
+  ];
+  for (const raw of candidates) {
+    if (typeof raw === "string" && SKILL_VERSION_REGEX.test(raw)) {
+      return raw;
+    }
+  }
+  return DEFAULT_VERSION;
+}
+
+function parseMajorMinor(version: string): { major: number; minor: number } {
+  const match = version.match(SKILL_VERSION_REGEX);
+  if (!match) {
+    throw new Error(`Unreachable — resolveVersion already validated: ${version}`);
+  }
+  return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+async function main(): Promise<void> {
+  const { uri, dbName } = readMongoConfig();
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(dbName);
+
+  const skills = db.collection("skills");
+  const skillVersions = db.collection("skill_versions");
+
+  // Make sure the same index the app relies on exists before we write.
+  await skillVersions.createIndex(
+    { skillGuid: 1, majorVersion: -1, minorVersion: -1 },
+    { name: "skill_versions_latest_lookup" },
+  );
+
+  const cursor = skills.find({});
+  let scanned = 0;
+  let inserted = 0;
+  let skipped = 0;
+  let backfilledLatestVersion = 0;
+
+  for await (const skill of cursor) {
+    scanned += 1;
+    const guid = skill._id as unknown as string;
+    const version = resolveVersion(skill);
+
+    // Backfill `latestVersion` on the skill doc when absent/invalid.
+    if (typeof skill.latestVersion !== "string" || !SKILL_VERSION_REGEX.test(skill.latestVersion)) {
+      await skills.updateOne({ _id: skill._id }, { $set: { latestVersion: version } });
+      backfilledLatestVersion += 1;
+    }
+
+    const versionId = `${guid}@${version}`;
+    const existing = await skillVersions.findOne({ _id: versionId as never });
+    if (existing) {
+      skipped += 1;
+      continue;
+    }
+
+    const { major, minor } = parseMajorMinor(version);
+
+    await skillVersions.insertOne({
+      _id: versionId as never,
+      skillGuid: guid,
+      version,
+      majorVersion: major,
+      minorVersion: minor,
+      storageKey: skill.storageKey ?? skill.s3Url ?? "",
+      skillHash: skill.skillHash ?? "",
+      metadata: skill.metadata ?? { category: "plain" },
+      license: skill.license ?? null,
+      compatibility: skill.compatibility ?? null,
+      createdBy: skill.createdBy ?? "",
+      createdByEmail: skill.createdByEmail ?? null,
+      createdByDisplayName: skill.createdByDisplayName ?? null,
+      createdOn: skill.createdOn ?? new Date(),
+    });
+    inserted += 1;
+  }
+
+  console.log(
+    `Skill versions migration complete — scanned=${scanned}, inserted=${inserted}, skipped=${skipped}, backfilledLatestVersion=${backfilledLatestVersion}`,
+  );
+
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exitCode = 1;
+});

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -30,6 +30,7 @@ import { NyxidServiceClient } from "./clients/nyxidServiceClient";
 
 // Domain: Skill CRUD
 import { SkillRepository } from "./domains/skillCrud/repository";
+import { SkillVersionRepository } from "./domains/skillCrud/skillVersionRepository";
 import { SkillService } from "./domains/skillCrud/service";
 import { createSkillRoutes } from "./domains/skillCrud/routes";
 
@@ -141,6 +142,8 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
 
   // ---- Repositories ----
   const skillRepo = new SkillRepository(db);
+  const skillVersionRepo = new SkillVersionRepository(db);
+  await skillVersionRepo.ensureIndexes();
   const categoryRepo = new CategoryRepository(db);
   const tagRepo = new TagRepository(db);
   const activityRepo = new ActivityRepository(db);
@@ -148,6 +151,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   // ---- Domain: Skill CRUD ----
   const skillService = new SkillService({
     skillRepo,
+    skillVersionRepo,
     storageClient,
     storageBucket: config.storageBucket,
   });

--- a/ornn-api/src/domains/skillCrud/interfaceDiff.test.ts
+++ b/ornn-api/src/domains/skillCrud/interfaceDiff.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "bun:test";
+import type { SkillMetadata } from "../../shared/types/index";
+import { diffSkillInterface } from "./interfaceDiff";
+
+function meta(overrides: Partial<SkillMetadata> = {}): SkillMetadata {
+  return { category: "plain", ...overrides };
+}
+
+describe("diffSkillInterface", () => {
+  test("no changes → empty diff", () => {
+    const prev = meta({ category: "runtime-based", outputType: "text", runtimes: [{ runtime: "node" }] });
+    const next = meta({ category: "runtime-based", outputType: "text", runtimes: [{ runtime: "node" }] });
+    expect(diffSkillInterface(prev, next)).toEqual([]);
+  });
+
+  test("category change is breaking", () => {
+    const prev = meta({ category: "plain" });
+    const next = meta({ category: "tool-based", tools: [{ tool: "bash", type: "mcp" }] });
+    const changes = diffSkillInterface(prev, next);
+    const fields = changes.map((c) => c.field);
+    expect(fields).toContain("category");
+  });
+
+  test("adding a tool is breaking", () => {
+    const prev = meta({ category: "tool-based", tools: [{ tool: "bash", type: "mcp" }] });
+    const next = meta({
+      category: "tool-based",
+      tools: [
+        { tool: "bash", type: "mcp" },
+        { tool: "edit", type: "mcp" },
+      ],
+    });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].field).toBe("tools");
+    expect(changes[0].kind).toBe("added");
+    expect(changes[0].detail).toContain("edit");
+  });
+
+  test("removing a tool is breaking", () => {
+    const prev = meta({
+      category: "tool-based",
+      tools: [
+        { tool: "bash", type: "mcp" },
+        { tool: "edit", type: "mcp" },
+      ],
+    });
+    const next = meta({ category: "tool-based", tools: [{ tool: "bash", type: "mcp" }] });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].kind).toBe("removed");
+    expect(changes[0].detail).toContain("edit");
+  });
+
+  test("adding a runtime is breaking", () => {
+    const prev = meta({ category: "runtime-based", outputType: "text", runtimes: [{ runtime: "node" }] });
+    const next = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node" }, { runtime: "python" }],
+    });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes.some((c) => c.field === "runtimes" && c.kind === "added" && c.detail.includes("python"))).toBe(true);
+  });
+
+  test("removing a runtime is breaking", () => {
+    const prev = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node" }, { runtime: "python" }],
+    });
+    const next = meta({ category: "runtime-based", outputType: "text", runtimes: [{ runtime: "node" }] });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes.some((c) => c.field === "runtimes" && c.kind === "removed" && c.detail.includes("python"))).toBe(true);
+  });
+
+  test("adding a dependency library is breaking", () => {
+    const prev = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node", dependencies: [{ library: "axios", version: "*" }] }],
+    });
+    const next = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [
+        {
+          runtime: "node",
+          dependencies: [
+            { library: "axios", version: "*" },
+            { library: "zod", version: "*" },
+          ],
+        },
+      ],
+    });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes.some((c) => c.field.includes("dependencies") && c.kind === "added" && c.detail.includes("zod"))).toBe(true);
+  });
+
+  test("removing a dependency library is breaking", () => {
+    const prev = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [
+        {
+          runtime: "node",
+          dependencies: [
+            { library: "axios", version: "*" },
+            { library: "zod", version: "*" },
+          ],
+        },
+      ],
+    });
+    const next = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node", dependencies: [{ library: "axios", version: "*" }] }],
+    });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes.some((c) => c.field.includes("dependencies") && c.kind === "removed" && c.detail.includes("zod"))).toBe(true);
+  });
+
+  test("dependency version-only bump is NOT breaking", () => {
+    const prev = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node", dependencies: [{ library: "axios", version: "1.0.0" }] }],
+    });
+    const next = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node", dependencies: [{ library: "axios", version: "2.0.0" }] }],
+    });
+    expect(diffSkillInterface(prev, next)).toEqual([]);
+  });
+
+  test("adding an env var is breaking", () => {
+    const prev = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node", envs: [{ var: "API_KEY", description: "" }] }],
+    });
+    const next = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [
+        {
+          runtime: "node",
+          envs: [
+            { var: "API_KEY", description: "" },
+            { var: "DB_URL", description: "" },
+          ],
+        },
+      ],
+    });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes.some((c) => c.field.includes("envs") && c.kind === "added" && c.detail.includes("DB_URL"))).toBe(true);
+  });
+
+  test("removing an env var is breaking", () => {
+    const prev = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [
+        {
+          runtime: "node",
+          envs: [
+            { var: "API_KEY", description: "" },
+            { var: "DB_URL", description: "" },
+          ],
+        },
+      ],
+    });
+    const next = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node", envs: [{ var: "API_KEY", description: "" }] }],
+    });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes.some((c) => c.field.includes("envs") && c.kind === "removed" && c.detail.includes("DB_URL"))).toBe(true);
+  });
+
+  test("outputType change is breaking", () => {
+    const prev = meta({ category: "runtime-based", outputType: "text", runtimes: [{ runtime: "node" }] });
+    const next = meta({ category: "runtime-based", outputType: "file", runtimes: [{ runtime: "node" }] });
+    const changes = diffSkillInterface(prev, next);
+    expect(changes.some((c) => c.field === "outputType" && c.kind === "changed")).toBe(true);
+  });
+
+  test("tag changes are NOT breaking", () => {
+    const prev = meta({ category: "plain", tags: ["old"] });
+    const next = meta({ category: "plain", tags: ["new", "tags"] });
+    expect(diffSkillInterface(prev, next)).toEqual([]);
+  });
+
+  test("env var description-only change is NOT breaking", () => {
+    const prev = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node", envs: [{ var: "API_KEY", description: "old desc" }] }],
+    });
+    const next = meta({
+      category: "runtime-based",
+      outputType: "text",
+      runtimes: [{ runtime: "node", envs: [{ var: "API_KEY", description: "new desc" }] }],
+    });
+    expect(diffSkillInterface(prev, next)).toEqual([]);
+  });
+});

--- a/ornn-api/src/domains/skillCrud/interfaceDiff.ts
+++ b/ornn-api/src/domains/skillCrud/interfaceDiff.ts
@@ -1,0 +1,139 @@
+/**
+ * Interface-diff for skill versions.
+ *
+ * A "breaking" change is anything the caller has to adapt to. We inspect only
+ * the fields that a consuming agent or runner actually binds to:
+ *   - category
+ *   - outputType
+ *   - declared runtimes (by name)
+ *   - required runtime dependencies (by library name only — version bumps
+ *     inside a library are ignored, they don't break the skill surface)
+ *   - declared env var names (description text is metadata, not breaking)
+ *   - tool names
+ *
+ * Description, tags, SKILL.md body, and dependency version bumps are
+ * deliberately NOT considered breaking.
+ *
+ * @module domains/skillCrud/interfaceDiff
+ */
+
+import type { SkillMetadata } from "../../shared/types/index";
+
+export interface InterfaceChange {
+  field: string;
+  kind: "added" | "removed" | "changed";
+  detail: string;
+}
+
+type RuntimeEntry = NonNullable<SkillMetadata["runtimes"]>[number];
+type ToolEntry = NonNullable<SkillMetadata["tools"]>[number];
+
+export function diffSkillInterface(prev: SkillMetadata, next: SkillMetadata): InterfaceChange[] {
+  const changes: InterfaceChange[] = [];
+
+  // category
+  if (prev.category !== next.category) {
+    changes.push({
+      field: "category",
+      kind: "changed",
+      detail: `${prev.category} -> ${next.category}`,
+    });
+  }
+
+  // outputType
+  const prevOut = prev.outputType;
+  const nextOut = next.outputType;
+  if (prevOut !== nextOut) {
+    if (prevOut === undefined) {
+      changes.push({ field: "outputType", kind: "added", detail: String(nextOut) });
+    } else if (nextOut === undefined) {
+      changes.push({ field: "outputType", kind: "removed", detail: String(prevOut) });
+    } else {
+      changes.push({ field: "outputType", kind: "changed", detail: `${prevOut} -> ${nextOut}` });
+    }
+  }
+
+  // runtimes — match by runtime name
+  const prevRuntimes = indexByKey(prev.runtimes, (r) => r.runtime);
+  const nextRuntimes = indexByKey(next.runtimes, (r) => r.runtime);
+
+  for (const [name, _] of prevRuntimes) {
+    if (!nextRuntimes.has(name)) {
+      changes.push({ field: "runtimes", kind: "removed", detail: name });
+    }
+  }
+  for (const [name, _] of nextRuntimes) {
+    if (!prevRuntimes.has(name)) {
+      changes.push({ field: "runtimes", kind: "added", detail: name });
+    }
+  }
+
+  // For runtimes that exist in both, diff their dependency libraries and env vars.
+  for (const [name, nextEntry] of nextRuntimes) {
+    const prevEntry = prevRuntimes.get(name);
+    if (!prevEntry) continue;
+    changes.push(...diffRuntimeInternals(name, prevEntry, nextEntry));
+  }
+
+  // tools — match by tool name
+  const prevTools = new Set((prev.tools ?? []).map((t: ToolEntry) => t.tool));
+  const nextTools = new Set((next.tools ?? []).map((t: ToolEntry) => t.tool));
+  for (const t of prevTools) {
+    if (!nextTools.has(t)) changes.push({ field: "tools", kind: "removed", detail: t });
+  }
+  for (const t of nextTools) {
+    if (!prevTools.has(t)) changes.push({ field: "tools", kind: "added", detail: t });
+  }
+
+  return changes;
+}
+
+function diffRuntimeInternals(runtimeName: string, prev: RuntimeEntry, next: RuntimeEntry): InterfaceChange[] {
+  const changes: InterfaceChange[] = [];
+
+  // Dependencies: identity = library name (version bumps intentionally ignored).
+  const prevLibs = new Set((prev.dependencies ?? []).map((d) => d.library));
+  const nextLibs = new Set((next.dependencies ?? []).map((d) => d.library));
+  for (const lib of prevLibs) {
+    if (!nextLibs.has(lib)) {
+      changes.push({
+        field: `runtimes.${runtimeName}.dependencies`,
+        kind: "removed",
+        detail: lib,
+      });
+    }
+  }
+  for (const lib of nextLibs) {
+    if (!prevLibs.has(lib)) {
+      changes.push({
+        field: `runtimes.${runtimeName}.dependencies`,
+        kind: "added",
+        detail: lib,
+      });
+    }
+  }
+
+  // Env vars: identity = var name (description text is not binding).
+  const prevEnvs = new Set((prev.envs ?? []).map((e) => e.var));
+  const nextEnvs = new Set((next.envs ?? []).map((e) => e.var));
+  for (const v of prevEnvs) {
+    if (!nextEnvs.has(v)) {
+      changes.push({ field: `runtimes.${runtimeName}.envs`, kind: "removed", detail: v });
+    }
+  }
+  for (const v of nextEnvs) {
+    if (!prevEnvs.has(v)) {
+      changes.push({ field: `runtimes.${runtimeName}.envs`, kind: "added", detail: v });
+    }
+  }
+
+  return changes;
+}
+
+function indexByKey<T>(list: T[] | undefined, key: (t: T) => string): Map<string, T> {
+  const m = new Map<string, T>();
+  for (const item of list ?? []) {
+    m.set(key(item), item);
+  }
+  return m;
+}

--- a/ornn-api/src/domains/skillCrud/repository.ts
+++ b/ornn-api/src/domains/skillCrud/repository.ts
@@ -25,6 +25,8 @@ export interface CreateSkillData {
   isPrivate?: boolean;
   isSystem?: boolean;
   nyxidServiceId?: string;
+  /** Initial version, e.g. "1.0". Required. */
+  latestVersion: string;
 }
 
 export interface UpdateSkillData {
@@ -36,6 +38,8 @@ export interface UpdateSkillData {
   skillHash?: string;
   storageKey?: string;
   isPrivate?: boolean;
+  /** Cached latest-version pointer; update when a new package version is published. */
+  latestVersion?: string;
   updatedBy: string;
 }
 
@@ -84,6 +88,7 @@ export class SkillRepository {
       isPrivate: data.isPrivate ?? true,
       isSystem: data.isSystem ?? false,
       nyxidServiceId: data.nyxidServiceId ?? null,
+      latestVersion: data.latestVersion,
     };
 
     try {
@@ -113,6 +118,7 @@ export class SkillRepository {
     if (data.skillHash !== undefined) setFields.skillHash = data.skillHash;
     if (data.storageKey !== undefined) setFields.storageKey = data.storageKey;
     if (data.isPrivate !== undefined) setFields.isPrivate = data.isPrivate;
+    if (data.latestVersion !== undefined) setFields.latestVersion = data.latestVersion;
 
     await this.collection.updateOne({ _id: guid as any }, { $set: setFields });
     logger.info({ guid }, "Skill updated");
@@ -256,6 +262,7 @@ function mapDoc(doc: Document | null): SkillDocument | null {
     isPrivate: doc.isPrivate ?? true,
     isSystem: doc.isSystem ?? false,
     nyxidServiceId: doc.nyxidServiceId ?? undefined,
+    latestVersion: doc.latestVersion ?? "0.1",
   };
 }
 

--- a/ornn-api/src/domains/skillCrud/routes.ts
+++ b/ornn-api/src/domains/skillCrud/routes.ts
@@ -102,7 +102,36 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
   );
 
   /**
+   * GET /skills/:idOrName/versions — List all published versions, newest first.
+   * Visibility rules match GET /skills/:idOrName.
+   */
+  app.get(
+    "/skills/:idOrName/versions",
+    optionalAuth,
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const authCtx = c.get("auth");
+
+      // Reuse getSkill for the visibility check; we throw SKILL_NOT_FOUND for
+      // unauthenticated readers of private skills, matching the existing rule.
+      const skill = await skillService.getSkill(idOrName);
+      if (!authCtx && skill.isPrivate) {
+        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      }
+      if (authCtx && skill.isPrivate && skill.createdBy !== authCtx.userId && !authCtx.permissions.includes("ornn:admin:skill")) {
+        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      }
+
+      const items = await skillService.listSkillVersions(idOrName);
+      return c.json({ data: { items }, error: null });
+    },
+  );
+
+  /**
    * GET /skills/:idOrName — Read a skill by GUID or name.
+   * Query params:
+   *   - version: optional `<major>.<minor>` — when set, return that version's
+   *     package (storageKey, metadata, hash). When omitted, return the latest.
    * Auth: Optional. Anonymous users can only view public skills.
    */
   app.get(
@@ -110,8 +139,9 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     optionalAuth,
     async (c) => {
       const idOrName = c.req.param("idOrName");
+      const version = c.req.query("version") || undefined;
       const authCtx = c.get("auth");
-      const skill = await skillService.getSkill(idOrName);
+      const skill = await skillService.getSkill(idOrName, version);
 
       // Anonymous users can only see public skills
       if (!authCtx && skill.isPrivate) {
@@ -185,7 +215,13 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       logger.info({ guid, userId: authCtx.userId }, "Skill update via API");
       const userEmail = c.req.header("X-User-Email") ?? "";
       const userDN = c.req.header("X-User-Display-Name") ?? "";
-      const result = await skillService.updateSkill(guid, authCtx.userId, { zipBuffer, isPrivate, skipValidation });
+      const result = await skillService.updateSkill(guid, authCtx.userId, {
+        zipBuffer,
+        isPrivate,
+        skipValidation,
+        userEmail: userEmail || undefined,
+        userDisplayName: userDN || undefined,
+      });
 
       const action = isPrivate !== undefined && zipBuffer === undefined ? "skill:visibility_change" : "skill:update";
       activityRepo?.log(authCtx.userId, userEmail, userDN, action, {

--- a/ornn-api/src/domains/skillCrud/routes.ts
+++ b/ornn-api/src/domains/skillCrud/routes.ts
@@ -8,6 +8,7 @@
  */
 
 import { Hono } from "hono";
+import { z } from "zod";
 import type { SkillService } from "./service";
 import type { SkillRepository } from "./repository";
 import type { ActivityRepository } from "../admin/activityRepository";
@@ -21,6 +22,11 @@ import {
 } from "../../middleware/nyxidAuth";
 import { AppError } from "../../shared/types/index";
 import pino from "pino";
+
+const deprecationPatchSchema = z.object({
+  isDeprecated: z.boolean(),
+  deprecationNote: z.string().max(1024).optional(),
+});
 
 const logger = pino({ level: "info" }).child({ module: "skillCrudRoutes" });
 
@@ -153,7 +159,73 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
       }
 
+      // Signal deprecation via response headers so non-JSON-aware clients
+      // (CLIs, agents) still get the warning. Notes are URL-encoded to keep
+      // header values ASCII-safe per RFC 7230.
+      if (skill.isDeprecated) {
+        c.header("X-Skill-Deprecated", "true");
+        if (skill.deprecationNote) {
+          c.header("X-Skill-Deprecation-Note", encodeURIComponent(skill.deprecationNote));
+        }
+      }
+
       return c.json({ data: skill, error: null });
+    },
+  );
+
+  /**
+   * PATCH /skills/:idOrName/versions/:version
+   * Toggle the deprecation flag on a specific version.
+   * Requires: ornn:skill:update + owner or admin on the skill.
+   */
+  app.patch(
+    "/skills/:idOrName/versions/:version",
+    auth,
+    requirePermission("ornn:skill:update"),
+    requireOwnerOrAdmin(async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const skill =
+        (await skillRepo.findByGuid(idOrName)) ??
+        (await skillRepo.findByName(idOrName));
+      return skill?.createdBy ?? "";
+    }),
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const version = c.req.param("version");
+      const authCtx = getAuth(c);
+
+      let body: unknown;
+      try {
+        body = await c.req.json();
+      } catch {
+        throw AppError.badRequest("INVALID_BODY", "Request body must be valid JSON");
+      }
+      const parsed = deprecationPatchSchema.safeParse(body);
+      if (!parsed.success) {
+        const msg = parsed.error.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ");
+        throw AppError.badRequest("INVALID_DEPRECATION_PATCH", msg);
+      }
+
+      const result = await skillService.setVersionDeprecation(
+        idOrName,
+        version,
+        parsed.data.isDeprecated,
+        parsed.data.deprecationNote ?? null,
+      );
+
+      const userEmail = c.req.header("X-User-Email") ?? "";
+      const userDN = c.req.header("X-User-Display-Name") ?? "";
+      activityRepo
+        ?.log(authCtx.userId, userEmail, userDN, "skill:update", {
+          skillId: result.skillGuid,
+          skillName: result.skillName,
+          version: result.version,
+          isDeprecated: result.isDeprecated,
+          deprecationChange: true,
+        })
+        .catch((err) => logger.warn({ err }, "Failed to log skill:deprecation activity"));
+
+      return c.json({ data: result, error: null });
     },
   );
 

--- a/ornn-api/src/domains/skillCrud/service.ts
+++ b/ornn-api/src/domains/skillCrud/service.ts
@@ -7,11 +7,13 @@
 import { createHash } from "node:crypto";
 import { randomUUID } from "node:crypto";
 import type { SkillRepository } from "./repository";
+import type { SkillVersionRepository } from "./skillVersionRepository";
 import type { IStorageClient } from "../../clients/storageClient";
-import type { SkillDocument, SkillMetadata, SkillDetailResponse } from "../../shared/types/index";
+import type { SkillDocument, SkillMetadata, SkillDetailResponse, SkillVersionDocument } from "../../shared/types/index";
 import { AppError } from "../../shared/types/index";
 import { validateSkillFrontmatter } from "../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../shared/utils/zip";
+import { parseVersion, isGreater } from "./version";
 import { parse as parseYaml } from "yaml";
 import JSZip from "jszip";
 import pino from "pino";
@@ -20,19 +22,32 @@ const logger = pino({ level: "info" }).child({ module: "skillCrudService" });
 
 const FRONTMATTER_REGEX = /^---\s*\n([\s\S]*?)\n---/;
 
+/**
+ * Versioned storage key layout: `skills/{guid}/{version}.zip`.
+ * Keeps every published version as its own immutable blob.
+ * Legacy, pre-migration skills may still live at `skills/{guid}.zip`; the
+ * migration script preserves that key when backfilling a version row.
+ */
+function buildVersionedStorageKey(guid: string, version: string): string {
+  return `skills/${guid}/${version}.zip`;
+}
+
 export interface SkillServiceDeps {
   skillRepo: SkillRepository;
+  skillVersionRepo: SkillVersionRepository;
   storageClient: IStorageClient;
   storageBucket: string;
 }
 
 export class SkillService {
   private readonly skillRepo: SkillRepository;
+  private readonly skillVersionRepo: SkillVersionRepository;
   private readonly storageClient: IStorageClient;
   private readonly storageBucket: string;
 
   constructor(deps: SkillServiceDeps) {
     this.skillRepo = deps.skillRepo;
+    this.skillVersionRepo = deps.skillVersionRepo;
     this.storageClient = deps.storageClient;
     this.storageBucket = deps.storageBucket;
   }
@@ -54,7 +69,8 @@ export class SkillService {
     }
 
     // 2. Parse SKILL.md from ZIP
-    const { name, description, license, compatibility, metadata } = await this.extractSkillInfo(zipBuffer);
+    const { name, description, version, license, compatibility, metadata } = await this.extractSkillInfo(zipBuffer);
+    const parsedVersion = parseVersion(version);
 
     // 3. Check name uniqueness
     const existing = await this.skillRepo.findByName(name);
@@ -66,12 +82,12 @@ export class SkillService {
     const guid = randomUUID();
     const skillHash = createHash("sha256").update(zipBuffer).digest("hex");
 
-    // 5. Upload ZIP to chrono-storage
-    const storageKey = `skills/${guid}.zip`;
+    // 5. Upload ZIP to chrono-storage under a versioned key (versions are immutable).
+    const storageKey = buildVersionedStorageKey(guid, version);
     await this.storageClient.upload(this.storageBucket, storageKey, zipBuffer, "application/zip");
-    logger.info({ guid, storageKey }, "Skill package uploaded to storage");
+    logger.info({ guid, storageKey, version }, "Skill package uploaded to storage");
 
-    // 6. Save to MongoDB
+    // 6. Save the skill document.
     await this.skillRepo.create({
       guid,
       name,
@@ -87,12 +103,72 @@ export class SkillService {
       isPrivate: options?.isSystem ? false : true,
       isSystem: options?.isSystem,
       nyxidServiceId: options?.nyxidServiceId,
+      latestVersion: version,
+    });
+
+    // 7. Record the initial version row.
+    await this.skillVersionRepo.create({
+      skillGuid: guid,
+      version,
+      majorVersion: parsedVersion.major,
+      minorVersion: parsedVersion.minor,
+      storageKey,
+      skillHash,
+      metadata,
+      license,
+      compatibility,
+      createdBy: userId,
+      createdByEmail: options?.userEmail,
+      createdByDisplayName: options?.userDisplayName,
     });
 
     return { guid };
   }
 
-  async getSkill(idOrName: string): Promise<SkillDetailResponse> {
+  /**
+   * Read a skill. Without `version` returns the latest (the skill doc's
+   * cached pointer). With `version`, reads from the `skill_versions` collection
+   * and overlays that version's storageKey / metadata / hash on the identity
+   * fields from the skill doc.
+   */
+  async getSkill(idOrName: string, version?: string): Promise<SkillDetailResponse> {
+    const skill = await this.findSkillByIdOrName(idOrName);
+    if (version !== undefined) {
+      // Validate format early so clients get a clear 400, not a 404.
+      parseVersion(version);
+      const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, version);
+      if (!versionDoc) {
+        throw AppError.notFound("SKILL_VERSION_NOT_FOUND", `Version '${version}' not found for skill '${skill.name}'`);
+      }
+      return this.buildDetailResponse(skill, versionDoc);
+    }
+    return this.buildDetailResponse(skill);
+  }
+
+  /**
+   * List every published version for a skill, newest first.
+   */
+  async listSkillVersions(idOrName: string): Promise<Array<{
+    version: string;
+    skillHash: string;
+    createdBy: string;
+    createdByEmail?: string;
+    createdByDisplayName?: string;
+    createdOn: string;
+  }>> {
+    const skill = await this.findSkillByIdOrName(idOrName);
+    const versions = await this.skillVersionRepo.listBySkill(skill.guid);
+    return versions.map((v) => ({
+      version: v.version,
+      skillHash: v.skillHash,
+      createdBy: v.createdBy,
+      createdByEmail: v.createdByEmail,
+      createdByDisplayName: v.createdByDisplayName,
+      createdOn: v.createdOn instanceof Date ? v.createdOn.toISOString() : String(v.createdOn),
+    }));
+  }
+
+  private async findSkillByIdOrName(idOrName: string): Promise<SkillDocument> {
     let skill = await this.skillRepo.findByGuid(idOrName);
     if (!skill) {
       skill = await this.skillRepo.findByName(idOrName);
@@ -100,14 +176,19 @@ export class SkillService {
     if (!skill) {
       throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
     }
-
-    return this.buildDetailResponse(skill);
+    return skill;
   }
 
   async updateSkill(
     guid: string,
     userId: string,
-    options: { zipBuffer?: Uint8Array; isPrivate?: boolean; skipValidation?: boolean },
+    options: {
+      zipBuffer?: Uint8Array;
+      isPrivate?: boolean;
+      skipValidation?: boolean;
+      userEmail?: string;
+      userDisplayName?: string;
+    },
   ): Promise<SkillDetailResponse> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {
@@ -127,13 +208,43 @@ export class SkillService {
         }
       }
 
-      const { name, description, license, compatibility, metadata } = await this.extractSkillInfo(options.zipBuffer);
+      const { name, description, version, license, compatibility, metadata } = await this.extractSkillInfo(options.zipBuffer);
+      const parsedNewVersion = parseVersion(version);
+
+      // Enforce strictly-incrementing version on every package update.
+      const currentLatest = await this.skillVersionRepo.findLatestBySkill(guid);
+      if (currentLatest) {
+        const parsedCurrent = parseVersion(currentLatest.version);
+        if (!isGreater(parsedNewVersion, parsedCurrent)) {
+          throw AppError.conflict(
+            "VERSION_NOT_INCREMENTED",
+            `New version '${version}' must be strictly greater than the current latest '${currentLatest.version}'. Bump the version in SKILL.md.`,
+          );
+        }
+      }
+
       const skillHash = createHash("sha256").update(options.zipBuffer).digest("hex");
 
-      // Upload new ZIP to chrono-storage (overwrite same key)
-      const storageKey = `skills/${guid}.zip`;
+      // Upload under a new, versioned storage key — versions are immutable.
+      const storageKey = buildVersionedStorageKey(guid, version);
       await this.storageClient.upload(this.storageBucket, storageKey, options.zipBuffer, "application/zip");
-      logger.info({ guid, storageKey }, "Skill package updated in storage");
+      logger.info({ guid, storageKey, version }, "Skill package updated in storage");
+
+      // Record the new version row.
+      await this.skillVersionRepo.create({
+        skillGuid: guid,
+        version,
+        majorVersion: parsedNewVersion.major,
+        minorVersion: parsedNewVersion.minor,
+        storageKey,
+        skillHash,
+        metadata,
+        license,
+        compatibility,
+        createdBy: userId,
+        createdByEmail: options.userEmail,
+        createdByDisplayName: options.userDisplayName,
+      });
 
       Object.assign(updateData, {
         name,
@@ -143,8 +254,8 @@ export class SkillService {
         metadata,
         skillHash,
         storageKey,
+        latestVersion: version,
       });
-
     }
 
     if (options.isPrivate !== undefined) {
@@ -161,16 +272,27 @@ export class SkillService {
       throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
     }
 
-    // Delete from chrono-storage
-    const storageKey = `skills/${guid}.zip`;
-    try {
-      await this.storageClient.delete(this.storageBucket, storageKey);
-      logger.info({ guid, storageKey }, "Skill package deleted from storage");
-    } catch (err) {
-      logger.warn({ guid, storageKey, err }, "Best-effort storage cleanup failed");
+    // Collect every storage key to clean up: the current pointer on the skill
+    // doc plus each versioned key in the skill_versions collection. Using a
+    // Set dedupes the overlap between the two.
+    const versions = await this.skillVersionRepo.listBySkill(guid);
+    const storageKeys = new Set<string>();
+    if (existing.storageKey) storageKeys.add(existing.storageKey);
+    for (const v of versions) {
+      if (v.storageKey) storageKeys.add(v.storageKey);
     }
 
-    // Hard delete from MongoDB
+    for (const key of storageKeys) {
+      try {
+        await this.storageClient.delete(this.storageBucket, key);
+      } catch (err) {
+        logger.warn({ guid, storageKey: key, err }, "Best-effort storage cleanup failed");
+      }
+    }
+    logger.info({ guid, storageKeys: Array.from(storageKeys) }, "Skill package(s) deleted from storage");
+
+    // Cascade-delete version rows first, then the skill doc.
+    await this.skillVersionRepo.deleteAllBySkill(guid);
     await this.skillRepo.hardDelete(guid);
   }
 
@@ -251,6 +373,7 @@ export class SkillService {
   private async extractSkillInfo(zipBuffer: Uint8Array): Promise<{
     name: string;
     description: string;
+    version: string;
     license: string | null;
     compatibility: string | null;
     metadata: SkillMetadata;
@@ -333,44 +456,58 @@ export class SkillService {
     return {
       name: fm.name,
       description: fm.description,
+      version: fm.version,
       license: fm.license ?? null,
       compatibility: fm.compatibility ?? null,
       metadata,
     };
   }
 
-  private async buildDetailResponse(skill: SkillDocument): Promise<SkillDetailResponse> {
+  private async buildDetailResponse(
+    skill: SkillDocument,
+    versionOverlay?: SkillVersionDocument,
+  ): Promise<SkillDetailResponse> {
+    // When reading a specific version, swap in that version's package fields;
+    // identity fields (name, createdBy, isPrivate, ...) still come from the
+    // skill doc.
+    const storageKey = versionOverlay?.storageKey ?? skill.storageKey;
+    const metadata = versionOverlay?.metadata ?? skill.metadata;
+    const skillHash = versionOverlay?.skillHash ?? skill.skillHash;
+    const license = versionOverlay ? versionOverlay.license : skill.license;
+    const compatibility = versionOverlay ? versionOverlay.compatibility : skill.compatibility;
+    const version = versionOverlay?.version ?? skill.latestVersion;
+
     let presignedPackageUrl = "";
-    if (skill.storageKey) {
+    if (storageKey) {
       try {
-        const result = await this.storageClient.getPresignedUrl(
-          this.storageBucket,
-          skill.storageKey,
-        );
+        const result = await this.storageClient.getPresignedUrl(this.storageBucket, storageKey);
         presignedPackageUrl = result.presignedUrl;
       } catch (err) {
-        logger.warn({ guid: skill.guid, err }, "Presigned URL generation failed");
+        logger.warn({ guid: skill.guid, version, err }, "Presigned URL generation failed");
       }
     }
 
-    const tags: string[] = skill.metadata?.tags ?? [];
+    const tags: string[] = metadata?.tags ?? [];
 
     return {
       guid: skill.guid,
       name: skill.name,
       description: skill.description,
-      license: skill.license,
-      compatibility: skill.compatibility,
-      metadata: skill.metadata as unknown as Record<string, unknown>,
+      license,
+      compatibility,
+      metadata: metadata as unknown as Record<string, unknown>,
       tags,
-      skillHash: skill.skillHash,
+      skillHash,
       presignedPackageUrl,
       isPrivate: skill.isPrivate,
+      isSystem: skill.isSystem,
+      nyxidServiceId: skill.nyxidServiceId,
       createdBy: skill.createdBy,
       createdByEmail: skill.createdByEmail,
       createdByDisplayName: skill.createdByDisplayName,
       createdOn: skill.createdOn instanceof Date ? skill.createdOn.toISOString() : String(skill.createdOn),
       updatedOn: skill.updatedOn instanceof Date ? skill.updatedOn.toISOString() : String(skill.updatedOn),
+      version,
     };
   }
 

--- a/ornn-api/src/domains/skillCrud/service.ts
+++ b/ornn-api/src/domains/skillCrud/service.ts
@@ -14,6 +14,7 @@ import { AppError } from "../../shared/types/index";
 import { validateSkillFrontmatter } from "../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../shared/utils/zip";
 import { parseVersion, isGreater } from "./version";
+import { diffSkillInterface, type InterfaceChange } from "./interfaceDiff";
 import { parse as parseYaml } from "yaml";
 import JSZip from "jszip";
 import pino from "pino";
@@ -30,6 +31,10 @@ const FRONTMATTER_REGEX = /^---\s*\n([\s\S]*?)\n---/;
  */
 function buildVersionedStorageKey(guid: string, version: string): string {
   return `skills/${guid}/${version}.zip`;
+}
+
+function formatInterfaceChanges(changes: InterfaceChange[]): string {
+  return changes.map((c) => `${c.field} ${c.kind} ${c.detail}`).join("; ");
 }
 
 export interface SkillServiceDeps {
@@ -146,7 +151,9 @@ export class SkillService {
   }
 
   /**
-   * List every published version for a skill, newest first.
+   * List every published version for a skill, newest first. Includes the
+   * deprecation flag + note so consumers can render a warning without another
+   * round-trip.
    */
   async listSkillVersions(idOrName: string): Promise<Array<{
     version: string;
@@ -155,6 +162,8 @@ export class SkillService {
     createdByEmail?: string;
     createdByDisplayName?: string;
     createdOn: string;
+    isDeprecated: boolean;
+    deprecationNote: string | null;
   }>> {
     const skill = await this.findSkillByIdOrName(idOrName);
     const versions = await this.skillVersionRepo.listBySkill(skill.guid);
@@ -165,7 +174,46 @@ export class SkillService {
       createdByEmail: v.createdByEmail,
       createdByDisplayName: v.createdByDisplayName,
       createdOn: v.createdOn instanceof Date ? v.createdOn.toISOString() : String(v.createdOn),
+      isDeprecated: v.isDeprecated === true,
+      deprecationNote: v.deprecationNote ?? null,
     }));
+  }
+
+  /**
+   * Mutate the deprecation flag on a single version. Caller is responsible
+   * for the owner/admin auth gate — we only validate the target exists.
+   *
+   * Returns a lightweight view; callers that need the full version doc can
+   * subsequently call `getSkill(idOrName, version)`.
+   */
+  async setVersionDeprecation(
+    idOrName: string,
+    version: string,
+    isDeprecated: boolean,
+    deprecationNote: string | null | undefined,
+  ): Promise<{
+    skillGuid: string;
+    skillName: string;
+    version: string;
+    isDeprecated: boolean;
+    deprecationNote: string | null;
+  }> {
+    // Validate version format up-front so clients get 400 rather than 404.
+    parseVersion(version);
+    const skill = await this.findSkillByIdOrName(idOrName);
+    const updated = await this.skillVersionRepo.setDeprecation(
+      skill.guid,
+      version,
+      isDeprecated,
+      deprecationNote ?? null,
+    );
+    return {
+      skillGuid: skill.guid,
+      skillName: skill.name,
+      version: updated.version,
+      isDeprecated: updated.isDeprecated === true,
+      deprecationNote: updated.deprecationNote ?? null,
+    };
   }
 
   private async findSkillByIdOrName(idOrName: string): Promise<SkillDocument> {
@@ -219,6 +267,16 @@ export class SkillService {
           throw AppError.conflict(
             "VERSION_NOT_INCREMENTED",
             `New version '${version}' must be strictly greater than the current latest '${currentLatest.version}'. Bump the version in SKILL.md.`,
+          );
+        }
+        // Breaking-change check: any interface diff requires a major bump.
+        const changes = diffSkillInterface(currentLatest.metadata, metadata);
+        if (changes.length > 0 && parsedNewVersion.major === parsedCurrent.major) {
+          throw AppError.conflict(
+            "BREAKING_CHANGE_WITHOUT_MAJOR_BUMP",
+            `Detected breaking interface change(s) between ${currentLatest.version} and ${version}. ` +
+              `A major-version bump is required for: ${formatInterfaceChanges(changes)}. ` +
+              `Either revert the change or bump the major version in SKILL.md.`,
           );
         }
       }
@@ -470,12 +528,26 @@ export class SkillService {
     // When reading a specific version, swap in that version's package fields;
     // identity fields (name, createdBy, isPrivate, ...) still come from the
     // skill doc.
-    const storageKey = versionOverlay?.storageKey ?? skill.storageKey;
-    const metadata = versionOverlay?.metadata ?? skill.metadata;
-    const skillHash = versionOverlay?.skillHash ?? skill.skillHash;
-    const license = versionOverlay ? versionOverlay.license : skill.license;
-    const compatibility = versionOverlay ? versionOverlay.compatibility : skill.compatibility;
-    const version = versionOverlay?.version ?? skill.latestVersion;
+    //
+    // For the latest-read path (no overlay), we do one extra lookup against
+    // `skill_versions` so the response can still surface `isDeprecated` /
+    // `deprecationNote` consistently with the versioned path. If this becomes
+    // a hot-path bottleneck we can denormalize those two fields onto the
+    // skill doc later (TODO).
+    let effectiveOverlay = versionOverlay;
+    if (!effectiveOverlay) {
+      effectiveOverlay =
+        (await this.skillVersionRepo.findLatestBySkill(skill.guid)) ?? undefined;
+    }
+
+    const storageKey = effectiveOverlay?.storageKey ?? skill.storageKey;
+    const metadata = effectiveOverlay?.metadata ?? skill.metadata;
+    const skillHash = effectiveOverlay?.skillHash ?? skill.skillHash;
+    const license = effectiveOverlay ? effectiveOverlay.license : skill.license;
+    const compatibility = effectiveOverlay ? effectiveOverlay.compatibility : skill.compatibility;
+    const version = effectiveOverlay?.version ?? skill.latestVersion;
+    const isDeprecated = effectiveOverlay?.isDeprecated === true;
+    const deprecationNote = effectiveOverlay?.deprecationNote ?? null;
 
     let presignedPackageUrl = "";
     if (storageKey) {
@@ -508,6 +580,8 @@ export class SkillService {
       createdOn: skill.createdOn instanceof Date ? skill.createdOn.toISOString() : String(skill.createdOn),
       updatedOn: skill.updatedOn instanceof Date ? skill.updatedOn.toISOString() : String(skill.updatedOn),
       version,
+      isDeprecated,
+      deprecationNote,
     };
   }
 

--- a/ornn-api/src/domains/skillCrud/skillVersionRepository.ts
+++ b/ornn-api/src/domains/skillCrud/skillVersionRepository.ts
@@ -111,6 +111,42 @@ export class SkillVersionRepository {
     logger.info({ skillGuid, deleted: result.deletedCount }, "Skill versions cascade-deleted");
     return result.deletedCount ?? 0;
   }
+
+  /**
+   * Toggle the deprecation flag on a single version. When `isDeprecated` is
+   * false the `deprecationNote` is cleared (empty note is never sticky).
+   * 404s via AppError if the version row does not exist.
+   */
+  async setDeprecation(
+    skillGuid: string,
+    version: string,
+    isDeprecated: boolean,
+    deprecationNote?: string | null,
+  ): Promise<SkillVersionDocument> {
+    const setFields: Record<string, unknown> = { isDeprecated };
+    if (isDeprecated) {
+      // Keep explicit `null` when the caller wants to drop an old note while
+      // still marking deprecated.
+      setFields.deprecationNote = deprecationNote ?? null;
+    } else {
+      setFields.deprecationNote = null;
+    }
+
+    const result = await this.collection.findOneAndUpdate(
+      { _id: `${skillGuid}@${version}` as never },
+      { $set: setFields },
+      { returnDocument: "after" },
+    );
+    const updated = mapDoc(result);
+    if (!updated) {
+      throw AppError.notFound(
+        "SKILL_VERSION_NOT_FOUND",
+        `Version '${version}' not found for skill '${skillGuid}'`,
+      );
+    }
+    logger.info({ skillGuid, version, isDeprecated }, "Skill version deprecation updated");
+    return updated;
+  }
 }
 
 function mapDoc(doc: Document | null): SkillVersionDocument | null {
@@ -130,5 +166,7 @@ function mapDoc(doc: Document | null): SkillVersionDocument | null {
     createdByEmail: doc.createdByEmail ?? undefined,
     createdByDisplayName: doc.createdByDisplayName ?? undefined,
     createdOn: doc.createdOn ?? new Date(),
+    isDeprecated: doc.isDeprecated === true,
+    deprecationNote: doc.deprecationNote ?? null,
   };
 }

--- a/ornn-api/src/domains/skillCrud/skillVersionRepository.ts
+++ b/ornn-api/src/domains/skillCrud/skillVersionRepository.ts
@@ -1,0 +1,134 @@
+/**
+ * Repository for the `skill_versions` Mongo collection.
+ * Each document is an immutable snapshot of a skill at a specific version.
+ *
+ * `_id` is `${skillGuid}@${version}` which gives us free uniqueness on
+ * (skillGuid, version) without a separate compound unique index.
+ *
+ * @module domains/skillCrud/skillVersionRepository
+ */
+
+import type { Collection, Db, Document } from "mongodb";
+import type { SkillVersionDocument, SkillMetadata } from "../../shared/types/index";
+import { AppError } from "../../shared/types/index";
+import pino from "pino";
+
+const logger = pino({ level: "info" }).child({ module: "skillVersionRepository" });
+
+export interface CreateSkillVersionData {
+  skillGuid: string;
+  version: string;
+  majorVersion: number;
+  minorVersion: number;
+  storageKey: string;
+  skillHash: string;
+  metadata: SkillMetadata;
+  license?: string | null;
+  compatibility?: string | null;
+  createdBy: string;
+  createdByEmail?: string;
+  createdByDisplayName?: string;
+  createdOn?: Date;
+}
+
+export class SkillVersionRepository {
+  private readonly collection: Collection;
+
+  constructor(db: Db) {
+    this.collection = db.collection("skill_versions");
+  }
+
+  /**
+   * Idempotent: should be called once on startup. Creates the compound
+   * index used for latest-version lookup; safe to call repeatedly.
+   */
+  async ensureIndexes(): Promise<void> {
+    await this.collection.createIndex(
+      { skillGuid: 1, majorVersion: -1, minorVersion: -1 },
+      { name: "skill_versions_latest_lookup" },
+    );
+  }
+
+  async create(data: CreateSkillVersionData): Promise<SkillVersionDocument> {
+    const createdOn = data.createdOn ?? new Date();
+    const doc: Document = {
+      _id: `${data.skillGuid}@${data.version}` as unknown as Document["_id"],
+      skillGuid: data.skillGuid,
+      version: data.version,
+      majorVersion: data.majorVersion,
+      minorVersion: data.minorVersion,
+      storageKey: data.storageKey,
+      skillHash: data.skillHash,
+      metadata: data.metadata,
+      license: data.license ?? null,
+      compatibility: data.compatibility ?? null,
+      createdBy: data.createdBy,
+      createdByEmail: data.createdByEmail ?? null,
+      createdByDisplayName: data.createdByDisplayName ?? null,
+      createdOn,
+    };
+
+    try {
+      await this.collection.insertOne(doc as never);
+      logger.info({ skillGuid: data.skillGuid, version: data.version }, "Skill version inserted");
+    } catch (err: unknown) {
+      if ((err as { code?: number }).code === 11000) {
+        throw AppError.conflict(
+          "SKILL_VERSION_EXISTS",
+          `Version '${data.version}' already exists for skill '${data.skillGuid}'`,
+        );
+      }
+      throw err;
+    }
+
+    return mapDoc(doc)!;
+  }
+
+  async findBySkillAndVersion(skillGuid: string, version: string): Promise<SkillVersionDocument | null> {
+    const doc = await this.collection.findOne({ _id: `${skillGuid}@${version}` as never });
+    return mapDoc(doc);
+  }
+
+  async findLatestBySkill(skillGuid: string): Promise<SkillVersionDocument | null> {
+    const doc = await this.collection
+      .find({ skillGuid })
+      .sort({ majorVersion: -1, minorVersion: -1 })
+      .limit(1)
+      .next();
+    return mapDoc(doc);
+  }
+
+  async listBySkill(skillGuid: string): Promise<SkillVersionDocument[]> {
+    const docs = await this.collection
+      .find({ skillGuid })
+      .sort({ majorVersion: -1, minorVersion: -1 })
+      .toArray();
+    return docs.map((d) => mapDoc(d)!);
+  }
+
+  async deleteAllBySkill(skillGuid: string): Promise<number> {
+    const result = await this.collection.deleteMany({ skillGuid });
+    logger.info({ skillGuid, deleted: result.deletedCount }, "Skill versions cascade-deleted");
+    return result.deletedCount ?? 0;
+  }
+}
+
+function mapDoc(doc: Document | null): SkillVersionDocument | null {
+  if (!doc) return null;
+  return {
+    _id: doc._id as string,
+    skillGuid: doc.skillGuid,
+    version: doc.version,
+    majorVersion: doc.majorVersion,
+    minorVersion: doc.minorVersion,
+    storageKey: doc.storageKey,
+    skillHash: doc.skillHash,
+    metadata: doc.metadata,
+    license: doc.license ?? null,
+    compatibility: doc.compatibility ?? null,
+    createdBy: doc.createdBy,
+    createdByEmail: doc.createdByEmail ?? undefined,
+    createdByDisplayName: doc.createdByDisplayName ?? undefined,
+    createdOn: doc.createdOn ?? new Date(),
+  };
+}

--- a/ornn-api/src/domains/skillCrud/version.test.ts
+++ b/ornn-api/src/domains/skillCrud/version.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { AppError } from "../../shared/types/index";
+import { parseVersion, compareVersions, isGreater } from "./version";
+
+describe("parseVersion", () => {
+  test("parses major.minor with single digits", () => {
+    expect(parseVersion("1.0")).toEqual({ major: 1, minor: 0 });
+    expect(parseVersion("0.1")).toEqual({ major: 0, minor: 1 });
+  });
+
+  test("parses multi-digit major/minor", () => {
+    expect(parseVersion("12.34")).toEqual({ major: 12, minor: 34 });
+    expect(parseVersion("100.200")).toEqual({ major: 100, minor: 200 });
+  });
+
+  test("parses 0.0 as a valid edge case", () => {
+    expect(parseVersion("0.0")).toEqual({ major: 0, minor: 0 });
+  });
+
+  test("rejects empty string", () => {
+    expect(() => parseVersion("")).toThrow(AppError);
+  });
+
+  test("rejects missing minor", () => {
+    expect(() => parseVersion("1")).toThrow(AppError);
+  });
+
+  test("rejects 3-digit semver", () => {
+    expect(() => parseVersion("1.0.0")).toThrow(AppError);
+  });
+
+  test("rejects leading zeroes", () => {
+    expect(() => parseVersion("01.0")).toThrow(AppError);
+    expect(() => parseVersion("1.00")).toThrow(AppError);
+  });
+
+  test("rejects negative numbers", () => {
+    expect(() => parseVersion("-1.0")).toThrow(AppError);
+    expect(() => parseVersion("1.-1")).toThrow(AppError);
+  });
+
+  test("rejects non-numeric parts", () => {
+    expect(() => parseVersion("a.b")).toThrow(AppError);
+    expect(() => parseVersion("1.a")).toThrow(AppError);
+  });
+
+  test("rejects whitespace", () => {
+    expect(() => parseVersion(" 1.0")).toThrow(AppError);
+    expect(() => parseVersion("1.0 ")).toThrow(AppError);
+  });
+
+  test("thrown AppError is 400 with INVALID_VERSION code", () => {
+    try {
+      parseVersion("bad");
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppError);
+      expect((err as AppError).statusCode).toBe(400);
+      expect((err as AppError).code).toBe("INVALID_VERSION");
+    }
+  });
+});
+
+describe("compareVersions", () => {
+  test("returns 0 for equal versions", () => {
+    expect(compareVersions({ major: 1, minor: 2 }, { major: 1, minor: 2 })).toBe(0);
+  });
+
+  test("major takes precedence over minor", () => {
+    expect(compareVersions({ major: 2, minor: 0 }, { major: 1, minor: 99 })).toBe(1);
+    expect(compareVersions({ major: 1, minor: 99 }, { major: 2, minor: 0 })).toBe(-1);
+  });
+
+  test("compares minor when major equal", () => {
+    expect(compareVersions({ major: 1, minor: 3 }, { major: 1, minor: 2 })).toBe(1);
+    expect(compareVersions({ major: 1, minor: 2 }, { major: 1, minor: 3 })).toBe(-1);
+  });
+});
+
+describe("isGreater", () => {
+  test("true when strictly greater", () => {
+    expect(isGreater({ major: 1, minor: 1 }, { major: 1, minor: 0 })).toBe(true);
+    expect(isGreater({ major: 2, minor: 0 }, { major: 1, minor: 99 })).toBe(true);
+  });
+
+  test("false when equal", () => {
+    expect(isGreater({ major: 1, minor: 0 }, { major: 1, minor: 0 })).toBe(false);
+  });
+
+  test("false when smaller", () => {
+    expect(isGreater({ major: 1, minor: 0 }, { major: 1, minor: 1 })).toBe(false);
+    expect(isGreater({ major: 1, minor: 99 }, { major: 2, minor: 0 })).toBe(false);
+  });
+});

--- a/ornn-api/src/domains/skillCrud/version.ts
+++ b/ornn-api/src/domains/skillCrud/version.ts
@@ -1,0 +1,59 @@
+/**
+ * Skill version utility.
+ *
+ * Ornn uses a 2-digit version format (`<major>.<minor>`) declared in each
+ * skill's SKILL.md frontmatter. This module parses and compares those
+ * strings; all version-related operations in the skill CRUD path go
+ * through here so the rules stay in one place.
+ *
+ * @module domains/skillCrud/version
+ */
+
+import { AppError } from "../../shared/types/index";
+import { SKILL_VERSION_REGEX } from "../../shared/schemas/skillFrontmatter";
+
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+}
+
+/**
+ * Parse a `<major>.<minor>` version string. Throws AppError.badRequest on
+ * any malformed input (including leading zeroes, 3-digit semver, whitespace,
+ * or non-numeric parts).
+ */
+export function parseVersion(raw: string): ParsedVersion {
+  if (typeof raw !== "string") {
+    throw AppError.badRequest("INVALID_VERSION", `version must be a string, got ${typeof raw}`);
+  }
+  const match = raw.match(SKILL_VERSION_REGEX);
+  if (!match) {
+    throw AppError.badRequest(
+      "INVALID_VERSION",
+      `version "${raw}" is invalid — expected "<major>.<minor>" (non-negative integers, no leading zeroes, no patch digit)`,
+    );
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+  };
+}
+
+/**
+ * Standard 3-way compare: returns -1 if a < b, 0 if equal, 1 if a > b.
+ * Major takes precedence; only consults minor on major tie.
+ */
+export function compareVersions(a: ParsedVersion, b: ParsedVersion): number {
+  if (a.major !== b.major) {
+    return a.major < b.major ? -1 : 1;
+  }
+  if (a.minor !== b.minor) {
+    return a.minor < b.minor ? -1 : 1;
+  }
+  return 0;
+}
+
+/** Strict greater-than: `a > b`. Equality returns false. */
+export function isGreater(a: ParsedVersion, b: ParsedVersion): boolean {
+  return compareVersions(a, b) > 0;
+}

--- a/ornn-api/src/shared/schemas/skillFrontmatter.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.ts
@@ -105,11 +105,19 @@ export const refinedMetadataSchema = metadataSchema.superRefine((data, ctx) => {
   }
 });
 
+/**
+ * Skill version format: `<major>.<minor>` (2-digit, no patch).
+ * Both parts must be non-negative integers. Leading zeroes are rejected.
+ */
+export const SKILL_VERSION_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
 // Full frontmatter schema
 export const skillFrontmatterSchema = z.object({
   name: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/, "Name must be kebab-case"),
   description: z.string().min(1).max(1024),
-  version: z.string().max(20).optional(),
+  version: z
+    .string()
+    .regex(SKILL_VERSION_REGEX, "version must be in `<major>.<minor>` format, e.g. `1.0` (non-negative integers, no leading zeroes, no patch digit)"),
   license: z.string().max(50).optional(),
   compatibility: z.string().max(500).optional(),
   metadata: refinedMetadataSchema,

--- a/ornn-api/src/shared/schemas/skillFrontmatter.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.ts
@@ -115,9 +115,19 @@ export const SKILL_VERSION_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 export const skillFrontmatterSchema = z.object({
   name: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/, "Name must be kebab-case"),
   description: z.string().min(1).max(1024),
+  // YAML parses `version: 0.1` (unquoted) as a float and `1.0` as an
+  // integer `1`, which both lose the intended two-digit shape. We require
+  // the author to quote it (`version: "0.1"`) so the round-trip is
+  // lossless. A clear message points them at the fix.
   version: z
-    .string()
-    .regex(SKILL_VERSION_REGEX, "version must be in `<major>.<minor>` format, e.g. `1.0` (non-negative integers, no leading zeroes, no patch digit)"),
+    .string({
+      invalid_type_error:
+        "version must be a quoted string — write `version: \"0.1\"` in SKILL.md, not `version: 0.1` (YAML parses the unquoted form as a number and loses the trailing zero).",
+    })
+    .regex(
+      SKILL_VERSION_REGEX,
+      "version must be in `<major>.<minor>` format, e.g. `1.0` (non-negative integers, no leading zeroes, no patch digit)",
+    ),
   license: z.string().max(50).optional(),
   compatibility: z.string().max(500).optional(),
   metadata: refinedMetadataSchema,

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -91,6 +91,39 @@ export interface SkillDocument {
   isSystem?: boolean;
   /** NyxID service ID this system skill was generated from. */
   nyxidServiceId?: string;
+  /**
+   * Cached pointer to the highest version published for this skill, e.g. "1.2".
+   * The `skill_versions` collection is the source of truth; this field exists
+   * for fast default-read access and must be kept in sync by the service layer.
+   */
+  latestVersion: string;
+}
+
+/**
+ * Immutable record of a single published version of a skill.
+ * Stored in the `skill_versions` collection. The corresponding `SkillDocument`
+ * carries the "latest version" pointer for fast default-read access; the
+ * version collection is the source of truth for history + specific-version
+ * fetches.
+ */
+export interface SkillVersionDocument {
+  /** `${skillGuid}@${version}` — uniqueness guaranteed via `_id`. */
+  _id: string;
+  skillGuid: string;
+  /** "<major>.<minor>" string, e.g. "1.2". */
+  version: string;
+  majorVersion: number;
+  minorVersion: number;
+  /** Storage key unique to this version — versions are immutable. */
+  storageKey: string;
+  skillHash: string;
+  metadata: SkillMetadata;
+  license: string | null;
+  compatibility: string | null;
+  createdBy: string;
+  createdByEmail?: string;
+  createdByDisplayName?: string;
+  createdOn: Date;
 }
 
 export interface SkillMetadata {
@@ -127,6 +160,11 @@ export interface SkillDetailResponse {
   createdByDisplayName?: string;
   createdOn: string;
   updatedOn: string;
+  /**
+   * Version of this skill payload: latest when no `?version=` query was
+   * passed, otherwise the specifically requested version.
+   */
+  version: string;
 }
 
 export interface SkillSearchItem {

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -124,6 +124,14 @@ export interface SkillVersionDocument {
   createdByEmail?: string;
   createdByDisplayName?: string;
   createdOn: Date;
+  /**
+   * Mutable deprecation flag (phase 2). Absent/undefined means "not deprecated".
+   * Deprecation only warns consumers — it does not hide the version from
+   * `GET /versions` or exclude it from latest-resolution.
+   */
+  isDeprecated?: boolean;
+  /** Optional human-readable explanation surfaced with the warning. */
+  deprecationNote?: string | null;
 }
 
 export interface SkillMetadata {
@@ -165,6 +173,10 @@ export interface SkillDetailResponse {
    * passed, otherwise the specifically requested version.
    */
   version: string;
+  /** True when the resolved version is marked deprecated by the author. */
+  isDeprecated?: boolean;
+  /** Optional note the author left when deprecating this version. */
+  deprecationNote?: string | null;
 }
 
 export interface SkillSearchItem {

--- a/ornn-api/src/shared/utils/frontmatter.test.ts
+++ b/ornn-api/src/shared/utils/frontmatter.test.ts
@@ -108,6 +108,7 @@ describe("validateFrontmatter", () => {
     const result = validateFrontmatter({
       name: "test-skill",
       description: "A test",
+      version: "1.0",
       metadata: { category: "plain" },
     });
     expect(result.valid).toBe(true);
@@ -120,6 +121,7 @@ describe("validateFrontmatter", () => {
     const result = validateFrontmatter({
       name: "test-skill",
       description: "A test",
+      version: "1.0",
       category: "imported",
     });
     expect(result.valid).toBe(true);
@@ -148,11 +150,33 @@ describe("validateFrontmatter", () => {
     const result = validateFrontmatter({
       name: "test-skill",
       description: "A test",
+      version: "1.0",
     });
     expect(result.valid).toBe(true);
     if (result.data) {
       expect(result.data.metadata.category).toBe("plain");
     }
+  });
+
+  test("missingVersion_returnsStructuredError", () => {
+    const result = validateFrontmatter({
+      name: "test-skill",
+      description: "A test",
+      metadata: { category: "plain" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "version")).toBe(true);
+  });
+
+  test("invalidVersionFormat_3DigitSemver_returnsError", () => {
+    const result = validateFrontmatter({
+      name: "test-skill",
+      description: "A test",
+      version: "1.0.0",
+      metadata: { category: "plain" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === "version")).toBe(true);
   });
 
   test("conditionalViolation_returnsFieldPath", () => {

--- a/ornn-web/src/components/skill/DeprecationBanner.tsx
+++ b/ornn-web/src/components/skill/DeprecationBanner.tsx
@@ -1,0 +1,84 @@
+import { useTranslation } from "react-i18next";
+
+export interface DeprecationBannerProps {
+  version: string;
+  note: string | null | undefined;
+  /** True when the currently-viewed version is an older one, not the latest. */
+  hasNewerVersion: boolean;
+  /** Label of the latest version, shown when offering to jump to it. */
+  latestVersion?: string;
+  onViewLatest?: () => void;
+  className?: string;
+}
+
+/**
+ * Warning banner rendered above the content area when the resolved version
+ * is marked deprecated by the author. Uses forge-gold to read as a warning
+ * without shouting "error".
+ */
+export function DeprecationBanner({
+  version,
+  note,
+  hasNewerVersion,
+  latestVersion,
+  onViewLatest,
+  className = "",
+}: DeprecationBannerProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      role="alert"
+      className={`
+        glass flex flex-col gap-2 rounded-xl border border-neon-yellow/40
+        bg-neon-yellow/5 p-4
+        ${className}
+      `}
+    >
+      <div className="flex items-start gap-3">
+        <svg
+          className="mt-0.5 h-5 w-5 shrink-0 text-neon-yellow"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01M5.07 19h13.86a2 2 0 001.74-3l-6.93-12a2 2 0 00-3.48 0l-6.93 12a2 2 0 001.74 3z"
+          />
+        </svg>
+        <div className="flex-1 min-w-0">
+          <p className="font-heading text-sm text-neon-yellow">
+            {t("skillDetail.deprecationBannerTitle", { version })}
+          </p>
+          {note ? (
+            <p className="mt-1 font-body text-sm text-text-primary/90">
+              {t("skillDetail.deprecationBannerBody", { note })}
+            </p>
+          ) : (
+            <p className="mt-1 font-body text-sm text-text-muted">
+              {t("skillDetail.deprecationWarning")}
+            </p>
+          )}
+        </div>
+      </div>
+      {hasNewerVersion && latestVersion && onViewLatest && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onViewLatest}
+            className="
+              font-body text-sm text-neon-yellow hover:text-neon-yellow/80
+              underline underline-offset-2 transition-colors cursor-pointer
+            "
+          >
+            {t("skillDetail.viewLatest", { version: latestVersion })}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ornn-web/src/components/skill/SkillVersionList.tsx
+++ b/ornn-web/src/components/skill/SkillVersionList.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+import type { SkillVersionEntry } from "@/types/domain";
+
+/** Format a date string to exact SGT (Asia/Singapore) timestamp. */
+function formatDateSGT(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleString("en-SG", {
+    timeZone: "Asia/Singapore",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+export interface SkillVersionListProps {
+  versions: SkillVersionEntry[];
+  currentVersion: string;
+  /** Fire when the user clicks a version row to switch to it. */
+  onSelect: (version: string) => void;
+  /** Show owner-only controls (deprecation toggle). */
+  canManage: boolean;
+  /** Fire when the deprecation flag changes; receives the target version. */
+  onToggleDeprecation?: (args: {
+    version: string;
+    isDeprecated: boolean;
+    deprecationNote?: string;
+  }) => Promise<void> | void;
+  /** Whether a deprecation mutation is currently in flight (for loading state). */
+  isMutating?: boolean;
+  className?: string;
+}
+
+/**
+ * Compact version history list rendered in the detail-page sidebar.
+ * Clicking a row switches the page to that version. Owner / admin sees a
+ * "mark deprecated / undeprecate" action per row; clicking it opens a modal
+ * that optionally captures a note before confirming.
+ */
+export function SkillVersionList({
+  versions,
+  currentVersion,
+  onSelect,
+  canManage,
+  onToggleDeprecation,
+  isMutating = false,
+  className = "",
+}: SkillVersionListProps) {
+  const { t } = useTranslation();
+  const [modalTarget, setModalTarget] = useState<SkillVersionEntry | null>(null);
+  const [noteDraft, setNoteDraft] = useState("");
+  const latestVersion = versions[0]?.version;
+
+  const openDeprecationModal = (entry: SkillVersionEntry) => {
+    setModalTarget(entry);
+    setNoteDraft(entry.deprecationNote ?? "");
+  };
+  const closeModal = () => {
+    setModalTarget(null);
+    setNoteDraft("");
+  };
+
+  const confirmToggle = async () => {
+    if (!modalTarget || !onToggleDeprecation) return;
+    await onToggleDeprecation({
+      version: modalTarget.version,
+      isDeprecated: !modalTarget.isDeprecated,
+      deprecationNote: modalTarget.isDeprecated ? undefined : noteDraft.trim() || undefined,
+    });
+    closeModal();
+  };
+
+  if (versions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={`glass rounded-xl p-5 space-y-3 ${className}`}>
+      <p className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+        {t("skillDetail.versions")}
+      </p>
+      <ul className="space-y-1.5">
+        {versions.map((v) => {
+          const isCurrent = v.version === currentVersion;
+          const isLatest = v.version === latestVersion;
+          return (
+            <li
+              key={v.version}
+              className={`
+                rounded-lg border p-2.5 transition-colors
+                ${
+                  isCurrent
+                    ? "border-neon-cyan/40 bg-neon-cyan/5"
+                    : "border-transparent bg-bg-elevated/40 hover:border-neon-cyan/20"
+                }
+              `}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <button
+                  type="button"
+                  onClick={() => !isCurrent && onSelect(v.version)}
+                  disabled={isCurrent}
+                  className={`
+                    flex-1 min-w-0 text-left
+                    ${isCurrent ? "cursor-default" : "cursor-pointer"}
+                  `}
+                >
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <span className="font-mono text-sm text-text-primary">{v.version}</span>
+                    {isLatest && (
+                      <Badge color="cyan" className="text-[10px]">
+                        {t("skillDetail.latest")}
+                      </Badge>
+                    )}
+                    {v.isDeprecated && (
+                      <Badge color="yellow" className="text-[10px]">
+                        {t("skillDetail.deprecated")}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="mt-0.5 font-body text-xs text-text-muted truncate">
+                    {formatDateSGT(v.createdOn)}
+                    {v.createdByDisplayName ? ` · ${v.createdByDisplayName}` : ""}
+                  </div>
+                </button>
+                {canManage && (
+                  <button
+                    type="button"
+                    onClick={() => openDeprecationModal(v)}
+                    disabled={isMutating}
+                    className="
+                      shrink-0 rounded border border-transparent px-2 py-1
+                      font-body text-xs text-text-muted
+                      hover:text-neon-yellow hover:border-neon-yellow/30
+                      disabled:opacity-50 disabled:cursor-not-allowed
+                      transition-colors cursor-pointer
+                    "
+                  >
+                    {v.isDeprecated
+                      ? t("skillDetail.unmarkDeprecated")
+                      : t("skillDetail.markDeprecated")}
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <Modal
+        isOpen={modalTarget !== null}
+        onClose={closeModal}
+        title={t("skillDetail.deprecationModalTitle", { version: modalTarget?.version ?? "" })}
+      >
+        {modalTarget && !modalTarget.isDeprecated && (
+          <div className="space-y-2">
+            <label
+              htmlFor="deprecation-note"
+              className="font-heading text-[11px] uppercase tracking-wider text-text-muted"
+            >
+              {t("skillDetail.deprecationNoteLabel")}
+            </label>
+            <textarea
+              id="deprecation-note"
+              value={noteDraft}
+              onChange={(e) => setNoteDraft(e.target.value)}
+              maxLength={1024}
+              rows={3}
+              placeholder={t("skillDetail.deprecationNotePlaceholder")}
+              className="
+                neon-input w-full rounded-lg px-3 py-2 font-body text-sm
+                text-text-primary resize-y
+              "
+            />
+          </div>
+        )}
+        {modalTarget?.isDeprecated && modalTarget.deprecationNote && (
+          <p className="font-body text-sm text-text-muted">
+            {t("skillDetail.deprecationBannerBody", { note: modalTarget.deprecationNote })}
+          </p>
+        )}
+        <div className="mt-6 flex justify-end gap-3">
+          <Button variant="secondary" size="sm" onClick={closeModal}>
+            {t("common.cancel")}
+          </Button>
+          <Button size="sm" loading={isMutating} onClick={confirmToggle}>
+            {modalTarget?.isDeprecated
+              ? t("skillDetail.unmarkDeprecated")
+              : t("skillDetail.markDeprecated")}
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/ornn-web/src/components/skill/VersionPicker.tsx
+++ b/ornn-web/src/components/skill/VersionPicker.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "framer-motion";
 import type { SkillVersionEntry } from "@/types/domain";
 import { formatVersionLabel } from "@/lib/versionLabel";
 
@@ -9,18 +11,17 @@ export interface VersionPickerProps {
   currentVersion: string;
   /**
    * Fire when the user picks a different version. Passed `null` when the user
-   * explicitly picks the "latest" sentinel (so the caller can drop the
-   * `?version=` URL param).
+   * explicitly picks the latest (so the caller can drop the `?version=` URL
+   * param).
    */
   onChange: (versionOrLatest: string | null) => void;
   className?: string;
 }
 
 /**
- * Dropdown (styled `<select>`) for picking a published version of a skill.
- * Marks the latest with "· latest" and any deprecated versions with
- * "· deprecated" in the visible label. Picking "latest" fires `null` so the
- * caller drops the URL's `?version=` parameter.
+ * Custom dropdown for picking a published version of a skill.
+ * Native `<select>` inherits OS chrome that clashes with the industrial-forge
+ * aesthetic, so this is a headless popover styled with the site's tokens.
  */
 export function VersionPicker({
   versions,
@@ -29,43 +30,128 @@ export function VersionPicker({
   className = "",
 }: VersionPickerProps) {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
   const latestVersion = versions[0]?.version;
+  const current = versions.find((v) => v.version === currentVersion);
+
+  // Close on outside click + Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const pick = (version: string) => {
+    setOpen(false);
+    onChange(version === latestVersion ? null : version);
+  };
+
+  const buttonLabel = current
+    ? formatVersionLabel(current.version, {
+        isLatest: current.version === latestVersion,
+        isDeprecated: current.isDeprecated,
+        latestText: t("skillDetail.latest"),
+        deprecatedText: t("skillDetail.deprecated"),
+      })
+    : currentVersion;
 
   return (
-    <div className={`flex items-center gap-2 ${className}`}>
-      <label
-        htmlFor="skill-version-picker"
-        className="font-heading text-[11px] uppercase tracking-wider text-text-muted"
-      >
+    <div ref={containerRef} className={`relative ${className}`}>
+      <span className="font-heading text-[11px] uppercase tracking-wider text-text-muted mr-2">
         {t("skillDetail.version")}
-      </label>
-      <select
-        id="skill-version-picker"
-        value={currentVersion}
-        onChange={(e) => {
-          const picked = e.target.value;
-          onChange(picked === latestVersion ? null : picked);
-        }}
-        className="
-          glass rounded-lg border border-neon-cyan/20 bg-bg-elevated
+      </span>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={`
+          glass inline-flex items-center gap-2 rounded-lg
+          border border-neon-cyan/20 bg-bg-elevated
           px-3 py-1.5 font-body text-sm text-text-primary
-          cursor-pointer
-          focus:outline-none focus:border-neon-cyan/60
-          hover:border-neon-cyan/40
-          transition-colors
-        "
+          cursor-pointer transition-colors
+          hover:border-neon-cyan/50
+          focus:outline-none focus:border-neon-cyan/70
+          ${open ? "border-neon-cyan/70" : ""}
+        `}
       >
-        {versions.map((v) => (
-          <option key={v.version} value={v.version} className="bg-bg-deep">
-            {formatVersionLabel(v.version, {
-              isLatest: v.version === latestVersion,
-              isDeprecated: v.isDeprecated,
-              latestText: t("skillDetail.latest"),
-              deprecatedText: t("skillDetail.deprecated"),
+        <span className="truncate max-w-[16rem]">{buttonLabel}</span>
+        <svg
+          className={`h-3.5 w-3.5 shrink-0 text-text-muted transition-transform ${open ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.ul
+            role="listbox"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.12, ease: "easeOut" }}
+            className="
+              absolute left-0 top-full mt-1 z-20 min-w-[14rem]
+              glass rounded-lg border border-neon-cyan/30
+              bg-bg-surface/95 backdrop-blur-md
+              shadow-[0_4px_24px_rgba(0,0,0,0.3)]
+              py-1 overflow-hidden
+            "
+          >
+            {versions.map((v) => {
+              const isCurrent = v.version === currentVersion;
+              const label = formatVersionLabel(v.version, {
+                isLatest: v.version === latestVersion,
+                isDeprecated: v.isDeprecated,
+                latestText: t("skillDetail.latest"),
+                deprecatedText: t("skillDetail.deprecated"),
+              });
+              return (
+                <li key={v.version} role="option" aria-selected={isCurrent}>
+                  <button
+                    type="button"
+                    onClick={() => pick(v.version)}
+                    className={`
+                      flex w-full items-center gap-2 px-3 py-2
+                      font-body text-sm text-left cursor-pointer transition-colors
+                      ${
+                        isCurrent
+                          ? "bg-neon-cyan/10 text-neon-cyan"
+                          : "text-text-primary hover:bg-bg-elevated"
+                      }
+                    `}
+                  >
+                    <span className="w-4 text-center">
+                      {isCurrent ? (
+                        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                        </svg>
+                      ) : null}
+                    </span>
+                    <span className="flex-1 truncate">{label}</span>
+                  </button>
+                </li>
+              );
             })}
-          </option>
-        ))}
-      </select>
+          </motion.ul>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/ornn-web/src/components/skill/VersionPicker.tsx
+++ b/ornn-web/src/components/skill/VersionPicker.tsx
@@ -1,0 +1,71 @@
+import { useTranslation } from "react-i18next";
+import type { SkillVersionEntry } from "@/types/domain";
+import { formatVersionLabel } from "@/lib/versionLabel";
+
+export interface VersionPickerProps {
+  /** All available versions, already sorted newest-first. */
+  versions: SkillVersionEntry[];
+  /** Version currently shown on the page (may be latest or a specific pick). */
+  currentVersion: string;
+  /**
+   * Fire when the user picks a different version. Passed `null` when the user
+   * explicitly picks the "latest" sentinel (so the caller can drop the
+   * `?version=` URL param).
+   */
+  onChange: (versionOrLatest: string | null) => void;
+  className?: string;
+}
+
+/**
+ * Dropdown (styled `<select>`) for picking a published version of a skill.
+ * Marks the latest with "· latest" and any deprecated versions with
+ * "· deprecated" in the visible label. Picking "latest" fires `null` so the
+ * caller drops the URL's `?version=` parameter.
+ */
+export function VersionPicker({
+  versions,
+  currentVersion,
+  onChange,
+  className = "",
+}: VersionPickerProps) {
+  const { t } = useTranslation();
+  const latestVersion = versions[0]?.version;
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <label
+        htmlFor="skill-version-picker"
+        className="font-heading text-[11px] uppercase tracking-wider text-text-muted"
+      >
+        {t("skillDetail.version")}
+      </label>
+      <select
+        id="skill-version-picker"
+        value={currentVersion}
+        onChange={(e) => {
+          const picked = e.target.value;
+          onChange(picked === latestVersion ? null : picked);
+        }}
+        className="
+          glass rounded-lg border border-neon-cyan/20 bg-bg-elevated
+          px-3 py-1.5 font-body text-sm text-text-primary
+          cursor-pointer
+          focus:outline-none focus:border-neon-cyan/60
+          hover:border-neon-cyan/40
+          transition-colors
+        "
+      >
+        {versions.map((v) => (
+          <option key={v.version} value={v.version} className="bg-bg-deep">
+            {formatVersionLabel(v.version, {
+              isLatest: v.version === latestVersion,
+              isDeprecated: v.isDeprecated,
+              latestText: t("skillDetail.latest"),
+              deprecatedText: t("skillDetail.deprecated"),
+            })}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -2,16 +2,19 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { searchSkills } from "@/services/searchApi";
 import {
   fetchSkill,
+  fetchSkillVersions,
   createSkill,
   updateSkill,
   updateSkillPackage,
   deleteSkill,
+  setSkillVersionDeprecation,
 } from "@/services/skillApi";
 import type { SkillSearchParams } from "@/types/search";
 import type { UpdateSkillMetadata } from "@/types/api";
 
 const SKILLS_KEY = "skills";
 const MY_SKILLS_KEY = "my-skills";
+const SKILL_VERSIONS_KEY = "skill-versions";
 
 /** Search public skills */
 export function useSkills(params: {
@@ -55,12 +58,46 @@ export function useMySkills(params: {
   });
 }
 
-/** Fetch a single skill by ID or name */
-export function useSkill(idOrName: string) {
+/**
+ * Fetch a single skill by ID or name.
+ * When `version` is provided, resolves to that specific published version;
+ * otherwise returns the latest. Query key includes `version` so switching
+ * between versions uses the cache correctly.
+ */
+export function useSkill(idOrName: string, version?: string) {
   return useQuery({
-    queryKey: [SKILLS_KEY, idOrName],
-    queryFn: () => fetchSkill(idOrName),
+    queryKey: [SKILLS_KEY, idOrName, version ?? "latest"],
+    queryFn: () => fetchSkill(idOrName, version),
     enabled: !!idOrName,
+  });
+}
+
+/** List every published version for a skill, newest first. */
+export function useSkillVersions(idOrName: string) {
+  return useQuery({
+    queryKey: [SKILL_VERSIONS_KEY, idOrName],
+    queryFn: () => fetchSkillVersions(idOrName),
+    enabled: !!idOrName,
+  });
+}
+
+/** Toggle the deprecation flag on a specific published version. */
+export function useSetVersionDeprecation(idOrName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      version,
+      isDeprecated,
+      deprecationNote,
+    }: {
+      version: string;
+      isDeprecated: boolean;
+      deprecationNote?: string;
+    }) => setSkillVersionDeprecation(idOrName, version, { isDeprecated, deprecationNote }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SKILLS_KEY, idOrName] });
+      queryClient.invalidateQueries({ queryKey: [SKILL_VERSIONS_KEY, idOrName] });
+    },
   });
 }
 

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -102,7 +102,22 @@
     "downloadSkill": "Download Package",
     "tryWithCli": "Try with Nyx CLI",
     "cliPromptCopied": "Prompt copied — paste it into your agent",
-    "cliCopyFailed": "Failed to copy prompt to clipboard"
+    "cliCopyFailed": "Failed to copy prompt to clipboard",
+    "version": "Version",
+    "versions": "Versions",
+    "latest": "latest",
+    "deprecated": "deprecated",
+    "deprecationWarning": "This version is marked deprecated by the author. Pin to a newer version if possible.",
+    "deprecationBannerTitle": "Version {{version}} is deprecated",
+    "deprecationBannerBody": "Author note: {{note}}",
+    "viewLatest": "Switch to latest ({{version}})",
+    "markDeprecated": "Mark deprecated",
+    "unmarkDeprecated": "Undeprecate",
+    "deprecationModalTitle": "Deprecation for version {{version}}",
+    "deprecationNoteLabel": "Note (optional)",
+    "deprecationNotePlaceholder": "Reason, migration path, or replacement version…",
+    "deprecationUpdated": "Deprecation status updated",
+    "deprecationFailed": "Failed to update deprecation status"
   },
   "playground": {
     "selectSkill": "Select a skill to try in the playground.",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -102,7 +102,22 @@
     "downloadSkill": "下载技能包",
     "tryWithCli": "在你的 Agent 中试用",
     "cliPromptCopied": "提示词已复制 —— 粘贴到你的 Agent 中",
-    "cliCopyFailed": "复制提示词到剪贴板失败"
+    "cliCopyFailed": "复制提示词到剪贴板失败",
+    "version": "版本",
+    "versions": "历史版本",
+    "latest": "最新",
+    "deprecated": "已弃用",
+    "deprecationWarning": "作者已将此版本标记为弃用，建议切换到更新的版本。",
+    "deprecationBannerTitle": "版本 {{version}} 已弃用",
+    "deprecationBannerBody": "作者说明：{{note}}",
+    "viewLatest": "切换到最新版本 ({{version}})",
+    "markDeprecated": "标记为弃用",
+    "unmarkDeprecated": "取消弃用",
+    "deprecationModalTitle": "版本 {{version}} 的弃用状态",
+    "deprecationNoteLabel": "说明（可选）",
+    "deprecationNotePlaceholder": "理由、迁移路径或替代版本…",
+    "deprecationUpdated": "弃用状态已更新",
+    "deprecationFailed": "更新弃用状态失败"
   },
   "playground": {
     "selectSkill": "选择一个技能在试验场中尝试。",

--- a/ornn-web/src/lib/versionLabel.test.ts
+++ b/ornn-web/src/lib/versionLabel.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { formatVersionLabel } from "./versionLabel";
+
+describe("formatVersionLabel", () => {
+  test("bare version when no flags", () => {
+    expect(formatVersionLabel("1.2")).toBe("1.2");
+  });
+
+  test("marks latest", () => {
+    expect(formatVersionLabel("1.2", { isLatest: true })).toBe("1.2 · latest");
+  });
+
+  test("marks deprecated", () => {
+    expect(formatVersionLabel("1.0", { isDeprecated: true })).toBe("1.0 · deprecated");
+  });
+
+  test("marks both when both flags set", () => {
+    expect(formatVersionLabel("1.1", { isLatest: true, isDeprecated: true })).toBe(
+      "1.1 · latest · deprecated",
+    );
+  });
+
+  test("respects localized label overrides", () => {
+    expect(
+      formatVersionLabel("2.0", {
+        isLatest: true,
+        isDeprecated: true,
+        latestText: "最新",
+        deprecatedText: "已弃用",
+      }),
+    ).toBe("2.0 · 最新 · 已弃用");
+  });
+});

--- a/ornn-web/src/lib/versionLabel.ts
+++ b/ornn-web/src/lib/versionLabel.ts
@@ -1,0 +1,22 @@
+/**
+ * Human-readable label for a version entry in the picker / list.
+ * Pure, side-effect-free — trivially unit-testable.
+ *
+ *   formatVersionLabel("1.2", { isLatest: true,  isDeprecated: false }) // "1.2 · latest"
+ *   formatVersionLabel("1.0", { isLatest: false, isDeprecated: true  }) // "1.0 · deprecated"
+ *   formatVersionLabel("1.1", { isLatest: true,  isDeprecated: true  }) // "1.1 · latest · deprecated"
+ */
+
+export interface VersionLabelFlags {
+  isLatest?: boolean;
+  isDeprecated?: boolean;
+  latestText?: string;
+  deprecatedText?: string;
+}
+
+export function formatVersionLabel(version: string, flags: VersionLabelFlags = {}): string {
+  const parts = [version];
+  if (flags.isLatest) parts.push(flags.latestText ?? "latest");
+  if (flags.isDeprecated) parts.push(flags.deprecatedText ?? "deprecated");
+  return parts.join(" · ");
+}

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import JSZip from "jszip";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { Card } from "@/components/ui/Card";
@@ -8,9 +8,19 @@ import { Modal } from "@/components/ui/Modal";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Badge } from "@/components/ui/Badge";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
-import { useSkill, useDeleteSkill, useUpdateSkill, useUpdateSkillPackage } from "@/hooks/useSkills";
+import { VersionPicker } from "@/components/skill/VersionPicker";
+import { DeprecationBanner } from "@/components/skill/DeprecationBanner";
+import { SkillVersionList } from "@/components/skill/SkillVersionList";
+import {
+  useSkill,
+  useDeleteSkill,
+  useUpdateSkill,
+  useUpdateSkillPackage,
+  useSkillVersions,
+  useSetVersionDeprecation,
+} from "@/hooks/useSkills";
 import { useSkillPackage } from "@/hooks/useSkillPackage";
-import { useCurrentUser, useIsAuthenticated } from "@/stores/authStore";
+import { useCurrentUser, useIsAuthenticated, isAdmin } from "@/stores/authStore";
 import { useToastStore } from "@/stores/toastStore";
 import { buildFileTreeFromEntries, type FileTreeEntry } from "@/utils/fileTreeBuilder";
 import { buildTrySkillPrompt } from "@/lib/buildTrySkillPrompt";
@@ -35,14 +45,19 @@ import type { FileNode } from "@/components/editor/FileTree";
 export function SkillDetailPage() {
   const { idOrName } = useParams<{ idOrName: string }>();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const addToast = useToastStore((s) => s.addToast);
   const user = useCurrentUser();
   const isAuthenticated = useIsAuthenticated();
   const { t } = useTranslation();
-  const { data: skill, isLoading, error, refetch } = useSkill(idOrName ?? "");
+
+  const versionParam = searchParams.get("version") ?? undefined;
+  const { data: skill, isLoading, error, refetch } = useSkill(idOrName ?? "", versionParam);
+  const { data: versionList = [] } = useSkillVersions(idOrName ?? "");
   const deleteMutation = useDeleteSkill();
   const updateMutation = useUpdateSkill(skill?.guid ?? "");
   const updatePackageMutation = useUpdateSkillPackage(skill?.guid ?? "");
+  const deprecationMutation = useSetVersionDeprecation(idOrName ?? "");
 
   const {
     files: packageFiles,
@@ -53,7 +68,46 @@ export function SkillDetailPage() {
   } = useSkillPackage(skill?.presignedPackageUrl);
 
   const isOwner = isAuthenticated && user?.id && skill?.createdBy === user.id;
+  const isAdminUser = isAdmin(user);
+  const canManageVersions = !!(isOwner || isAdminUser);
   const canTryWithCli = !!skill && (skill.isSystem === true || !skill.isPrivate || !!isOwner);
+
+  const latestVersion = versionList[0]?.version;
+  const viewingLatest = !versionParam || (latestVersion && versionParam === latestVersion);
+
+  const handleVersionChange = useCallback(
+    (versionOrLatest: string | null) => {
+      const next = new URLSearchParams(searchParams);
+      if (versionOrLatest === null) {
+        next.delete("version");
+      } else {
+        next.set("version", versionOrLatest);
+      }
+      setSearchParams(next, { replace: false });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const handleToggleDeprecation = useCallback(
+    async ({
+      version,
+      isDeprecated,
+      deprecationNote,
+    }: {
+      version: string;
+      isDeprecated: boolean;
+      deprecationNote?: string;
+    }) => {
+      try {
+        await deprecationMutation.mutateAsync({ version, isDeprecated, deprecationNote });
+        addToast({ type: "success", message: t("skillDetail.deprecationUpdated") });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : t("skillDetail.deprecationFailed");
+        addToast({ type: "error", message });
+      }
+    },
+    [deprecationMutation, addToast, t],
+  );
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showSaveConfirm, setShowSaveConfirm] = useState(false);
@@ -272,13 +326,32 @@ export function SkillDetailPage() {
   return (
     <PageTransition>
       <div className="flex flex-col h-full py-2">
+      {skill.isDeprecated && (
+        <DeprecationBanner
+          className="mb-3 shrink-0"
+          version={skill.version}
+          note={skill.deprecationNote}
+          hasNewerVersion={!viewingLatest && !!latestVersion}
+          latestVersion={latestVersion}
+          onViewLatest={() => handleVersionChange(null)}
+        />
+      )}
       <div className="flex-1 min-h-0 grid gap-4 lg:grid-cols-[1fr_300px]">
         {/* Main content — Package Contents (fills available height) */}
         <Card className="flex flex-col min-h-0 overflow-hidden">
-          <div className="mb-3 flex items-center justify-between shrink-0">
-            <h3 className="font-heading text-sm uppercase tracking-wider text-neon-cyan">
-              {t("skillDetail.packageContents")}
-            </h3>
+          <div className="mb-3 flex items-center justify-between gap-3 shrink-0">
+            <div className="flex items-center gap-3 min-w-0">
+              <h3 className="font-heading text-sm uppercase tracking-wider text-neon-cyan truncate">
+                {t("skillDetail.packageContents")}
+              </h3>
+              {versionList.length > 0 && (
+                <VersionPicker
+                  versions={versionList}
+                  currentVersion={skill.version}
+                  onChange={handleVersionChange}
+                />
+              )}
+            </div>
             {isOwner && (
               <Button
                 size="sm"
@@ -454,6 +527,17 @@ export function SkillDetailPage() {
               </>
             )}
           </div>
+
+          {versionList.length > 0 && (
+            <SkillVersionList
+              versions={versionList}
+              currentVersion={skill.version}
+              onSelect={(v) => handleVersionChange(v === latestVersion ? null : v)}
+              canManage={canManageVersions}
+              onToggleDeprecation={handleToggleDeprecation}
+              isMutating={deprecationMutation.isPending}
+            />
+          )}
         </div>
       </div>
 

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -1,14 +1,65 @@
 import { apiGet, apiPut, apiDelete } from "./apiClient";
 import type { UpdateSkillMetadata } from "@/types/api";
-import type { SkillDetail } from "@/types/domain";
+import type { SkillDetail, SkillVersionEntry } from "@/types/domain";
 import { useAuthStore } from "@/stores/authStore";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
 
-/** Fetch a single skill by GUID or name */
-export async function fetchSkill(idOrName: string): Promise<SkillDetail> {
-  const res = await apiGet<SkillDetail>(`/api/skills/${encodeURIComponent(idOrName)}`);
+/**
+ * Fetch a single skill by GUID or name.
+ * Without `version` → latest. With `version` → that specific version's payload.
+ */
+export async function fetchSkill(idOrName: string, version?: string): Promise<SkillDetail> {
+  const suffix = version ? `?version=${encodeURIComponent(version)}` : "";
+  const res = await apiGet<SkillDetail>(`/api/skills/${encodeURIComponent(idOrName)}${suffix}`);
   return res.data!;
+}
+
+/** List every published version for a skill, newest first. */
+export async function fetchSkillVersions(idOrName: string): Promise<SkillVersionEntry[]> {
+  const res = await apiGet<{ items: SkillVersionEntry[] }>(
+    `/api/skills/${encodeURIComponent(idOrName)}/versions`,
+  );
+  return res.data?.items ?? [];
+}
+
+/** Toggle the deprecation flag on a specific published version. */
+export async function setSkillVersionDeprecation(
+  idOrName: string,
+  version: string,
+  body: { isDeprecated: boolean; deprecationNote?: string },
+): Promise<{
+  skillGuid: string;
+  skillName: string;
+  version: string;
+  isDeprecated: boolean;
+  deprecationNote: string | null;
+}> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  const response = await fetch(
+    `${API_BASE}/api/skills/${encodeURIComponent(idOrName)}/versions/${encodeURIComponent(version)}`,
+    {
+      method: "PATCH",
+      headers,
+      credentials: "include",
+      body: JSON.stringify(body),
+    },
+  );
+  if (!response.ok) {
+    const json = await response.json().catch(() => null);
+    throw new Error(
+      (json as { error?: { message?: string } })?.error?.message ??
+        `HTTP ${response.status}: ${response.statusText}`,
+    );
+  }
+  const json = await response.json();
+  return json.data;
 }
 
 /**

--- a/ornn-web/src/types/domain.ts
+++ b/ornn-web/src/types/domain.ts
@@ -17,4 +17,21 @@ export interface SkillDetail extends SkillSummary {
   presignedPackageUrl: string;
   metadata: Record<string, unknown>;
   isSystem?: boolean;
+  /** Version of the currently-returned payload (latest by default). */
+  version: string;
+  /** True when the resolved version is deprecated by the author. */
+  isDeprecated?: boolean;
+  /** Optional note the author left when deprecating this version. */
+  deprecationNote?: string | null;
+}
+
+export interface SkillVersionEntry {
+  version: string;
+  skillHash: string;
+  createdBy: string;
+  createdByEmail?: string;
+  createdByDisplayName?: string;
+  createdOn: string;
+  isDeprecated: boolean;
+  deprecationNote: string | null;
 }

--- a/ornn-web/src/types/skillPackage.ts
+++ b/ornn-web/src/types/skillPackage.ts
@@ -49,6 +49,11 @@ export interface SkillMetadataBlock {
 export interface SkillMetadata {
   name: string;
   description: string;
+  /**
+   * Two-digit version string, e.g. `"0.1"`. Required by the backend on every
+   * publish. Guided / generative creation paths default to `"0.1"`.
+   */
+  version: string;
 
   /** Nested metadata block (new canonical structure) */
   metadata: SkillMetadataBlock;
@@ -75,6 +80,7 @@ export function createDefaultSkillMetadata(
   return {
     name: "",
     description: "",
+    version: "0.1",
     metadata: {
       category: "plain",
       outputType: undefined,

--- a/ornn-web/src/utils/frontmatterBuilder.ts
+++ b/ornn-web/src/utils/frontmatterBuilder.ts
@@ -65,8 +65,10 @@ export function buildFrontmatter(meta: SkillMetadata): string {
   // Core fields
   lines.push(`name: ${formatYamlValue(meta.name)}`);
   lines.push(`description: ${formatYamlValue(meta.description)}`);
-  // version is required by the backend; default "0.1" for guided/generative paths.
-  lines.push(`version: ${formatYamlValue(meta.version || "0.1")}`);
+  // version is required by the backend. Quoted unconditionally — without
+  // quotes, YAML parses "0.1" as a float and the backend's string schema
+  // rejects it with "Expected string, received number".
+  lines.push(`version: "${(meta.version || "0.1").replace(/"/g, '\\"')}"`);
 
   // Official Claude fields (only if non-default)
   if (meta.disableModelInvocation) {

--- a/ornn-web/src/utils/frontmatterBuilder.ts
+++ b/ornn-web/src/utils/frontmatterBuilder.ts
@@ -65,6 +65,8 @@ export function buildFrontmatter(meta: SkillMetadata): string {
   // Core fields
   lines.push(`name: ${formatYamlValue(meta.name)}`);
   lines.push(`description: ${formatYamlValue(meta.description)}`);
+  // version is required by the backend; default "0.1" for guided/generative paths.
+  lines.push(`version: ${formatYamlValue(meta.version || "0.1")}`);
 
   // Official Claude fields (only if non-default)
   if (meta.disableModelInvocation) {

--- a/ornn-web/src/utils/skillFrontmatterSchema.ts
+++ b/ornn-web/src/utils/skillFrontmatterSchema.ts
@@ -148,6 +148,12 @@ export const refinedMetadataSchema = metadataSchema.superRefine(
 
 // --- Full frontmatter schema ---
 
+/**
+ * Skill version format: `<major>.<minor>` (2-digit, no patch).
+ * Both parts must be non-negative integers. Leading zeroes are rejected.
+ */
+export const SKILL_VERSION_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
 export const skillFrontmatterSchema = z.object({
   // Official Claude skill fields (top-level)
   name: z
@@ -159,6 +165,12 @@ export const skillFrontmatterSchema = z.object({
       "Name must start with a letter or number and contain only lowercase letters, numbers, and hyphens",
     ),
   description: z.string().min(1).max(1024),
+  version: z
+    .string()
+    .regex(
+      SKILL_VERSION_REGEX,
+      "version must be in `<major>.<minor>` format, e.g. `1.0` (non-negative integers, no leading zeroes, no patch digit)",
+    ),
   disableModelInvocation: z.boolean().default(false),
   userInvocable: z.boolean().default(true),
   allowedTools: z.array(z.string()).optional(),


### PR DESCRIPTION
Closes #25.

3-phase implementation, single branch, 4 commits (phase 1 + 2 + 3 + changeset).

## Phase 1 — Foundation
- `SKILL.md` frontmatter: **required** `version: "<major>.<minor>"`. Backend schema + frontend mirror both enforce it.
- New `skill_versions` Mongo collection. Each publish snapshots an immutable row keyed by `${skillGuid}@${version}` with its own storage key. Compound index `(skillGuid, majorVersion↓, minorVersion↓)` for latest lookup.
- Service wiring: create emits the initial version row; package-update validates the new version is strictly greater than current latest (409 `VERSION_NOT_INCREMENTED` otherwise), uploads to a fresh versioned key (`skills/{guid}/{version}.zip`), inserts a new row, and advances the skill doc's `latestVersion` pointer. Metadata-only updates don't bump. Delete cascades both version rows and storage.
- New API: `GET /api/skills/:idOrName?version=X.Y` returns that version's package; `GET /api/skills/:idOrName/versions` lists history newest-first. `SkillDetailResponse.version` is always populated.
- Migration script `bun run migrate:versions` backfills existing skills to `0.1` (or their `metadata.version` if valid), idempotent. Documented in `docs/migrations.md`.
- Version util (parse / compare / isGreater) + 17 unit tests.

## Phase 2 — Deprecation + breaking-change detection
- New mutable `isDeprecated` / `deprecationNote` fields on `SkillVersionDocument` + `SkillDetailResponse`.
- `PATCH /api/skills/:idOrName/versions/:version` (owner/admin, Zod-validated body) toggles the flag.
- `GET` sets `X-Skill-Deprecated` and URL-encoded `X-Skill-Deprecation-Note` response headers when the resolved version is deprecated, so CLIs / agents get the warning even without parsing the body.
- New `interfaceDiff.ts` (14 unit tests). Breaking = change to `category`, `outputType`, declared runtimes, dependency library names, env-var names, or tools. Dependency version bumps, description changes, and tag changes are deliberately not breaking.
- `updateSkill` rejects interface-breaking changes within the same major with 409 `BREAKING_CHANGE_WITHOUT_MAJOR_BUMP`, listing the offending fields.

## Phase 3 — UI
- Skill detail page reads `?version=` via `useSearchParams`, threads it through `useSkill`.
- **VersionPicker** (styled `<select>`): picking the latest drops the URL param.
- **DeprecationBanner**: forge-gold warning above the content card; offers a "switch to latest" link when viewing an older deprecated version.
- **SkillVersionList** in the sidebar: per-row badges for `latest` / `deprecated`, owner/admin-only deprecation toggle that opens a modal with an optional note input.
- Pure `lib/versionLabel.ts` (5 unit tests) formats picker / list labels with localized `latest` / `deprecated` suffixes.
- 15 new `skillDetail.*` i18n keys in both `en.json` and `zh.json`.

## Migration

**Required** against any pre-existing database:

```bash
cd ornn-api
MONGODB_URI=... MONGODB_DB=... bun run migrate:versions
```

Idempotent. See `docs/migrations.md` for details.

## Test plan

- [ ] Local deploy: create a new skill with `version: "1.0"` in SKILL.md → succeeds.
- [ ] Publish the same skill with `version: "1.0"` (repeat) → 409 VERSION_NOT_INCREMENTED.
- [ ] Bump to `version: "1.1"` → succeeds, version list now shows both.
- [ ] Remove a declared `tool-list` entry and keep major at 1 → 409 BREAKING_CHANGE_WITHOUT_MAJOR_BUMP.
- [ ] Same change with `version: "2.0"` → succeeds.
- [ ] `GET /api/skills/<name>?version=1.0` returns old package with matching hash.
- [ ] `PATCH /api/skills/<name>/versions/1.0` with `{"isDeprecated": true, "deprecationNote": "superseded"}` → flag persists; subsequent `GET ?version=1.0` sets `X-Skill-Deprecated: true` header and body carries the note.
- [ ] Detail page: picker switches versions, banner appears on deprecated versions, owner sees the toggle, modal captures note, toast confirms.

## Judgment calls worth a look

- **Latest resolution does not skip deprecated versions.** The highest numbered version is still latest; we warn instead of hiding. Add `?skip_deprecated` later if this surprises anyone.
- **One extra Mongo read per `GET /api/skills/:idOrName`** for latest-reads to overlay deprecation state. Acceptable for now; denormalize onto the skill doc if profiling shows it.
- **Dependency version-only bumps are non-breaking by design** (matches npm `^` range semantics).
- **Registry cards don't yet show deprecation badges** — search items don't carry the flag. Follow-up if it matters.