### PR TITLE
refactor: Epic 1 foundations (config, requestId, livez/readyz, apiClient) [part of #66]

### DIFF
--- a/.changeset/epic-1-foundations.md
+++ b/.changeset/epic-1-foundations.md
@@ -1,0 +1,11 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+Epic 1 foundations (part of #66):
+
+- **Config**: `ornn-api/src/infra/config.ts` rewritten on top of Zod. Missing or invalid env vars throw `ConfigError` with a full summary of every violation; library code no longer calls `process.exit()` (the entry point owns that).
+- **Request correlation**: new `requestIdMiddleware` generates or echoes `X-Request-ID` per request, exposes it via response header, and threads it through structured logs and the global error handler.
+- **Kubernetes probes**: split `/health` into `/livez` (liveness — no dependency checks) and `/readyz` (pings Mongo with a 2s timeout; 503 when unreachable). `/health` kept as a backward-compat alias for the liveness handler.
+- **Frontend `apiClient`**: removed dead `X-User-Email` / `X-User-Display-Name` headers (stripped by the NyxID proxy, not read by the backend). Stopped triggering token refresh on 403 responses — 403 means permission denied, not token expiry, so the previous retry path hammered the refresh endpoint on legitimate authorization failures.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -17,6 +17,7 @@ const pkg = JSON.parse(readFileSync(join(import.meta.dir, "..", "package.json"),
 
 // Auth setup
 import { proxyAuthSetup, nyxidOrgLookupMiddleware } from "./middleware/nyxidAuth";
+import { requestIdMiddleware, getRequestId } from "./middleware/requestId";
 
 // Infrastructure
 import { connectMongo, type MongoConnection } from "./infra/db/mongodb";
@@ -234,22 +235,31 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   // ---- Hono App ----
   const app = new Hono();
 
-  // CORS — must run before auth so OPTIONS preflights are handled
+  // CORS — must run before auth so OPTIONS preflights are handled.
+  // NOTE: origin reflection + credentials is a security gap that a follow-up
+  // PR replaces with an env-driven allowlist. Deployment env changes are
+  // coordinated separately; until then, the behavior below matches what
+  // shipped previously.
   app.use("*", cors({
     origin: (origin) => origin,
     allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization", "X-API-Key", "X-User-Email", "X-User-Display-Name"],
-    exposeHeaders: ["Content-Length"],
+    exposeHeaders: ["Content-Length", "X-Request-ID"],
     credentials: true,
     maxAge: 86400,
   }));
 
-  // Global request logging
+  // Request-ID middleware — generate or echo X-Request-ID per request so
+  // every log line and error response carries the correlation id.
+  app.use("*", requestIdMiddleware());
+
+  // Global request logging (uses requestId set by middleware above)
   app.use("*", async (c, next) => {
     const start = Date.now();
     await next();
     const ms = Date.now() - start;
     logger.info({
+      requestId: getRequestId(c),
       method: c.req.method,
       path: c.req.path,
       status: c.res.status,
@@ -261,13 +271,14 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   // Use duck-typing: nyxidAuth inlines its own AppError class, so instanceof
   // against the shared AppError fails across module boundaries.
   app.onError((err, c) => {
+    const requestId = getRequestId(c);
     const appErr = err as AppError;
     if (appErr.name === "AppError" && typeof appErr.statusCode === "number" && typeof appErr.code === "string") {
-      logger.warn({ code: appErr.code, status: appErr.statusCode }, appErr.message);
+      logger.warn({ requestId, code: appErr.code, status: appErr.statusCode }, appErr.message);
       return c.json({ data: null, error: { code: appErr.code, message: appErr.message } }, appErr.statusCode as any);
     }
 
-    logger.error({ err }, "Unhandled error");
+    logger.error({ requestId, err }, "Unhandled error");
     return c.json(
       { data: null, error: { code: "INTERNAL_ERROR", message: "Internal server error" } },
       500,
@@ -303,15 +314,48 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const spec = buildSpec();
   app.get("/api/openapi.json", (c) => c.json(spec));
 
-  // Health endpoint
-  app.get("/health", (c) =>
+  // Kubernetes liveness probe — process is alive. No dependency checks.
+  // `/health` kept as an alias for backward compatibility; K8s manifests
+  // should migrate to `/livez`.
+  const livenessHandler = (c: any) =>
     c.json({
       status: "ok",
       service: "ornn-api",
       version: pkg.version,
       timestamp: new Date().toISOString(),
-    }),
-  );
+    });
+  app.get("/livez", livenessHandler);
+  app.get("/health", livenessHandler);
+
+  // Kubernetes readiness probe — pings Mongo with a short timeout. Returns
+  // 503 when the dependency is unreachable so traffic is drained from this
+  // pod until it recovers.
+  app.get("/readyz", async (c) => {
+    const start = Date.now();
+    try {
+      const pingResult = Promise.resolve(db.command({ ping: 1 }));
+      await Promise.race([
+        pingResult,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("mongo ping timeout")), 2000),
+        ),
+      ]);
+      return c.json(
+        {
+          status: "ready",
+          service: "ornn-api",
+          mongoLatencyMs: Date.now() - start,
+        },
+        200,
+      );
+    } catch (err) {
+      logger.warn({ err: (err as Error).message }, "readyz: Mongo unreachable");
+      return c.json(
+        { status: "not_ready", reason: "mongo_unreachable" },
+        503,
+      );
+    }
+  });
 
   logger.info("ornn-api bootstrap complete");
 

--- a/ornn-api/src/index.ts
+++ b/ornn-api/src/index.ts
@@ -3,11 +3,22 @@
  * Handles skill CRUD, search, generation, playground, and admin.
  */
 
-import { loadConfig } from "./infra/config";
+import { loadConfig, ConfigError, type SkillConfig } from "./infra/config";
 import { bootstrap } from "./bootstrap";
 import pino from "pino";
 
-const config = loadConfig();
+let config: SkillConfig;
+try {
+  config = loadConfig();
+} catch (err) {
+  if (err instanceof ConfigError) {
+    // Print every missing/invalid var so operators don't have to retry.
+    console.error(`[ornn-api] ${err.message}`);
+  } else {
+    console.error("[ornn-api] Unexpected error loading config:", err);
+  }
+  process.exit(1);
+}
 
 const logger = pino({
   level: config.logLevel,

--- a/ornn-api/src/infra/config.ts
+++ b/ornn-api/src/infra/config.ts
@@ -1,12 +1,14 @@
 /**
  * Environment variable configuration for ornn-api.
- * Fails fast on missing required variables.
+ *
+ * Validation is schema-driven via Zod. Library code throws `ConfigError`
+ * on invalid env; the entry point (`src/index.ts`) decides what to do
+ * with the failure (typically: log and exit 1).
+ *
  * @module infra/config
  */
 
-import pino from "pino";
-
-const logger = pino({ level: "error" });
+import { z } from "zod";
 
 export interface SkillConfig {
   // Service
@@ -19,9 +21,9 @@ export interface SkillConfig {
   readonly nyxidClientId: string;
   readonly nyxidClientSecret: string;
   /**
-   * NyxID API base URL (no trailing slash, no `/oauth/token` suffix). Derived
-   * from `NYXID_TOKEN_URL` when `NYXID_BASE_URL` is not set explicitly so local
-   * dev works with just the token URL.
+   * NyxID API base URL (no trailing slash, no `/oauth/token` suffix).
+   * Derived from `NYXID_TOKEN_URL` when `NYXID_BASE_URL` is not set
+   * explicitly so local dev works with just the token URL.
    */
   readonly nyxidBaseUrl: string;
 
@@ -49,55 +51,96 @@ export interface SkillConfig {
   readonly maxPackageSizeBytes: number;
 }
 
-function requiredEnv(key: string): string {
-  const value = process.env[key];
-  if (!value) {
-    logger.fatal({ key }, `Missing required environment variable: ${key}`);
-    process.exit(1);
-  }
-  return value;
-}
+/** Parses "true"/"false"/"1"/"0" into a real boolean. */
+const booleanFromEnv = z
+  .string()
+  .default("false")
+  .transform((v) => {
+    const s = v.trim().toLowerCase();
+    return s === "true" || s === "1" || s === "yes";
+  });
 
-function optionalEnv(key: string, fallback: string): string {
-  return process.env[key] ?? fallback;
+const envSchema = z.object({
+  PORT: z.coerce.number().int().positive().default(3802),
+  LOG_LEVEL: z.enum(["trace", "debug", "info", "warn", "error", "fatal"]).default("info"),
+  LOG_PRETTY: booleanFromEnv,
+
+  NYXID_TOKEN_URL: z.string().url(),
+  NYXID_BASE_URL: z.string().url().optional(),
+  NYXID_CLIENT_ID: z.string().min(1),
+  NYXID_CLIENT_SECRET: z.string().min(1),
+
+  NYX_LLM_GATEWAY_URL: z.string().url(),
+
+  MONGODB_URI: z.string().min(1),
+  MONGODB_DB: z.string().min(1).default("ornn"),
+
+  STORAGE_SERVICE_URL: z.string().min(1),
+  STORAGE_BUCKET: z.string().min(1).default("ornn"),
+
+  SANDBOX_SERVICE_URL: z.string().min(1),
+
+  DEFAULT_LLM_MODEL: z.string().min(1).default("gpt-4o"),
+  LLM_MAX_OUTPUT_TOKENS: z.coerce.number().int().positive().default(8192),
+  LLM_TEMPERATURE: z.coerce.number().min(0).max(2).default(0.7),
+  SSE_KEEP_ALIVE_INTERVAL_MS: z.coerce.number().int().positive().default(15000),
+
+  MAX_PACKAGE_SIZE_BYTES: z.coerce.number().int().positive().default(52428800),
+});
+
+/**
+ * Thrown when env parsing fails. Caller decides how to surface the
+ * failure (log + exit, throw upward, etc.). The message enumerates
+ * every missing or invalid var so operators don't have to retry.
+ */
+export class ConfigError extends Error {
+  readonly issues: z.ZodIssue[];
+
+  constructor(issues: z.ZodIssue[]) {
+    const summary = issues
+      .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+      .join("; ");
+    super(`Invalid configuration: ${summary}`);
+    this.name = "ConfigError";
+    this.issues = issues;
+  }
 }
 
 export function loadConfig(): SkillConfig {
-  const tokenUrl = requiredEnv("NYXID_TOKEN_URL");
-  const baseUrl = (process.env.NYXID_BASE_URL ?? tokenUrl.replace(/\/oauth\/token\/?$/, "")).replace(/\/+$/, "");
-  return {
-    // Service
-    port: Number(optionalEnv("PORT", "3802")),
-    logLevel: optionalEnv("LOG_LEVEL", "info"),
-    logPretty: optionalEnv("LOG_PRETTY", "false") === "true",
+  const result = envSchema.safeParse(process.env);
+  if (!result.success) {
+    throw new ConfigError(result.error.issues);
+  }
+  const env = result.data;
 
-    // NyxID
+  const tokenUrl = env.NYXID_TOKEN_URL;
+  const baseUrl = (env.NYXID_BASE_URL ?? tokenUrl.replace(/\/oauth\/token\/?$/, "")).replace(/\/+$/, "");
+
+  return {
+    port: env.PORT,
+    logLevel: env.LOG_LEVEL,
+    logPretty: env.LOG_PRETTY,
+
     nyxidTokenUrl: tokenUrl,
-    nyxidClientId: requiredEnv("NYXID_CLIENT_ID"),
-    nyxidClientSecret: requiredEnv("NYXID_CLIENT_SECRET"),
+    nyxidClientId: env.NYXID_CLIENT_ID,
+    nyxidClientSecret: env.NYXID_CLIENT_SECRET,
     nyxidBaseUrl: baseUrl,
 
-    // Nyx Provider
-    nyxLlmGatewayUrl: requiredEnv("NYX_LLM_GATEWAY_URL"),
+    nyxLlmGatewayUrl: env.NYX_LLM_GATEWAY_URL,
 
-    // MongoDB
-    mongodbUri: requiredEnv("MONGODB_URI"),
-    mongodbDb: optionalEnv("MONGODB_DB", "ornn"),
+    mongodbUri: env.MONGODB_URI,
+    mongodbDb: env.MONGODB_DB,
 
-    // chrono-storage
-    storageServiceUrl: requiredEnv("STORAGE_SERVICE_URL"),
-    storageBucket: optionalEnv("STORAGE_BUCKET", "ornn"),
+    storageServiceUrl: env.STORAGE_SERVICE_URL,
+    storageBucket: env.STORAGE_BUCKET,
 
-    // chrono-sandbox
-    sandboxServiceUrl: requiredEnv("SANDBOX_SERVICE_URL"),
+    sandboxServiceUrl: env.SANDBOX_SERVICE_URL,
 
-    // LLM defaults
-    defaultLlmModel: optionalEnv("DEFAULT_LLM_MODEL", "gpt-4o"),
-    llmMaxOutputTokens: Number(optionalEnv("LLM_MAX_OUTPUT_TOKENS", "8192")),
-    llmTemperature: Number(optionalEnv("LLM_TEMPERATURE", "0.7")),
-    sseKeepAliveIntervalMs: Number(optionalEnv("SSE_KEEP_ALIVE_INTERVAL_MS", "15000")),
+    defaultLlmModel: env.DEFAULT_LLM_MODEL,
+    llmMaxOutputTokens: env.LLM_MAX_OUTPUT_TOKENS,
+    llmTemperature: env.LLM_TEMPERATURE,
+    sseKeepAliveIntervalMs: env.SSE_KEEP_ALIVE_INTERVAL_MS,
 
-    // Skill package
-    maxPackageSizeBytes: Number(optionalEnv("MAX_PACKAGE_SIZE_BYTES", "52428800")),
+    maxPackageSizeBytes: env.MAX_PACKAGE_SIZE_BYTES,
   };
 }

--- a/ornn-api/src/middleware/requestId.ts
+++ b/ornn-api/src/middleware/requestId.ts
@@ -1,0 +1,46 @@
+/**
+ * Request-ID middleware.
+ *
+ * Generates or echoes an `X-Request-ID` header on every request. The id
+ * is exposed as a response header on both success and error paths and
+ * attached to the Hono context as `requestId` so handlers / loggers can
+ * correlate entries with a single request.
+ *
+ * Client-provided IDs are accepted verbatim (common when the request
+ * enters via an ingress / proxy that already generated one). When the
+ * request has no id, the server generates `req_<32-hex>`.
+ *
+ * Must run before logging middleware so that every log line carries the
+ * correlation id.
+ *
+ * @module middleware/requestId
+ */
+
+import type { MiddlewareHandler } from "hono";
+import { randomUUID } from "node:crypto";
+
+const HEADER_NAME = "X-Request-ID";
+
+export interface RequestIdVariables {
+  requestId: string;
+}
+
+export function requestIdMiddleware(): MiddlewareHandler<{ Variables: RequestIdVariables }> {
+  return async (c, next) => {
+    const incoming = c.req.header(HEADER_NAME);
+    const id = incoming?.trim() || `req_${randomUUID().replace(/-/g, "")}`;
+    c.set("requestId", id);
+    c.header(HEADER_NAME, id);
+    await next();
+  };
+}
+
+/**
+ * Best-effort accessor for use in error handlers and logging middleware.
+ * Returns empty string when no middleware has attached an id, which should
+ * only happen for static routes outside the `/api/*` mount.
+ */
+export function getRequestId(c: { get: (key: string) => unknown }): string {
+  const value = c.get("requestId");
+  return typeof value === "string" ? value : "";
+}

--- a/ornn-web/src/services/apiClient.ts
+++ b/ornn-web/src/services/apiClient.ts
@@ -89,6 +89,11 @@ function buildUrl(
 
 /**
  * Create headers with auth token.
+ *
+ * `X-User-Email` and `X-User-Display-Name` used to ride along here; they
+ * were stripped by the NyxID proxy and never read by the backend (identity
+ * is sourced from the proxy-forwarded identity token). Dead code removed
+ * in the Epic 1 architecture refactor.
  */
 function createHeaders(includeAuth: boolean = true): HeadersInit {
   const headers: HeadersInit = {
@@ -100,14 +105,6 @@ function createHeaders(includeAuth: boolean = true): HeadersInit {
     if (token) {
       headers["Authorization"] = `Bearer ${token}`;
     }
-  }
-
-  const user = useAuthStore.getState().user;
-  if (user?.email) {
-    headers["X-User-Email"] = user.email;
-  }
-  if (user?.displayName) {
-    headers["X-User-Display-Name"] = user.displayName;
   }
 
   return headers;
@@ -154,8 +151,9 @@ async function fetchWithRetry<T>(
 
   const response = await fetch(url, options);
 
-  // Handle 401/403 — attempt refresh if user was authenticated and not already retried
-  if ((response.status === 401 || response.status === 403) && !retried) {
+  // Handle 401 — attempt token refresh if the user was authenticated and we haven't retried.
+  // 403 means authenticated-but-forbidden: refresh cannot fix that, so we skip it.
+  if (response.status === 401 && !retried) {
     const hadToken = !!getAccessToken();
 
     if (hadToken) {
@@ -271,8 +269,8 @@ export async function apiDelete(path: string): Promise<void> {
     headers: createHeaders(),
   });
 
-  // Handle 401/403
-  if (response.status === 401 || response.status === 403) {
+  // Handle 401 (not 403 — token refresh cannot resolve permission errors).
+  if (response.status === 401) {
     const refreshSuccess = await attemptTokenRefresh();
 
     if (refreshSuccess) {


### PR DESCRIPTION
## Summary

Second increment of the Epic 1 architecture refactor. All internal — `/api/*` contract is unchanged. Covers 5 foundation items:

### Backend
- **Zod config** — `infra/config.ts` rewritten on top of a Zod env schema. Missing or invalid vars throw `ConfigError` with a full summary; library code no longer calls `process.exit()`. `index.ts` catches and exits 1.
- **requestId middleware** — new `middleware/requestId.ts` generates or echoes `X-Request-ID` per request, attaches it to the Hono context, and threads it through the global request logger and error handler.
- **K8s probes** — split `/health` into `/livez` (pure liveness) and `/readyz` (pings Mongo with 2s timeout; 503 when unreachable). `/health` kept as alias so existing probes keep working.
- **CORS `exposeHeaders`** now advertises `X-Request-ID`. The origin-reflection + credentials security gap is called out in a comment; the env-driven allowlist fix lands in a follow-up PR that coordinates with deployment config.

### Frontend
- **apiClient dead headers** — removed `X-User-Email` / `X-User-Display-Name` from request headers. Both were stripped by the NyxID proxy and never read by the backend.
- **403 refresh bug** — token refresh now only triggers on 401, not 403. 403 = permission denied, refresh cannot fix it, and the previous retry path hammered the refresh endpoint on legitimate authz failures.

## Scope boundaries

- No `/api/*` behavior change for non-probe routes; existing clients work unchanged.
- `/livez` and `/readyz` added at root (outside `/api/*`); K8s manifests can migrate to them after this merges.
- CORS allowlist hardening deferred to a dedicated follow-up PR to coordinate with deployment configmap updates.

Part of #66 (Epic 1). Does not close the Epic 1 issue — remaining items (unified `AppError`, validation middleware, domain reorg, clients/nyxid grouping, CORS allowlist) ship in subsequent PRs.

## Test plan

- [ ] CI green (lint + typecheck (web) + test + build + gitleaks + check-changeset)
- [ ] `bun test` in `ornn-api/` — 136/136 pass (verified locally)
- [ ] Web typecheck green locally
- [ ] Post-merge: verify `/livez` returns 200 and `/readyz` returns 200 when Mongo is up, 503 when Mongo is intentionally stopped (dev cluster)
- [ ] Post-merge: verify response headers carry `X-Request-ID` on both success and error responses
- [ ] Post-merge: verify server logs include `requestId` field on `Request completed` lines
- [ ] Post-merge: verify a 403 response from any `ornn:*:admin` endpoint does not trigger a client-side token refresh (check Network tab — no `/oauth/token` call)