### PR TITLE
refactor: unify AppError class [part of #66]

### DIFF
--- a/.changeset/epic-1-unify-apperror.md
+++ b/.changeset/epic-1-unify-apperror.md
@@ -1,0 +1,11 @@
+---
+"ornn-api": patch
+---
+
+Epic 1: unify `AppError` class (part of #66).
+
+Previously two `AppError` classes existed — the canonical one in `shared/types/index.ts` and an inlined duplicate in `middleware/nyxidAuth.ts`. The global error handler had to fall back to duck-typing (`err.name === "AppError" && typeof err.statusCode === "number" && typeof err.code === "string"`) so errors thrown from either class were caught. A third class or subclass would silently slip past the check.
+
+- Delete the inlined copy in `nyxidAuth.ts`.
+- Import the canonical `AppError` from `shared/types/index`. No circular dependency (`shared/types/index.ts` has zero imports).
+- Replace duck-typing in `bootstrap.ts`'s `app.onError` with `instanceof AppError` — single source of truth, faster, and a third class would surface immediately as an unhandled error instead of being silently wrapped.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -268,15 +268,16 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     }, "Request completed");
   });
 
-  // Global error handler
-  // Use duck-typing: nyxidAuth inlines its own AppError class, so instanceof
-  // against the shared AppError fails across module boundaries.
+  // Global error handler — single `AppError` hierarchy across the whole
+  // service, so `instanceof` is sufficient (no more duck-typing).
   app.onError((err, c) => {
     const requestId = getRequestId(c);
-    const appErr = err as AppError;
-    if (appErr.name === "AppError" && typeof appErr.statusCode === "number" && typeof appErr.code === "string") {
-      logger.warn({ requestId, code: appErr.code, status: appErr.statusCode }, appErr.message);
-      return c.json({ data: null, error: { code: appErr.code, message: appErr.message } }, appErr.statusCode as any);
+    if (err instanceof AppError) {
+      logger.warn({ requestId, code: err.code, status: err.statusCode }, err.message);
+      return c.json(
+        { data: null, error: { code: err.code, message: err.message } },
+        err.statusCode as any,
+      );
     }
 
     logger.error({ requestId, err }, "Unhandled error");

--- a/ornn-api/src/middleware/nyxidAuth.ts
+++ b/ornn-api/src/middleware/nyxidAuth.ts
@@ -16,6 +16,7 @@
 import type { Context, Next } from "hono";
 import { createMiddleware } from "hono/factory";
 import pino from "pino";
+import { AppError } from "../shared/types/index";
 
 const logger = pino({ level: "info" }).child({ module: "nyxidAuth" });
 
@@ -75,21 +76,6 @@ export type AuthVariables = {
    */
   getUserOrgMemberships?: () => Promise<OrgMembershipFact[]>;
 };
-
-// ---------------------------------------------------------------------------
-// AppError (inlined to avoid circular dependency)
-// ---------------------------------------------------------------------------
-
-class AppError extends Error {
-  constructor(
-    public readonly statusCode: number,
-    public readonly code: string,
-    message: string,
-  ) {
-    super(message);
-    this.name = "AppError";
-  }
-}
 
 // ---------------------------------------------------------------------------
 // JWT decode (no verification — proxy already verified the token)


### PR DESCRIPTION
## Summary

Tiny but meaningful fix — remove the duplicated \`AppError\` class from \`middleware/nyxidAuth.ts\` and import the canonical one from \`shared/types/index\`.

### Why

Two classes existed with identical shape:
- \`ornn-api/src/shared/types/index.ts:19\` (canonical, with static factories)
- \`ornn-api/src/middleware/nyxidAuth.ts:83\` (inlined duplicate, no factories)

Because they're different classes in different modules, \`instanceof\` would fail for errors thrown from \`nyxidAuth.ts\`. The global handler in \`bootstrap.ts\` worked around it with duck-typing: \`err.name === \"AppError\" && typeof err.statusCode === \"number\" && typeof err.code === \"string\"\`. A third class or subclass would silently slip past and be wrapped as \`INTERNAL_ERROR\`.

The comment on the inlined class said \"inlined to avoid circular dependency\" — stale. \`shared/types/index.ts\` has zero imports, so no cycle is possible.

### Changes

- Delete inlined class in \`middleware/nyxidAuth.ts\`; import the canonical one.
- Replace duck-typing in \`bootstrap.ts\` \`app.onError\` with \`instanceof AppError\`.

Part of #66 (Epic 1).

## Test plan

- [ ] CI green
- [ ] \`bun test\` in \`ornn-api/\` — 136/136 pass (verified locally)
- [ ] Post-merge smoke: any auth-related error (e.g. hit an endpoint without NyxID proxy headers) returns the same \`{ data: null, error: { code: \"AUTH_MISSING\", message: \"Authentication required\" } }\` as before, with status 401