### PR TITLE
refactor: validate{Body,Query,Params} middleware + route migration [part of #66]

### DIFF
--- a/.changeset/epic-1-validate-middleware.md
+++ b/.changeset/epic-1-validate-middleware.md
@@ -1,0 +1,34 @@
+---
+"ornn-api": patch
+---
+
+Epic 1: request validation middleware (part of #66).
+
+New `ornn-api/src/middleware/validate.ts` replaces the per-route `c.req.json() → try/catch → schema.safeParse() → throw AppError` boilerplate with declarative composition: routes receive pre-validated data via typed helpers.
+
+```ts
+app.put(
+  "/skills/:id/permissions",
+  auth,
+  requirePermission("ornn:skill:update"),
+  validateBody(permissionsPatchSchema, "INVALID_PERMISSIONS"),
+  async (c) => {
+    const body = getValidatedBody<z.infer<typeof permissionsPatchSchema>>(c);
+    // ...
+  },
+);
+```
+
+Routes migrated:
+- `PUT /api/skills/:id/permissions` (body)
+- `PATCH /api/skills/:idOrName/versions/:version` (body)
+- `GET /api/skill-search` (query)
+- `POST /api/playground/chat` (body)
+- `POST /api/admin/categories` (body)
+- `PUT /api/admin/categories/:id` (body)
+- `POST /api/admin/tags` (body)
+- `GET /api/users/search` (query)
+
+External contract preserved: each route passes its existing error code (e.g. `INVALID_PERMISSIONS`, `INVALID_DEPRECATION_PATCH`) into `validateBody` / `validateQuery`. Error responses look identical to clients. Error code catalog collapse lands in Epic 2.
+
+Non-JSON bodies (ZIP uploads, multipart forms) keep their bespoke parsing — the middleware is `Content-Type: application/json` only.

--- a/ornn-api/src/domains/admin/routes.ts
+++ b/ornn-api/src/domains/admin/routes.ts
@@ -18,6 +18,7 @@ import {
   requirePermission,
   getAuth,
 } from "../../middleware/nyxidAuth";
+import { validateBody, getValidatedBody } from "../../middleware/validate";
 import { AppError } from "../../shared/types/index";
 import pino from "pino";
 
@@ -254,18 +255,11 @@ export function createAdminRoutes(config: AdminRoutesConfig): Hono<{ Variables: 
   app.post(
     "/admin/categories",
     requirePermission("ornn:admin:category"),
+    validateBody(createCategorySchema, "VALIDATION_ERROR"),
     async (c) => {
-      const body = await c.req.json();
-      const parsed = createCategorySchema.safeParse(body);
-      if (!parsed.success) {
-        throw AppError.badRequest(
-          "VALIDATION_ERROR",
-          parsed.error.issues.map((i) => i.message).join(", "),
-        );
-      }
-
-      const category = await adminService.createCategory(parsed.data);
-      logger.info({ name: parsed.data.name }, "Category created via admin API");
+      const body = getValidatedBody<z.infer<typeof createCategorySchema>>(c);
+      const category = await adminService.createCategory(body);
+      logger.info({ name: body.name }, "Category created via admin API");
       return c.json({ data: category, error: null }, 201);
     },
   );
@@ -273,18 +267,11 @@ export function createAdminRoutes(config: AdminRoutesConfig): Hono<{ Variables: 
   app.put(
     "/admin/categories/:id",
     requirePermission("ornn:admin:category"),
+    validateBody(updateCategorySchema, "VALIDATION_ERROR"),
     async (c) => {
       const id = c.req.param("id");
-      const body = await c.req.json();
-      const parsed = updateCategorySchema.safeParse(body);
-      if (!parsed.success) {
-        throw AppError.badRequest(
-          "VALIDATION_ERROR",
-          parsed.error.issues.map((i) => i.message).join(", "),
-        );
-      }
-
-      const category = await adminService.updateCategory(id, parsed.data);
+      const body = getValidatedBody<z.infer<typeof updateCategorySchema>>(c);
+      const category = await adminService.updateCategory(id, body);
       return c.json({ data: category, error: null });
     },
   );
@@ -316,17 +303,10 @@ export function createAdminRoutes(config: AdminRoutesConfig): Hono<{ Variables: 
   app.post(
     "/admin/tags",
     requirePermission("ornn:admin:skill"),
+    validateBody(createTagSchema, "VALIDATION_ERROR"),
     async (c) => {
-      const body = await c.req.json();
-      const parsed = createTagSchema.safeParse(body);
-      if (!parsed.success) {
-        throw AppError.badRequest(
-          "VALIDATION_ERROR",
-          parsed.error.issues.map((i) => i.message).join(", "),
-        );
-      }
-
-      const tag = await adminService.createTag(parsed.data.name);
+      const body = getValidatedBody<z.infer<typeof createTagSchema>>(c);
+      const tag = await adminService.createTag(body.name);
       return c.json({ data: tag, error: null }, 201);
     },
   );

--- a/ornn-api/src/domains/admin/routes.ts
+++ b/ornn-api/src/domains/admin/routes.ts
@@ -19,7 +19,6 @@ import {
   getAuth,
 } from "../../middleware/nyxidAuth";
 import { validateBody, getValidatedBody } from "../../middleware/validate";
-import { AppError } from "../../shared/types/index";
 import pino from "pino";
 
 const logger = pino({ level: "info" }).child({ module: "adminRoutes" });

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -14,7 +14,7 @@ import {
   requirePermission,
   getAuth,
 } from "../../middleware/nyxidAuth";
-import { AppError } from "../../shared/types/index";
+import { validateBody, getValidatedBody } from "../../middleware/validate";
 import pino from "pino";
 
 const logger = pino({ level: "info" }).child({ module: "playgroundRoutes" });
@@ -58,18 +58,12 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
   app.post(
     "/playground/chat",
     requirePermission("ornn:playground:use"),
+    validateBody(chatRequestSchema, "VALIDATION_ERROR"),
     async (c) => {
       const authCtx = getAuth(c);
-      const body = await c.req.json();
-      const parsed = chatRequestSchema.safeParse(body);
-      if (!parsed.success) {
-        throw AppError.badRequest(
-          "VALIDATION_ERROR",
-          parsed.error.issues.map((i) => i.message).join(", "),
-        );
-      }
+      const parsed = getValidatedBody<z.infer<typeof chatRequestSchema>>(c);
 
-      logger.info({ userId: authCtx.userId, messageCount: parsed.data.messages.length }, "Chat request");
+      logger.info({ userId: authCtx.userId, messageCount: parsed.messages.length }, "Chat request");
 
       c.header("Cache-Control", "no-cache");
       c.header("Connection", "keep-alive");
@@ -82,7 +76,7 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
 
         try {
           const signal = c.req.raw.signal;
-          const chatRequest: PlaygroundChatRequest = parsed.data;
+          const chatRequest: PlaygroundChatRequest = parsed;
 
           for await (const event of chatService.chat(authCtx.userId, chatRequest, signal)) {
             await stream.writeSSE({ data: JSON.stringify(event) });

--- a/ornn-api/src/domains/skillCrud/routes.ts
+++ b/ornn-api/src/domains/skillCrud/routes.ts
@@ -20,6 +20,7 @@ import {
   getAuth,
   readUserOrgMemberships,
 } from "../../middleware/nyxidAuth";
+import { validateBody, getValidatedBody } from "../../middleware/validate";
 import { AppError } from "../../shared/types/index";
 import { canReadSkill, canManageSkill } from "./authorize";
 import pino from "pino";
@@ -213,6 +214,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     "/skills/:idOrName/versions/:version",
     auth,
     requirePermission("ornn:skill:update"),
+    validateBody(deprecationPatchSchema, "INVALID_DEPRECATION_PATCH"),
     async (c) => {
       const idOrName = c.req.param("idOrName");
       const version = c.req.param("version");
@@ -237,23 +239,12 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         );
       }
 
-      let body: unknown;
-      try {
-        body = await c.req.json();
-      } catch {
-        throw AppError.badRequest("INVALID_BODY", "Request body must be valid JSON");
-      }
-      const parsed = deprecationPatchSchema.safeParse(body);
-      if (!parsed.success) {
-        const msg = parsed.error.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ");
-        throw AppError.badRequest("INVALID_DEPRECATION_PATCH", msg);
-      }
-
+      const body = getValidatedBody<z.infer<typeof deprecationPatchSchema>>(c);
       const result = await skillService.setVersionDeprecation(
         idOrName,
         version,
-        parsed.data.isDeprecated,
-        parsed.data.deprecationNote ?? null,
+        body.isDeprecated,
+        body.deprecationNote ?? null,
       );
 
       activityRepo
@@ -371,6 +362,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     "/skills/:id/permissions",
     auth,
     requirePermission("ornn:skill:update"),
+    validateBody(permissionsPatchSchema, "INVALID_PERMISSIONS"),
     async (c) => {
       const guid = c.req.param("id");
       const authCtx = getAuth(c);
@@ -392,21 +384,8 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         );
       }
 
-      let body: unknown;
-      try {
-        body = await c.req.json();
-      } catch {
-        throw AppError.badRequest("INVALID_BODY", "Request body must be valid JSON");
-      }
-      const parsed = permissionsPatchSchema.safeParse(body);
-      if (!parsed.success) {
-        throw AppError.badRequest(
-          "INVALID_PERMISSIONS",
-          parsed.error.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; "),
-        );
-      }
-
-      const updated = await skillService.setSkillPermissions(guid, authCtx.userId, parsed.data);
+      const body = getValidatedBody<z.infer<typeof permissionsPatchSchema>>(c);
+      const updated = await skillService.setSkillPermissions(guid, authCtx.userId, body);
 
       activityRepo?.log(authCtx.userId, authCtx.email, authCtx.displayName, "skill:permissions_change", {
         skillId: guid,

--- a/ornn-api/src/domains/skillSearch/routes.ts
+++ b/ornn-api/src/domains/skillSearch/routes.ts
@@ -16,6 +16,7 @@ import {
   optionalAuthMiddleware,
   readUserOrgIds,
 } from "../../middleware/nyxidAuth";
+import { validateQuery, getValidatedQuery } from "../../middleware/validate";
 import { AppError } from "../../shared/types/index";
 import pino from "pino";
 
@@ -82,38 +83,16 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
   app.get(
     "/skill-search",
     optionalAuth,
+    validateQuery(searchQuerySchema, "INVALID_QUERY"),
     async (c) => {
-      const raw = {
-        query: c.req.query("query"),
-        mode: c.req.query("mode"),
-        scope: c.req.query("scope"),
-        page: c.req.query("page"),
-        pageSize: c.req.query("pageSize"),
-        model: c.req.query("model"),
-        systemFilter: c.req.query("systemFilter"),
-        sharedWithOrgs: c.req.query("sharedWithOrgs"),
-        sharedWithUsers: c.req.query("sharedWithUsers"),
-        createdByAny: c.req.query("createdByAny"),
-      };
-
-      const parsed = searchQuerySchema.safeParse(raw);
-      if (!parsed.success) {
-        throw AppError.badRequest(
-          "INVALID_QUERY",
-          parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", "),
-        );
-      }
-
-      const { query, mode, page, pageSize, model, systemFilter } = parsed.data;
+      const parsed = getValidatedQuery<z.infer<typeof searchQuerySchema>>(c);
+      const { query, mode, page, pageSize, model, systemFilter } = parsed;
       const authCtx = c.get("auth");
       const isAnonymous = !authCtx;
 
       // Anonymous users can only search public scope.
       // `shared-with-me` implies an identified caller — collapse to public for anonymous.
-      const requestedScope = parsed.data.scope;
-      const scope = isAnonymous
-        ? "public"
-        : requestedScope;
+      const scope = isAnonymous ? "public" : parsed.scope;
       const currentUserId = authCtx?.userId ?? "";
 
       if (mode === "semantic") {
@@ -153,9 +132,9 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
         model,
         callerServices,
         systemFilter,
-        sharedWithOrgsAny: parseCsv(parsed.data.sharedWithOrgs),
-        sharedWithUsersAny: parseCsv(parsed.data.sharedWithUsers),
-        createdByAny: parseCsv(parsed.data.createdByAny),
+        sharedWithOrgsAny: parseCsv(parsed.sharedWithOrgs),
+        sharedWithUsersAny: parseCsv(parsed.sharedWithUsers),
+        createdByAny: parseCsv(parsed.createdByAny),
       });
 
       return c.json({ data: response, error: null });

--- a/ornn-api/src/domains/users/routes.ts
+++ b/ornn-api/src/domains/users/routes.ts
@@ -18,7 +18,7 @@ import {
   type AuthVariables,
   nyxidAuthMiddleware,
 } from "../../middleware/nyxidAuth";
-import { AppError } from "../../shared/types/index";
+import { validateQuery, getValidatedQuery } from "../../middleware/validate";
 
 const searchQuerySchema = z.object({
   q: z.string().max(256).optional().default(""),
@@ -42,21 +42,16 @@ export function createUserRoutes(config: UserRoutesConfig): Hono<{ Variables: Au
    * set is scoped to users who have actually interacted with Ornn
    * (have an activity row).
    */
-  app.get("/users/search", auth, async (c) => {
-    const parsed = searchQuerySchema.safeParse({
-      q: c.req.query("q"),
-      limit: c.req.query("limit"),
-    });
-    if (!parsed.success) {
-      throw AppError.badRequest(
-        "INVALID_QUERY",
-        parsed.error.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; "),
-      );
-    }
-
-    const results = await activityRepo.searchUsersByEmail(parsed.data.q, parsed.data.limit);
-    return c.json({ data: { items: results }, error: null });
-  });
+  app.get(
+    "/users/search",
+    auth,
+    validateQuery(searchQuerySchema, "INVALID_QUERY"),
+    async (c) => {
+      const parsed = getValidatedQuery<z.infer<typeof searchQuerySchema>>(c);
+      const results = await activityRepo.searchUsersByEmail(parsed.q, parsed.limit);
+      return c.json({ data: { items: results }, error: null });
+    },
+  );
 
   /**
    * GET /users/resolve?ids=id1,id2,...

--- a/ornn-api/src/middleware/validate.ts
+++ b/ornn-api/src/middleware/validate.ts
@@ -1,0 +1,131 @@
+/**
+ * Request validation middleware.
+ *
+ * Replaces the per-route `c.req.json() → try/catch → schema.safeParse() →
+ * throw AppError` boilerplate with declarative composition:
+ *
+ *   app.post(
+ *     "/skills",
+ *     auth,
+ *     requirePermission("ornn:skill:create"),
+ *     validateBody(skillCreateSchema, "INVALID_SKILL_BODY"),
+ *     async (c) => {
+ *       const data = getValidatedBody<z.infer<typeof skillCreateSchema>>(c);
+ *       ...
+ *     },
+ *   );
+ *
+ * Each middleware stores its parsed value under a well-known context
+ * key; handlers read it via `getValidatedBody` / `getValidatedQuery` /
+ * `getValidatedParams`. Typed helpers keep route code honest without
+ * forcing every handler into a generic Hono type chain.
+ *
+ * Error code is caller-supplied so the external contract stays stable
+ * (e.g. `INVALID_TOPIC_UPDATE` remains `INVALID_TOPIC_UPDATE`). Epic 2
+ * collapses the catalog; this middleware is the seam that makes the
+ * one-line change possible.
+ *
+ * Non-JSON body routes (ZIP uploads, multipart forms) keep their
+ * bespoke parsing — this middleware is for `Content-Type:
+ * application/json` only.
+ *
+ * @module middleware/validate
+ */
+
+import type { Context, MiddlewareHandler } from "hono";
+import type { z } from "zod";
+import { AppError } from "../shared/types/index";
+
+const BODY_KEY = "validatedBody";
+const QUERY_KEY = "validatedQuery";
+const PARAMS_KEY = "validatedParams";
+
+function formatIssues(issues: z.ZodIssue[]): string {
+  return issues
+    .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+    .join("; ");
+}
+
+/**
+ * Validate a JSON request body against a Zod schema. Throws 400 with
+ * `errorCode` when the body is missing, not valid JSON, or fails the
+ * schema.
+ */
+export function validateBody<T extends z.ZodTypeAny>(
+  schema: T,
+  errorCode: string = "INVALID_BODY",
+): MiddlewareHandler {
+  return async (c, next) => {
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch {
+      throw AppError.badRequest(errorCode, "Request body must be valid JSON");
+    }
+    const result = schema.safeParse(raw);
+    if (!result.success) {
+      throw AppError.badRequest(errorCode, formatIssues(result.error.issues));
+    }
+    c.set(BODY_KEY, result.data);
+    await next();
+  };
+}
+
+/**
+ * Validate `c.req.query()` entries against a Zod schema. Useful for
+ * list / search endpoints — the schema usually declares `z.coerce` for
+ * numeric filters and optional defaults for pagination.
+ */
+export function validateQuery<T extends z.ZodTypeAny>(
+  schema: T,
+  errorCode: string = "INVALID_QUERY",
+): MiddlewareHandler {
+  return async (c, next) => {
+    const raw: Record<string, string | undefined> = {};
+    for (const [key, value] of Object.entries(c.req.query())) {
+      raw[key] = value;
+    }
+    const result = schema.safeParse(raw);
+    if (!result.success) {
+      throw AppError.badRequest(errorCode, formatIssues(result.error.issues));
+    }
+    c.set(QUERY_KEY, result.data);
+    await next();
+  };
+}
+
+/**
+ * Validate path params against a Zod schema. Less commonly needed but
+ * useful when a param has a constrained shape (e.g. UUID, version
+ * string).
+ */
+export function validateParams<T extends z.ZodTypeAny>(
+  schema: T,
+  errorCode: string = "INVALID_PARAMS",
+): MiddlewareHandler {
+  return async (c, next) => {
+    const result = schema.safeParse(c.req.param());
+    if (!result.success) {
+      throw AppError.badRequest(errorCode, formatIssues(result.error.issues));
+    }
+    c.set(PARAMS_KEY, result.data);
+    await next();
+  };
+}
+
+/**
+ * Typed accessor. The generic is a hint for the caller — the runtime
+ * value is whatever `validateBody(...)` actually parsed. Keep the
+ * generic aligned with the schema that populated it.
+ */
+export function getValidatedBody<T>(c: Context): T {
+  return c.get(BODY_KEY) as T;
+}
+
+export function getValidatedQuery<T>(c: Context): T {
+  return c.get(QUERY_KEY) as T;
+}
+
+export function getValidatedParams<T>(c: Context): T {
+  return c.get(PARAMS_KEY) as T;
+}


### PR DESCRIPTION
## Summary

DRY up request validation. New \`middleware/validate.ts\` replaces the per-route boilerplate across 8 routes.

### Before (every route)
\`\`\`ts
let raw: unknown;
try {
  raw = await c.req.json();
} catch {
  throw AppError.badRequest(\"INVALID_BODY\", \"...\");
}
const parsed = someSchema.safeParse(raw);
if (!parsed.success) {
  throw AppError.badRequest(\"INVALID_XXX\", parsed.error.issues.map(...).join(\"; \"));
}
const data = parsed.data;
\`\`\`

### After
\`\`\`ts
app.post(
  \"/path\",
  auth,
  requirePermission(\"...\"),
  validateBody(someSchema, \"INVALID_XXX\"),
  async (c) => {
    const data = getValidatedBody<z.infer<typeof someSchema>>(c);
    ...
  },
);
\`\`\`

### Routes migrated (8)

| Route | Validator |
|---|---|
| \`PUT /api/skills/:id/permissions\` | \`validateBody\` |
| \`PATCH /api/skills/:idOrName/versions/:version\` | \`validateBody\` |
| \`GET /api/skill-search\` | \`validateQuery\` |
| \`POST /api/playground/chat\` | \`validateBody\` |
| \`POST /api/admin/categories\` | \`validateBody\` |
| \`PUT /api/admin/categories/:id\` | \`validateBody\` |
| \`POST /api/admin/tags\` | \`validateBody\` |
| \`GET /api/users/search\` | \`validateQuery\` |

### External contract

Unchanged. Each route passes its existing error code (\`INVALID_PERMISSIONS\`, \`INVALID_DEPRECATION_PATCH\`, etc.) into the middleware. Response bodies look identical. Epic 2 collapses the catalog.

### Non-scope

- Non-JSON body routes (\`POST /skills\` ZIP, \`PUT /skills/:id\` hybrid, \`POST /skills/generate\` multipart, \`POST /skill-format/validate\` ZIP) keep their bespoke parsing. The middleware targets \`application/json\` only.
- Admin list endpoints (\`/admin/activities\`, \`/admin/users\`, \`/admin/skills\`, \`/admin/tags\`) parse query params manually without Zod schemas — out of scope here.

Part of #66 (Epic 1).

## Test plan

- [ ] CI green
- [ ] 136 backend tests pass (verified locally)
- [ ] Web typecheck green
- [ ] Post-merge smoke: every migrated route returns the same error codes/messages for invalid input as before