### PR TITLE
[Feature] Epic 2 prep: Reserved-verb DB audit

### DIFF
--- a/.changeset/reserved-verbs-audit.md
+++ b/.changeset/reserved-verbs-audit.md
@@ -1,0 +1,18 @@
+---
+"ornn-api": patch
+---
+
+Reserved-verb enforcement + DB audit tooling (closes #69).
+
+Epic 2's `/v1/skills/{verb}` sub-resource action paths (`format`, `validate`, `search`, `counts`, `generate`, `lookup`) take router priority over `:id` captures, so a skill named after any of these verbs would become unreachable via its canonical read endpoint.
+
+This PR ships the enforcement + an audit tool:
+
+- **`ornn-api/src/shared/reservedVerbs.ts`** — single-source catalog of reserved verbs per resource. `isReservedVerb("skill", name)` is the check.
+- **`SkillService.createSkill`** rejects reserved names with `RESERVED_NAME` (400) before the uniqueness check. Covers all create paths (direct API upload, skill generation).
+- **`ornn-api/scripts/audit-reserved-verbs.ts`** — new one-shot script, exposed as `bun run audit:reserved-verbs`. Scans the `skills` collection for name collisions and exits non-zero when any are found. **Must be run against prod once before the Epic 2 deploy** so any colliding rows can be renamed with their owners' consent.
+- **`ornn-api/src/shared/reservedVerbs.test.ts`** — unit tests for the catalog + guard.
+
+Category and tag names currently use constrained whitelists (fixed enum / regex), so no enforcement needed on those paths yet. The `RESERVED_VERBS.category` / `RESERVED_VERBS.tag` slots are present and empty, ready for future v1-style action paths if any are added.
+
+Frontend mirror deferred: the skill name comes from `SKILL.md` frontmatter inside the uploaded ZIP, not a UI input — server-side enforcement is the only gate worth mirroring. If future skill-generation flows introduce a name input, a `ornn-web/src/lib/reservedVerbs.ts` mirror is a small follow-up.

--- a/ornn-api/package.json
+++ b/ornn-api/package.json
@@ -9,7 +9,8 @@
     "test": "bun test",
     "migrate:versions": "bun run scripts/migrate-skill-versions.ts",
     "migrate:ownership": "bun run scripts/migrate-skill-ownership.ts",
-    "migrate:drop-topics": "bun run scripts/drop-topics.ts"
+    "migrate:drop-topics": "bun run scripts/drop-topics.ts",
+    "audit:reserved-verbs": "bun run scripts/audit-reserved-verbs.ts"
   },
   "dependencies": {
     "@xenova/transformers": "^2.17.0",

--- a/ornn-api/scripts/audit-reserved-verbs.ts
+++ b/ornn-api/scripts/audit-reserved-verbs.ts
@@ -1,0 +1,72 @@
+/**
+ * Audit script: find existing `skills` (and `categories`) whose names
+ * collide with reserved API-v1 action verbs. Report-only — run this
+ * before deploying the Epic 2 `/v1/` cut so any colliding rows can be
+ * renamed beforehand (otherwise the canonical read endpoint for those
+ * resources becomes unreachable).
+ *
+ * Run with (from ornn-api/):
+ *   MONGODB_URI=... MONGODB_DB=... bun run audit:reserved-verbs
+ *
+ * Exit code:
+ *   0 — no collisions
+ *   1 — collisions found (rows printed to stdout)
+ *
+ * @module scripts/audit-reserved-verbs
+ */
+
+import { MongoClient } from "mongodb";
+import { RESERVED_VERBS } from "../src/shared/reservedVerbs";
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const MONGODB_DB = process.env.MONGODB_DB ?? "ornn";
+
+if (!MONGODB_URI) {
+  console.error("MONGODB_URI is required");
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const client = new MongoClient(MONGODB_URI as string);
+  await client.connect();
+  const db = client.db(MONGODB_DB);
+
+  console.log(`Scanning ${MONGODB_DB}...`);
+
+  let totalCollisions = 0;
+
+  for (const [resource, verbs] of Object.entries(RESERVED_VERBS)) {
+    if (verbs.length === 0) continue;
+    const collection = resource === "category" ? "categories" : `${resource}s`;
+    const rows = await db
+      .collection(collection)
+      .find({ name: { $in: verbs as string[] } })
+      .project({ _id: 1, name: 1, createdBy: 1, createdByEmail: 1, isPrivate: 1 })
+      .toArray();
+
+    if (rows.length === 0) {
+      console.log(`[${collection}] 0 collisions against ${verbs.length} reserved verbs`);
+      continue;
+    }
+
+    totalCollisions += rows.length;
+    console.log(`[${collection}] ${rows.length} collision(s):`);
+    for (const row of rows) {
+      console.log(`  - name=${row.name}  _id=${row._id}  createdBy=${row.createdBy ?? "-"}  email=${row.createdByEmail ?? "-"}  isPrivate=${row.isPrivate ?? "-"}`);
+    }
+  }
+
+  await client.close();
+
+  if (totalCollisions > 0) {
+    console.log(`\nFound ${totalCollisions} row(s) with reserved-verb names.`);
+    console.log(`Rename these rows (coordinate with owners) before deploying the /v1/ cut.`);
+    process.exit(1);
+  }
+  console.log(`\nNo collisions. Safe to deploy reserved-verb enforcement.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -11,6 +11,7 @@ import type { SkillVersionRepository } from "./skillVersionRepository";
 import type { IStorageClient } from "../../../clients/storageClient";
 import type { SkillDocument, SkillMetadata, SkillDetailResponse, SkillVersionDocument } from "../../../shared/types/index";
 import { AppError } from "../../../shared/types/index";
+import { isReservedVerb } from "../../../shared/reservedVerbs";
 import { validateSkillFrontmatter } from "../../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../../shared/utils/zip";
 import { parseVersion, isGreater } from "./version";
@@ -81,7 +82,16 @@ export class SkillService {
     const { name, description, version, license, compatibility, metadata } = await this.extractSkillInfo(zipBuffer);
     const parsedVersion = parseVersion(version);
 
-    // 3. Check name uniqueness
+    // 3a. Reject reserved-verb names — would collide with `/v1/skills/{verb}`
+    //     action paths and make the skill unreachable via the canonical read.
+    if (isReservedVerb("skill", name)) {
+      throw AppError.badRequest(
+        "RESERVED_NAME",
+        `Skill name '${name}' is reserved — pick a different name`,
+      );
+    }
+
+    // 3b. Check name uniqueness
     const existing = await this.skillRepo.findByName(name);
     if (existing) {
       throw AppError.conflict("SKILL_NAME_EXISTS", `Skill '${name}' already exists`);

--- a/ornn-api/src/shared/reservedVerbs.test.ts
+++ b/ornn-api/src/shared/reservedVerbs.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test";
+import { RESERVED_VERBS, isReservedVerb } from "./reservedVerbs";
+
+describe("reservedVerbs", () => {
+  test("skill verbs cover the v1 action paths", () => {
+    expect(RESERVED_VERBS.skill).toEqual([
+      "format",
+      "validate",
+      "search",
+      "counts",
+      "generate",
+      "lookup",
+    ]);
+  });
+
+  test("category and tag have no reserved verbs yet", () => {
+    expect(RESERVED_VERBS.category).toEqual([]);
+    expect(RESERVED_VERBS.tag).toEqual([]);
+  });
+
+  test("isReservedVerb detects skill collisions", () => {
+    expect(isReservedVerb("skill", "format")).toBe(true);
+    expect(isReservedVerb("skill", "validate")).toBe(true);
+    expect(isReservedVerb("skill", "generate")).toBe(true);
+    expect(isReservedVerb("skill", "search")).toBe(true);
+    expect(isReservedVerb("skill", "counts")).toBe(true);
+    expect(isReservedVerb("skill", "lookup")).toBe(true);
+  });
+
+  test("isReservedVerb is case-sensitive (matches canonical kebab-case)", () => {
+    expect(isReservedVerb("skill", "Format")).toBe(false);
+    expect(isReservedVerb("skill", "FORMAT")).toBe(false);
+  });
+
+  test("isReservedVerb allows safe names", () => {
+    expect(isReservedVerb("skill", "pdf-extract")).toBe(false);
+    expect(isReservedVerb("skill", "my-skill")).toBe(false);
+    expect(isReservedVerb("skill", "formatter")).toBe(false); // substring OK
+  });
+
+  test("isReservedVerb returns false for resources with no reserved verbs", () => {
+    expect(isReservedVerb("category", "format")).toBe(false);
+    expect(isReservedVerb("tag", "generate")).toBe(false);
+  });
+});

--- a/ornn-api/src/shared/reservedVerbs.ts
+++ b/ornn-api/src/shared/reservedVerbs.ts
@@ -1,0 +1,28 @@
+/**
+ * Reserved action verbs per resource.
+ *
+ * Under the API v1 convention (`docs/conventions.md` §2.3), custom
+ * actions live as sub-resource paths — `POST /v1/skills/generate`,
+ * `POST /v1/skills/validate`, etc. Router configs give these static
+ * segments priority over `:id` captures, which means a resource named
+ * the same as a reserved verb becomes unreachable via its canonical
+ * read endpoint.
+ *
+ * To prevent silently losing access to data, create-time validation
+ * rejects names matching this list. Any migration of existing rows with
+ * colliding names ships separately (see issue #69).
+ *
+ * @module shared/reservedVerbs
+ */
+
+export const RESERVED_VERBS = {
+  skill: ["format", "validate", "search", "counts", "generate", "lookup"],
+  category: [] as string[],
+  tag: [] as string[],
+} as const satisfies Record<string, readonly string[]>;
+
+export type ReservedResource = keyof typeof RESERVED_VERBS;
+
+export function isReservedVerb(resource: ReservedResource, name: string): boolean {
+  return (RESERVED_VERBS[resource] as readonly string[]).includes(name);
+}


### PR DESCRIPTION
## Summary

Closes #69. Adds reserved-verb enforcement at skill-create time + a one-shot DB audit script that **must be run against prod before the Epic 2 deploy**.

### Why

Epic 2's \`/v1/skills/{verb}\` sub-resource action paths (\`format\`, \`validate\`, \`search\`, \`counts\`, \`generate\`, \`lookup\`) take router priority over \`:id\` captures. A skill named after any of these verbs would become unreachable via its canonical read endpoint — users would silently lose access to their data. This PR prevents the problem going forward and ships a tool to catch any existing rows.

### Changes

- **\`ornn-api/src/shared/reservedVerbs.ts\`** — single-source catalog with an \`isReservedVerb(resource, name)\` guard.
- **\`SkillService.createSkill\`** rejects reserved names with \`RESERVED_NAME\` (400) before the uniqueness check.
- **\`ornn-api/scripts/audit-reserved-verbs.ts\`** — one-shot scanner, exposed as \`bun run audit:reserved-verbs\`. Non-zero exit on any collisions.
- **\`reservedVerbs.test.ts\`** — unit tests.

Category and tag creation already constrain names via enum / regex whitelists, so no enforcement needed on those paths. The \`RESERVED_VERBS.category\` / \`RESERVED_VERBS.tag\` slots are present and empty.

### Audit procedure (must complete before Epic 2 deploy)

\`\`\`bash
# dev
MONGODB_URI=<dev> MONGODB_DB=ornn bun run audit:reserved-verbs

# staging
MONGODB_URI=<staging> MONGODB_DB=ornn bun run audit:reserved-verbs

# production (read-only)
MONGODB_URI=<prod> MONGODB_DB=ornn bun run audit:reserved-verbs
\`\`\`

If any row is returned, rename it with the owner's consent before #68 deploys. Since reserved-verb rejection is now in place, no new colliding rows can be created post-merge.

Part of Epic 2 (#68).

## Test plan

- [ ] CI green
- [ ] \`bun test\` passes (142/142 — 6 new tests for \`reservedVerbs\`)
- [ ] Post-merge: dry-run \`audit:reserved-verbs\` against staging DB. If clean, run against prod DB. If any hits, file a tracking issue for rename before #68 merges.
- [ ] Post-merge smoke: try creating a skill with name \`format\` via an agent or ornn-web — expect 400 \`RESERVED_NAME\`.