### PR TITLE
[Feature] Epic 4b: graceful shutdown timeout [part of #72]

### DIFF
--- a/.changeset/epic-4b-graceful-shutdown.md
+++ b/.changeset/epic-4b-graceful-shutdown.md
@@ -1,0 +1,19 @@
+---
+"ornn-api": patch
+---
+
+Epic 4b: graceful shutdown timeout (part of #72).
+
+`index.ts` now wraps `shutdown()` in a 25s deadline. K8s sends `SIGTERM` then `SIGKILL`s after `terminationGracePeriodSeconds` (default 30s). A stuck Mongo close could hang past that window, leading to dirty pod termination and non-deterministic exit codes.
+
+The new `gracefulShutdown(signal)`:
+- logs the received signal
+- arms a `setTimeout` with `.unref()` so it doesn't block exit when shutdown resolves early
+- awaits `shutdown()` (MongoDB close etc.)
+- on success: `clearTimeout` + `process.exit(0)`
+- on error: `clearTimeout` + log + `process.exit(1)`
+- on timeout: `logger.fatal` + `process.exit(1)`
+
+Exit codes are now deterministic (0 for clean, 1 for any failure or timeout) so the ops dashboard can alert cleanly on non-clean shutdowns.
+
+Scope note: the lint rule enforcing "routes do not import repositories directly" is deferred. All current offending imports are type-only (`import type`), which ESLint's `no-restricted-imports` can't ergonomically distinguish from value imports. Enforcing the real boundary (route handlers calling repo methods directly) requires first refactoring routes to depend on services only — separate follow-up issue.

--- a/ornn-api/src/index.ts
+++ b/ornn-api/src/index.ts
@@ -29,16 +29,39 @@ logger.info({ port: config.port }, "ornn-api starting");
 
 const { app, shutdown } = await bootstrap(config);
 
-// Graceful shutdown
-process.on("SIGTERM", async () => {
-  logger.info("Received SIGTERM");
-  await shutdown();
-  process.exit(0);
+// Graceful shutdown with a hard-deadline fallback. K8s sends SIGTERM
+// then SIGKILLs after `terminationGracePeriodSeconds` (default 30s). A
+// stuck Mongo close can hang the service past that window; the timeout
+// here force-exits before K8s notices so pod termination logs stay
+// clean and we get a deterministic exit code we can alert on.
+const SHUTDOWN_TIMEOUT_MS = 25_000;
+
+async function gracefulShutdown(signal: string): Promise<void> {
+  logger.info({ signal }, "Shutdown signal received");
+  const timeout = setTimeout(() => {
+    logger.fatal({ signal, timeoutMs: SHUTDOWN_TIMEOUT_MS }, "Shutdown timed out, forcing exit");
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+  // Allow Node to exit as soon as shutdown resolves, even if the timer is still active.
+  timeout.unref();
+
+  try {
+    await shutdown();
+    clearTimeout(timeout);
+    logger.info({ signal }, "Graceful shutdown complete");
+    process.exit(0);
+  } catch (err) {
+    clearTimeout(timeout);
+    logger.error({ signal, err }, "Graceful shutdown failed");
+    process.exit(1);
+  }
+}
+
+process.on("SIGTERM", () => {
+  void gracefulShutdown("SIGTERM");
 });
-process.on("SIGINT", async () => {
-  logger.info("Received SIGINT");
-  await shutdown();
-  process.exit(0);
+process.on("SIGINT", () => {
+  void gracefulShutdown("SIGINT");
 });
 
 export default {


### PR DESCRIPTION
## Summary

Small focused PR. Wraps \`shutdown()\` in a 25s deadline with deterministic exit codes so a stuck Mongo close can't hang past the K8s \`terminationGracePeriodSeconds\` window.

### Change

\`ornn-api/src/index.ts\`:

\`\`\`ts
async function gracefulShutdown(signal: string) {
  logger.info({ signal }, "Shutdown signal received");
  const timeout = setTimeout(() => {
    logger.fatal({ signal, timeoutMs: SHUTDOWN_TIMEOUT_MS }, "Shutdown timed out, forcing exit");
    process.exit(1);
  }, SHUTDOWN_TIMEOUT_MS);
  timeout.unref();
  try {
    await shutdown();
    clearTimeout(timeout);
    logger.info({ signal }, "Graceful shutdown complete");
    process.exit(0);
  } catch (err) {
    clearTimeout(timeout);
    logger.error({ signal, err }, "Graceful shutdown failed");
    process.exit(1);
  }
}
\`\`\`

### Exit-code contract

| Situation | Exit code |
|---|---|
| Clean shutdown within 25s | 0 |
| Shutdown threw | 1 |
| Timed out (still running at 25s) | 1 |

Ops can alert on non-zero exit without ambiguity.

### Scope note

Lint rule for \"routes must not import repositories\" is **deferred**. Every current offending import in \`ornn-api/src/domains/*/routes.ts\` is \`import type\` — ESLint's \`no-restricted-imports\` can't ergonomically separate type-only from value imports. The real boundary (handlers calling repo methods directly) needs a routes-depend-on-services-only refactor first. Separate follow-up issue.

Part of #72 (Epic 4).

## Test plan

- [ ] CI green
- [ ] Post-merge: verify K8s rolling restart cycles clean (exit 0 in logs); trigger a stuck-Mongo scenario on dev cluster (e.g., SIGSTOP the Mongo container during rollout) and confirm the fatal log + exit 1 after 25s