### PR TITLE
[CI/CD] Epic 4c: ESLint route↛repo boundary rule [part of #72]

### DIFF
--- a/.changeset/epic-4c-boundary-lint.md
+++ b/.changeset/epic-4c-boundary-lint.md
@@ -1,0 +1,15 @@
+---
+"ornn-api": patch
+---
+
+Epic 4c: ESLint rule enforcing the route↛repository boundary at import time (part of #72).
+
+`eslint.config.js` now rejects **runtime** imports of `**/repository`, `**/repositories/*`, and `**/activityRepository` from files matching `ornn-api/src/domains/**/routes.ts`. `import type { ... }` is still allowed via `allowTypeImports: true` — routes still need repo types to type their Config interfaces.
+
+Current state:
+- All 8 existing repo imports in route files are `import type`, so lint remains clean at introduction.
+- Any new code that does `import { SkillRepository } from ".../repository"` (runtime) inside a routes file fails CI.
+
+Scope note:
+- This catches the **easy** class of boundary violation (runtime repo imports).
+- The **harder** class — routes invoking methods on config-passed repo instances at runtime (e.g. `skillRepo.findByGuid()` inside a handler) — needs a custom rule or a structural refactor (push remaining direct calls into services + pass services only into route factories). Tracked as follow-up; defer until the service-layer cleanup work.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,4 +28,39 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "warn",
     },
   },
+  // Architecture boundary: route handlers must not invoke repositories
+  // directly. Routes depend on services; services own data access.
+  //
+  // This rule catches only *runtime* repo imports in route files.
+  // `import type { ... }` is still allowed so route files can type
+  // their Config interfaces off the repository classes (common pattern
+  // while the full service-extraction refactor is pending).
+  //
+  // Catches the easy case. The harder case (runtime method calls via
+  // config-passed repo instances) requires a custom rule; tracked as
+  // follow-up to Epic 4.
+  {
+    files: ["ornn-api/src/domains/**/routes.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/repository", "**/repositories/*"],
+              message:
+                "Routes must not import repositories at runtime. Use the service layer instead. `import type` is still allowed.",
+              allowTypeImports: true,
+            },
+            {
+              group: ["**/activityRepository"],
+              message:
+                "Routes must not import ActivityRepository at runtime. Use ActivityService (or the domain service) instead. `import type` is still allowed.",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
+  },
 );


### PR DESCRIPTION
## Summary

Tiny PR — one ESLint config block. Forbids **runtime** repository imports from route files.

### The rule

\`eslint.config.js\`:

\`\`\`js
{
  files: [\"ornn-api/src/domains/**/routes.ts\"],
  rules: {
    \"no-restricted-imports\": [\"error\", {
      patterns: [
        {
          group: [\"**/repository\", \"**/repositories/*\"],
          message: \"...\",
          allowTypeImports: true,
        },
        {
          group: [\"**/activityRepository\"],
          message: \"...\",
          allowTypeImports: true,
        },
      ],
    }],
  },
},
\`\`\`

\`import type { ... }\` is still allowed so route files can type their Config interfaces off the repository classes. All 8 existing repo imports in route files are type-only — lint stays clean at introduction.

### What it catches

- ✅ \`import { SkillRepository } from \"./repository\"\` in \`routes.ts\` → CI fail
- ❌ \`import type { SkillRepository } from \"./repository\"\` → still allowed
- ❌ \`skillRepo.findByGuid(...)\` inside a handler (runtime method call via config-passed repo instance) → NOT caught; needs custom rule or structural refactor

### Follow-up

The harder case (runtime method calls on config-passed repo instances) needs service-extraction refactor: push the direct calls into services, change route Config interfaces to accept only services, then tighten the rule further. Deferred — tracked as follow-up to Epic 4.

Part of #72 (Epic 4).

## Test plan

- [ ] CI green
- [ ] Temporarily add \`import { SkillRepository } from \"./repository\"\` (value import) to a route file → lint fails with the custom message → revert (smoke-test the rule actually triggers)