### PR TITLE
[CI/CD] ci(release): move version bump to develop-side, main-push only tags

### DIFF
--- a/.changeset/release-flow-main-direct.md
+++ b/.changeset/release-flow-main-direct.md
@@ -1,0 +1,4 @@
+---
+---
+
+Release flow refactor: version bump now happens on `develop` (via `bun run release:prep`) before a `develop → main` PR. The changeset-release workflow on `main` only tags + creates GitHub Releases — it no longer tries to open a Version Packages PR, which sidesteps the org-level "Allow GitHub Actions to create and approve pull requests" restriction. No runtime code changes; tooling + CLAUDE.md only.

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -1,8 +1,16 @@
 name: Changeset release
 
+# Runs when something lands on `main`. At that point the Version Packages
+# bump (consume .changeset, update package.json + CHANGELOG) has already
+# happened via `bun run release:prep` on develop. This workflow only
+# handles the tag + GitHub Release half.
+#
+# Hard-guards against a main push that still carries unconsumed changesets
+# — that would mean the release:prep flow was skipped.
+
 on:
   push:
-    branches: [develop]
+    branches: [main]
 
 concurrency:
   group: changeset-release
@@ -13,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,12 +30,22 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: Create release PR or tag
+      - name: Guard — no pending changesets on main
+        run: |
+          PENDING=$(find .changeset -name "*.md" ! -name "README.md" 2>/dev/null | wc -l | xargs)
+          if [ "$PENDING" != "0" ]; then
+            echo "::error::Found ${PENDING} unconsumed .changeset/*.md files on main."
+            echo "::error::Run 'bun run release:prep' on develop first, merge that PR, then promote develop → main."
+            exit 1
+          fi
+
+      - name: Create tags + GitHub Releases
         uses: changesets/action@v1
         with:
-          version: bun run version-packages
+          # With no pending changesets (guarded above), the action skips
+          # the Version Packages PR branch entirely and goes straight to
+          # tag + Release creation via `bun run release` (`changeset tag`).
           publish: bun run release
-          title: "chore: version packages"
-          commit: "chore: version packages"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,26 +53,53 @@ This project uses **Changesets** (`@changesets/cli`) for versioning.
 - Each package has its own `CHANGELOG.md`, auto-generated with GitHub PR links.
 - Release notes are published on [GitHub Releases](https://github.com/ChronoAIProject/Ornn/releases).
 
-**Workflow:**
+### During development
 
-1. After completing a feature or fix, create a changeset:
-   ```bash
-   bun changeset
-   ```
-   Select affected package(s), semver bump level (`patch`/`minor`/`major`), and write a short description. Commit the generated `.changeset/*.md` file with the PR.
+Every feature PR targeting `develop` MUST include a changeset:
 
-2. When preparing a release, consume all pending changesets:
-   ```bash
-   bun run version-packages
-   ```
-   This updates `package.json` versions, appends to `CHANGELOG.md`, and deletes consumed changeset files.
+```bash
+bun changeset
+```
 
-3. Tag the release:
-   ```bash
-   bun run release
-   ```
+Select affected package(s), semver bump level (`patch` / `minor` / `major`), write a short description. Commit the generated `.changeset/*.md` file with the PR. CI (`check-changeset.yml`) blocks PRs that don't include one — use `bun changeset --empty` for docs-only / CI-only PRs.
 
-4. Merge `develop` → `main` via PR, then create a GitHub Release with release notes.
+### Cutting a release
+
+Done in two PRs. Everything scriptable is in `scripts/release-prep.sh` (`bun run release:prep`).
+
+**Step 1 — Version-bump PR (on develop).** Run locally:
+
+```bash
+bun run release:prep
+```
+
+The script:
+1. Fetches + fast-forwards local `develop`.
+2. Confirms there are pending `.changeset/*.md` to consume.
+3. Creates branch `release/version-packages` off `develop`.
+4. Runs `bun run version-packages` — consumes changesets, bumps `package.json` in both packages, appends to `CHANGELOG.md`.
+5. Commits `chore: version packages → v<next>`.
+6. Force-pushes the branch.
+7. Opens (or updates) the PR: `release/version-packages → develop`.
+
+Review the PR. Merge it into `develop`. `develop` now has the bumped versions + CHANGELOG entries, and the `.changeset/*.md` files that were consumed are deleted.
+
+**Step 2 — Promote to main.** Open a PR `develop → main`. When it merges, `.github/workflows/changeset-release.yml` runs on the `main` push and:
+
+- Hard-guards against unconsumed `.changeset/*.md` on `main` (fails loudly — means Step 1 was skipped).
+- Runs `bun run release` (`changeset tag`) to tag each package at the new version.
+- Pushes tags.
+- Creates GitHub Releases per tag with the corresponding CHANGELOG section as the body.
+
+### Why this shape
+
+- No bot pushes to `main` — the bump commit comes in via the Step-1 PR through `develop`. `main`'s branch protection stays strict.
+- No bot creates PRs — `release:prep` runs from your local `gh` auth, so the org's "Allow GitHub Actions to create and approve pull requests" policy doesn't block anything.
+- `develop` and `main` stay in sync version-wise after each release — no back-merge needed because Step 1 lands the bump on `develop` before `main`.
+
+### Hotfixes directly to main
+
+If something goes straight to `main` without a changeset (e.g. emergency patch), the release workflow's guard just exits cleanly (no unconsumed changesets = no tag work to do). No versions bump. Make a proper changeset-carrying PR via `develop` afterward to stamp the version.
 
 ## Scripts
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset tag",
+    "release:prep": "bash scripts/release-prep.sh",
     "lint": "eslint ornn-api/src ornn-web/src",
     "lint:fix": "eslint ornn-api/src ornn-web/src --fix",
     "typecheck:api": "bunx tsc --noEmit -p ornn-api/tsconfig.json",

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Prepare a release on develop.
+#
+# What it does (in order):
+#   1. Fetches origin and fast-forwards local develop.
+#   2. Confirms there are pending changesets to consume.
+#   3. Creates (or resets) branch `release/version-packages` off develop.
+#   4. Runs `bun run version-packages` — consumes `.changeset/*.md`, bumps
+#      `ornn-api/package.json` + `ornn-web/package.json`, appends CHANGELOG.md
+#      entries.
+#   5. Commits the bump.
+#   6. Force-pushes the branch.
+#   7. Opens (or updates) a PR `release/version-packages → develop`.
+#
+# After that PR merges:
+#   - Open a second PR: `develop → main`
+#   - Merging that triggers `.github/workflows/changeset-release.yml`,
+#     which tags the release and creates GitHub Releases.
+#
+# Usage: bun run release:prep
+# Requires: gh CLI authed against the repo.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BRANCH="release/version-packages"
+
+# 1. sync develop
+git fetch origin
+git checkout develop
+git pull --ff-only
+
+# 2. any pending?
+PENDING=$(find .changeset -name "*.md" ! -name "README.md" 2>/dev/null | wc -l | xargs)
+if [ "$PENDING" = "0" ]; then
+  echo "No pending changesets. Nothing to release."
+  exit 0
+fi
+echo "Found $PENDING pending changesets. Preparing release branch..."
+
+# 3. branch
+git checkout -B "$BRANCH"
+
+# 4. consume + bump
+bun run version-packages
+
+# 5. capture new version (ornn-api and ornn-web are fixed-linked, same version)
+VERSION=$(node -p "require('./ornn-api/package.json').version")
+echo "New version: v${VERSION}"
+
+# 6. commit + push
+git add -A
+git commit -m "chore: version packages → v${VERSION}"
+git push -fu origin "$BRANCH"
+
+# 7. open (or report) PR
+EXISTING_PR=$(gh pr list --head "$BRANCH" --base develop --state open --json number --jq '.[0].number // empty')
+if [ -n "$EXISTING_PR" ]; then
+  echo "PR #${EXISTING_PR} already open for ${BRANCH} — force-pushed latest."
+else
+  gh pr create \
+    --base develop \
+    --head "$BRANCH" \
+    --title "chore: version packages → v${VERSION}" \
+    --body "Automated by \`bun run release:prep\`. Consumes ${PENDING} pending changesets, bumps to v${VERSION}."
+fi
+
+cat <<EOF
+
+✅ Release branch ready.
+Next steps:
+  1. Review + merge the release PR on develop.
+  2. Open PR: develop → main
+  3. Merging to main auto-tags and creates GitHub Releases (via changeset-release workflow).
+EOF


### PR DESCRIPTION
## Summary

Rewrites the release flow so version bumps happen on `develop` (in a regular PR you can review) and `main` pushes only tag + create GitHub Releases. Sidesteps the org-level "Allow GitHub Actions to create and approve pull requests" restriction entirely — no bot tries to open a PR anywhere in this flow.

### New flow

**Step 1 — locally:**

```bash
bun run release:prep
```

`scripts/release-prep.sh`:
1. Fetches + fast-forwards `develop`
2. Checks for pending `.changeset/*.md`
3. Branches `release/version-packages` off `develop`
4. Runs `bun run version-packages` — consumes changesets, bumps both packages, updates CHANGELOG
5. Commits `chore: version packages → v<next>`
6. Force-pushes branch
7. Opens (or updates) PR `release/version-packages → develop` via user-scoped `gh` CLI

Merge that PR. `develop` now has the bump.

**Step 2 — on GitHub:**

Open PR `develop → main`. Merge.

`changeset-release.yml` now triggers only on push to `main`:
- Guards against unconsumed `.changeset/*.md` on `main` (fails loud if Step 1 was skipped)
- Runs `bun run release` (`changeset tag`)
- Uses `changesets/action@v1` with `createGithubReleases: true` so each tag gets a Release with the CHANGELOG section as body

### Why this shape

- `main`'s "no direct push" protection stays strict — the bump commit arrives via PR through `develop`.
- No bot creates PRs anywhere. `release:prep` uses your `gh` CLI auth → org restriction irrelevant.
- `develop` and `main` stay version-aligned after each release → no back-merge workflow needed.

### Files

| File | Change |
|---|---|
| `scripts/release-prep.sh` | **new** — local release-prep automation |
| `package.json` | add `release:prep` script pointer |
| `.github/workflows/changeset-release.yml` | trigger: `develop` → `main`; logic simplified to tag + GH Release; guard against unconsumed changesets |
| `CLAUDE.md` | Versioning & Releases section rewritten: two-step flow + hotfix note + "why this shape" |

## Test plan

- [ ] CI green
- [ ] Post-merge: run `bun run release:prep` against the 34 currently pending changesets → release PR opens on develop → merge → develop → main PR → merge → `main` push triggers tag + GitHub Release for v0.1.4
- [ ] Frontend footer shows `frontend v0.1.4` after rebuild