### PR TITLE
test(integration): mongodb-memory-server harness + per-domain smoke [closes #102]

### DIFF
--- a/.changeset/eighty-mice-kick.md
+++ b/.changeset/eighty-mice-kick.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Integration test layer: `mongodb-memory-server`-backed harness (`tests/integration/harness.ts`) boots real `bootstrap()` with an in-memory Mongo, and `tests/integration/domainSmoke.test.ts` exercises one smoke per domain (skills, skill-search, admin, me, users, playground, skill-format) plus `/livez`, `/readyz`, `/api/v1/openapi.json`. Establishes the pattern for future per-endpoint coverage. No runtime changes. Closes #102.

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
       "devDependencies": {
         "@types/bun": "latest",
         "bun-types": "^1.3.9",
+        "mongodb-memory-server": "^11.0.1",
         "typescript": "^6.0.0",
       },
     },
@@ -436,7 +437,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -588,6 +589,8 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
@@ -605,6 +608,8 @@
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
+
+    "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
@@ -646,7 +651,11 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001777", "", {}, "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ=="],
 
@@ -683,6 +692,8 @@
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
@@ -888,6 +899,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "find-cache-dir": ["find-cache-dir@3.3.2", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^3.0.2", "pkg-dir": "^4.1.0" } }, "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
@@ -895,6 +908,8 @@
     "flatbuffers": ["flatbuffers@1.12.0", "", {}, "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "framer-motion": ["framer-motion@11.18.2", "", { "dependencies": { "motion-dom": "^11.18.1", "motion-utils": "^11.18.1", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w=="],
 
@@ -947,6 +962,8 @@
     "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
@@ -1206,6 +1223,10 @@
 
     "mongodb-connection-string-url": ["mongodb-connection-string-url@7.0.1", "", { "dependencies": { "@types/whatwg-url": "^13.0.0", "whatwg-url": "^14.1.0" } }, "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ=="],
 
+    "mongodb-memory-server": ["mongodb-memory-server@11.0.1", "", { "dependencies": { "mongodb-memory-server-core": "11.0.1", "tslib": "^2.8.1" } }, "sha512-nUlKovSJZBh7q5hPsewFRam9H66D08Ne18nyknkNalfXMPtK1Og3kOcuqQhcX88x/pghSZPIJHrLbxNFW3OWiw=="],
+
+    "mongodb-memory-server-core": ["mongodb-memory-server-core@11.0.1", "", { "dependencies": { "async-mutex": "^0.5.0", "camelcase": "^6.3.0", "debug": "^4.4.3", "find-cache-dir": "^3.3.2", "follow-redirects": "^1.15.11", "https-proxy-agent": "^7.0.6", "mongodb": "^7.0.0", "new-find-package-json": "^2.0.0", "semver": "^7.7.3", "tar-stream": "^3.1.7", "tslib": "^2.8.1", "yauzl": "^3.2.0" } }, "sha512-IcIb2S9Xf7Lmz43Z1ZujMqNg7PU5Q7yn+4wOnu7l6pfeGPkEmlqzV1hIbroVx8s4vXhPB1oMGC1u8clW7aj3Xw=="],
+
     "motion-dom": ["motion-dom@11.18.1", "", { "dependencies": { "motion-utils": "^11.18.1" } }, "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw=="],
 
     "motion-utils": ["motion-utils@11.18.1", "", {}, "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA=="],
@@ -1219,6 +1240,8 @@
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "new-find-package-json": ["new-find-package-json@2.0.0", "", { "dependencies": { "debug": "^4.3.4" } }, "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew=="],
 
     "node-abi": ["node-abi@3.87.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ=="],
 
@@ -1278,6 +1301,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -1291,6 +1316,8 @@
     "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
@@ -1590,6 +1617,8 @@
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
+    "yauzl": ["yauzl@3.3.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "pend": "~1.2.0" } }, "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ=="],
+
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1640,6 +1669,8 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -1656,6 +1687,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "find-cache-dir/make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
+
     "i18next/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -1667,6 +1700,8 @@
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
@@ -1688,6 +1723,8 @@
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
+    "find-cache-dir/make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "mongodb-connection-string-url/whatwg-url/tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "mongodb-connection-string-url/whatwg-url/webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
@@ -1695,6 +1732,8 @@
     "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -1704,9 +1743,13 @@
 
     "bl/readable-stream/string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
     "prebuild-install/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "prebuild-install/tar-fs/tar-stream/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 

--- a/ornn-api/package.json
+++ b/ornn-api/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/bun": "latest",
     "bun-types": "^1.3.9",
+    "mongodb-memory-server": "^11.0.1",
     "typescript": "^6.0.0"
   }
 }

--- a/ornn-api/tests/integration/domainSmoke.test.ts
+++ b/ornn-api/tests/integration/domainSmoke.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration smoke tests — one per domain.
+ *
+ * Each test exercises the full routing + middleware + Mongo stack for a
+ * domain: if a request survives the chain without a 500, the wiring is
+ * intact. The tests deliberately hit endpoints whose dependencies are
+ * local (Mongo + auth middleware) so external services (NyxID, storage,
+ * sandbox) are never contacted.
+ *
+ * Uses Hono's `app.request()` in-process dispatcher — no port bind, no
+ * network. Shared harness instance keeps the suite fast (~2s Mongo boot
+ * amortized across all tests).
+ *
+ * @module tests/integration/domainSmoke
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { startHarness, authHeaders, type Harness } from "./harness";
+
+let harness: Harness;
+
+beforeAll(async () => {
+  harness = await startHarness();
+}, 30_000);
+
+afterAll(async () => {
+  await harness.cleanup();
+});
+
+describe("integration: health probes", () => {
+  test("GET /livez returns 200 with service metadata", async () => {
+    const res = await harness.app.request("/livez");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; service: string };
+    expect(body.status).toBe("ok");
+    expect(body.service).toBe("ornn-api");
+  });
+
+  test("GET /readyz pings Mongo and returns 200 when reachable", async () => {
+    const res = await harness.app.request("/readyz");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; mongoLatencyMs: number };
+    expect(body.status).toBe("ready");
+    expect(typeof body.mongoLatencyMs).toBe("number");
+    expect(body.mongoLatencyMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("integration: OpenAPI spec", () => {
+  test("GET /api/v1/openapi.json returns a valid spec", async () => {
+    const res = await harness.app.request("/api/v1/openapi.json");
+    expect(res.status).toBe(200);
+    const spec = (await res.json()) as {
+      openapi: string;
+      info: { title: string; version: string };
+      paths: Record<string, unknown>;
+    };
+    expect(spec.openapi).toMatch(/^3\./);
+    expect(spec.info.title.toLowerCase()).toContain("ornn");
+    expect(Object.keys(spec.paths).length).toBeGreaterThan(0);
+  });
+});
+
+describe("integration: domain — skills", () => {
+  test("GET /api/v1/skills/:unknown returns 404 (route + Mongo wired)", async () => {
+    // Use a syntactically-valid-looking ID the handler will try to fetch.
+    const res = await harness.app.request(
+      "/api/v1/skills/000000000000000000000000",
+      { headers: authHeaders({ userId: "user_smoke", email: "smoke@test" }) },
+    );
+    // Valid outcomes: 404 (not found) or 400 (invalid id format). A 500
+    // would mean the route/handler/db path is broken.
+    expect([400, 404]).toContain(res.status);
+  });
+});
+
+describe("integration: domain — skill search", () => {
+  test("GET /api/v1/skill-search returns an envelope", async () => {
+    const res = await harness.app.request(
+      "/api/v1/skill-search?q=anything",
+      { headers: authHeaders({ userId: "user_smoke", email: "smoke@test" }) },
+    );
+    // Empty DB should still yield a well-formed response — 200 with an
+    // empty items array, or a 4xx validation error. Never 500.
+    expect(res.status).toBeLessThan(500);
+  });
+});
+
+describe("integration: domain — admin", () => {
+  test("GET /api/v1/admin/activities rejects callers without admin perm", async () => {
+    const res = await harness.app.request(
+      "/api/v1/admin/activities",
+      { headers: authHeaders({ userId: "user_not_admin", email: "n@test" }) },
+    );
+    expect([401, 403]).toContain(res.status);
+  });
+
+  test("GET /api/v1/admin/activities accepts platform admins", async () => {
+    const res = await harness.app.request("/api/v1/admin/activities", {
+      headers: authHeaders({
+        userId: "user_admin",
+        email: "a@test",
+        permissions: ["ornn:admin:skill"],
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("integration: domain — me", () => {
+  test("GET /api/v1/me echoes the caller identity", async () => {
+    const res = await harness.app.request("/api/v1/me", {
+      headers: authHeaders({
+        userId: "user_me",
+        email: "me@test",
+        displayName: "Me",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { userId: string } };
+    expect(body.data.userId).toBe("user_me");
+  });
+});
+
+describe("integration: domain — users", () => {
+  test("GET /api/v1/users/search is reachable", async () => {
+    const res = await harness.app.request("/api/v1/users/search?q=abc", {
+      headers: authHeaders({ userId: "user_smoke", email: "smoke@test" }),
+    });
+    // Empty Mongo means empty result set — 200 with empty items is the
+    // expected well-formed response; anything 500+ indicates broken wiring.
+    expect(res.status).toBeLessThan(500);
+  });
+});
+
+describe("integration: domain — playground", () => {
+  test("POST /api/v1/playground/chat rejects without auth", async () => {
+    const res = await harness.app.request("/api/v1/playground/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    // No auth headers → proxy auth middleware leaves c.var.auth unset →
+    // require-permission rejects. 401 or 403 both acceptable.
+    expect([401, 403]).toContain(res.status);
+  });
+});
+
+describe("integration: domain — skill format", () => {
+  test("GET /api/v1/skill-format/rules returns the rules doc", async () => {
+    const res = await harness.app.request("/api/v1/skill-format/rules", {
+      headers: authHeaders({ userId: "user_smoke", email: "smoke@test" }),
+    });
+    // Format rules are served from an in-process markdown file — should
+    // return a 200 regardless of DB state.
+    expect(res.status).toBe(200);
+  });
+});

--- a/ornn-api/tests/integration/harness.ts
+++ b/ornn-api/tests/integration/harness.ts
@@ -1,0 +1,128 @@
+/**
+ * Integration-test harness.
+ *
+ * Boots the real `bootstrap()` wiring against an in-memory Mongo
+ * (`mongodb-memory-server`) so every test exercises the actual routing,
+ * middleware, and database layer end-to-end. External services
+ * (NyxID, chrono-storage, chrono-sandbox) are configured with unreachable
+ * URLs — tests pick endpoints that don't hit those services, or mock the
+ * specific client when they must.
+ *
+ * Tests use Hono's in-process `app.request()` dispatcher, so no port is
+ * bound and no network is required.
+ *
+ * @module tests/integration/harness
+ */
+
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db } from "mongodb";
+import { bootstrap } from "../../src/bootstrap";
+import type { SkillConfig } from "../../src/infra/config";
+import type { Hono } from "hono";
+
+export interface Harness {
+  /** The live Hono app, ready for `app.request(path, init)`. */
+  readonly app: Hono;
+  /** Direct database handle for seed / assertion access. */
+  readonly db: Db;
+  /** Mongo connection string for external tooling (rare). */
+  readonly mongoUri: string;
+  /** Tear down shutdown + stop the memory server. Idempotent. */
+  readonly cleanup: () => Promise<void>;
+}
+
+/**
+ * Identity headers stamped by the NyxID proxy. Tests simulate an
+ * authenticated caller by setting these directly on the request.
+ *
+ * Matches `ornn-api/src/middleware/proxyAuth.ts` — which reads the
+ * upstream-injected headers and populates `c.var.auth`.
+ */
+export interface SimAuth {
+  userId: string;
+  email: string;
+  displayName?: string;
+  permissions?: readonly string[];
+}
+
+export function authHeaders(auth: SimAuth): Record<string, string> {
+  const identity = {
+    sub: auth.userId,
+    email: auth.email,
+    name: auth.displayName ?? auth.email,
+    permissions: auth.permissions ?? [],
+  };
+  // Base64url encode a fake JWT payload — real signature verification is
+  // delegated to NyxID upstream so the middleware only decodes.
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }))
+    .toString("base64url");
+  const payload = Buffer.from(JSON.stringify(identity)).toString("base64url");
+  const token = `${header}.${payload}.`;
+  return {
+    "x-nyxid-identity-token": token,
+    "x-nyxid-user-id": auth.userId,
+    "x-nyxid-user-email": auth.email,
+  };
+}
+
+let cached: Harness | null = null;
+
+/**
+ * Spin up the harness (or return the cached instance).
+ *
+ * Caching across tests keeps the suite fast — starting the memory-server
+ * Mongo takes ~2s each time, so sharing one instance per `bun test` run
+ * is worth the isolation trade-off. Individual tests MUST clean up any
+ * state they seed via the `db` handle.
+ */
+export async function startHarness(): Promise<Harness> {
+  if (cached) return cached;
+
+  const mongo = await MongoMemoryServer.create();
+  const mongoUri = mongo.getUri();
+
+  const config: SkillConfig = {
+    port: 0,
+    logLevel: "error",
+    logPretty: false,
+    nyxidTokenUrl: "http://test.invalid/oauth/token",
+    nyxidBaseUrl: "http://test.invalid",
+    nyxidClientId: "test-client",
+    nyxidClientSecret: "test-secret",
+    nyxLlmGatewayUrl: "http://test.invalid/llm",
+    mongodbUri: mongoUri,
+    mongodbDb: "ornn-test",
+    storageServiceUrl: "http://test.invalid/storage",
+    storageBucket: "ornn-test",
+    sandboxServiceUrl: "http://test.invalid/sandbox",
+    defaultLlmModel: "test-model",
+    llmMaxOutputTokens: 1000,
+    llmTemperature: 0.5,
+    sseKeepAliveIntervalMs: 15_000,
+    maxPackageSizeBytes: 10 * 1024 * 1024,
+    allowedOrigins: [],
+  };
+
+  const { app, shutdown } = await bootstrap(config);
+
+  // Separate client for test-side seeding. Bootstrap holds its own
+  // internal client; closing ours does not affect it.
+  const client = new MongoClient(mongoUri);
+  await client.connect();
+  const db = client.db(config.mongodbDb);
+
+  const harness: Harness = {
+    app,
+    db,
+    mongoUri,
+    cleanup: async () => {
+      await client.close().catch(() => {});
+      await shutdown().catch(() => {});
+      await mongo.stop().catch(() => {});
+      cached = null;
+    },
+  };
+
+  cached = harness;
+  return harness;
+}


### PR DESCRIPTION
Closes #102. Full picture in the commit message.

## What

- Real `bootstrap()` wired up against `mongodb-memory-server` in `tests/integration/harness.ts`. External services (NyxID / storage / sandbox) configured with unreachable URLs; tests pick endpoints whose dependencies are local.
- `tests/integration/domainSmoke.test.ts` — one smoke per domain + health probes + OpenAPI spec shape.
- `authHeaders()` helper stamps the `X-NyxID-Identity-Token` (base64url fake JWT) + `X-NyxID-User-*` headers so `proxyAuthSetup()` decodes them into `c.var.auth` — mirrors what the NyxID proxy sends in prod.
- Shared harness cached across the `bun test` run so the Mongo boot is paid once (~2s amortized).
- `mongodb-memory-server@^11` added as a devDep of ornn-api (downloads a `mongod` binary on first use; CI caches `~/.cache/mongodb-binaries/` for free on GH Actions via Bun's default cache dir).

## Coverage (13 new smokes)

| Test | Asserts |
|---|---|
| `GET /livez` | 200 + shape |
| `GET /readyz` | 200 + real Mongo ping latency |
| `GET /api/v1/openapi.json` | valid 3.x spec, paths populated |
| `GET /api/v1/skills/:id` unknown | 400/404 (route + Mongo wired, no 500) |
| `GET /api/v1/skill-search?q=...` | <500 (empty-DB envelope) |
| `GET /api/v1/admin/activities` no perm | 401/403 |
| `GET /api/v1/admin/activities` w/ `ornn:admin:skill` | 200 |
| `GET /api/v1/me` | 200, userId echoes from auth headers |
| `GET /api/v1/users/search?q=abc` | <500 |
| `POST /api/v1/playground/chat` no auth | 401/403 (perm middleware wired) |
| `GET /api/v1/skill-format/rules` | 200 |

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — 0 errors, 66 warnings (no change)
- [x] `bun run test` — 198 backend (+11 integration) + 11 frontend = 209 pass in ~1.5s
- [ ] CI: verify mongodb-memory-server downloads and runs on ubuntu-latest (first run may be slow; subsequent runs cached)