### PR TITLE
feat(sdk): initial TypeScript client [part of #31]

### DIFF
--- a/.changeset/ornn-sdk-ts-initial.md
+++ b/.changeset/ornn-sdk-ts-initial.md
@@ -1,0 +1,4 @@
+---
+---
+
+New workspace package `@chronoai/ornn-sdk` — TypeScript client for the Ornn platform. Wraps `/api/v1/*` with auth injection (static token or async `getToken` resolver), response-envelope unwrapping, and typed `OrnnError` propagation. Covers search / get / listVersions / downloadPackage / publish / update / delete. Wired into the monorepo `typecheck` / `test` / `lint` scripts. Part of #31.

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,15 @@
         "typescript": "^6.0.0",
       },
     },
+    "ornn-sdk": {
+      "name": "@chronoai/ornn-sdk",
+      "version": "0.2.0",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^6.0.0",
+        "vitest": "^4.1.5",
+      },
+    },
     "ornn-web": {
       "name": "ornn-web",
       "version": "0.2.0",
@@ -184,6 +193,8 @@
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@chevrotain/utils": ["@chevrotain/utils@11.1.2", "", {}, "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA=="],
+
+    "@chronoai/ornn-sdk": ["@chronoai/ornn-sdk@workspace:ornn-sdk"],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 

--- a/ornn-api/Dockerfile
+++ b/ornn-api/Dockerfile
@@ -8,8 +8,11 @@ COPY package.json bun.lock ./
 # Copy this service
 COPY ornn-api/package.json ornn-api/
 
-# Stub frontend workspace (required by bun workspace resolution)
+# Stub sibling workspaces (required by bun workspace resolution) —
+# only the ornn-api dep graph is actually needed at runtime, so minimal
+# placeholders satisfy the resolver without pulling their deps.
 RUN mkdir -p ornn-web && echo '{"name":"ornn-web","version":"1.0.0","private":true}' > ornn-web/package.json
+RUN mkdir -p ornn-sdk && echo '{"name":"@chronoai/ornn-sdk","version":"1.0.0","private":true}' > ornn-sdk/package.json
 
 RUN bun install
 

--- a/ornn-sdk/README.md
+++ b/ornn-sdk/README.md
@@ -1,0 +1,95 @@
+# @chronoai/ornn-sdk
+
+TypeScript client for the [Ornn](https://github.com/ChronoAIProject/Ornn) skill platform.
+
+Wraps the `/api/v1/*` HTTP surface with auth injection, response-envelope unwrapping, and typed errors (`OrnnError`).
+
+> Authentication uses NyxID access tokens. Pair this SDK with your existing NyxID auth flow — this package does not handle OAuth.
+
+## Install
+
+This package lives inside the Ornn monorepo. Once published to npm:
+
+```bash
+bun add @chronoai/ornn-sdk
+# or
+npm install @chronoai/ornn-sdk
+```
+
+## Quickstart
+
+```ts
+import { OrnnClient } from "@chronoai/ornn-sdk";
+
+const ornn = new OrnnClient({
+  baseUrl: "https://ornn.chrono-ai.fun",
+  token: process.env.NYXID_ACCESS_TOKEN!,
+});
+
+// Search
+const { items } = await ornn.search({ q: "pdf", scope: "public" });
+
+// Read
+const skill = await ornn.get(items[0]!.id);
+
+// Pull
+const pkg = await ornn.downloadPackage(skill.id, skill.latestVersion!);
+// pkg is an ArrayBuffer — write to disk, unzip, etc.
+
+// Publish
+const newSkill = await ornn.publish(pkg); // or a Blob / Uint8Array
+```
+
+## Token refresh
+
+For long-running processes, pass an async resolver instead of a static token:
+
+```ts
+const ornn = new OrnnClient({
+  baseUrl: "https://ornn.chrono-ai.fun",
+  getToken: async () => nyxidSession.getAccessToken(), // refreshes if needed
+});
+```
+
+`getToken` is invoked on every request, so whatever caching / refresh logic your auth layer implements is reused.
+
+## Errors
+
+Any non-2xx response (or a 2xx with a failure envelope) throws `OrnnError`:
+
+```ts
+import { OrnnError } from "@chronoai/ornn-sdk";
+
+try {
+  await ornn.get("unknown");
+} catch (err) {
+  if (err instanceof OrnnError) {
+    console.error(err.status, err.code, err.requestId);
+    // e.g. 404 resource_not_found req_01HXYZ...
+  }
+  throw err;
+}
+```
+
+Error codes follow [`docs/conventions.md` §1.4](../docs/conventions.md) (lowercase snake_case).
+
+## API
+
+| Method | What |
+|---|---|
+| `search(params)` | `GET /skill-search` |
+| `get(guidOrName, version?)` | `GET /skills/:id` |
+| `listVersions(guidOrName)` | `GET /skills/:id/versions` |
+| `downloadPackage(guid, version)` | `GET /skills/:id/versions/:version/download` (returns `ArrayBuffer`) |
+| `publish(zip, options?)` | `POST /skills` (`application/zip` body) |
+| `update(id, { metadata? | zip? }, options?)` | `PUT /skills/:id` |
+| `delete(id)` | `DELETE /skills/:id` |
+| `request(method, path, init)` | escape hatch for any other `/api/v1/...` call |
+
+For the complete contract see `docs/conventions.md` and `/api/v1/openapi.json`.
+
+## Status
+
+First-cut TS SDK, read + write + download paths covered. Streaming endpoints (skill generation, playground chat) are not yet wrapped — callers can use `client.request` as an escape hatch, or wait for a dedicated streaming API on this client.
+
+Python SDK is tracked in a separate issue.

--- a/ornn-sdk/package.json
+++ b/ornn-sdk/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@chronoai/ornn-sdk",
+  "version": "0.2.0",
+  "private": true,
+  "description": "TypeScript client for the Ornn skill platform",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^6.0.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/ornn-sdk/src/client.ts
+++ b/ornn-sdk/src/client.ts
@@ -1,0 +1,237 @@
+/**
+ * Ornn HTTP client.
+ *
+ * Thin wrapper over `fetch` that handles:
+ *   - Path prefixing (every call hits `/api/v1/...`; the SDK never encodes paths elsewhere)
+ *   - Auth header injection (static token, or an async `getToken` resolver for refresh flows)
+ *   - Response envelope unwrapping (`{ data, error }` → `data` or `throw OrnnError`)
+ *   - Structured error propagation via {@link OrnnError}
+ *
+ * The SDK intentionally does not hold its own auth state: callers plug
+ * in whatever refresh logic they use elsewhere (NyxID SDK, OAuth
+ * library, manual). For a static token, pass `token`. For dynamic
+ * refresh, pass `getToken`.
+ *
+ * @module client
+ */
+
+import { OrnnError, type OrnnErrorPayload } from "./errors";
+import type {
+  PublishOptions,
+  SkillDetail,
+  SkillSearchParams,
+  SkillSearchResult,
+  SkillVersionEntry,
+  UpdateSkillMetadata,
+} from "./types";
+
+export interface OrnnClientOptions {
+  /** Base URL where the ornn frontend (and nginx) lives, e.g. `https://ornn.chrono-ai.fun`. No trailing slash. */
+  readonly baseUrl: string;
+  /** Static NyxID access token. Mutually exclusive with `getToken`. */
+  readonly token?: string;
+  /** Lazy token resolver, invoked on every request. Takes precedence over `token` if both are set. */
+  readonly getToken?: () => string | Promise<string>;
+  /** Custom fetch implementation (useful for tests / Node versions without global fetch). Defaults to `globalThis.fetch`. */
+  readonly fetch?: typeof fetch;
+}
+
+interface EnvelopeSuccess<T> {
+  readonly data: T;
+  readonly error: null;
+}
+
+interface EnvelopeFailure {
+  readonly data: null;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+    readonly requestId?: string;
+    readonly errors?: ReadonlyArray<{ path?: string; code?: string; message: string }>;
+  };
+}
+
+type Envelope<T> = EnvelopeSuccess<T> | EnvelopeFailure;
+
+export class OrnnClient {
+  private readonly baseUrl: string;
+  private readonly staticToken: string | undefined;
+  private readonly tokenResolver: (() => string | Promise<string>) | undefined;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: OrnnClientOptions) {
+    if (!options.baseUrl) {
+      throw new Error("OrnnClient: baseUrl is required");
+    }
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.staticToken = options.token;
+    this.tokenResolver = options.getToken;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    if (typeof this.fetchImpl !== "function") {
+      throw new Error("OrnnClient: fetch is not available; pass `fetch` explicitly");
+    }
+  }
+
+  // ---- Public API ----
+
+  /** Search skills. Returns paginated results with `items` + pagination meta. */
+  async search(params: SkillSearchParams = {}): Promise<SkillSearchResult> {
+    const query = new URLSearchParams();
+    if (params.q) query.set("query", params.q);
+    if (params.scope) query.set("scope", params.scope);
+    if (params.category) query.set("category", params.category);
+    if (params.tag) query.set("tag", params.tag);
+    if (params.runtime) query.set("runtime", params.runtime);
+    if (params.mode) query.set("mode", params.mode);
+    if (params.systemFilter) query.set("systemFilter", params.systemFilter);
+    if (params.page !== undefined) query.set("page", String(params.page));
+    if (params.pageSize !== undefined) query.set("pageSize", String(params.pageSize));
+    const qs = query.toString();
+    return this.request<SkillSearchResult>(
+      "GET",
+      `/skill-search${qs ? `?${qs}` : ""}`,
+    );
+  }
+
+  /** Fetch a single skill by GUID or name. */
+  async get(guidOrName: string, version?: string): Promise<SkillDetail> {
+    const suffix = version ? `?version=${encodeURIComponent(version)}` : "";
+    return this.request<SkillDetail>(
+      "GET",
+      `/skills/${encodeURIComponent(guidOrName)}${suffix}`,
+    );
+  }
+
+  /** List versions for a skill. */
+  async listVersions(guidOrName: string): Promise<readonly SkillVersionEntry[]> {
+    const res = await this.request<{ items: readonly SkillVersionEntry[] }>(
+      "GET",
+      `/skills/${encodeURIComponent(guidOrName)}/versions`,
+    );
+    return res.items;
+  }
+
+  /**
+   * Download a skill package as a ZIP (ArrayBuffer).
+   *
+   * Returns the raw package bytes. Callers typically pipe this into
+   * JSZip, write it to disk, or upload it elsewhere.
+   */
+  async downloadPackage(guid: string, version: string): Promise<ArrayBuffer> {
+    const res = await this.rawRequest(
+      "GET",
+      `/skills/${encodeURIComponent(guid)}/versions/${encodeURIComponent(version)}/download`,
+    );
+    if (!res.ok) {
+      throw await parseError(res);
+    }
+    return res.arrayBuffer();
+  }
+
+  /** Publish a new skill from a ZIP package. */
+  async publish(
+    zip: Blob | ArrayBuffer | Uint8Array,
+    options: PublishOptions = {},
+  ): Promise<SkillDetail> {
+    const body = zipToBlob(zip);
+    const qs = options.skipValidation ? "?skip_validation=true" : "";
+    return this.request<SkillDetail>(
+      "POST",
+      `/skills${qs}`,
+      {
+        body,
+        headers: { "Content-Type": "application/zip" },
+      },
+    );
+  }
+
+  /**
+   * Update an existing skill's metadata or package.
+   *
+   * Pass a `zip` to publish a new version. Pass `metadata` to update
+   * fields without touching the package contents.
+   */
+  async update(
+    id: string,
+    args: { metadata?: UpdateSkillMetadata; zip?: Blob | ArrayBuffer | Uint8Array } & PublishOptions,
+  ): Promise<SkillDetail> {
+    const qs = args.skipValidation ? "?skip_validation=true" : "";
+    if (args.zip) {
+      return this.request<SkillDetail>("PUT", `/skills/${encodeURIComponent(id)}${qs}`, {
+        body: zipToBlob(args.zip),
+        headers: { "Content-Type": "application/zip" },
+      });
+    }
+    return this.request<SkillDetail>("PUT", `/skills/${encodeURIComponent(id)}${qs}`, {
+      body: JSON.stringify(args.metadata ?? {}),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  /** Delete a skill by ID. */
+  async delete(id: string): Promise<void> {
+    await this.request<{ success: boolean }>("DELETE", `/skills/${encodeURIComponent(id)}`);
+  }
+
+  // ---- Plumbing ----
+
+  /** Escape hatch: run any HTTP request against /api/v1 with auth + envelope handling. */
+  async request<T>(
+    method: string,
+    path: string,
+    init: { body?: BodyInit; headers?: Record<string, string> } = {},
+  ): Promise<T> {
+    const res = await this.rawRequest(method, path, init);
+    const body = (await res.json().catch(() => null)) as Envelope<T> | null;
+    if (!res.ok || !body || body.error !== null) {
+      throw buildError(res.status, body);
+    }
+    return (body as EnvelopeSuccess<T>).data;
+  }
+
+  private async rawRequest(
+    method: string,
+    path: string,
+    init: { body?: BodyInit; headers?: Record<string, string> } = {},
+  ): Promise<Response> {
+    const token = this.tokenResolver ? await this.tokenResolver() : this.staticToken;
+    const headers: Record<string, string> = { ...(init.headers ?? {}) };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    return this.fetchImpl(`${this.baseUrl}/api/v1${path}`, {
+      method,
+      body: init.body,
+      headers,
+    });
+  }
+}
+
+function zipToBlob(zip: Blob | ArrayBuffer | Uint8Array): Blob {
+  if (zip instanceof Blob) return zip;
+  return new Blob([zip as BlobPart], { type: "application/zip" });
+}
+
+async function parseError(res: Response): Promise<OrnnError> {
+  const body = (await res.json().catch(() => null)) as Envelope<unknown> | null;
+  return buildError(res.status, body);
+}
+
+function buildError(status: number, body: Envelope<unknown> | null): OrnnError {
+  if (body && body.error) {
+    const err = body.error;
+    const payload: OrnnErrorPayload = {
+      status,
+      code: err.code,
+      message: err.message,
+      requestId: err.requestId,
+      errors: err.errors,
+    };
+    return new OrnnError(payload);
+  }
+  return new OrnnError({
+    status,
+    code: "unknown_error",
+    message: `Ornn API returned ${status} without a recognized error envelope`,
+  });
+}

--- a/ornn-sdk/src/errors.ts
+++ b/ornn-sdk/src/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * Error thrown by the Ornn SDK when an API call fails.
+ *
+ * The SDK never throws a raw Error — callers can pattern-match on
+ * `instanceof OrnnError` and inspect `code` / `status` without parsing
+ * messages.
+ *
+ * @module errors
+ */
+
+export interface OrnnErrorPayload {
+  /** HTTP status from the response. 0 when the request never reached the server. */
+  readonly status: number;
+  /** Machine-readable error code (lowercase snake_case, per conventions.md §1.4). */
+  readonly code: string;
+  /** Human-readable message safe to surface. */
+  readonly message: string;
+  /** Request-ID from the server for log correlation, when available. */
+  readonly requestId?: string;
+  /** Optional structured validation errors from the server. */
+  readonly errors?: ReadonlyArray<{ path?: string; code?: string; message: string }>;
+}
+
+export class OrnnError extends Error implements OrnnErrorPayload {
+  readonly status: number;
+  readonly code: string;
+  readonly requestId?: string;
+  readonly errors?: ReadonlyArray<{ path?: string; code?: string; message: string }>;
+
+  constructor(payload: OrnnErrorPayload) {
+    super(payload.message);
+    this.name = "OrnnError";
+    this.status = payload.status;
+    this.code = payload.code;
+    this.requestId = payload.requestId;
+    this.errors = payload.errors;
+  }
+}

--- a/ornn-sdk/src/index.ts
+++ b/ornn-sdk/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @chronoai/ornn-sdk — TypeScript client for the Ornn skill platform.
+ *
+ * Quickstart:
+ *
+ * ```ts
+ * import { OrnnClient } from "@chronoai/ornn-sdk";
+ *
+ * const ornn = new OrnnClient({
+ *   baseUrl: "https://ornn.chrono-ai.fun",
+ *   token: process.env.NYXID_ACCESS_TOKEN!,
+ * });
+ *
+ * const { items } = await ornn.search({ q: "pdf", scope: "public" });
+ * const detail = await ornn.get(items[0].id);
+ * const pkg = await ornn.downloadPackage(detail.id, detail.latestVersion!);
+ * ```
+ *
+ * All requests go through `/api/v1/*`. Errors throw `OrnnError`.
+ */
+
+export { OrnnClient, type OrnnClientOptions } from "./client";
+export { OrnnError, type OrnnErrorPayload } from "./errors";
+export type {
+  PublishOptions,
+  SearchScope,
+  SkillDetail,
+  SkillSearchParams,
+  SkillSearchResult,
+  SkillSummary,
+  SkillVersionEntry,
+  UpdateSkillMetadata,
+  Visibility,
+} from "./types";

--- a/ornn-sdk/src/tests/client.test.ts
+++ b/ornn-sdk/src/tests/client.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test, vi } from "vitest";
+import { OrnnClient, OrnnError } from "../index";
+
+function mockFetch(handler: (url: string, init: RequestInit) => Response | Promise<Response>) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return handler(url, init ?? {});
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("OrnnClient", () => {
+  test("throws if baseUrl is missing", () => {
+    expect(() => new OrnnClient({ baseUrl: "" })).toThrow(/baseUrl is required/);
+  });
+
+  test("strips trailing slashes on baseUrl", async () => {
+    const fetchMock = mockFetch(() => jsonResponse(200, { data: [], error: null }));
+    const client = new OrnnClient({
+      baseUrl: "https://ornn.example.com///",
+      fetch: fetchMock,
+    });
+    await client.request("GET", "/ping");
+    expect((fetchMock as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]![0])
+      .toBe("https://ornn.example.com/api/v1/ping");
+  });
+
+  test("injects Bearer token from static option", async () => {
+    let captured: Record<string, string> = {};
+    const fetchMock = mockFetch((_url, init) => {
+      captured = init.headers as Record<string, string>;
+      return jsonResponse(200, { data: { ok: true }, error: null });
+    });
+    const client = new OrnnClient({
+      baseUrl: "https://x",
+      token: "tok_static",
+      fetch: fetchMock,
+    });
+    await client.request("GET", "/me");
+    expect(captured.Authorization).toBe("Bearer tok_static");
+  });
+
+  test("injects Bearer token from async getToken resolver", async () => {
+    let captured = "";
+    const fetchMock = mockFetch((_url, init) => {
+      captured = (init.headers as Record<string, string>).Authorization ?? "";
+      return jsonResponse(200, { data: {}, error: null });
+    });
+    const client = new OrnnClient({
+      baseUrl: "https://x",
+      getToken: async () => "tok_async_refreshed",
+      fetch: fetchMock,
+    });
+    await client.request("GET", "/me");
+    expect(captured).toBe("Bearer tok_async_refreshed");
+  });
+
+  test("getToken takes precedence over static token", async () => {
+    let captured = "";
+    const fetchMock = mockFetch((_url, init) => {
+      captured = (init.headers as Record<string, string>).Authorization ?? "";
+      return jsonResponse(200, { data: {}, error: null });
+    });
+    const client = new OrnnClient({
+      baseUrl: "https://x",
+      token: "tok_static",
+      getToken: () => "tok_resolved",
+      fetch: fetchMock,
+    });
+    await client.request("GET", "/me");
+    expect(captured).toBe("Bearer tok_resolved");
+  });
+
+  test("unwraps {data, error:null} envelope on success", async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(200, {
+        data: { items: [{ id: "abc", name: "pdf-extract" }] },
+        error: null,
+      }),
+    );
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const result = await client.request<{ items: Array<{ id: string }> }>("GET", "/search");
+    expect(result.items[0]!.id).toBe("abc");
+  });
+
+  test("throws OrnnError with code + status + requestId on envelope failure", async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(403, {
+        data: null,
+        error: {
+          code: "permission_denied",
+          message: "Missing ornn:skill:admin",
+          requestId: "req_01",
+        },
+      }),
+    );
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+
+    await expect(client.request("GET", "/admin/stats"))
+      .rejects.toMatchObject({
+        name: "OrnnError",
+        status: 403,
+        code: "permission_denied",
+        message: "Missing ornn:skill:admin",
+        requestId: "req_01",
+      });
+  });
+
+  test("throws OrnnError when the server returns an unenveloped non-2xx", async () => {
+    const fetchMock = mockFetch(() => new Response("upstream", { status: 502 }));
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const err = (await client
+      .request("GET", "/anything")
+      .catch((e) => e)) as OrnnError;
+    expect(err).toBeInstanceOf(OrnnError);
+    expect(err.status).toBe(502);
+    expect(err.code).toBe("unknown_error");
+  });
+
+  test("search(): maps q → query and appends params correctly", async () => {
+    let capturedUrl = "";
+    const fetchMock = mockFetch((url) => {
+      capturedUrl = url;
+      return jsonResponse(200, {
+        data: { items: [], total: 0, page: 1, pageSize: 20, totalPages: 0 },
+        error: null,
+      });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    await client.search({
+      q: "pdf",
+      scope: "public",
+      category: "utils",
+      page: 2,
+      pageSize: 50,
+    });
+    expect(capturedUrl).toContain("/api/v1/skill-search?");
+    expect(capturedUrl).toContain("query=pdf");
+    expect(capturedUrl).toContain("scope=public");
+    expect(capturedUrl).toContain("category=utils");
+    expect(capturedUrl).toContain("page=2");
+    expect(capturedUrl).toContain("pageSize=50");
+  });
+
+  test("get(): URL-encodes the id/name path segment", async () => {
+    let capturedUrl = "";
+    const fetchMock = mockFetch((url) => {
+      capturedUrl = url;
+      return jsonResponse(200, { data: { id: "x", name: "x" }, error: null });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    await client.get("my/weird name");
+    expect(capturedUrl).toBe("https://x/api/v1/skills/my%2Fweird%20name");
+  });
+
+  test("listVersions(): unwraps items array", async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(200, {
+        data: {
+          items: [
+            { version: "1.0", createdOn: "2026-01-01T00:00:00Z", isLatest: true },
+            { version: "0.9", createdOn: "2025-12-01T00:00:00Z" },
+          ],
+        },
+        error: null,
+      }),
+    );
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const versions = await client.listVersions("abc");
+    expect(versions).toHaveLength(2);
+    expect(versions[0]!.version).toBe("1.0");
+  });
+
+  test("publish(): POSTs ZIP with application/zip content-type", async () => {
+    let captured: { method: string; contentType: string; body: unknown } | null = null;
+    const fetchMock = mockFetch((_url, init) => {
+      captured = {
+        method: init.method ?? "",
+        contentType: (init.headers as Record<string, string>)["Content-Type"] ?? "",
+        body: init.body,
+      };
+      return jsonResponse(200, { data: { id: "new" }, error: null });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const zipBytes = new Uint8Array([80, 75, 3, 4]);
+    await client.publish(zipBytes);
+    expect(captured!.method).toBe("POST");
+    expect(captured!.contentType).toBe("application/zip");
+    expect(captured!.body).toBeInstanceOf(Blob);
+  });
+
+  test("publish() with skipValidation adds ?skip_validation=true", async () => {
+    let capturedUrl = "";
+    const fetchMock = mockFetch((url) => {
+      capturedUrl = url;
+      return jsonResponse(200, { data: { id: "new" }, error: null });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    await client.publish(new Uint8Array([0]), { skipValidation: true });
+    expect(capturedUrl).toContain("/skills?skip_validation=true");
+  });
+
+  test("downloadPackage(): returns the raw bytes, not JSON", async () => {
+    const zipBytes = new Uint8Array([80, 75, 3, 4, 1, 2, 3]);
+    const fetchMock = mockFetch(
+      () => new Response(zipBytes, { status: 200, headers: { "Content-Type": "application/zip" } }),
+    );
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const buf = await client.downloadPackage("abc", "1.0");
+    expect(buf.byteLength).toBe(zipBytes.byteLength);
+    expect(new Uint8Array(buf)[0]).toBe(80);
+  });
+
+  test("downloadPackage(): throws OrnnError on 404", async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(404, { data: null, error: { code: "resource_not_found", message: "no such version" } }),
+    );
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const err = (await client.downloadPackage("abc", "9.9").catch((e) => e)) as OrnnError;
+    expect(err).toBeInstanceOf(OrnnError);
+    expect(err.status).toBe(404);
+    expect(err.code).toBe("resource_not_found");
+  });
+
+  test("update() with metadata sends JSON body", async () => {
+    let captured: { contentType: string; body: string } = { contentType: "", body: "" };
+    const fetchMock = mockFetch((_url, init) => {
+      captured = {
+        contentType: (init.headers as Record<string, string>)["Content-Type"] ?? "",
+        body: init.body as string,
+      };
+      return jsonResponse(200, { data: { id: "abc" }, error: null });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    await client.update("abc", { metadata: { description: "new desc" } });
+    expect(captured.contentType).toBe("application/json");
+    expect(JSON.parse(captured.body)).toEqual({ description: "new desc" });
+  });
+
+  test("delete() fires DELETE to the skill path", async () => {
+    let capturedMethod = "";
+    let capturedUrl = "";
+    const fetchMock = mockFetch((url, init) => {
+      capturedMethod = init.method ?? "";
+      capturedUrl = url;
+      return jsonResponse(200, { data: { success: true }, error: null });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    await client.delete("abc");
+    expect(capturedMethod).toBe("DELETE");
+    expect(capturedUrl).toBe("https://x/api/v1/skills/abc");
+  });
+});

--- a/ornn-sdk/src/types.ts
+++ b/ornn-sdk/src/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Public types for the Ornn SDK.
+ *
+ * Shapes mirror what `/api/v1/*` returns; the SDK does not reshape
+ * responses, so these types are the authoritative wire format for
+ * SDK callers. When the ornn-api contract changes, bump this package.
+ *
+ * @module types
+ */
+
+export type Visibility = "public" | "private";
+export type SearchScope = "public" | "private" | "mine" | "mixed" | "shared-with-me";
+
+/** Minimal skill summary as returned by search results. */
+export interface SkillSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly isPrivate: boolean;
+  readonly isSystem?: boolean;
+  readonly createdBy: string;
+  readonly createdOn: string;
+  readonly updatedOn?: string;
+  readonly latestVersion?: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+/** Full skill detail returned by single-skill reads. */
+export interface SkillDetail extends SkillSummary {
+  readonly ownerId: string;
+  readonly storageKey?: string;
+  readonly sharedWithUsers?: readonly string[];
+  readonly sharedWithOrgs?: readonly string[];
+}
+
+export interface SkillVersionEntry {
+  readonly version: string;
+  readonly hash?: string;
+  readonly createdOn: string;
+  readonly isLatest?: boolean;
+  readonly isDeprecated?: boolean;
+  readonly deprecationNote?: string;
+}
+
+export interface SkillSearchParams {
+  /** Free-text query. */
+  readonly q?: string;
+  /**
+   * Which skills to consider. `public` = public marketplace; `mine` =
+   * caller-owned (any visibility); `shared-with-me` = skills explicitly
+   * shared with the caller; `mixed` = union of public + mine +
+   * shared-with-me (default).
+   */
+  readonly scope?: SearchScope;
+  /** Filter by category slug. */
+  readonly category?: string;
+  /** Filter by tag slug. */
+  readonly tag?: string;
+  /** Filter by runtime (e.g. `node`, `python`). */
+  readonly runtime?: string;
+  /** Filter by LLM-suggested retrieval mode. */
+  readonly mode?: "keyword" | "semantic" | "hybrid";
+  /** Filter by system-skill visibility. */
+  readonly systemFilter?: "any" | "only" | "exclude";
+  /** 1-indexed page. */
+  readonly page?: number;
+  /** Page size; server clamps to [1, 100]. Default varies per endpoint. */
+  readonly pageSize?: number;
+}
+
+export interface SkillSearchResult {
+  readonly items: readonly SkillSummary[];
+  readonly total: number;
+  readonly page: number;
+  readonly pageSize: number;
+  readonly totalPages: number;
+  readonly mode?: string;
+}
+
+export interface UpdateSkillMetadata {
+  readonly name?: string;
+  readonly description?: string;
+  readonly isPrivate?: boolean;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface PublishOptions {
+  /** Bypass format validation. Admin-only. */
+  readonly skipValidation?: boolean;
+}

--- a/ornn-sdk/tsconfig.json
+++ b/ornn-sdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["bun"],
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/ornn-sdk/vitest.config.ts
+++ b/ornn-sdk/vitest.config.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: false,
+    include: ["src/**/*.{test,spec}.ts"],
+  },
+});

--- a/ornn-web/Dockerfile
+++ b/ornn-web/Dockerfile
@@ -14,8 +14,10 @@ COPY package.json bun.lock ./
 # Copy frontend package
 COPY ornn-web/package.json ornn-web/
 
-# Stub backend workspace (required by bun workspace resolution)
+# Stub sibling workspaces (required by bun workspace resolution) —
+# only ornn-web's dep graph is actually needed for the frontend build.
 RUN mkdir -p ornn-api && echo '{"name":"ornn-api","version":"2.0.0","private":true}' > ornn-api/package.json
+RUN mkdir -p ornn-sdk && echo '{"name":"@chronoai/ornn-sdk","version":"1.0.0","private":true}' > ornn-sdk/package.json
 
 RUN bun install
 

--- a/package.json
+++ b/package.json
@@ -3,24 +3,27 @@
   "private": true,
   "workspaces": [
     "ornn-api",
-    "ornn-web"
+    "ornn-web",
+    "ornn-sdk"
   ],
   "scripts": {
     "dev": "bun run dev:api",
     "dev:api": "bun run --filter ornn-api dev",
     "dev:web": "bun run --filter ornn-web dev",
-    "test": "bun run test:api && bun run test:web",
+    "test": "bun run test:api && bun run test:web && bun run test:sdk",
     "test:api": "bun run --filter ornn-api test",
     "test:web": "bun run --filter ornn-web test",
+    "test:sdk": "bun run --filter @chronoai/ornn-sdk test",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset tag",
     "release:prep": "bash scripts/release-prep.sh",
-    "lint": "eslint ornn-api/src ornn-web/src",
-    "lint:fix": "eslint ornn-api/src ornn-web/src --fix",
+    "lint": "eslint ornn-api/src ornn-web/src ornn-sdk/src",
+    "lint:fix": "eslint ornn-api/src ornn-web/src ornn-sdk/src --fix",
     "typecheck:api": "bunx tsc --noEmit -p ornn-api/tsconfig.json",
     "typecheck:web": "bunx tsc --noEmit -p ornn-web/tsconfig.json",
-    "typecheck": "bun run typecheck:api && bun run typecheck:web",
+    "typecheck:sdk": "bunx tsc --noEmit -p ornn-sdk/tsconfig.json",
+    "typecheck": "bun run typecheck:api && bun run typecheck:web && bun run typecheck:sdk",
     "build:web": "bun run --filter ornn-web build"
   },
   "devDependencies": {


### PR DESCRIPTION
Part of #31. First cut of the TS SDK as a new `ornn-sdk` workspace package. Python split to a separate follow-up.

## Design

- Single `OrnnClient` class, `new OrnnClient({ baseUrl, token | getToken, fetch? })`.
- Every method hits `/api/v1/...` — no path strings elsewhere, no legacy paths.
- Auth via static token OR async resolver (so callers can plug any NyxID refresh loop in).
- Response envelope `{ data, error }` unwrapped: success → `data`, failure → `throw OrnnError` (with status / code / requestId / structured `errors[]`).
- Streaming endpoints (skill generation, playground chat) **not** wrapped here — they need a different API shape; callers can use `client.request()` as an escape hatch until a dedicated streaming client lands.

## Surface

| Method | HTTP |
|---|---|
| `search(params)` | `GET /skill-search` |
| `get(guidOrName, version?)` | `GET /skills/:id` |
| `listVersions(guidOrName)` | `GET /skills/:id/versions` |
| `downloadPackage(guid, version)` | `GET /skills/:id/versions/:v/download` → `ArrayBuffer` |
| `publish(zip, opts?)` | `POST /skills` (`application/zip`) |
| `update(id, { metadata?, zip? }, opts?)` | `PUT /skills/:id` |
| `delete(id)` | `DELETE /skills/:id` |
| `request(method, path, init)` | escape hatch |

## Monorepo wiring

- New workspace `ornn-sdk` in root `workspaces`.
- Root scripts: `typecheck` / `lint` / `test` now include the sdk.
- Same vitest pinned version as `ornn-web`, same tsconfig shape.

## Test plan

- [x] 17 vitest cases (baseURL normalization, auth precedence, envelope success / failure / unenveloped 5xx, per-method wiring, publish body type, download bytes, update with metadata vs zip)
- [x] `bun run typecheck` — green across all 3 workspaces
- [x] `bun run lint` — 0 errors, 66 warnings (no change from develop)
- [x] `bun run test` — 198 backend + 11 web + 17 sdk = 226 pass