### PR TITLE
feat(sdk): Python client [closes #110, completes #31]

### DIFF
--- a/.changeset/chilly-dodos-smoke.md
+++ b/.changeset/chilly-dodos-smoke.md
@@ -1,0 +1,4 @@
+---
+---
+
+New `ornn-sdk-python/` package — Python client mirroring the TS SDK (search / get / list_versions / download_package / publish / update / delete). `httpx`-based, sync, with `OrnnError` raising on failures and typed dataclasses for responses. Wired into CI via a dedicated `python-sdk-test` job. Closes #110 and completes #31. Python SDK versions independently from the bun packages (own pyproject.toml / PyPI cadence); no ornn-api or ornn-web runtime changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,22 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run test
 
+  python-sdk-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: ornn-sdk-python/pyproject.toml
+      - name: Install ornn-sdk-python
+        working-directory: ornn-sdk-python
+        run: pip install -e ".[dev]"
+      - name: Run pytest
+        working-directory: ornn-sdk-python
+        run: pytest -q
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ credentials.json
 .DS_Store
 .claude/
 ornn-web/public/logo_candidate.jpg
+
+# Python
+.venv/
+__pycache__/
+*.pyc
+*.egg-info/
+.pytest_cache/
+build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,16 @@ TypeScript, Bun workspace monorepo
 - **Database:** MongoDB 7
 - **Validation:** Zod
 - **Logging:** Pino
-- **Testing:** Bun test (backend); Vitest + Testing Library + jsdom (frontend). Both packages run in CI via `bun run test`.
+- **Testing:** Bun test (backend); Vitest + Testing Library + jsdom (frontend + TS SDK); pytest + respx (Python SDK). All run in CI — bun packages via `bun run test`, Python via a dedicated `python-sdk-test` job.
 
 **Packages:**
 
-| Package | Description |
-|---------|-------------|
-| `ornn-api` | Backend API |
-| `ornn-web` | React SPA |
+| Package | Path | Description |
+|---------|------|-------------|
+| `ornn-api` | `ornn-api/` | Backend API (Bun + Hono + MongoDB) |
+| `ornn-web` | `ornn-web/` | React SPA (Vite + React 19 + Zustand + TanStack Query) |
+| `@chronoai/ornn-sdk` | `ornn-sdk/` | TypeScript client for `/api/v1/*` |
+| `ornn-sdk` (Python) | `ornn-sdk-python/` | Python client for `/api/v1/*` (httpx) — separate release cadence |
 
 ## Architecture
 

--- a/ornn-sdk-python/README.md
+++ b/ornn-sdk-python/README.md
@@ -1,0 +1,101 @@
+# ornn-sdk (Python)
+
+Python client for the [Ornn](https://github.com/ChronoAIProject/Ornn) skill platform.
+
+Wraps the `/api/v1/*` HTTP surface with auth injection, response-envelope unwrapping, and typed errors (`OrnnError`). Mirrors the [TypeScript SDK](../ornn-sdk) so agents written in either language have the same programmatic entry point.
+
+> Authentication uses NyxID access tokens. Pair this SDK with your existing NyxID auth flow — this package does not handle OAuth.
+
+## Install
+
+```bash
+pip install ornn-sdk
+# or with uv / poetry / pdm — whichever you prefer
+```
+
+Requires Python 3.10+.
+
+## Quickstart
+
+```python
+import os
+from ornn_sdk import OrnnClient
+
+with OrnnClient(
+    base_url="https://ornn.chrono-ai.fun",
+    token=os.environ["NYXID_ACCESS_TOKEN"],
+) as ornn:
+    # Search
+    result = ornn.search(q="pdf", scope="public")
+
+    # Read
+    skill = ornn.get(result.items[0].id)
+
+    # Pull
+    pkg = ornn.download_package(skill.id, skill.latest_version)
+    # pkg is raw bytes — write to disk, pass to zipfile, etc.
+
+    # Publish
+    new_skill = ornn.publish(pkg)
+```
+
+## Token refresh
+
+For long-running processes, pass a `token_resolver` callable instead of a static token:
+
+```python
+ornn = OrnnClient(
+    base_url="https://ornn.chrono-ai.fun",
+    token_resolver=lambda: nyxid_session.access_token(),
+)
+```
+
+The resolver is invoked on every request, so your existing caching / refresh logic is reused.
+
+## Errors
+
+Any non-2xx response (or a 2xx with a failure envelope) raises `OrnnError`:
+
+```python
+from ornn_sdk import OrnnClient, OrnnError
+
+try:
+    ornn.get("unknown")
+except OrnnError as err:
+    print(err.status, err.code, err.request_id)
+    # 404 resource_not_found req_01HXYZ...
+    raise
+```
+
+Error codes follow [`docs/conventions.md` §1.4](../docs/conventions.md) (lowercase snake_case).
+
+## API
+
+| Method | What |
+|---|---|
+| `search(...)` | `GET /skill-search` — returns `SkillSearchResult` |
+| `get(guid_or_name, version=None)` | `GET /skills/:id` — returns `SkillDetail` |
+| `list_versions(guid_or_name)` | `GET /skills/:id/versions` — returns `list[SkillVersionEntry]` |
+| `download_package(guid, version)` | `GET /skills/:id/versions/:v/download` — returns `bytes` |
+| `publish(zip_bytes, skip_validation=False)` | `POST /skills` — returns `SkillDetail` |
+| `update(id, metadata=..., zip_bytes=..., skip_validation=False)` | `PUT /skills/:id` — returns `SkillDetail` |
+| `delete(id)` | `DELETE /skills/:id` |
+| `request(method, path, **kwargs)` | escape hatch for any other `/api/v1/...` call |
+
+For the complete contract see [`docs/conventions.md`](../docs/conventions.md) and `/api/v1/openapi.json`.
+
+## Status
+
+First-cut Python SDK, covers read + write + download paths. Streaming endpoints (skill generation, playground chat) are not yet wrapped — callers can use `client.request()` as an escape hatch, or wait for a dedicated streaming API.
+
+Async flavor (`AsyncOrnnClient` backed by `httpx.AsyncClient`) is a small follow-up; the sync client is intentionally the default for notebook / script use.
+
+## Development
+
+```bash
+# From ornn-sdk-python/
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+pytest
+```

--- a/ornn-sdk-python/pyproject.toml
+++ b/ornn-sdk-python/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ornn-sdk"
+version = "0.2.0"
+description = "Python client for the Ornn skill platform"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Chrono AI" }]
+keywords = ["ornn", "skills", "ai", "agents", "nyxid"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "License :: OSI Approved :: MIT License",
+]
+dependencies = [
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "respx>=0.21",
+    "pytest-asyncio>=0.23",
+]
+
+[project.urls]
+Homepage = "https://github.com/ChronoAIProject/Ornn"
+Issues = "https://github.com/ChronoAIProject/Ornn/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ornn_sdk"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/ornn-sdk-python/src/ornn_sdk/__init__.py
+++ b/ornn-sdk-python/src/ornn_sdk/__init__.py
@@ -1,0 +1,49 @@
+"""Ornn Python SDK.
+
+Quickstart::
+
+    from ornn_sdk import OrnnClient
+
+    ornn = OrnnClient(
+        base_url="https://ornn.chrono-ai.fun",
+        token=os.environ["NYXID_ACCESS_TOKEN"],
+    )
+
+    result = ornn.search(q="pdf", scope="public")
+    detail = ornn.get(result.items[0].id)
+    pkg = ornn.download_package(detail.id, detail.latest_version)
+
+    ornn.close()  # or use ``with OrnnClient(...) as ornn: ...``
+
+All requests go through ``/api/v1/*``. Errors raise :class:`OrnnError`.
+"""
+
+from .client import OrnnClient
+from .errors import OrnnError
+from .types import (
+    SearchMode,
+    SearchScope,
+    SkillDetail,
+    SkillSearchResult,
+    SkillSummary,
+    SkillVersionEntry,
+    SystemFilter,
+    UpdateSkillMetadata,
+    Visibility,
+)
+
+__all__ = [
+    "OrnnClient",
+    "OrnnError",
+    "SearchMode",
+    "SearchScope",
+    "SkillDetail",
+    "SkillSearchResult",
+    "SkillSummary",
+    "SkillVersionEntry",
+    "SystemFilter",
+    "UpdateSkillMetadata",
+    "Visibility",
+]
+
+__version__ = "0.2.0"

--- a/ornn-sdk-python/src/ornn_sdk/client.py
+++ b/ornn-sdk-python/src/ornn_sdk/client.py
@@ -1,0 +1,252 @@
+"""Ornn HTTP client (sync).
+
+Thin wrapper over httpx that mirrors the TypeScript SDK:
+
+* Path prefixing -- every call hits ``/api/v1/*``
+* Auth header injection -- static token or a ``token_resolver`` callable
+* Response envelope unwrapping -- ``{data, error}`` -> ``data`` or raises :class:`OrnnError`
+* Structured error propagation via :class:`OrnnError`
+
+The client is synchronous by default (easier in notebooks, scripts, simple
+agents). An async flavor can be added later by swapping ``httpx.Client``
+for ``httpx.AsyncClient``; the shape is identical.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+from .errors import OrnnError
+from .types import (
+    SearchMode,
+    SearchScope,
+    SkillDetail,
+    SkillSearchResult,
+    SkillVersionEntry,
+    SystemFilter,
+    UpdateSkillMetadata,
+)
+
+
+class OrnnClient:
+    """Synchronous client for Ornn's ``/api/v1/*`` surface.
+
+    Example:
+
+        >>> from ornn_sdk import OrnnClient
+        >>> ornn = OrnnClient(
+        ...     base_url="https://ornn.chrono-ai.fun",
+        ...     token=os.environ["NYXID_ACCESS_TOKEN"],
+        ... )
+        >>> result = ornn.search(q="pdf", scope="public")
+        >>> for skill in result.items:
+        ...     print(skill.id, skill.name)
+
+    For dynamic token refresh, pass a ``token_resolver`` callable instead
+    of a static ``token``::
+
+        >>> ornn = OrnnClient(
+        ...     base_url="https://ornn.chrono-ai.fun",
+        ...     token_resolver=lambda: session.access_token(),
+        ... )
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        token: str | None = None,
+        token_resolver: Callable[[], str] | None = None,
+        transport: httpx.BaseTransport | None = None,
+        timeout: float | httpx.Timeout = 30.0,
+    ) -> None:
+        if not base_url:
+            raise ValueError("OrnnClient: base_url is required")
+        self._base_url = base_url.rstrip("/")
+        self._static_token = token
+        self._token_resolver = token_resolver
+        self._http = httpx.Client(
+            base_url=f"{self._base_url}/api/v1",
+            transport=transport,
+            timeout=timeout,
+        )
+
+    # ---- Resource lifecycle -------------------------------------------------
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> "OrnnClient":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    # ---- Public API ---------------------------------------------------------
+
+    def search(
+        self,
+        *,
+        q: str | None = None,
+        scope: SearchScope | None = None,
+        category: str | None = None,
+        tag: str | None = None,
+        runtime: str | None = None,
+        mode: SearchMode | None = None,
+        system_filter: SystemFilter | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+    ) -> SkillSearchResult:
+        """Search skills. Returns a paginated :class:`SkillSearchResult`."""
+        params: dict[str, str] = {}
+        if q is not None:
+            params["query"] = q
+        if scope is not None:
+            params["scope"] = scope
+        if category is not None:
+            params["category"] = category
+        if tag is not None:
+            params["tag"] = tag
+        if runtime is not None:
+            params["runtime"] = runtime
+        if mode is not None:
+            params["mode"] = mode
+        if system_filter is not None:
+            params["systemFilter"] = system_filter
+        if page is not None:
+            params["page"] = str(page)
+        if page_size is not None:
+            params["pageSize"] = str(page_size)
+        qs = f"?{urlencode(params)}" if params else ""
+        data = self.request("GET", f"/skill-search{qs}")
+        return SkillSearchResult.from_dict(data)
+
+    def get(self, guid_or_name: str, *, version: str | None = None) -> SkillDetail:
+        """Fetch a single skill by GUID or name."""
+        suffix = f"?version={httpx.QueryParams({'version': version})['version']}" if version else ""
+        data = self.request("GET", f"/skills/{_quote(guid_or_name)}{suffix}")
+        return SkillDetail.from_dict(data)
+
+    def list_versions(self, guid_or_name: str) -> list[SkillVersionEntry]:
+        """List versions for a skill (newest first)."""
+        data = self.request("GET", f"/skills/{_quote(guid_or_name)}/versions")
+        return [SkillVersionEntry.from_dict(v) for v in data.get("items") or []]
+
+    def download_package(self, guid: str, version: str) -> bytes:
+        """Download a skill package ZIP. Returns raw bytes."""
+        res = self._raw_request("GET", f"/skills/{_quote(guid)}/versions/{_quote(version)}/download")
+        if res.status_code >= 400:
+            raise _build_error(res)
+        return res.content
+
+    def publish(self, zip_bytes: bytes, *, skip_validation: bool = False) -> SkillDetail:
+        """Publish a new skill from a ZIP package (raw bytes)."""
+        qs = "?skip_validation=true" if skip_validation else ""
+        data = self.request(
+            "POST",
+            f"/skills{qs}",
+            content=zip_bytes,
+            headers={"Content-Type": "application/zip"},
+        )
+        return SkillDetail.from_dict(data)
+
+    def update(
+        self,
+        skill_id: str,
+        *,
+        metadata: UpdateSkillMetadata | dict[str, Any] | None = None,
+        zip_bytes: bytes | None = None,
+        skip_validation: bool = False,
+    ) -> SkillDetail:
+        """Update metadata or publish a new version.
+
+        Exactly one of ``metadata`` or ``zip_bytes`` must be provided.
+        """
+        if (metadata is None) == (zip_bytes is None):
+            raise ValueError(
+                "update(): exactly one of metadata or zip_bytes must be provided",
+            )
+        qs = "?skip_validation=true" if skip_validation else ""
+        if zip_bytes is not None:
+            data = self.request(
+                "PUT",
+                f"/skills/{_quote(skill_id)}{qs}",
+                content=zip_bytes,
+                headers={"Content-Type": "application/zip"},
+            )
+        else:
+            payload = (
+                metadata.to_json()
+                if isinstance(metadata, UpdateSkillMetadata)
+                else (metadata or {})
+            )
+            data = self.request(
+                "PUT",
+                f"/skills/{_quote(skill_id)}{qs}",
+                json=payload,
+            )
+        return SkillDetail.from_dict(data)
+
+    def delete(self, skill_id: str) -> None:
+        """Delete a skill by ID."""
+        self.request("DELETE", f"/skills/{_quote(skill_id)}")
+
+    # ---- Escape hatch -------------------------------------------------------
+
+    def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        """Issue any HTTP request against ``/api/v1{path}`` with auth + envelope handling.
+
+        Returns the unwrapped ``data`` field on success. Raises
+        :class:`OrnnError` on any failure.
+        """
+        res = self._raw_request(method, path, **kwargs)
+        body: Any = None
+        try:
+            body = res.json()
+        except ValueError:
+            body = None
+        if res.status_code >= 400 or not isinstance(body, dict) or body.get("error") is not None:
+            raise _build_error(res, body)
+        return body.get("data")
+
+    # ---- Plumbing -----------------------------------------------------------
+
+    def _raw_request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        headers: dict[str, str] = dict(kwargs.pop("headers", {}) or {})
+        token = self._token_resolver() if self._token_resolver else self._static_token
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return self._http.request(method, path, headers=headers, **kwargs)
+
+
+def _quote(segment: str) -> str:
+    """URL-encode a single path segment (fwd slashes encoded)."""
+    from urllib.parse import quote
+
+    return quote(segment, safe="")
+
+
+def _build_error(res: httpx.Response, body: Any | None = None) -> OrnnError:
+    if body is None:
+        try:
+            body = res.json()
+        except ValueError:
+            body = None
+    if isinstance(body, dict) and isinstance(body.get("error"), dict):
+        err = body["error"]
+        return OrnnError(
+            status=res.status_code,
+            code=str(err.get("code") or "unknown_error"),
+            message=str(err.get("message") or f"Ornn API returned {res.status_code}"),
+            request_id=err.get("requestId"),
+            errors=list(err.get("errors") or []) or None,
+        )
+    return OrnnError(
+        status=res.status_code,
+        code="unknown_error",
+        message=f"Ornn API returned {res.status_code} without a recognized error envelope",
+    )

--- a/ornn-sdk-python/src/ornn_sdk/errors.py
+++ b/ornn-sdk-python/src/ornn_sdk/errors.py
@@ -1,0 +1,41 @@
+"""Error types for the Ornn SDK.
+
+Mirrors the TypeScript SDK's `OrnnError` shape so users who have agents
+written in both languages see the same surface:
+
+    status      -- HTTP status from the response (0 if the request never reached the server)
+    code        -- lowercase snake_case code (per docs/conventions.md §1.4)
+    message     -- human-readable message safe to surface
+    request_id  -- server-side correlation id, when available
+    errors      -- structured validation errors (list of dicts), when available
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class OrnnError(Exception):
+    """Raised on any non-2xx response, or a 2xx response with a failure envelope."""
+
+    def __init__(
+        self,
+        *,
+        status: int,
+        code: str,
+        message: str,
+        request_id: str | None = None,
+        errors: list[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+        self.request_id = request_id
+        self.errors = errors
+
+    def __repr__(self) -> str:
+        return (
+            f"OrnnError(status={self.status}, code={self.code!r}, "
+            f"message={self.message!r}, request_id={self.request_id!r})"
+        )

--- a/ornn-sdk-python/src/ornn_sdk/types.py
+++ b/ornn-sdk-python/src/ornn_sdk/types.py
@@ -1,0 +1,167 @@
+"""Public types for the Ornn Python SDK.
+
+Shapes mirror the TypeScript SDK and what `/api/v1/*` actually returns.
+Dataclasses keep the wire format explicit without pulling in pydantic.
+
+Responses from the server arrive as plain dicts; the client methods
+convert them into these dataclasses via `from_dict` helpers so callers
+get typed objects. Unknown fields are preserved on a dataclass's
+`_extra` dict for forward-compat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+Visibility = Literal["public", "private"]
+SearchScope = Literal["public", "private", "mine", "mixed", "shared-with-me"]
+SearchMode = Literal["keyword", "semantic", "hybrid"]
+SystemFilter = Literal["any", "only", "exclude"]
+
+
+@dataclass
+class SkillSummary:
+    id: str
+    name: str
+    description: str
+    is_private: bool
+    created_by: str
+    created_on: str
+    is_system: bool | None = None
+    updated_on: str | None = None
+    latest_version: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    _extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "SkillSummary":
+        known = {
+            "id",
+            "name",
+            "description",
+            "isPrivate",
+            "isSystem",
+            "createdBy",
+            "createdOn",
+            "updatedOn",
+            "latestVersion",
+            "metadata",
+        }
+        extra = {k: v for k, v in raw.items() if k not in known}
+        return cls(
+            id=raw["id"],
+            name=raw["name"],
+            description=raw.get("description", ""),
+            is_private=bool(raw.get("isPrivate", False)),
+            is_system=raw.get("isSystem"),
+            created_by=raw.get("createdBy", ""),
+            created_on=raw.get("createdOn", ""),
+            updated_on=raw.get("updatedOn"),
+            latest_version=raw.get("latestVersion"),
+            metadata=raw.get("metadata") or {},
+            _extra=extra,
+        )
+
+
+@dataclass
+class SkillDetail(SkillSummary):
+    owner_id: str = ""
+    storage_key: str | None = None
+    shared_with_users: list[str] = field(default_factory=list)
+    shared_with_orgs: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "SkillDetail":
+        base = SkillSummary.from_dict(raw).__dict__
+        base.pop("_extra")
+        known_extra = {"ownerId", "storageKey", "sharedWithUsers", "sharedWithOrgs"}
+        summary_known = {
+            "id",
+            "name",
+            "description",
+            "isPrivate",
+            "isSystem",
+            "createdBy",
+            "createdOn",
+            "updatedOn",
+            "latestVersion",
+            "metadata",
+        }
+        extra = {
+            k: v
+            for k, v in raw.items()
+            if k not in summary_known and k not in known_extra
+        }
+        return cls(
+            **base,
+            owner_id=raw.get("ownerId", ""),
+            storage_key=raw.get("storageKey"),
+            shared_with_users=list(raw.get("sharedWithUsers") or []),
+            shared_with_orgs=list(raw.get("sharedWithOrgs") or []),
+            _extra=extra,
+        )
+
+
+@dataclass
+class SkillVersionEntry:
+    version: str
+    created_on: str
+    hash: str | None = None
+    is_latest: bool | None = None
+    is_deprecated: bool | None = None
+    deprecation_note: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "SkillVersionEntry":
+        return cls(
+            version=raw["version"],
+            created_on=raw.get("createdOn", ""),
+            hash=raw.get("hash"),
+            is_latest=raw.get("isLatest"),
+            is_deprecated=raw.get("isDeprecated"),
+            deprecation_note=raw.get("deprecationNote"),
+        )
+
+
+@dataclass
+class SkillSearchResult:
+    items: list[SkillSummary]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+    mode: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "SkillSearchResult":
+        return cls(
+            items=[SkillSummary.from_dict(i) for i in raw.get("items") or []],
+            total=int(raw.get("total", 0)),
+            page=int(raw.get("page", 1)),
+            page_size=int(raw.get("pageSize", 0)),
+            total_pages=int(raw.get("totalPages", 0)),
+            mode=raw.get("mode"),
+        )
+
+
+@dataclass
+class UpdateSkillMetadata:
+    """Partial metadata update payload. Omit fields you don't want to change."""
+
+    name: str | None = None
+    description: str | None = None
+    is_private: bool | None = None
+    metadata: dict[str, Any] | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        if self.name is not None:
+            out["name"] = self.name
+        if self.description is not None:
+            out["description"] = self.description
+        if self.is_private is not None:
+            out["isPrivate"] = self.is_private
+        if self.metadata is not None:
+            out["metadata"] = self.metadata
+        return out

--- a/ornn-sdk-python/tests/test_client.py
+++ b/ornn-sdk-python/tests/test_client.py
@@ -1,0 +1,397 @@
+"""Tests for OrnnClient. Mocks httpx transport via respx so no network is required."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from ornn_sdk import (
+    OrnnClient,
+    OrnnError,
+    SkillDetail,
+    SkillSearchResult,
+    UpdateSkillMetadata,
+)
+
+
+BASE = "https://ornn.example.com"
+
+
+def make_client(**kwargs) -> OrnnClient:
+    return OrnnClient(base_url=BASE, **kwargs)
+
+
+class TestConstruction:
+    def test_base_url_required(self) -> None:
+        with pytest.raises(ValueError, match="base_url is required"):
+            OrnnClient(base_url="")
+
+    def test_strips_trailing_slashes(self) -> None:
+        client = OrnnClient(base_url="https://ornn.example.com///")
+        assert client._base_url == "https://ornn.example.com"
+
+
+class TestAuth:
+    @respx.mock
+    def test_injects_static_token(self) -> None:
+        route = respx.get(f"{BASE}/api/v1/me").respond(
+            200, json={"data": {"id": "u1"}, "error": None}
+        )
+        with make_client(token="tok_static") as ornn:
+            ornn.request("GET", "/me")
+        assert route.calls.last.request.headers["authorization"] == "Bearer tok_static"
+
+    @respx.mock
+    def test_resolver_takes_precedence(self) -> None:
+        route = respx.get(f"{BASE}/api/v1/me").respond(
+            200, json={"data": {}, "error": None}
+        )
+        with make_client(
+            token="tok_static",
+            token_resolver=lambda: "tok_dynamic",
+        ) as ornn:
+            ornn.request("GET", "/me")
+        assert route.calls.last.request.headers["authorization"] == "Bearer tok_dynamic"
+
+    @respx.mock
+    def test_no_auth_header_when_no_token(self) -> None:
+        route = respx.get(f"{BASE}/api/v1/public").respond(
+            200, json={"data": {}, "error": None}
+        )
+        with make_client() as ornn:
+            ornn.request("GET", "/public")
+        assert "authorization" not in route.calls.last.request.headers
+
+
+class TestEnvelope:
+    @respx.mock
+    def test_unwraps_success(self) -> None:
+        respx.get(f"{BASE}/api/v1/thing").respond(
+            200, json={"data": {"hello": "world"}, "error": None}
+        )
+        with make_client() as ornn:
+            result = ornn.request("GET", "/thing")
+        assert result == {"hello": "world"}
+
+    @respx.mock
+    def test_raises_ornn_error_on_failure_envelope(self) -> None:
+        respx.get(f"{BASE}/api/v1/admin").respond(
+            403,
+            json={
+                "data": None,
+                "error": {
+                    "code": "permission_denied",
+                    "message": "Missing ornn:skill:admin",
+                    "requestId": "req_01HXYZ",
+                },
+            },
+        )
+        with make_client() as ornn:
+            with pytest.raises(OrnnError) as excinfo:
+                ornn.request("GET", "/admin")
+        err = excinfo.value
+        assert err.status == 403
+        assert err.code == "permission_denied"
+        assert err.request_id == "req_01HXYZ"
+        assert err.message == "Missing ornn:skill:admin"
+
+    @respx.mock
+    def test_raises_on_unenveloped_5xx(self) -> None:
+        respx.get(f"{BASE}/api/v1/any").respond(502, text="bad gateway")
+        with make_client() as ornn:
+            with pytest.raises(OrnnError) as excinfo:
+                ornn.request("GET", "/any")
+        err = excinfo.value
+        assert err.status == 502
+        assert err.code == "unknown_error"
+
+    @respx.mock
+    def test_preserves_structured_errors_list(self) -> None:
+        respx.post(f"{BASE}/api/v1/skills").respond(
+            400,
+            json={
+                "data": None,
+                "error": {
+                    "code": "validation_error",
+                    "message": "Validation failed",
+                    "errors": [
+                        {"path": "name", "code": "required", "message": "name is required"},
+                    ],
+                },
+            },
+        )
+        with make_client() as ornn:
+            with pytest.raises(OrnnError) as excinfo:
+                ornn.publish(b"PK\x03\x04")
+        assert excinfo.value.errors == [
+            {"path": "name", "code": "required", "message": "name is required"},
+        ]
+
+
+class TestSearch:
+    @respx.mock
+    def test_maps_q_to_query_param(self) -> None:
+        route = respx.get(f"{BASE}/api/v1/skill-search").respond(
+            200,
+            json={
+                "data": {
+                    "items": [],
+                    "total": 0,
+                    "page": 1,
+                    "pageSize": 20,
+                    "totalPages": 0,
+                },
+                "error": None,
+            },
+        )
+        with make_client() as ornn:
+            result = ornn.search(q="pdf", scope="public", page=2, page_size=50)
+        assert isinstance(result, SkillSearchResult)
+        req_url = str(route.calls.last.request.url)
+        assert "query=pdf" in req_url
+        assert "scope=public" in req_url
+        assert "page=2" in req_url
+        assert "pageSize=50" in req_url
+
+    @respx.mock
+    def test_parses_items_as_skill_summaries(self) -> None:
+        respx.get(f"{BASE}/api/v1/skill-search").respond(
+            200,
+            json={
+                "data": {
+                    "items": [
+                        {
+                            "id": "abc",
+                            "name": "pdf-extract",
+                            "description": "Extract pdf text",
+                            "isPrivate": False,
+                            "createdBy": "u1",
+                            "createdOn": "2026-01-01T00:00:00Z",
+                            "latestVersion": "1.2",
+                        }
+                    ],
+                    "total": 1,
+                    "page": 1,
+                    "pageSize": 20,
+                    "totalPages": 1,
+                    "mode": "keyword",
+                },
+                "error": None,
+            },
+        )
+        with make_client() as ornn:
+            result = ornn.search()
+        assert result.total == 1
+        assert result.mode == "keyword"
+        assert result.items[0].id == "abc"
+        assert result.items[0].latest_version == "1.2"
+        assert result.items[0].is_private is False
+
+
+class TestGet:
+    @respx.mock
+    def test_url_encodes_path_segment(self) -> None:
+        route = respx.get(f"{BASE}/api/v1/skills/my%2Fweird%20name").respond(
+            200,
+            json={
+                "data": {
+                    "id": "x",
+                    "name": "my/weird name",
+                    "description": "",
+                    "isPrivate": False,
+                    "createdBy": "u1",
+                    "createdOn": "2026-01-01T00:00:00Z",
+                    "ownerId": "u1",
+                },
+                "error": None,
+            },
+        )
+        with make_client() as ornn:
+            detail = ornn.get("my/weird name")
+        assert isinstance(detail, SkillDetail)
+        assert detail.owner_id == "u1"
+        assert route.called
+
+    @respx.mock
+    def test_raises_ornn_error_on_404(self) -> None:
+        respx.get(f"{BASE}/api/v1/skills/nope").respond(
+            404,
+            json={
+                "data": None,
+                "error": {"code": "resource_not_found", "message": "no such skill"},
+            },
+        )
+        with make_client() as ornn:
+            with pytest.raises(OrnnError) as excinfo:
+                ornn.get("nope")
+        assert excinfo.value.status == 404
+        assert excinfo.value.code == "resource_not_found"
+
+
+class TestVersions:
+    @respx.mock
+    def test_list_versions_unwraps_items(self) -> None:
+        respx.get(f"{BASE}/api/v1/skills/abc/versions").respond(
+            200,
+            json={
+                "data": {
+                    "items": [
+                        {"version": "1.0", "createdOn": "2026-01-01T00:00:00Z", "isLatest": True},
+                        {"version": "0.9", "createdOn": "2025-12-01T00:00:00Z"},
+                    ],
+                },
+                "error": None,
+            },
+        )
+        with make_client() as ornn:
+            versions = ornn.list_versions("abc")
+        assert [v.version for v in versions] == ["1.0", "0.9"]
+        assert versions[0].is_latest is True
+
+
+class TestDownload:
+    @respx.mock
+    def test_download_returns_raw_bytes(self) -> None:
+        zip_bytes = b"PK\x03\x04\x01\x02\x03"
+        respx.get(f"{BASE}/api/v1/skills/abc/versions/1.0/download").respond(
+            200,
+            content=zip_bytes,
+            headers={"Content-Type": "application/zip"},
+        )
+        with make_client() as ornn:
+            result = ornn.download_package("abc", "1.0")
+        assert result == zip_bytes
+
+    @respx.mock
+    def test_download_raises_on_error(self) -> None:
+        respx.get(f"{BASE}/api/v1/skills/abc/versions/9.9/download").respond(
+            404,
+            json={
+                "data": None,
+                "error": {"code": "resource_not_found", "message": "no such version"},
+            },
+        )
+        with make_client() as ornn:
+            with pytest.raises(OrnnError) as excinfo:
+                ornn.download_package("abc", "9.9")
+        assert excinfo.value.status == 404
+        assert excinfo.value.code == "resource_not_found"
+
+
+class TestPublish:
+    @respx.mock
+    def test_publish_sends_zip_bytes(self) -> None:
+        route = respx.post(f"{BASE}/api/v1/skills").respond(
+            200,
+            json={
+                "data": {
+                    "id": "new_abc",
+                    "name": "my-skill",
+                    "description": "",
+                    "isPrivate": True,
+                    "createdBy": "u1",
+                    "createdOn": "2026-01-01T00:00:00Z",
+                    "ownerId": "u1",
+                },
+                "error": None,
+            },
+        )
+        zip_bytes = b"PK\x03\x04fakezip"
+        with make_client() as ornn:
+            detail = ornn.publish(zip_bytes)
+        assert detail.id == "new_abc"
+        req = route.calls.last.request
+        assert req.headers["content-type"] == "application/zip"
+        assert req.content == zip_bytes
+
+    @respx.mock
+    def test_publish_adds_skip_validation_query(self) -> None:
+        route = respx.post(f"{BASE}/api/v1/skills", params={"skip_validation": "true"}).respond(
+            200,
+            json={
+                "data": {
+                    "id": "admin_x",
+                    "name": "admin-skill",
+                    "description": "",
+                    "isPrivate": False,
+                    "createdBy": "admin",
+                    "createdOn": "2026-01-01T00:00:00Z",
+                    "ownerId": "admin",
+                },
+                "error": None,
+            },
+        )
+        with make_client() as ornn:
+            ornn.publish(b"PK", skip_validation=True)
+        assert route.called
+
+
+class TestUpdate:
+    @respx.mock
+    def test_update_metadata_sends_json(self) -> None:
+        import json as _json
+
+        route = respx.put(f"{BASE}/api/v1/skills/abc").respond(
+            200,
+            json={
+                "data": {
+                    "id": "abc",
+                    "name": "abc",
+                    "description": "updated",
+                    "isPrivate": False,
+                    "createdBy": "u1",
+                    "createdOn": "2026-01-01T00:00:00Z",
+                    "ownerId": "u1",
+                },
+                "error": None,
+            },
+        )
+        with make_client() as ornn:
+            ornn.update("abc", metadata=UpdateSkillMetadata(description="updated"))
+        req = route.calls.last.request
+        assert "application/json" in req.headers["content-type"]
+        assert _json.loads(req.content) == {"description": "updated"}
+
+    @respx.mock
+    def test_update_with_zip_sends_zip(self) -> None:
+        route = respx.put(f"{BASE}/api/v1/skills/abc").respond(
+            200,
+            json={
+                "data": {
+                    "id": "abc",
+                    "name": "abc",
+                    "description": "",
+                    "isPrivate": False,
+                    "createdBy": "u1",
+                    "createdOn": "2026-01-01T00:00:00Z",
+                    "ownerId": "u1",
+                },
+                "error": None,
+            },
+        )
+        with make_client() as ornn:
+            ornn.update("abc", zip_bytes=b"PK\x03\x04new")
+        assert route.calls.last.request.headers["content-type"] == "application/zip"
+
+    def test_update_requires_one_of_metadata_or_zip(self) -> None:
+        with make_client() as ornn:
+            with pytest.raises(ValueError, match="exactly one"):
+                ornn.update("abc")
+
+    def test_update_rejects_both_metadata_and_zip(self) -> None:
+        with make_client() as ornn:
+            with pytest.raises(ValueError, match="exactly one"):
+                ornn.update("abc", metadata={"name": "x"}, zip_bytes=b"PK")
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_fires_http_delete(self) -> None:
+        route = respx.delete(f"{BASE}/api/v1/skills/abc").respond(
+            200, json={"data": {"success": True}, "error": None}
+        )
+        with make_client() as ornn:
+            ornn.delete("abc")
+        assert route.called
+        assert route.calls.last.request.method == "DELETE"


### PR DESCRIPTION
Closes #110 and completes #31 (#109 shipped the TS half).

## Design

Mirrors the TS SDK on purpose — same method signatures, same auth plumbing, same error shape. Agents written in either language see the same surface.

- `OrnnClient(base_url, token=None, token_resolver=None, transport=None, timeout=30.0)`
- Static token **or** async/sync `token_resolver` callable — resolver wins if both set
- `httpx.Client` under the hood; sync by default (notebook / script ergonomics)
- Context-manager support (`with OrnnClient(...) as ornn:`)
- Response envelope `{data, error}` unwrapped: success → `data` (mapped to dataclass), failure → `raise OrnnError`

## Surface

| Method | HTTP |
|---|---|
| `search(q=..., scope=..., ...)` | `GET /skill-search` → `SkillSearchResult` |
| `get(guid_or_name, version=None)` | `GET /skills/:id` → `SkillDetail` |
| `list_versions(guid_or_name)` | `GET /skills/:id/versions` → `list[SkillVersionEntry]` |
| `download_package(guid, version)` | `GET /skills/:id/versions/:v/download` → `bytes` |
| `publish(zip_bytes, skip_validation=False)` | `POST /skills` (`application/zip`) → `SkillDetail` |
| `update(id, metadata=..., zip_bytes=..., skip_validation=False)` | `PUT /skills/:id` → `SkillDetail` |
| `delete(id)` | `DELETE /skills/:id` |
| `request(method, path, **kwargs)` | escape hatch |

## Dataclasses

`SkillSummary`, `SkillDetail`, `SkillVersionEntry`, `SkillSearchResult`, `UpdateSkillMetadata` — plain dataclasses, no pydantic dep. `from_dict` translates camelCase wire format to snake_case Python and preserves unknown fields on `_extra` for forward compat.

## CI

New dedicated `python-sdk-test` job: `setup-python@v5` @ 3.12, `pip install -e .[dev]`, `pytest -q`. Runs in parallel with the bun jobs — Python artifacts aren't coupled to the bun workspace graph.

## Release cadence

Python SDK publishes to PyPI on its own schedule (package name `ornn-sdk`). Does **not** share the changeset fixed-mode version with `ornn-api` / `ornn-web`. See pyproject.toml for the independent version.

## Test plan

- [x] 23 pytest cases (construction, auth precedence, envelope success / failure / structured errors / unenveloped 5xx, per-method wiring, publish body + skip_validation, download bytes, update dispatch + mutual-exclusion validation, delete)
- [x] `pytest -q` — 23/23 pass in ~0.1s
- [ ] CI: `python-sdk-test` job passes on Python 3.12
- [x] No ornn-api / ornn-web changes; existing bun `typecheck` / `lint` / `test` unaffected