### PR TITLE
fix(web): drop bundled MinIO proxy from nginx image [closes #112]

### DIFF
--- a/.changeset/drop-ornn-web-minio-hack.md
+++ b/.changeset/drop-ornn-web-minio-hack.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Drop the MinIO-specific proxy from `ornn-web/nginx.conf` and its frontend companion `toBrowserAccessibleUrl` in `useSkillPackage.ts`. These were local-dev bandaids that got baked into the production nginx image, causing deploys to fail with `host not found in upstream "minio"` on clusters without a MinIO service. Local dev now exposes MinIO through a dedicated ingress (`deployment/dependencies/minio/ingress.yaml`) at `minio.ornn-cluster.local`.

--- a/deployment/dependencies/minio/ingress.yaml
+++ b/deployment/dependencies/minio/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-ingress
+  namespace: ${NAMESPACE}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: minio.ornn-cluster.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio
+                port:
+                  number: 9000

--- a/ornn-web/nginx.conf
+++ b/ornn-web/nginx.conf
@@ -59,15 +59,6 @@ server {
         proxy_cache off;
     }
 
-    # ── S3/MinIO proxy for presigned URLs ────────────────────────────────
-    # Rewrites browser requests from /s3/<path> to minio:9000/<path>
-    # preserving the Host header so presigned URL signatures remain valid.
-    location /s3/ {
-        rewrite ^/s3/(.*)$ /$1 break;
-        proxy_pass http://minio:9000;
-        proxy_set_header Host minio:9000;
-    }
-
     # ── SPA fallback ──────────────────────────────────────────────────────
     location / {
         try_files $uri $uri/ /index.html;

--- a/ornn-web/src/hooks/useSkillPackage.ts
+++ b/ornn-web/src/hooks/useSkillPackage.ts
@@ -46,24 +46,6 @@ function isTextFile(filename: string): boolean {
   return TEXT_EXTENSIONS.has(ext);
 }
 
-/**
- * Rewrite Docker-internal presigned URLs to go through the nginx /s3/ proxy.
- * e.g. http://minio:9000/bucket/key?sig=... → /s3/bucket/key?sig=...
- * Nginx then forwards to minio:9000 with the correct Host header,
- * keeping the presigned signature valid.
- */
-function toBrowserAccessibleUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    if (parsed.hostname === "minio" || parsed.hostname === "ornn-storage") {
-      return `/s3${parsed.pathname}${parsed.search}`;
-    }
-    return url;
-  } catch {
-    return url;
-  }
-}
-
 interface UseSkillPackageResult {
   files: FileNode[];
   fileContents: Map<string, string>;
@@ -97,7 +79,7 @@ export function useSkillPackage(
       setError(null);
 
       try {
-        const response = await fetch(toBrowserAccessibleUrl(presignedUrl!));
+        const response = await fetch(presignedUrl!);
         if (!response.ok) {
           throw new Error(`Failed to download package: ${response.status}`);
         }


### PR DESCRIPTION
## Summary

- `ornn-web/nginx.conf` had a `/s3/` proxy block hardcoding `proxy_pass http://minio:9000;`. nginx resolves upstream hostnames at startup, so the production image crashed with `host not found in upstream "minio"` on any cluster without a MinIO Service.
- The block was a local-dev bandaid for browser → in-cluster MinIO skill-package downloads; it never belonged in the production image.
- Remove the `/s3/` block and its frontend companion `toBrowserAccessibleUrl`; expose local-dev MinIO via a dedicated Ingress at `minio.ornn-cluster.local` so browser access in local-dev is handled by standard infra.

## Changes

| File | Action |
|---|---|
| `ornn-web/nginx.conf` | Delete `/s3/` location block |
| `ornn-web/src/hooks/useSkillPackage.ts` | Delete `toBrowserAccessibleUrl`; `fetch` uses presigned URL directly |
| `deployment/dependencies/minio/ingress.yaml` | New — `minio.ornn-cluster.local` → `svc/minio:9000` |
| `.changeset/drop-ornn-web-minio-hack.md` | Changeset (ornn-web patch) |

## Test plan

- [x] `bun run typecheck` → 0 errors
- [x] `bun run lint` → 0 errors (66 pre-existing warnings, unrelated)
- [x] `bun run test` → all pass (ornn-api + ornn-web + ornn-sdk)
- [ ] Rebuild `ornn-web` image on the failing deploy platform → nginx starts (no more `host not found in upstream "minio"`)
- [ ] For local dev: add `127.0.0.1 minio.ornn-cluster.local` to `/etc/hosts`, apply the new Ingress, verify skill-package detail page loads the ZIP via `minio.ornn-cluster.local`

Closes #112