### PR TITLE
feat(api): POST /skills/generate/from-source [closes #42]

### DIFF
--- a/.changeset/petite-flies-tell.md
+++ b/.changeset/petite-flies-tell.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+New endpoint `POST /api/v1/skills/generate/from-source` — generates a skill by analyzing backend source code. Accepts either inline `code` or a public GitHub `repoUrl` (optional `path` subfolder). Backend fetches a small bundle of likely route files via the GitHub contents API, auto-detects the framework (Express / Hono / FastAPI / Flask / Spring Boot / Gin / …) and streams the generation via the same SSE event vocabulary as `from-openapi`. Closes #42.

--- a/ornn-api/src/domains/skills/generation/githubFetcher.test.ts
+++ b/ornn-api/src/domains/skills/generation/githubFetcher.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { fetchGithubSourceBundle, parseRepoUrl } from "./githubFetcher";
+
+describe("parseRepoUrl", () => {
+  test("plain repo URL", () => {
+    expect(parseRepoUrl("https://github.com/honojs/hono")).toEqual({
+      owner: "honojs",
+      repo: "hono",
+      ref: "HEAD",
+      subpath: undefined,
+    });
+  });
+
+  test("strips .git suffix", () => {
+    expect(parseRepoUrl("https://github.com/honojs/hono.git")).toMatchObject({
+      owner: "honojs",
+      repo: "hono",
+    });
+  });
+
+  test("tree URL with ref", () => {
+    expect(parseRepoUrl("https://github.com/honojs/hono/tree/main")).toEqual({
+      owner: "honojs",
+      repo: "hono",
+      ref: "main",
+      subpath: undefined,
+    });
+  });
+
+  test("tree URL with ref and subpath", () => {
+    expect(parseRepoUrl("https://github.com/honojs/hono/tree/main/src/routing")).toEqual({
+      owner: "honojs",
+      repo: "hono",
+      ref: "main",
+      subpath: "src/routing",
+    });
+  });
+
+  test("rejects non-github URL", () => {
+    expect(parseRepoUrl("https://gitlab.com/x/y")).toBeNull();
+  });
+
+  test("rejects malformed URL", () => {
+    expect(parseRepoUrl("not a url")).toBeNull();
+  });
+
+  test("rejects repo URL missing repo segment", () => {
+    expect(parseRepoUrl("https://github.com/honojs")).toBeNull();
+  });
+});
+
+describe("fetchGithubSourceBundle", () => {
+  test("fetches top-level files + concatenates with FILE markers", async () => {
+    const fetchMock = (async (url: string | URL): Promise<Response> => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (href.startsWith("https://api.github.com/repos/acme/api/contents/src/routes")) {
+        return new Response(
+          JSON.stringify([
+            {
+              name: "users.ts",
+              path: "src/routes/users.ts",
+              type: "file",
+              size: 120,
+              download_url: "https://raw.example/users.ts",
+            },
+            {
+              name: "README.md",
+              path: "src/routes/README.md",
+              type: "file",
+              size: 99,
+              download_url: "https://raw.example/README.md",
+            },
+            {
+              name: "items.ts",
+              path: "src/routes/items.ts",
+              type: "file",
+              size: 200,
+              download_url: "https://raw.example/items.ts",
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (href === "https://raw.example/users.ts") {
+        return new Response(
+          "import { Hono } from 'hono';\napp.get('/users', handler);\n",
+          { status: 200 },
+        );
+      }
+      if (href === "https://raw.example/items.ts") {
+        return new Response("app.get('/items', itemsHandler);\n", { status: 200 });
+      }
+      return new Response("404", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const bundle = await fetchGithubSourceBundle(
+      "https://github.com/acme/api/tree/main/src/routes",
+      { maxFiles: 5 },
+      fetchMock,
+    );
+    expect(bundle.files.length).toBe(2);
+    expect(bundle.code).toContain("// FILE: src/routes/users.ts");
+    expect(bundle.code).toContain("// FILE: src/routes/items.ts");
+    expect(bundle.code).not.toContain("README.md");
+    expect(bundle.frameworkHint).toBe("hono");
+    expect(bundle.source).toEqual({ owner: "acme", repo: "api", ref: "main" });
+  });
+
+  test("falls back to repo root when no common route folders match", async () => {
+    let firstContentsCall = true;
+    const fetchMock = (async (url: string | URL): Promise<Response> => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (href.startsWith("https://api.github.com/repos/flat/lib/contents")) {
+        // All sub-path lookups 404
+        if (href.includes("/contents/src") || href.includes("/contents/routes") || href.includes("/contents/controllers") || href.includes("/contents/handlers") || href.includes("/contents/app")) {
+          return new Response("{}", { status: 404 });
+        }
+        // Root listing
+        if (href.endsWith("/contents")) {
+          firstContentsCall = false;
+          return new Response(
+            JSON.stringify([
+              {
+                name: "main.py",
+                path: "main.py",
+                type: "file",
+                size: 500,
+                download_url: "https://raw.example/main.py",
+              },
+            ]),
+            { status: 200 },
+          );
+        }
+      }
+      if (href === "https://raw.example/main.py") {
+        return new Response("from fastapi import FastAPI\napp = FastAPI()\n", { status: 200 });
+      }
+      return new Response("404", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const bundle = await fetchGithubSourceBundle(
+      "https://github.com/flat/lib",
+      {},
+      fetchMock,
+    );
+    expect(firstContentsCall).toBe(false);
+    expect(bundle.files[0]?.path).toBe("main.py");
+    expect(bundle.frameworkHint).toBe("fastapi");
+  });
+
+  test("rejects non-GitHub URL", async () => {
+    await expect(
+      fetchGithubSourceBundle("https://gitlab.com/x/y", {}, globalThis.fetch),
+    ).rejects.toThrow(/Not a recognized GitHub URL/);
+  });
+
+  test("truncates files larger than maxBytesPerFile", async () => {
+    const bigFile = "x".repeat(5_000);
+    const fetchMock = (async (url: string | URL): Promise<Response> => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (href.includes("/contents/")) {
+        return new Response(
+          JSON.stringify([
+            {
+              name: "big.ts",
+              path: "src/routes/big.ts",
+              type: "file",
+              size: bigFile.length,
+              download_url: "https://raw.example/big.ts",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (href === "https://raw.example/big.ts") {
+        return new Response(bigFile, { status: 200 });
+      }
+      return new Response("404", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const bundle = await fetchGithubSourceBundle(
+      "https://github.com/acme/api/tree/main/src/routes",
+      { maxBytesPerFile: 1_000 },
+      fetchMock,
+    );
+    expect(bundle.code).toContain("... truncated");
+    expect(bundle.code.length).toBeLessThan(bigFile.length);
+  });
+});

--- a/ornn-api/src/domains/skills/generation/githubFetcher.ts
+++ b/ornn-api/src/domains/skills/generation/githubFetcher.ts
@@ -1,0 +1,234 @@
+/**
+ * Minimal GitHub public-repo source fetcher for the from-source skill
+ * generator. Not a general-purpose GitHub client — purpose-built to feed
+ * a few route files into the LLM context window.
+ *
+ * Public GitHub API, unauthenticated. Rate limit: 60 req / hour / IP.
+ * Fine for individual use; production at scale needs a token-backed
+ * client.
+ *
+ * @module domains/skills/generation/githubFetcher
+ */
+
+import pino from "pino";
+
+const logger = pino({ level: "info" }).child({ module: "githubFetcher" });
+
+export interface FetchOptions {
+  /** Default: tries common route-folder names. */
+  readonly path?: string;
+  /** Max files to pull. Default 8. LLM context budget keeps this low. */
+  readonly maxFiles?: number;
+  /** Max bytes per file. Default 16 KiB. Prevents one giant file blowing context. */
+  readonly maxBytesPerFile?: number;
+}
+
+export interface FetchedBundle {
+  /** Concatenated source, each chunk separated by a `// FILE: <path>` marker. */
+  readonly code: string;
+  /** Files that were included in the bundle. */
+  readonly files: ReadonlyArray<{ readonly path: string; readonly bytes: number }>;
+  /** Detected framework hint ("express" / "fastapi" / ...), or undefined. */
+  readonly frameworkHint?: string;
+  /** Original owner/repo/ref for audit. */
+  readonly source: { readonly owner: string; readonly repo: string; readonly ref: string };
+}
+
+interface ParsedRepoUrl {
+  readonly owner: string;
+  readonly repo: string;
+  readonly ref: string;
+  readonly subpath: string | undefined;
+}
+
+/** Parse `https://github.com/{owner}/{repo}[/tree/{ref}[/path/...]]` into pieces. */
+export function parseRepoUrl(url: string): ParsedRepoUrl | null {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return null;
+  }
+  if (u.hostname !== "github.com") return null;
+  const parts = u.pathname.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+  const owner = parts[0]!;
+  const repo = parts[1]!.replace(/\.git$/, "");
+
+  // /tree/<ref>/<subpath...> or just /<owner>/<repo>
+  if (parts.length >= 4 && parts[2] === "tree") {
+    const ref = parts[3]!;
+    const subpath = parts.slice(4).join("/") || undefined;
+    return { owner, repo, ref, subpath };
+  }
+  return { owner, repo, ref: "HEAD", subpath: undefined };
+}
+
+const LIKELY_ROUTE_PATHS = [
+  "src/routes",
+  "src/controllers",
+  "src/handlers",
+  "src/api",
+  "src/app/api",
+  "routes",
+  "controllers",
+  "app",
+];
+
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".mjs", ".py", ".go", ".java", ".rb", ".rs"]);
+
+interface GithubContentEntry {
+  readonly name: string;
+  readonly path: string;
+  readonly type: "file" | "dir" | "symlink" | string;
+  readonly size: number;
+  readonly download_url: string | null;
+}
+
+/**
+ * Fetch a small bundle of source files from a public GitHub repo.
+ * Returns the concatenated source + metadata, or throws with a
+ * user-safe message when the repo/path can't be resolved.
+ */
+export async function fetchGithubSourceBundle(
+  url: string,
+  options: FetchOptions = {},
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<FetchedBundle> {
+  const parsed = parseRepoUrl(url);
+  if (!parsed) {
+    throw new Error(`Not a recognized GitHub URL: ${url}`);
+  }
+
+  const maxFiles = options.maxFiles ?? 8;
+  const maxBytesPerFile = options.maxBytesPerFile ?? 16 * 1024;
+  const candidatePaths = options.path
+    ? [options.path]
+    : parsed.subpath
+      ? [parsed.subpath]
+      : LIKELY_ROUTE_PATHS;
+
+  let chosenPath: string | null = null;
+  let listing: GithubContentEntry[] = [];
+  for (const path of candidatePaths) {
+    const entries = await listContents(parsed, path, fetchImpl);
+    if (entries && entries.length > 0) {
+      chosenPath = path;
+      listing = entries;
+      break;
+    }
+  }
+  if (!chosenPath) {
+    // Fallback: try the repo root
+    const root = await listContents(parsed, "", fetchImpl);
+    if (root && root.length > 0) {
+      chosenPath = "";
+      listing = root;
+    }
+  }
+  if (!chosenPath && listing.length === 0) {
+    throw new Error("Could not locate any source files in the repo (tried common route folders + root)");
+  }
+
+  // Filter to source files, sort by size ascending so smaller files (more likely
+  // to be route definitions than bundles) come first.
+  const sources = listing
+    .filter((e) => e.type === "file" && hasSourceExt(e.name) && e.size > 0)
+    .sort((a, b) => a.size - b.size)
+    .slice(0, maxFiles);
+
+  if (sources.length === 0) {
+    throw new Error(`No recognized source files under ${chosenPath || "/"}`);
+  }
+
+  const chunks: string[] = [];
+  const files: Array<{ path: string; bytes: number }> = [];
+  for (const entry of sources) {
+    if (!entry.download_url) continue;
+    const res = await fetchImpl(entry.download_url);
+    if (!res.ok) {
+      logger.warn({ path: entry.path, status: res.status }, "Failed to fetch file");
+      continue;
+    }
+    let text = await res.text();
+    if (text.length > maxBytesPerFile) {
+      text = text.slice(0, maxBytesPerFile) + "\n// ... truncated\n";
+    }
+    chunks.push(`// FILE: ${entry.path}\n${text}`);
+    files.push({ path: entry.path, bytes: text.length });
+  }
+
+  const code = chunks.join("\n\n");
+  const frameworkHint = detectFrameworkHint(code);
+
+  logger.info(
+    {
+      owner: parsed.owner,
+      repo: parsed.repo,
+      ref: parsed.ref,
+      path: chosenPath,
+      fileCount: files.length,
+      totalBytes: code.length,
+      frameworkHint,
+    },
+    "Fetched GitHub source bundle",
+  );
+
+  return {
+    code,
+    files,
+    frameworkHint,
+    source: { owner: parsed.owner, repo: parsed.repo, ref: parsed.ref },
+  };
+}
+
+async function listContents(
+  parsed: ParsedRepoUrl,
+  path: string,
+  fetchImpl: typeof fetch,
+): Promise<GithubContentEntry[] | null> {
+  const encodedPath = path ? `/${encodeURI(path)}` : "";
+  const refQuery = parsed.ref && parsed.ref !== "HEAD" ? `?ref=${encodeURIComponent(parsed.ref)}` : "";
+  const apiUrl = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/contents${encodedPath}${refQuery}`;
+  try {
+    const res = await fetchImpl(apiUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "ornn-api/generate-from-source",
+      },
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      logger.warn({ status: res.status, apiUrl }, "GitHub contents API non-OK");
+      return null;
+    }
+    const body = (await res.json()) as GithubContentEntry[] | GithubContentEntry;
+    return Array.isArray(body) ? body : [body];
+  } catch (err) {
+    logger.warn({ err: (err as Error).message, apiUrl }, "GitHub contents fetch failed");
+    return null;
+  }
+}
+
+function hasSourceExt(name: string): boolean {
+  const i = name.lastIndexOf(".");
+  if (i < 0) return false;
+  return SOURCE_EXTENSIONS.has(name.slice(i).toLowerCase());
+}
+
+function detectFrameworkHint(code: string): string | undefined {
+  const probes: Array<[RegExp, string]> = [
+    [/\bfrom\s+['"]hono['"]/i, "hono"],
+    [/require\(['"]express['"]\)|\bfrom\s+['"]express['"]/i, "express"],
+    [/\bfrom\s+['"]fastify['"]/i, "fastify"],
+    [/\bfrom\s+fastapi\b/i, "fastapi"],
+    [/\bfrom\s+flask\b/i, "flask"],
+    [/@SpringBootApplication\b|@RequestMapping\b/i, "spring-boot"],
+    [/gin\.Default\(\)|gin\.Engine\b/i, "gin"],
+    [/\brouter\s*:?=\s*mux\./i, "gorilla-mux"],
+  ];
+  for (const [re, name] of probes) {
+    if (re.test(code)) return name;
+  }
+  return undefined;
+}

--- a/ornn-api/src/domains/skills/generation/prompts.ts
+++ b/ornn-api/src/domains/skills/generation/prompts.ts
@@ -240,3 +240,51 @@ export function buildOpenApiGenerationPrompt(
 
   return prompt;
 }
+
+// ---------------------------------------------------------------------------
+// Source code → skill generation
+// ---------------------------------------------------------------------------
+
+export const SOURCE_CODE_GENERATION_SYSTEM_PROMPT = `You are a skill generator for the ornn AI skill platform. You generate PLAIN API reference skills from backend source code.
+
+Given raw source code (typically route/controller/handler files from a backend service), you:
+1. Identify the framework (Express / Hono / Fastify / FastAPI / Flask / Spring Boot / etc).
+2. Extract every HTTP endpoint: method, path, request shape, response shape, auth requirements.
+3. Emit a single JSON document matching the ornn skill format. The skill documents the discovered API so that an AI agent could call those endpoints correctly.
+
+Output rules:
+- Respond with ONLY the JSON document. No markdown fences. No prose.
+- Skill category MUST be "plain" (reference / documentation skill, no executable runtime).
+- \`readmeBody\`: markdown describing the API — base URL (if discoverable), auth model, endpoint table, and request/response examples.
+- NO YAML frontmatter in \`readmeBody\`.
+- If the source is incomplete, partial, or ambiguous, extract what you can confidently identify. DO NOT fabricate endpoints the code does not support.
+`;
+
+/**
+ * Builds prompt for source-code → skill generation.
+ *
+ * `code` is typically the concatenation of several route files separated
+ * by "// FILE: <path>" markers. Handler knows what it is because the
+ * system prompt names common frameworks.
+ */
+export function buildSourceCodeGenerationPrompt(
+  code: string,
+  options?: { framework?: string; description?: string; sourceUrl?: string },
+): string {
+  let prompt = "Generate a PLAIN API reference skill from the backend source code below. Document every endpoint you can identify.";
+
+  if (options?.framework) {
+    prompt += `\n\nDetected framework hint: ${options.framework}.`;
+  }
+
+  if (options?.sourceUrl) {
+    prompt += `\n\nSource URL (for context only; do NOT invent additional endpoints not in the code): ${options.sourceUrl}`;
+  }
+
+  if (options?.description) {
+    prompt += `\n\nAdditional context: ${options.description}`;
+  }
+
+  prompt += `\n\n--- SOURCE CODE ---\n${code}\n--- END SOURCE CODE ---`;
+  return prompt;
+}

--- a/ornn-api/src/domains/skills/generation/routes.ts
+++ b/ornn-api/src/domains/skills/generation/routes.ts
@@ -15,6 +15,7 @@ import {
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
 import { resolveZipRoot } from "../../../shared/utils/zip";
+import { fetchGithubSourceBundle } from "./githubFetcher";
 import JSZip from "jszip";
 import pino from "pino";
 
@@ -167,6 +168,106 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
       return streamGenerationEvents(
         c,
         generationService.generateStream(query, signal),
+        keepAliveIntervalMs,
+      );
+    },
+  );
+
+  /**
+   * POST /skills/generate/from-source
+   * Input: JSON {
+   *   code?: string,         // inline source (concatenated files, "// FILE: <path>" markers optional)
+   *   repoUrl?: string,      // public GitHub URL; backend fetches a small bundle of route files
+   *   path?: string,         // optional subpath to look under when fetching repoUrl
+   *   framework?: string,    // optional hint ("hono"/"express"/...); auto-detected otherwise
+   *   description?: string,  // optional free-form context
+   * }
+   * Exactly one of `code` or `repoUrl` is required.
+   * Response: SSE stream of generation events
+   * Requires: ornn:skill:build
+   */
+  app.post(
+    "/skills/generate/from-source",
+    auth,
+    requirePermission("ornn:skill:build"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const body = (await c.req.json().catch(() => ({}))) as {
+        code?: unknown;
+        repoUrl?: unknown;
+        path?: unknown;
+        framework?: unknown;
+        description?: unknown;
+      };
+
+      const inlineCode = typeof body.code === "string" ? body.code : undefined;
+      const repoUrl = typeof body.repoUrl === "string" ? body.repoUrl : undefined;
+      const path = typeof body.path === "string" ? body.path : undefined;
+      const framework = typeof body.framework === "string" ? body.framework : undefined;
+      const description = typeof body.description === "string" ? body.description : undefined;
+
+      if (!inlineCode && !repoUrl) {
+        throw AppError.badRequest(
+          "MISSING_SOURCE",
+          "Provide either 'code' (inline source) or 'repoUrl' (public GitHub URL)",
+        );
+      }
+      if (inlineCode && repoUrl) {
+        throw AppError.badRequest(
+          "AMBIGUOUS_SOURCE",
+          "Provide exactly one of 'code' or 'repoUrl', not both",
+        );
+      }
+
+      let code = inlineCode ?? "";
+      let fetchedFramework = framework;
+      let sourceUrl: string | undefined;
+
+      if (repoUrl) {
+        try {
+          const bundle = await fetchGithubSourceBundle(repoUrl, { path });
+          code = bundle.code;
+          fetchedFramework = framework ?? bundle.frameworkHint;
+          sourceUrl = repoUrl;
+          logger.info(
+            {
+              userId: authCtx.userId,
+              repoUrl,
+              fileCount: bundle.files.length,
+              frameworkHint: bundle.frameworkHint,
+            },
+            "Fetched repo bundle for from-source generation",
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw AppError.badRequest("REPO_FETCH_FAILED", `Could not fetch repository: ${message}`);
+        }
+      }
+
+      if (!code.trim()) {
+        throw AppError.badRequest("EMPTY_SOURCE", "Source code is empty — nothing to analyze");
+      }
+
+      logger.info(
+        {
+          userId: authCtx.userId,
+          mode: repoUrl ? "repo" : "inline",
+          codeLength: code.length,
+          framework: fetchedFramework,
+          hasDescription: !!description,
+        },
+        "from-source generation request",
+      );
+
+      const signal = c.req.raw.signal;
+
+      return streamGenerationEvents(
+        c,
+        generationService.generateFromSource(
+          code,
+          { framework: fetchedFramework, description, sourceUrl },
+          signal,
+        ),
         keepAliveIntervalMs,
       );
     },

--- a/ornn-api/src/domains/skills/generation/service.ts
+++ b/ornn-api/src/domains/skills/generation/service.ts
@@ -8,7 +8,14 @@
 import { z } from "zod";
 import type { NyxLlmClient, ResponsesApiStreamEvent, ResponsesApiInputMessage } from "../../../clients/nyxid/llm";
 import type { GeneratedSkill, SkillStreamEvent } from "../../../shared/types/index";
-import { buildDirectGenerationPrompt, buildOpenApiGenerationPrompt, GENERATION_SYSTEM_PROMPT, OPENAPI_GENERATION_SYSTEM_PROMPT } from "./prompts";
+import {
+  buildDirectGenerationPrompt,
+  buildOpenApiGenerationPrompt,
+  buildSourceCodeGenerationPrompt,
+  GENERATION_SYSTEM_PROMPT,
+  OPENAPI_GENERATION_SYSTEM_PROMPT,
+  SOURCE_CODE_GENERATION_SYSTEM_PROMPT,
+} from "./prompts";
 import pino from "pino";
 
 const logger = pino({ level: "info" }).child({ module: "skillGenerationService" });
@@ -281,6 +288,71 @@ export class SkillGenerationService {
     const parsed = this.parseAndValidate(accumulated);
     if (!parsed) {
       logger.warn("OpenAPI generation output failed validation");
+      yield { type: "validation_error", message: "Invalid JSON from LLM", retrying: false };
+    }
+
+    yield { type: "generation_complete", raw: accumulated };
+  }
+
+  /**
+   * Generate a skill from raw backend source code (route / controller /
+   * handler files). Streams tokens via the same SSE event vocabulary as
+   * the other generators.
+   *
+   * `code` is typically a concatenation of several source files, each
+   * preceded by a `// FILE: <path>` marker — that's exactly what
+   * {@link fetchGithubSourceBundle} produces.
+   */
+  async *generateFromSource(
+    code: string,
+    options?: { framework?: string; description?: string; sourceUrl?: string },
+    signal?: AbortSignal,
+  ): AsyncIterable<SkillStreamEvent> {
+    if (signal?.aborted) {
+      yield { type: "error", message: "Request aborted" };
+      return;
+    }
+
+    yield { type: "generation_start" };
+
+    const userPrompt = buildSourceCodeGenerationPrompt(code, options);
+    const input: ResponsesApiInputMessage[] = [
+      { role: "developer", content: SOURCE_CODE_GENERATION_SYSTEM_PROMPT },
+      { role: "user", content: userPrompt },
+    ];
+
+    let accumulated = "";
+
+    try {
+      const streamEvents = this.llmClient.stream({
+        model: this.defaultModel,
+        input,
+        max_output_tokens: this.maxOutputTokens,
+        temperature: this.temperature,
+      });
+
+      for await (const event of streamEvents) {
+        if (signal?.aborted) {
+          yield { type: "error", message: "Request aborted" };
+          return;
+        }
+
+        const text = extractTextFromEvent(event);
+        if (text) {
+          accumulated += text;
+          yield { type: "token", content: text };
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ err: message }, "Source-code generation LLM stream error");
+      yield { type: "error", message: `LLM error: ${message}` };
+      return;
+    }
+
+    const parsed = this.parseAndValidate(accumulated);
+    if (!parsed) {
+      logger.warn("Source-code generation output failed validation");
       yield { type: "validation_error", message: "Invalid JSON from LLM", retrying: false };
     }
 


### PR DESCRIPTION
Closes #42.

## Two input modes

- **inline code**: `{ code: string, framework?, description? }` — client sends its own concatenated source
- **public repo**: `{ repoUrl: string, path?, framework?, description? }` — backend fetches a small bundle via GitHub contents API, auto-detects the framework, feeds into the LLM

Exactly one of `code` or `repoUrl` required (handler enforces both-or-neither rejection).

## Fetch pipeline

1. `parseRepoUrl` turns `https://github.com/{owner}/{repo}[/tree/{ref}[/subpath]]` into pieces
2. `fetchGithubSourceBundle` tries the parsed subpath, then common route folders (`src/routes`, `src/controllers`, `src/handlers`, `src/api`, `src/app/api`, `routes`, `controllers`, `app`), then root as fallback
3. Selects source files by extension (`.ts .tsx .js .mjs .py .go .java .rb .rs`), sorts by size ascending (small files → route definitions; big files → bundles), caps at `maxFiles` (default 8)
4. Truncates per-file at `maxBytesPerFile` (default 16 KiB) so one vendored file can't blow the LLM context
5. Detects framework hint via pattern match — `hono`, `express`, `fastify`, `fastapi`, `flask`, `spring-boot`, `gin`, `gorilla-mux`

Unauthenticated GitHub requests (60 / hr / IP). Private repos and token-backed fetching are explicit follow-ups.

## Prompting

New `SOURCE_CODE_GENERATION_SYSTEM_PROMPT` instructs the LLM to:

1. Identify the framework
2. Extract every HTTP endpoint (method, path, request/response shape, auth)
3. Emit a PLAIN category skill — `readmeBody` with a base-URL + auth model + endpoint table + examples
4. **Never fabricate endpoints** that aren't in the source

## Streaming

Reuses the existing SSE event vocabulary from `generateFromOpenApi`: `generation_start` → N × `token` → optional `validation_error` → `generation_complete`. Same `streamGenerationEvents` helper, same keep-alive cadence.

## Tests

- `githubFetcher.test.ts` — 11 cases (URL parsing, file selection with size sort + extension filter, root fallback, non-GitHub rejection, truncation)
- Full suite still green: 209 backend + 11 web + 17 sdk + 23 python-sdk = 260 pass

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — all green
- [ ] Manual smoke: POST with `repoUrl=https://github.com/honojs/hono/tree/main/src` and verify SSE events flow