### PR TITLE
feat(api): GitHub pull + refresh for skills [closes #57]

### DIFF
--- a/.changeset/twelve-wombats-search.md
+++ b/.changeset/twelve-wombats-search.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+Skills can now be pulled from public GitHub repos. `POST /api/v1/skills/pull` accepts `{ repo: "owner/name", ref?, path? }`, fetches the target directory via the GitHub contents API, builds a ZIP, validates, and publishes. `POST /api/v1/skills/:id/refresh` re-pulls the stored source and publishes as a new version. Skill docs carry an optional `source` field (type `github`, with repo/ref/path/lastSyncedAt/lastSyncedCommit) that's returned on `GET /api/v1/skills/:id` when present. Closes #57.

--- a/ornn-api/src/domains/admin/activityRepository.ts
+++ b/ornn-api/src/domains/admin/activityRepository.ts
@@ -16,7 +16,8 @@ export type ActivityAction =
   | "skill:update"
   | "skill:delete"
   | "skill:visibility_change"
-  | "skill:permissions_change";
+  | "skill:permissions_change"
+  | "skill:refresh";
 
 export interface ActivityDocument {
   _id: string;

--- a/ornn-api/src/domains/skills/crud/repository.ts
+++ b/ornn-api/src/domains/skills/crud/repository.ts
@@ -30,6 +30,8 @@ export interface CreateSkillData {
   isPrivate?: boolean;
   /** Initial version, e.g. "1.0". Required. */
   latestVersion: string;
+  /** Origin metadata when the skill was created via a pull from an external source. */
+  source?: import("../../../shared/types/index").SkillSource;
 }
 
 export interface UpdateSkillData {
@@ -50,6 +52,8 @@ export interface UpdateSkillData {
   sharedWithOrgs?: string[];
   /** Cached latest-version pointer; update when a new package version is published. */
   latestVersion?: string;
+  /** Origin metadata; bumped by the refresh-from-source path. */
+  source?: import("../../../shared/types/index").SkillSource;
   updatedBy: string;
 }
 
@@ -118,6 +122,10 @@ export class SkillRepository {
       latestVersion: data.latestVersion,
     };
 
+    if (data.source) {
+      doc.source = data.source;
+    }
+
     try {
       await this.collection.insertOne(doc);
       logger.info({ guid: data.guid, name: data.name }, "Skill created");
@@ -147,6 +155,7 @@ export class SkillRepository {
     if (data.isPrivate !== undefined) setFields.isPrivate = data.isPrivate;
     if (data.sharedWithUsers !== undefined) setFields.sharedWithUsers = data.sharedWithUsers;
     if (data.sharedWithOrgs !== undefined) setFields.sharedWithOrgs = data.sharedWithOrgs;
+    if (data.source !== undefined) setFields.source = data.source;
     if (data.latestVersion !== undefined) setFields.latestVersion = data.latestVersion;
 
     await this.collection.updateOne({ _id: guid as any }, { $set: setFields });
@@ -507,6 +516,16 @@ function mapDoc(doc: Document | null): SkillDocument | null {
     sharedWithUsers: Array.isArray(doc.sharedWithUsers) ? (doc.sharedWithUsers as string[]) : [],
     sharedWithOrgs: Array.isArray(doc.sharedWithOrgs) ? (doc.sharedWithOrgs as string[]) : [],
     latestVersion: doc.latestVersion ?? "0.1",
+    source: doc.source
+      ? {
+          type: "github",
+          repo: String(doc.source.repo ?? ""),
+          ref: String(doc.source.ref ?? ""),
+          path: String(doc.source.path ?? ""),
+          lastSyncedAt: doc.source.lastSyncedAt instanceof Date ? doc.source.lastSyncedAt : new Date(doc.source.lastSyncedAt),
+          lastSyncedCommit: String(doc.source.lastSyncedCommit ?? ""),
+        }
+      : undefined,
   };
 }
 

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -109,6 +109,125 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
   );
 
   /**
+   * POST /skills/pull — Create a skill by pulling from a public GitHub repo.
+   * Body: { repo: "owner/name", ref?: string, path?: string }
+   * Requires: ornn:skill:create
+   *
+   * This creates a one-way link GitHub → Ornn: subsequent updates to the
+   * upstream repo can be brought in via POST /skills/:id/refresh without
+   * re-uploading a ZIP.
+   */
+  app.post(
+    "/skills/pull",
+    auth,
+    requirePermission("ornn:skill:create"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const body = (await c.req.json().catch(() => ({}))) as {
+        repo?: unknown;
+        ref?: unknown;
+        path?: unknown;
+        skip_validation?: unknown;
+      };
+
+      if (typeof body.repo !== "string" || !body.repo) {
+        throw AppError.badRequest("MISSING_REPO", "A 'repo' field (format 'owner/name') is required");
+      }
+
+      const ref = typeof body.ref === "string" && body.ref ? body.ref : undefined;
+      const path = typeof body.path === "string" ? body.path : undefined;
+      const skipValidation = body.skip_validation === true;
+      const userEmail = authCtx.email || undefined;
+      const userDisplayName = authCtx.displayName || undefined;
+
+      try {
+        const { guid } = await skillService.createSkillFromGitHub(
+          { repo: body.repo, ref, path },
+          authCtx.userId,
+          { userEmail, userDisplayName, skipValidation },
+        );
+        const skill = await skillService.getSkill(guid);
+
+        logger.info(
+          { guid, userId: authCtx.userId, repo: body.repo, ref, path },
+          "Skill created via GitHub pull",
+        );
+
+        activityRepo
+          ?.log(authCtx.userId, userEmail ?? "", userDisplayName ?? "", "skill:create", {
+            skillId: guid,
+            skillName: skill.name,
+            source: "github-pull",
+          })
+          .catch((err) => logger.warn({ err }, "Failed to log skill:create activity"));
+
+        return c.json({ data: skill, error: null });
+      } catch (err) {
+        if (err instanceof AppError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        throw AppError.badRequest("PULL_FAILED", message);
+      }
+    },
+  );
+
+  /**
+   * POST /skills/:id/refresh — Re-pull a skill's package from its stored
+   * GitHub source and publish as a new version.
+   * Requires: ornn:skill:update, and caller must be the skill's author or a
+   * platform admin.
+   */
+  app.post(
+    "/skills/:id/refresh",
+    auth,
+    requirePermission("ornn:skill:update"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const guid = c.req.param("id");
+
+      const existing = await skillService.getSkill(guid);
+      const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
+      if (existing.createdBy !== authCtx.userId && !isPlatformAdmin) {
+        throw AppError.forbidden(
+          "NOT_SKILL_OWNER",
+          "Only the skill's author or a platform admin may refresh it",
+        );
+      }
+
+      try {
+        const refreshed = await skillService.refreshSkillFromSource(guid, authCtx.userId, {
+          userEmail: authCtx.email || undefined,
+          userDisplayName: authCtx.displayName || undefined,
+        });
+
+        logger.info(
+          { guid, userId: authCtx.userId, newCommit: refreshed.source?.lastSyncedCommit },
+          "Skill refreshed from GitHub source",
+        );
+
+        activityRepo
+          ?.log(
+            authCtx.userId,
+            authCtx.email ?? "",
+            authCtx.displayName ?? "",
+            "skill:refresh",
+            {
+              skillId: guid,
+              skillName: refreshed.name,
+              commit: refreshed.source?.lastSyncedCommit,
+            },
+          )
+          .catch((err) => logger.warn({ err }, "Failed to log skill:refresh activity"));
+
+        return c.json({ data: refreshed, error: null });
+      } catch (err) {
+        if (err instanceof AppError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        throw AppError.badRequest("REFRESH_FAILED", message);
+      }
+    },
+  );
+
+  /**
    * GET /skills/:idOrName/json — Return skill package as JSON with all file contents.
    * Requires: ornn:skill:read
    */

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -9,8 +9,9 @@ import { randomUUID } from "node:crypto";
 import type { SkillRepository } from "./repository";
 import type { SkillVersionRepository } from "./skillVersionRepository";
 import type { IStorageClient } from "../../../clients/storageClient";
-import type { SkillDocument, SkillMetadata, SkillDetailResponse, SkillVersionDocument } from "../../../shared/types/index";
+import type { SkillDocument, SkillMetadata, SkillDetailResponse, SkillVersionDocument, SkillSource } from "../../../shared/types/index";
 import { AppError } from "../../../shared/types/index";
+import { fetchSkillFromGitHub, type GitHubPullInput } from "./utils/githubPull";
 import { isReservedVerb } from "../../../shared/reservedVerbs";
 import { validateSkillFrontmatter } from "../../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../../shared/utils/zip";
@@ -65,6 +66,8 @@ export class SkillService {
       skipValidation?: boolean;
       userEmail?: string;
       userDisplayName?: string;
+      /** Origin metadata stamped on the skill doc when created from an external pull. */
+      source?: import("../../../shared/types/index").SkillSource;
     },
   ): Promise<{ guid: string }> {
     // 1. Validate ZIP format rules
@@ -125,6 +128,7 @@ export class SkillService {
       createdByDisplayName: options?.userDisplayName,
       isPrivate: true,
       latestVersion: version,
+      source: options?.source,
     });
 
     // 7. Record the initial version row.
@@ -294,6 +298,8 @@ export class SkillService {
       skipValidation?: boolean;
       userEmail?: string;
       userDisplayName?: string;
+      /** Refresh-from-source path stamps this so lastSyncedAt/Commit move forward. */
+      source?: import("../../../shared/types/index").SkillSource;
     },
   ): Promise<SkillDetailResponse> {
     const existing = await this.skillRepo.findByGuid(guid);
@@ -378,8 +384,90 @@ export class SkillService {
       updateData.isPrivate = options.isPrivate;
     }
 
+    if (options.source !== undefined) {
+      updateData.source = options.source;
+    }
+
     const updated = await this.skillRepo.update(guid, updateData as any);
     return this.buildDetailResponse(updated);
+  }
+
+  /**
+   * Pull a skill package from a public GitHub repo and publish it as a new
+   * skill. Returns the created skill's GUID + the source manifest that was
+   * stamped on the doc so callers can show "linked to X".
+   *
+   * Distinct from `createSkill` because the caller doesn't provide the ZIP —
+   * this method builds it from the repo contents via
+   * {@link fetchSkillFromGitHub} and then hands off to `createSkill` with
+   * the source stamped.
+   */
+  async createSkillFromGitHub(
+    input: GitHubPullInput,
+    userId: string,
+    options?: { userEmail?: string; userDisplayName?: string; skipValidation?: boolean },
+  ): Promise<{ guid: string; source: SkillSource }> {
+    const pulled = await fetchSkillFromGitHub(input);
+    const source: SkillSource = {
+      type: "github",
+      repo: pulled.source.repo,
+      ref: pulled.source.ref,
+      path: pulled.source.path,
+      lastSyncedAt: new Date(),
+      lastSyncedCommit: pulled.resolvedCommitSha,
+    };
+    const { guid } = await this.createSkill(pulled.zipBuffer, userId, {
+      skipValidation: options?.skipValidation,
+      userEmail: options?.userEmail,
+      userDisplayName: options?.userDisplayName,
+      source,
+    });
+    return { guid, source };
+  }
+
+  /**
+   * Re-pull the skill's stored GitHub source and publish the fetched package
+   * as a new version. Fails if the skill has no `source` or the source is
+   * not of type `github`.
+   */
+  async refreshSkillFromSource(
+    guid: string,
+    userId: string,
+    options?: { userEmail?: string; userDisplayName?: string; skipValidation?: boolean },
+  ): Promise<SkillDetailResponse> {
+    const existing = await this.skillRepo.findByGuid(guid);
+    if (!existing) {
+      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+    }
+    if (!existing.source || existing.source.type !== "github") {
+      throw AppError.badRequest(
+        "NO_SOURCE",
+        "Skill has no linked GitHub source; use POST /api/v1/skills/pull to create a new linked skill",
+      );
+    }
+
+    const pulled = await fetchSkillFromGitHub({
+      repo: existing.source.repo,
+      ref: existing.source.ref,
+      path: existing.source.path,
+    });
+
+    const newSource: SkillSource = {
+      type: "github",
+      repo: existing.source.repo,
+      ref: existing.source.ref,
+      path: existing.source.path,
+      lastSyncedAt: new Date(),
+      lastSyncedCommit: pulled.resolvedCommitSha,
+    };
+
+    return this.updateSkill(guid, userId, {
+      zipBuffer: pulled.zipBuffer,
+      skipValidation: options?.skipValidation,
+      userEmail: options?.userEmail,
+      userDisplayName: options?.userDisplayName,
+      source: newSource,
+    });
   }
 
   async deleteSkill(guid: string): Promise<void> {
@@ -641,6 +729,19 @@ export class SkillService {
       version,
       isDeprecated,
       deprecationNote,
+      source: skill.source
+        ? {
+            type: "github",
+            repo: skill.source.repo,
+            ref: skill.source.ref,
+            path: skill.source.path,
+            lastSyncedAt:
+              skill.source.lastSyncedAt instanceof Date
+                ? skill.source.lastSyncedAt.toISOString()
+                : String(skill.source.lastSyncedAt),
+            lastSyncedCommit: skill.source.lastSyncedCommit,
+          }
+        : undefined,
     };
   }
 

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
@@ -86,7 +86,9 @@ function buildStubFetch(config: {
       const p = href.replace("https://raw.example/", "");
       const content = config.rawFiles[p];
       if (!content) return new Response("raw not found", { status: 404 });
-      return new Response(content);
+      const body: BodyInit =
+        typeof content === "string" ? content : (content.slice().buffer as ArrayBuffer);
+      return new Response(body);
     }
     return new Response("unknown", { status: 404 });
   };

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+import {
+  fetchSkillFromGitHub,
+  normalizePath,
+  normalizeRepoIdentifier,
+} from "./githubPull";
+
+describe("normalizeRepoIdentifier", () => {
+  test("accepts owner/name", () => {
+    expect(normalizeRepoIdentifier("acme/skill")).toBe("acme/skill");
+  });
+  test("trims whitespace", () => {
+    expect(normalizeRepoIdentifier("  acme/skill  ")).toBe("acme/skill");
+  });
+  test("rejects single segment", () => {
+    expect(() => normalizeRepoIdentifier("acme")).toThrow(/Invalid GitHub repo/);
+  });
+  test("rejects bad chars", () => {
+    expect(() => normalizeRepoIdentifier("acme/s kill")).toThrow();
+    expect(() => normalizeRepoIdentifier("acme/skill#branch")).toThrow();
+  });
+});
+
+describe("normalizePath", () => {
+  test("empty / undefined -> ''", () => {
+    expect(normalizePath(undefined)).toBe("");
+    expect(normalizePath("")).toBe("");
+    expect(normalizePath("/")).toBe("");
+  });
+  test("strips leading/trailing slashes", () => {
+    expect(normalizePath("/skills/pdf/")).toBe("skills/pdf");
+  });
+  test("rejects .. traversal", () => {
+    expect(() => normalizePath("../etc")).toThrow(/traversal/);
+    expect(() => normalizePath("foo/../bar")).toThrow(/traversal/);
+  });
+  test("rejects . segments", () => {
+    expect(() => normalizePath("./foo")).toThrow(/traversal/);
+  });
+});
+
+/** Minimal stub that walks calls like GitHub's contents + raw APIs. */
+function buildStubFetch(config: {
+  sha: string;
+  tree: Record<string, Array<{ name: string; type: "file" | "dir"; size?: number }>>;
+  rawFiles: Record<string, string | Uint8Array>;
+}): typeof fetch {
+  const impl = async (input: RequestInfo | URL): Promise<Response> => {
+    const href = typeof input === "string" ? input : input.toString();
+    const u = new URL(href);
+
+    // /repos/{owner}/{repo}/commits/{ref}
+    if (u.pathname.includes("/commits/")) {
+      return new Response(JSON.stringify({ sha: config.sha }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    // /repos/{owner}/{repo}/contents[/{path}]
+    if (u.pathname.includes("/contents")) {
+      const m = u.pathname.match(/\/contents(?:\/(.*))?$/);
+      const path = m && m[1] ? decodeURI(m[1]) : "";
+      const entries = config.tree[path];
+      if (!entries) {
+        return new Response("not found", { status: 404 });
+      }
+      const items = entries.map((e) => {
+        const full = path ? `${path}/${e.name}` : e.name;
+        return {
+          name: e.name,
+          path: full,
+          type: e.type,
+          size: e.size ?? 0,
+          sha: "sha-" + full,
+          download_url:
+            e.type === "file" ? `https://raw.example/${full}` : null,
+        };
+      });
+      return new Response(JSON.stringify(items), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (href.startsWith("https://raw.example/")) {
+      const p = href.replace("https://raw.example/", "");
+      const content = config.rawFiles[p];
+      if (!content) return new Response("raw not found", { status: 404 });
+      return new Response(content);
+    }
+    return new Response("unknown", { status: 404 });
+  };
+  return impl as unknown as typeof fetch;
+}
+
+describe("fetchSkillFromGitHub", () => {
+  test("pulls SKILL.md + scripts from a subdirectory and returns a zip", async () => {
+    const SKILL_MD = `---
+name: demo-skill
+description: A demo skill pulled from GitHub
+---
+# Demo
+
+Hello world.
+`;
+    const fetchMock = buildStubFetch({
+      sha: "abc1234def",
+      tree: {
+        "skills/demo": [
+          { name: "SKILL.md", type: "file", size: SKILL_MD.length },
+          { name: "scripts", type: "dir" },
+        ],
+        "skills/demo/scripts": [
+          { name: "main.js", type: "file", size: 20 },
+        ],
+      },
+      rawFiles: {
+        "skills/demo/SKILL.md": SKILL_MD,
+        "skills/demo/scripts/main.js": "console.log('hi');\n",
+      },
+    });
+
+    const result = await fetchSkillFromGitHub(
+      { repo: "acme/skills-repo", ref: "main", path: "skills/demo" },
+      fetchMock,
+    );
+    expect(result.resolvedCommitSha).toBe("abc1234def");
+    expect(result.source).toEqual({
+      repo: "acme/skills-repo",
+      ref: "main",
+      path: "skills/demo",
+    });
+    expect(result.files.map((f) => f.path).sort()).toEqual([
+      "skills/demo/SKILL.md",
+      "skills/demo/scripts/main.js",
+    ]);
+
+    // Verify ZIP contents: root folder is the last path segment.
+    const zip = await JSZip.loadAsync(result.zipBuffer);
+    expect(Object.keys(zip.files).sort()).toContain("demo/SKILL.md");
+    expect(Object.keys(zip.files).sort()).toContain("demo/scripts/main.js");
+    const skillMd = await zip.file("demo/SKILL.md")!.async("string");
+    expect(skillMd).toContain("name: demo-skill");
+  });
+
+  test("rejects when SKILL.md is missing at the target path", async () => {
+    const fetchMock = buildStubFetch({
+      sha: "deadbeef",
+      tree: {
+        "": [{ name: "README.md", type: "file", size: 10 }],
+      },
+      rawFiles: { "README.md": "# noop\n" },
+    });
+    await expect(
+      fetchSkillFromGitHub({ repo: "acme/x", ref: "main", path: "" }, fetchMock),
+    ).rejects.toThrow(/No SKILL\.md/);
+  });
+
+  test("rejects when the ref cannot be resolved", async () => {
+    const fetchMock = (async (input: RequestInfo | URL): Promise<Response> => {
+      const href = typeof input === "string" ? input : input.toString();
+      if (href.includes("/commits/")) {
+        return new Response("", { status: 404 });
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+    await expect(
+      fetchSkillFromGitHub({ repo: "acme/x", ref: "nope" }, fetchMock),
+    ).rejects.toThrow(/Ref 'nope' not found/);
+  });
+
+  test("honors the maxFiles cap", async () => {
+    const files: Array<{ name: string; type: "file"; size: number }> = [
+      { name: "SKILL.md", type: "file", size: 10 },
+    ];
+    for (let i = 0; i < 10; i++) {
+      files.push({ name: `f${i}.txt`, type: "file", size: 1 });
+    }
+    const raw: Record<string, string> = { "SKILL.md": "---\nname: x\n---\n" };
+    for (let i = 0; i < 10; i++) raw[`f${i}.txt`] = "x";
+
+    const fetchMock = buildStubFetch({
+      sha: "a",
+      tree: { "": files },
+      rawFiles: raw,
+    });
+
+    await expect(
+      fetchSkillFromGitHub(
+        { repo: "acme/x", ref: "main", maxFiles: 5 },
+        fetchMock,
+      ),
+    ).rejects.toThrow(/exceeds the 5-file cap/);
+  });
+
+  test("defaults to HEAD when ref is not provided", async () => {
+    const fetchMock = buildStubFetch({
+      sha: "headsha",
+      tree: {
+        "": [{ name: "SKILL.md", type: "file", size: 10 }],
+      },
+      rawFiles: { "SKILL.md": "---\nname: r\n---\n" },
+    });
+    const result = await fetchSkillFromGitHub({ repo: "acme/x" }, fetchMock);
+    expect(result.source.ref).toBe("HEAD");
+    expect(result.resolvedCommitSha).toBe("headsha");
+  });
+});

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.ts
@@ -1,0 +1,236 @@
+/**
+ * Pull a skill package directly from a public GitHub repo.
+ *
+ * The SKILL.md + supporting files live at `{owner}/{name}:{ref}/{path}`.
+ * We resolve the ref to a commit SHA for audit, walk the directory via
+ * the contents API, fetch each file's raw bytes, and build a ZIP in the
+ * shape the existing upload pipeline expects (skill-root/SKILL.md, etc.).
+ *
+ * MVP constraints:
+ *   - public repos only (no auth header)
+ *   - single directory, recursive (enumerates via contents API)
+ *   - max 200 files / 10 MiB total to keep the pull bounded
+ *
+ * @module domains/skills/crud/utils/githubPull
+ */
+
+import JSZip from "jszip";
+import pino from "pino";
+
+const logger = pino({ level: "info" }).child({ module: "githubSkillPull" });
+
+export interface GitHubPullInput {
+  /** `owner/name`. */
+  readonly repo: string;
+  /** Branch, tag, or commit SHA. Defaults to the repo's default branch. */
+  readonly ref?: string;
+  /** Directory inside the repo containing SKILL.md. `""` = repo root. */
+  readonly path?: string;
+  /** Max files to pull. Safety cap. Default 200. */
+  readonly maxFiles?: number;
+  /** Max total bytes. Safety cap. Default 10 MiB. */
+  readonly maxTotalBytes?: number;
+}
+
+export interface GitHubPullResult {
+  /** Packaged ZIP ready to hand to createSkill / updateSkill. */
+  readonly zipBuffer: Uint8Array;
+  /** Actual commit SHA that was fetched (ref resolved at pull time). */
+  readonly resolvedCommitSha: string;
+  /** Manifest of files included (path + bytes). Useful for logs + tests. */
+  readonly files: ReadonlyArray<{ readonly path: string; readonly bytes: number }>;
+  /** Normalized inputs, echoed back for persistence convenience. */
+  readonly source: {
+    readonly repo: string;
+    readonly ref: string;
+    readonly path: string;
+  };
+}
+
+interface GitHubContentEntry {
+  readonly name: string;
+  readonly path: string;
+  readonly type: "file" | "dir" | "symlink" | string;
+  readonly size: number;
+  readonly sha: string;
+  readonly download_url: string | null;
+}
+
+const DEFAULT_MAX_FILES = 200;
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+
+/** Validates `owner/name` and strips any trailing whitespace. */
+export function normalizeRepoIdentifier(repo: string): string {
+  const trimmed = repo.trim();
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(trimmed)) {
+    throw new Error(
+      `Invalid GitHub repo identifier '${repo}'. Expected 'owner/name'.`,
+    );
+  }
+  return trimmed;
+}
+
+/** Normalizes a `path` argument: strips leading/trailing slashes, rejects traversal. */
+export function normalizePath(path: string | undefined): string {
+  const raw = (path ?? "").trim().replace(/^\/+|\/+$/g, "");
+  if (raw.split("/").some((seg) => seg === ".." || seg === ".")) {
+    throw new Error(`Invalid path '${path}' — no traversal or current-dir segments`);
+  }
+  return raw;
+}
+
+/**
+ * Fetch and package a skill from a public GitHub repo.
+ */
+export async function fetchSkillFromGitHub(
+  input: GitHubPullInput,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<GitHubPullResult> {
+  const repo = normalizeRepoIdentifier(input.repo);
+  const refInput = input.ref?.trim() || "HEAD";
+  const path = normalizePath(input.path);
+  const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
+  const maxTotalBytes = input.maxTotalBytes ?? DEFAULT_MAX_BYTES;
+
+  // Resolve the ref to a concrete commit SHA for audit logging.
+  const resolvedCommitSha = await resolveRefToSha(repo, refInput, fetchImpl);
+
+  // Walk the target directory recursively.
+  const allFiles: GitHubContentEntry[] = [];
+  await walkContents(repo, resolvedCommitSha, path, fetchImpl, allFiles);
+
+  if (allFiles.length === 0) {
+    throw new Error(`No files found under '${path || "/"}' in ${repo}@${refInput}`);
+  }
+  if (allFiles.length > maxFiles) {
+    throw new Error(
+      `Refusing to pull: ${allFiles.length} files exceeds the ${maxFiles}-file cap`,
+    );
+  }
+
+  // Verify a SKILL.md exists at the target directory — every skill package
+  // requires one. Existing createSkill will also validate, but failing early
+  // here gives a clearer error.
+  const skillMdRelative = path ? `${path}/SKILL.md` : "SKILL.md";
+  if (!allFiles.some((f) => f.path === skillMdRelative)) {
+    throw new Error(`No SKILL.md found at '${skillMdRelative}' in ${repo}@${refInput}`);
+  }
+
+  // Build the ZIP with a skill-root folder (the upload pipeline expects
+  // `skill-root/SKILL.md`, not flat `SKILL.md`). Use the last path segment
+  // as the folder name, or the repo name when pulling from repo root.
+  const rootName = path ? path.split("/").pop()! : repo.split("/")[1]!;
+  const zip = new JSZip();
+  const folder = zip.folder(rootName);
+  if (!folder) throw new Error("JSZip: failed to create root folder");
+
+  let totalBytes = 0;
+  const manifest: Array<{ path: string; bytes: number }> = [];
+
+  for (const entry of allFiles) {
+    if (!entry.download_url || entry.type !== "file") continue;
+    const relPath = path ? entry.path.slice(path.length + 1) : entry.path;
+    const res = await fetchImpl(entry.download_url);
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch ${entry.path}: HTTP ${res.status} ${res.statusText}`,
+      );
+    }
+    const buf = new Uint8Array(await res.arrayBuffer());
+    totalBytes += buf.byteLength;
+    if (totalBytes > maxTotalBytes) {
+      throw new Error(
+        `Refusing to pull: total bytes ${totalBytes} exceeds the ${maxTotalBytes}-byte cap`,
+      );
+    }
+    folder.file(relPath, buf);
+    manifest.push({ path: entry.path, bytes: buf.byteLength });
+  }
+
+  const zipBuffer = await zip.generateAsync({ type: "uint8array" });
+
+  logger.info(
+    {
+      repo,
+      ref: refInput,
+      resolvedCommitSha,
+      path,
+      fileCount: manifest.length,
+      totalBytes,
+      zipBytes: zipBuffer.byteLength,
+    },
+    "Built skill package from GitHub source",
+  );
+
+  return {
+    zipBuffer,
+    resolvedCommitSha,
+    files: manifest,
+    source: { repo, ref: refInput, path },
+  };
+}
+
+async function resolveRefToSha(
+  repo: string,
+  ref: string,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  const url = `https://api.github.com/repos/${repo}/commits/${encodeURIComponent(ref)}`;
+  const res = await fetchImpl(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "ornn-api/skills-github-pull",
+    },
+  });
+  if (res.status === 404) {
+    throw new Error(`Ref '${ref}' not found in ${repo}`);
+  }
+  if (!res.ok) {
+    throw new Error(
+      `GitHub commits API returned ${res.status} for ${repo}@${ref}`,
+    );
+  }
+  const body = (await res.json()) as { sha?: string };
+  if (!body.sha) {
+    throw new Error(`GitHub commits API returned no SHA for ${repo}@${ref}`);
+  }
+  return body.sha;
+}
+
+async function walkContents(
+  repo: string,
+  ref: string,
+  path: string,
+  fetchImpl: typeof fetch,
+  out: GitHubContentEntry[],
+): Promise<void> {
+  const encodedPath = path ? `/${encodeURI(path)}` : "";
+  const url = `https://api.github.com/repos/${repo}/contents${encodedPath}?ref=${encodeURIComponent(ref)}`;
+  const res = await fetchImpl(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "ornn-api/skills-github-pull",
+    },
+  });
+  if (res.status === 404) {
+    // The target path doesn't exist on this ref. Callers decide whether
+    // that's acceptable — for the top-level call it isn't; for an empty
+    // recursed subdir we just return.
+    return;
+  }
+  if (!res.ok) {
+    throw new Error(
+      `GitHub contents API returned ${res.status} for ${repo}@${ref}:${path}`,
+    );
+  }
+  const body = (await res.json()) as GitHubContentEntry[] | GitHubContentEntry;
+  const entries = Array.isArray(body) ? body : [body];
+  for (const entry of entries) {
+    if (entry.type === "file") {
+      out.push(entry);
+    } else if (entry.type === "dir") {
+      await walkContents(repo, ref, entry.path, fetchImpl, out);
+    }
+    // symlinks, submodules → skip
+  }
+}

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -123,7 +123,36 @@ export interface SkillDocument {
    * for fast default-read access and must be kept in sync by the service layer.
    */
   latestVersion: string;
+  /**
+   * Optional origin metadata. When a skill was created or last refreshed by
+   * pulling from an external source (public GitHub repo today, potentially
+   * other Git hosts later), we record where it came from so the refresh
+   * endpoint knows what to re-fetch.
+   *
+   * Absent for hand-uploaded skills.
+   */
+  source?: SkillSource;
 }
+
+/**
+ * Origin metadata for a skill pulled from an external source. The `type`
+ * discriminator lets future additions (GitLab, Bitbucket, ...) live
+ * alongside `github` without touching callers that only care about one.
+ */
+export type SkillSource =
+  | {
+      type: "github";
+      /** `owner/name`. */
+      repo: string;
+      /** Branch, tag, or commit SHA. The actual commit SHA at pull time lives in `lastSyncedCommit`. */
+      ref: string;
+      /** Subdirectory inside the repo that contains SKILL.md. Empty string = repo root. */
+      path: string;
+      /** ISO timestamp of the most recent successful pull / refresh. */
+      lastSyncedAt: Date;
+      /** Commit SHA that was fetched at `lastSyncedAt`. Allows drift detection. */
+      lastSyncedCommit: string;
+    };
 
 /**
  * Immutable record of a single published version of a skill.
@@ -207,6 +236,20 @@ export interface SkillDetailResponse {
   isDeprecated?: boolean;
   /** Optional note the author left when deprecating this version. */
   deprecationNote?: string | null;
+  /**
+   * Present when the skill was created or refreshed by pulling from an
+   * external source (e.g. a public GitHub repo). Clients use this to
+   * render a "source" link on the detail page and to power "Refresh from
+   * source" actions. Serialized form — `lastSyncedAt` is an ISO string.
+   */
+  source?: {
+    type: "github";
+    repo: string;
+    ref: string;
+    path: string;
+    lastSyncedAt: string;
+    lastSyncedCommit: string;
+  };
 }
 
 export interface SkillSearchItem {


### PR DESCRIPTION
Closes #57. One-way GitHub → Ornn pull so authors can maintain their skill in Git and publish to Ornn without hand-zipping.

## What

- **New endpoints**:
  - `POST /api/v1/skills/pull` — body `{ repo, ref?, path? }`; fetches, packages, validates, creates a skill with `source` stamped.
  - `POST /api/v1/skills/:id/refresh` — owner-or-admin; re-pulls the stored source and publishes a new version.
- **Data model**: new optional `SkillDocument.source` (discriminated, `type: "github"`) with `repo` / `ref` / `path` / `lastSyncedAt` / `lastSyncedCommit`. Surfaces on `SkillDetailResponse` (ISO-serialized `lastSyncedAt`).
- **Fetch layer**: `domains/skills/crud/utils/githubPull.ts` — normalizes inputs, resolves ref → commit SHA, walks contents API recursively, caps 200 files / 10 MiB, fails early when `SKILL.md` is missing at target path, builds ZIP with a skill-root folder matching the existing upload pipeline.
- **Service layer**: `createSkillFromGitHub` + `refreshSkillFromSource`; existing `createSkill` / `updateSkill` gain an optional `source` parameter (no-op when omitted).
- **Activity log**: adds `skill:refresh` action; pull-create events use `skill:create` with `details.source: "github-pull"`.

## Constraints (MVP)

Per the issue scope:

- Public repos only — unauthenticated GitHub API. 60 req/hr/IP is fine for low-volume use; token-brokered auth (GitHub App) is explicit follow-up.
- No webhooks or auto-refresh on upstream push.
- No UI — 'Import from GitHub' button on the upload page is a separate feature issue (UI follow-up per the issue body).

## Tests

- **New** `githubPull.test.ts` — 13 cases:
  - Identifier + path normalization (owner/name validation, traversal rejection, trailing-slash trim)
  - End-to-end ZIP build from a stubbed GitHub tree
  - Rejection on missing SKILL.md at target path
  - Rejection on unresolvable ref
  - `maxFiles` cap enforcement
  - Default-HEAD behavior when `ref` is omitted

- **Suite totals**: 211 api (+11) + 11 web + 17 sdk + 23 python-sdk = 262 pass locally.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — 0 errors, 66 warnings (no change from develop)
- [x] `bun run test` — green
- [ ] Manual smoke against a real public repo once merged (e.g. `POST /api/v1/skills/pull` body `{ repo: "ChronoAIProject/Ornn", path: ".ornn-apis/ornn-search-and-run" }`)