### PR TITLE
feat(web): runtime-driven ornn-web config via ConfigMap [closes #116]

### DIFF
--- a/.changeset/ornn-web-runtime-config.md
+++ b/.changeset/ornn-web-runtime-config.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+Convert ornn-web config from build-time to runtime. Both the nginx upstream URLs (`NYXID_BACKEND_URL`, `ORNN_API_URL`) and the Vite-side `VITE_NYXID_*` / `VITE_API_BASE_URL` values are now injected at container startup via the new `ornn-web-config` ConfigMap instead of being baked into the image. `nginx.conf` → `nginx.conf.template` (envsubst'd by the image's built-in 20-envsubst-on-templates.sh); a new 40-envsubst-config-js.sh script generates `/config.js` from a template, which sets `window.__ORNN_CONFIG__` before the main bundle loads. A new `src/config.ts` module is the single entrypoint for config reads (falls back to `import.meta.env.VITE_*` for `bun run dev` / Vitest). `VITE_NYXID_SETTINGS_URL` was used in code but missing from the Dockerfile ARG list — now covered as part of the runtime config. Drops all `--build-arg VITE_*` from the frontend `docker build` command in CLAUDE.md; one image now runs across every environment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,21 +205,12 @@ done
 ### Step 6: Build ornn images (run from repo root)
 
 ```bash
-# Source env for build args
-set -a; source deployment/.env.ornn; set +a
-
 # Backend
 docker build -t "${ORNN_API_IMAGE}" -f ornn-api/Dockerfile .
 
-# Frontend (build args baked into static bundle)
-docker build -t "${ORNN_WEB_IMAGE}" \
-  --build-arg VITE_API_BASE_URL="${VITE_API_BASE_URL}" \
-  --build-arg VITE_NYXID_AUTHORIZE_URL="${VITE_NYXID_AUTHORIZE_URL}" \
-  --build-arg VITE_NYXID_TOKEN_URL="${VITE_NYXID_TOKEN_URL}" \
-  --build-arg VITE_NYXID_CLIENT_ID="${VITE_NYXID_CLIENT_ID}" \
-  --build-arg VITE_NYXID_REDIRECT_URI="${VITE_NYXID_REDIRECT_URI}" \
-  --build-arg VITE_NYXID_LOGOUT_URL="${VITE_NYXID_LOGOUT_URL}" \
-  -f ornn-web/Dockerfile .
+# Frontend — no build args. All config (nginx upstreams + Vite env)
+# is injected at container startup via the `ornn-web-config` ConfigMap.
+docker build -t "${ORNN_WEB_IMAGE}" -f ornn-web/Dockerfile .
 ```
 
 ### Step 7: Deploy ornn

--- a/deployment/.env.sample.ornn
+++ b/deployment/.env.sample.ornn
@@ -28,11 +28,16 @@ SSE_KEEP_ALIVE_INTERVAL_MS=<keep-alive-ms>
 MAX_PACKAGE_SIZE_BYTES=<max-package-size>
 ALLOWED_ORIGINS=<comma-separated-origins, e.g. https://app.ornn.xyz,http://localhost:5173>
 
-# -- ornn-web (docker build args) --
+# -- ornn-web (runtime env vars — injected via ConfigMap at container start) --
 ORNN_WEB_IMAGE=<ornn-web-image>
-VITE_API_BASE_URL=<ornn-api-base-url>
-VITE_NYXID_AUTHORIZE_URL=<nyxid-authorize-url>
-VITE_NYXID_TOKEN_URL=<nyxid-token-url>
-VITE_NYXID_CLIENT_ID=<nyxid-oauth-client-id>
-VITE_NYXID_REDIRECT_URI=<oauth-redirect-uri>
-VITE_NYXID_LOGOUT_URL=<nyxid-logout-url>
+# nginx upstream targets (consumed by /etc/nginx/templates/default.conf.template)
+NYXID_BACKEND_URL=<nyxid-backend-url>
+ORNN_API_URL=<ornn-api-url>
+# Frontend runtime config (injected into window.__ORNN_CONFIG__ via /config.js)
+API_BASE_URL=<api-base-url-for-frontend>
+NYXID_AUTHORIZE_URL=<nyxid-authorize-url>
+NYXID_REDIRECT_URI=<oauth-redirect-uri>
+NYXID_LOGOUT_URL=<nyxid-logout-url>
+NYXID_SETTINGS_URL=<nyxid-settings-url>
+# NYXID_TOKEN_URL and NYXID_CLIENT_ID are declared in the ornn-api section
+# above and reused here (same NyxID tenant).

--- a/deployment/ornn-web/configmap.yaml
+++ b/deployment/ornn-web/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ornn-web-config
+  namespace: ${NAMESPACE}
+data:
+  # nginx upstreams — consumed by /etc/nginx/templates/default.conf.template
+  # via the image's built-in 20-envsubst-on-templates.sh. NGINX_ENVSUBST_FILTER
+  # narrows substitution to these two so $host / $remote_addr / $scheme etc.
+  # inside the template stay literal.
+  NYXID_BACKEND_URL: "${NYXID_BACKEND_URL}"
+  ORNN_API_URL: "${ORNN_API_URL}"
+  NGINX_ENVSUBST_FILTER: "^(NYXID_BACKEND_URL|ORNN_API_URL)$"
+
+  # Frontend runtime config — consumed by 40-envsubst-config-js.sh,
+  # injected into window.__ORNN_CONFIG__ via /config.js at page load.
+  API_BASE_URL: "${API_BASE_URL}"
+  NYXID_AUTHORIZE_URL: "${NYXID_AUTHORIZE_URL}"
+  NYXID_TOKEN_URL: "${NYXID_TOKEN_URL}"
+  NYXID_CLIENT_ID: "${NYXID_CLIENT_ID}"
+  NYXID_REDIRECT_URI: "${NYXID_REDIRECT_URI}"
+  NYXID_LOGOUT_URL: "${NYXID_LOGOUT_URL}"
+  NYXID_SETTINGS_URL: "${NYXID_SETTINGS_URL}"

--- a/deployment/ornn-web/deployment.yaml
+++ b/deployment/ornn-web/deployment.yaml
@@ -21,6 +21,9 @@ spec:
           imagePullPolicy: ${IMAGE_PULL_POLICY}
           ports:
             - containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: ornn-web-config
           readinessProbe:
             httpGet:
               path: /

--- a/ornn-web/Dockerfile
+++ b/ornn-web/Dockerfile
@@ -1,13 +1,6 @@
 FROM oven/bun:latest AS build
 WORKDIR /app
 
-ARG VITE_API_BASE_URL
-ARG VITE_NYXID_AUTHORIZE_URL
-ARG VITE_NYXID_TOKEN_URL
-ARG VITE_NYXID_CLIENT_ID
-ARG VITE_NYXID_REDIRECT_URI
-ARG VITE_NYXID_LOGOUT_URL
-
 # Copy workspace root package files
 COPY package.json bun.lock ./
 
@@ -29,6 +22,14 @@ RUN bun run build
 
 FROM nginx:alpine
 COPY --from=build /app/ornn-web/dist /usr/share/nginx/html
-COPY ornn-web/nginx.conf /etc/nginx/conf.d/default.conf
+# nginx:alpine envsubst's /etc/nginx/templates/*.template at startup
+# (see /docker-entrypoint.d/20-envsubst-on-templates.sh). Substitution is
+# scoped to NYXID_BACKEND_URL / ORNN_API_URL via NGINX_ENVSUBST_FILTER
+# in the ConfigMap — $host / $scheme etc. stay literal.
+COPY ornn-web/nginx.conf.template /etc/nginx/templates/default.conf.template
+# Runtime frontend config: generate /config.js from its template and
+# inject window.__ORNN_CONFIG__ at container startup.
+COPY ornn-web/docker-entrypoint.d/40-envsubst-config-js.sh /docker-entrypoint.d/40-envsubst-config-js.sh
+RUN chmod +x /docker-entrypoint.d/40-envsubst-config-js.sh
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/ornn-web/docker-entrypoint.d/40-envsubst-config-js.sh
+++ b/ornn-web/docker-entrypoint.d/40-envsubst-config-js.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Generate /usr/share/nginx/html/config.js from its template at container
+# startup, substituting ornn-web's runtime config env vars. Sister script
+# to the image's own 20-envsubst-on-templates.sh (which only handles
+# /etc/nginx/templates/*.template for nginx config).
+set -eu
+
+ME=$(basename "$0")
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$ME: $*"
+    fi
+}
+
+template="/usr/share/nginx/html/config.js.template"
+output="/usr/share/nginx/html/config.js"
+
+if [ ! -f "$template" ]; then
+    entrypoint_log "info: $template not found, skipping"
+    exit 0
+fi
+
+entrypoint_log "info: rendering $output from $template"
+
+envsubst '${API_BASE_URL} ${NYXID_AUTHORIZE_URL} ${NYXID_TOKEN_URL} ${NYXID_CLIENT_ID} ${NYXID_REDIRECT_URI} ${NYXID_LOGOUT_URL} ${NYXID_SETTINGS_URL}' \
+    < "$template" > "$output"
+
+# Drop the template so it isn't served publicly.
+rm -f "$template"

--- a/ornn-web/index.html
+++ b/ornn-web/index.html
@@ -14,6 +14,11 @@
   </head>
   <body class="bg-[#0a0a0f] text-[#e8e8e8] antialiased">
     <div id="root"></div>
+    <!-- Runtime config, generated per-environment at container startup
+         by /docker-entrypoint.d/40-envsubst-config-js.sh. Must load before
+         the main bundle so window.__ORNN_CONFIG__ is set when src/config.ts
+         evaluates. -->
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ornn-web/nginx.conf.template
+++ b/ornn-web/nginx.conf.template
@@ -20,6 +20,14 @@ server {
         application/xml
         image/svg+xml;
 
+    # ── Runtime config — MUST NOT be cached. window.__ORNN_CONFIG__ varies
+    #    per environment; matched ahead of the generic .js rule below.
+    location = /config.js {
+        expires -1;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        try_files $uri =404;
+    }
+
     # ── Static asset caching ──────────────────────────────────────────────
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
@@ -36,14 +44,14 @@ server {
 
     # ── Public API route → direct to ornn-api (no auth required) ────
     location = /api/v1/openapi.json {
-        proxy_pass http://ornn-api:3802/api/v1/openapi.json;
+        proxy_pass ${ORNN_API_URL}/api/v1/openapi.json;
         proxy_set_header Host $host;
     }
 
     # ── Authenticated API routes → NyxID proxy → ornn-api ─────────
     # /api/v1/X → NyxID proxy /api/v1/proxy/s/ornn-api/api/v1/X → ornn-api /api/v1/X
     location /api/v1/ {
-        proxy_pass http://nyxid-backend:3001/api/v1/proxy/s/ornn-api/api/v1/;
+        proxy_pass ${NYXID_BACKEND_URL}/api/v1/proxy/s/ornn-api/api/v1/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ornn-web/public/config.js
+++ b/ornn-web/public/config.js
@@ -1,0 +1,5 @@
+// Dev stub. Overwritten in production by
+// /docker-entrypoint.d/40-envsubst-config-js.sh at container startup.
+// With an empty object, src/config.ts falls back to import.meta.env.VITE_*
+// (populated from .env.local during `bun run dev`).
+window.__ORNN_CONFIG__ = {};

--- a/ornn-web/public/config.js.template
+++ b/ornn-web/public/config.js.template
@@ -1,0 +1,9 @@
+window.__ORNN_CONFIG__ = {
+  apiBaseUrl: "${API_BASE_URL}",
+  nyxidAuthorizeUrl: "${NYXID_AUTHORIZE_URL}",
+  nyxidTokenUrl: "${NYXID_TOKEN_URL}",
+  nyxidClientId: "${NYXID_CLIENT_ID}",
+  nyxidRedirectUri: "${NYXID_REDIRECT_URI}",
+  nyxidLogoutUrl: "${NYXID_LOGOUT_URL}",
+  nyxidSettingsUrl: "${NYXID_SETTINGS_URL}"
+};

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ import { logActivity } from "@/services/activityApi";
 import { useThemeStore } from "@/stores/themeStore";
 import { useTranslation } from "react-i18next";
 import { Logo } from "@/components/brand/Logo";
+import { config } from "@/config";
 
 /** Admin icon */
 function AdminIcon({ className }: { className?: string }) {
@@ -44,7 +45,7 @@ function NyxIdIcon({ className }: { className?: string }) {
 /** Derive NyxID home URL from the authorize URL env var */
 function getNyxIdUrl(): string {
   try {
-    const authorizeUrl = import.meta.env.VITE_NYXID_AUTHORIZE_URL ?? "";
+    const authorizeUrl = config.nyxidAuthorizeUrl;
     if (authorizeUrl) {
       const url = new URL(authorizeUrl);
       return url.origin;

--- a/ornn-web/src/config.ts
+++ b/ornn-web/src/config.ts
@@ -1,0 +1,57 @@
+/**
+ * Runtime configuration reader.
+ *
+ * Values are injected into `window.__ORNN_CONFIG__` at container startup
+ * by `/docker-entrypoint.d/40-envsubst-config-js.sh`, which envsubst's
+ * `public/config.js.template` into `/config.js`. `index.html` loads that
+ * script before the main bundle.
+ *
+ * For `bun run dev` / Vitest, `window.__ORNN_CONFIG__` is either empty
+ * (dev stub at `public/config.js`) or unset; values fall back to
+ * `import.meta.env.VITE_*` so `.env.local` keeps working.
+ *
+ * @module config
+ */
+
+export interface OrnnConfig {
+  apiBaseUrl: string;
+  nyxidAuthorizeUrl: string;
+  nyxidTokenUrl: string;
+  nyxidClientId: string;
+  nyxidRedirectUri: string;
+  nyxidLogoutUrl: string;
+  nyxidSettingsUrl: string;
+}
+
+declare global {
+  interface Window {
+    __ORNN_CONFIG__?: Partial<OrnnConfig>;
+  }
+}
+
+const runtime =
+  typeof window !== "undefined" && window.__ORNN_CONFIG__
+    ? window.__ORNN_CONFIG__
+    : {};
+
+export const config: OrnnConfig = {
+  apiBaseUrl: runtime.apiBaseUrl ?? import.meta.env.VITE_API_BASE_URL ?? "",
+  nyxidAuthorizeUrl:
+    runtime.nyxidAuthorizeUrl ??
+    import.meta.env.VITE_NYXID_AUTHORIZE_URL ??
+    "",
+  nyxidTokenUrl:
+    runtime.nyxidTokenUrl ?? import.meta.env.VITE_NYXID_TOKEN_URL ?? "",
+  nyxidClientId:
+    runtime.nyxidClientId ?? import.meta.env.VITE_NYXID_CLIENT_ID ?? "",
+  nyxidRedirectUri:
+    runtime.nyxidRedirectUri ??
+    import.meta.env.VITE_NYXID_REDIRECT_URI ??
+    "",
+  nyxidLogoutUrl:
+    runtime.nyxidLogoutUrl ?? import.meta.env.VITE_NYXID_LOGOUT_URL ?? "",
+  nyxidSettingsUrl:
+    runtime.nyxidSettingsUrl ??
+    import.meta.env.VITE_NYXID_SETTINGS_URL ??
+    "",
+};

--- a/ornn-web/src/pages/ServiceDetailPage.tsx
+++ b/ornn-web/src/pages/ServiceDetailPage.tsx
@@ -12,8 +12,9 @@ import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { useAuthStore, isAdmin as checkIsAdmin, useCurrentUser } from "@/stores/authStore";
 import { GenerateSkillModal } from "@/components/skill/GenerateSkillModal";
+import { config } from "@/config";
 
-const NYXID_API_BASE = import.meta.env.VITE_NYXID_AUTHORIZE_URL?.replace("/oauth/authorize", "") ?? "";
+const NYXID_API_BASE = config.nyxidAuthorizeUrl.replace("/oauth/authorize", "");
 
 interface ServiceDetail {
   id: string;

--- a/ornn-web/src/pages/SettingsPage.tsx
+++ b/ornn-web/src/pages/SettingsPage.tsx
@@ -12,8 +12,9 @@ import { motion } from "framer-motion";
 import { Button } from "@/components/ui/Button";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { useAuthStore } from "@/stores/authStore";
+import { config } from "@/config";
 
-const NYXID_SETTINGS_URL = import.meta.env.VITE_NYXID_SETTINGS_URL ?? "";
+const NYXID_SETTINGS_URL = config.nyxidSettingsUrl;
 
 export function SettingsPage() {
   const { t } = useTranslation();

--- a/ornn-web/src/pages/landing/LandingFooter.tsx
+++ b/ornn-web/src/pages/landing/LandingFooter.tsx
@@ -6,8 +6,9 @@
  */
 
 import { useState, useEffect } from "react";
+import { config } from "@/config";
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_BASE = config.apiBaseUrl;
 
 export function LandingFooter() {
   const year = new Date().getFullYear();

--- a/ornn-web/src/services/activityApi.ts
+++ b/ornn-web/src/services/activityApi.ts
@@ -5,8 +5,9 @@
  */
 
 import { useAuthStore } from "@/stores/authStore";
+import { config } from "@/config";
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_BASE = config.apiBaseUrl;
 
 const logger = {
   info: (msg: string, data?: Record<string, unknown>) =>

--- a/ornn-web/src/services/apiClient.ts
+++ b/ornn-web/src/services/apiClient.ts
@@ -7,13 +7,14 @@
 
 import type { ApiResponse } from "@/types/api";
 import { useAuthStore } from "@/stores/authStore";
+import { config } from "@/config";
 
 const logger = {
   error: (msg: string, data?: Record<string, unknown>) =>
     console.error(`[apiClient] ${msg}`, data ?? ""),
 };
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_BASE = config.apiBaseUrl;
 
 /**
  * Custom error class for API failures.

--- a/ornn-web/src/services/generateStreamApi.ts
+++ b/ornn-web/src/services/generateStreamApi.ts
@@ -7,8 +7,9 @@
 import type { GenerationStreamEvent } from "@/types/streaming";
 import { parseSseChunk } from "@/utils/sseParser";
 import { useAuthStore } from "@/stores/authStore";
+import { config } from "@/config";
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_BASE = config.apiBaseUrl;
 
 export interface GenerateStreamParams {
   messages: Array<{ role: string; content: string }>;

--- a/ornn-web/src/services/playgroundStreamApi.ts
+++ b/ornn-web/src/services/playgroundStreamApi.ts
@@ -7,8 +7,9 @@
 import { parseSseChunk } from "@/utils/sseParser";
 import { useAuthStore } from "@/stores/authStore";
 import { PLAYGROUND_EVENT_TYPES, type PlaygroundChatEvent } from "@/types/playground";
+import { config } from "@/config";
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_BASE = config.apiBaseUrl;
 
 export interface ChatStreamParams {
   messages: Array<{ role: string; content: string }>;

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -2,8 +2,9 @@ import { apiGet, apiPut, apiDelete } from "./apiClient";
 import type { UpdateSkillMetadata } from "@/types/api";
 import type { SkillDetail, SkillVersionEntry } from "@/types/domain";
 import { useAuthStore } from "@/stores/authStore";
+import { config } from "@/config";
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_BASE = config.apiBaseUrl;
 
 /**
  * Fetch a single skill by GUID or name.

--- a/ornn-web/src/stores/authStore.ts
+++ b/ornn-web/src/stores/authStore.ts
@@ -7,6 +7,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { AuthUser, NyxIDTokenResponse, NyxIDJwtClaims, NyxIDIdTokenClaims } from "@/types/auth";
+import { config } from "@/config";
 
 const logger = {
   info: (msg: string, data?: Record<string, unknown>) =>
@@ -21,13 +22,13 @@ const TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
 /** Consider token expired if less than 30s remaining (for proactive refresh). */
 const TOKEN_EXPIRY_THRESHOLD_MS = 30 * 1000;
 
-/** NyxID OAuth configuration from environment variables. */
+/** NyxID OAuth configuration from runtime config. */
 const NYXID_CONFIG = {
-  authorizeUrl: import.meta.env.VITE_NYXID_AUTHORIZE_URL ?? "",
-  tokenUrl: import.meta.env.VITE_NYXID_TOKEN_URL ?? "",
-  clientId: import.meta.env.VITE_NYXID_CLIENT_ID ?? "",
-  redirectUri: import.meta.env.VITE_NYXID_REDIRECT_URI ?? "",
-  logoutUrl: import.meta.env.VITE_NYXID_LOGOUT_URL ?? "",
+  authorizeUrl: config.nyxidAuthorizeUrl,
+  tokenUrl: config.nyxidTokenUrl,
+  clientId: config.nyxidClientId,
+  redirectUri: config.nyxidRedirectUri,
+  logoutUrl: config.nyxidLogoutUrl,
 };
 
 interface AuthState {


### PR DESCRIPTION
## Summary

One ornn-web image now runs in every environment. Both the nginx upstream URLs (`NYXID_BACKEND_URL`, `ORNN_API_URL`) and the Vite-side `VITE_*` values are injected at container start from the new `ornn-web-config` ConfigMap instead of being baked in at build time.

**Before:** rebuild the image per environment (6 `--build-arg VITE_*` flags) and nginx crashed on any cluster without the exact `ornn-api` / `nyxid-backend` service names.

**After:** rebuild once, swap ConfigMap per environment. Custom deploy platforms / staging / prod just point the env vars at the right URLs.

## Mechanism

**nginx side (server URLs):** `ornn-web/nginx.conf` → `ornn-web/nginx.conf.template`, mounted at `/etc/nginx/templates/default.conf.template`. The nginx:alpine image's built-in `20-envsubst-on-templates.sh` substitutes `${ORNN_API_URL}` / `${NYXID_BACKEND_URL}` at startup. `NGINX_ENVSUBST_FILTER` scopes substitution to just those two vars so nginx built-ins (`$host`, `$scheme`, ...) stay literal.

**Vite side (client config):** Since Vite inlines `import.meta.env.VITE_*` at build time, a runtime shim:

- `public/config.js.template` defines `window.__ORNN_CONFIG__ = {...}`
- New `/docker-entrypoint.d/40-envsubst-config-js.sh` envsubst's template → `/config.js` at container start
- `index.html` loads `/config.js` before the main bundle
- New `src/config.ts` is the single typed entrypoint; falls back to `import.meta.env.VITE_*` for `bun run dev` / Vitest
- All 13 `import.meta.env.VITE_*` call sites across 8 files collapse onto `config.*`

**Bonus cleanup:** `VITE_NYXID_SETTINGS_URL` was used in code but missing from the Dockerfile ARG list — now covered as part of the runtime config.

## Changes

| File | Action |
|---|---|
| `ornn-web/nginx.conf` → `nginx.conf.template` | Rename + parameterize upstreams, add no-cache rule for `/config.js` |
| `ornn-web/Dockerfile` | Drop all `ARG VITE_*`; copy template to `/etc/nginx/templates/`; copy entrypoint script |
| `ornn-web/docker-entrypoint.d/40-envsubst-config-js.sh` | New |
| `ornn-web/public/config.js.template` | New (production template) |
| `ornn-web/public/config.js` | New (dev stub — empty object) |
| `ornn-web/src/config.ts` | New (typed config reader) |
| `ornn-web/index.html` | Load `/config.js` before main bundle |
| `ornn-web/src/{stores,services,pages,components}/**` (8 files) | Replace `import.meta.env.VITE_*` with `config.*` |
| `deployment/ornn-web/configmap.yaml` | New |
| `deployment/ornn-web/deployment.yaml` | Add `envFrom: configMapRef: ornn-web-config` |
| `deployment/.env.sample.ornn` | Rewrite ornn-web section as runtime env vars |
| `CLAUDE.md` | Drop `--build-arg VITE_*` from frontend docker build |
| `.changeset/ornn-web-runtime-config.md` | `ornn-web` minor bump |

## Test plan

- [x] `bun run typecheck` → 0 errors
- [x] `bun run lint` → 0 errors (66 pre-existing warnings)
- [x] `bun run test` → all pass (ornn-web 11/11, ornn-sdk 17/17)
- [x] `bun run --filter ornn-web build` → dist/ includes `config.js` + `config.js.template`, index.html loads `/config.js` before the main bundle
- [ ] Rebuild ornn-web image on failing deploy platform: pod starts, `/config.js` returns rendered template values
- [ ] Local dev K8s: apply ConfigMap, `kubectl rollout restart deployment/ornn-web`, open `https://ornn.ornn-cluster.local`, verify login + API calls work

Closes #116