### PR TITLE
feat(api): skill version diff [part of #26]

### DIFF
--- a/.changeset/sour-ties-report.md
+++ b/.changeset/sour-ties-report.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+New endpoint `GET /api/v1/skills/:idOrName/versions/:fromVersion/diff/:toVersion` returns a structured diff between two published versions: per-file added / removed / modified with SHA-256 hashes, byte sizes, and — for text files — both sides' contents (truncated at 64 KiB/side) so the UI can render any line-level diff client-side. Visibility rules mirror the canonical skill read. Part of #26.

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -277,6 +277,46 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
   );
 
   /**
+   * GET /skills/:idOrName/versions/:fromVersion/diff/:toVersion
+   *
+   * Return a structured diff between two versions. File-level
+   * (added/removed/modified) plus text content on both sides for the UI
+   * to render line-level diffs client-side. Visibility rules match
+   * GET /skills/:idOrName.
+   *
+   * Auth: Optional. Anonymous users can only diff public skills.
+   */
+  app.get(
+    "/skills/:idOrName/versions/:fromVersion/diff/:toVersion",
+    optionalAuth,
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const fromVersion = c.req.param("fromVersion");
+      const toVersion = c.req.param("toVersion");
+      const authCtx = c.get("auth");
+
+      const skill = await skillService.getSkill(idOrName);
+      if (!authCtx && skill.isPrivate) {
+        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      }
+      if (authCtx && skill.isPrivate) {
+        const memberships = await readUserOrgMemberships(c);
+        const actor = {
+          userId: authCtx.userId,
+          memberships,
+          isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+        };
+        if (!canReadSkill(skill, actor)) {
+          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        }
+      }
+
+      const result = await skillService.diffVersions(idOrName, fromVersion, toVersion);
+      return c.json({ data: result, error: null });
+    },
+  );
+
+  /**
    * GET /skills/:idOrName — Read a skill by GUID or name.
    * Query params:
    *   - version: optional `<major>.<minor>` — when set, return that version's

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -12,6 +12,7 @@ import type { IStorageClient } from "../../../clients/storageClient";
 import type { SkillDocument, SkillMetadata, SkillDetailResponse, SkillVersionDocument, SkillSource } from "../../../shared/types/index";
 import { AppError } from "../../../shared/types/index";
 import { fetchSkillFromGitHub, type GitHubPullInput } from "./utils/githubPull";
+import { computeVersionDiff, type VersionDiffResult } from "./utils/versionDiff";
 import { isReservedVerb } from "../../../shared/reservedVerbs";
 import { validateSkillFrontmatter } from "../../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../../shared/utils/zip";
@@ -468,6 +469,102 @@ export class SkillService {
       userDisplayName: options?.userDisplayName,
       source: newSource,
     });
+  }
+
+  /**
+   * Compute a structured diff between two versions of a skill.
+   *
+   * Downloads both version ZIPs from storage, extracts, and compares
+   * file-level (added / removed / modified). For text files the diff
+   * includes both sides' contents so the UI can render side-by-side or
+   * any line-level diff it wants client-side.
+   *
+   * Throws NOT_FOUND when the skill or either version is unknown; throws
+   * BAD_REQUEST when `from` and `to` are the same.
+   */
+  async diffVersions(
+    idOrName: string,
+    fromVersion: string,
+    toVersion: string,
+  ): Promise<{
+    skill: { guid: string; name: string };
+    from: { version: string; hash: string; createdOn: string; isDeprecated: boolean };
+    to: { version: string; hash: string; createdOn: string; isDeprecated: boolean };
+    diff: VersionDiffResult;
+  }> {
+    if (fromVersion === toVersion) {
+      throw AppError.badRequest(
+        "SAME_VERSION",
+        `'from' and 'to' refer to the same version '${fromVersion}'`,
+      );
+    }
+
+    const skill = await this.findSkillByIdOrName(idOrName);
+
+    parseVersion(fromVersion);
+    parseVersion(toVersion);
+
+    const [fromDoc, toDoc] = await Promise.all([
+      this.skillVersionRepo.findBySkillAndVersion(skill.guid, fromVersion),
+      this.skillVersionRepo.findBySkillAndVersion(skill.guid, toVersion),
+    ]);
+    if (!fromDoc) {
+      throw AppError.notFound(
+        "SKILL_VERSION_NOT_FOUND",
+        `Version '${fromVersion}' not found for skill '${skill.name}'`,
+      );
+    }
+    if (!toDoc) {
+      throw AppError.notFound(
+        "SKILL_VERSION_NOT_FOUND",
+        `Version '${toVersion}' not found for skill '${skill.name}'`,
+      );
+    }
+
+    const [fromZip, toZip] = await Promise.all([
+      this.downloadPackage(fromDoc.storageKey),
+      this.downloadPackage(toDoc.storageKey),
+    ]);
+
+    const diff = await computeVersionDiff(fromZip, toZip);
+
+    return {
+      skill: { guid: skill.guid, name: skill.name },
+      from: {
+        version: fromDoc.version,
+        hash: fromDoc.skillHash,
+        createdOn:
+          fromDoc.createdOn instanceof Date
+            ? fromDoc.createdOn.toISOString()
+            : String(fromDoc.createdOn),
+        isDeprecated: fromDoc.isDeprecated === true,
+      },
+      to: {
+        version: toDoc.version,
+        hash: toDoc.skillHash,
+        createdOn:
+          toDoc.createdOn instanceof Date
+            ? toDoc.createdOn.toISOString()
+            : String(toDoc.createdOn),
+        isDeprecated: toDoc.isDeprecated === true,
+      },
+      diff,
+    };
+  }
+
+  private async downloadPackage(storageKey: string): Promise<Uint8Array> {
+    const presigned = await this.storageClient.getPresignedUrl(
+      this.storageBucket,
+      storageKey,
+    );
+    const res = await fetch(presigned.presignedUrl);
+    if (!res.ok) {
+      throw AppError.internalError(
+        "PACKAGE_DOWNLOAD_FAILED",
+        `Failed to download package for key '${storageKey}' (HTTP ${res.status})`,
+      );
+    }
+    return new Uint8Array(await res.arrayBuffer());
   }
 
   async deleteSkill(guid: string): Promise<void> {

--- a/ornn-api/src/domains/skills/crud/utils/versionDiff.test.ts
+++ b/ornn-api/src/domains/skills/crud/utils/versionDiff.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+import { computeVersionDiff } from "./versionDiff";
+
+async function buildZip(files: Record<string, string | Uint8Array>, rootFolder = "my-skill"): Promise<Uint8Array> {
+  const zip = new JSZip();
+  const folder = zip.folder(rootFolder);
+  if (!folder) throw new Error("JSZip folder creation failed");
+  for (const [path, content] of Object.entries(files)) {
+    folder.file(path, content);
+  }
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+describe("computeVersionDiff", () => {
+  test("detects added / removed / modified / unchanged", async () => {
+    const fromZip = await buildZip({
+      "SKILL.md": "---\nname: my-skill\n---\n# v1\n",
+      "scripts/main.js": "console.log('v1');\n",
+      "kept.txt": "same on both sides\n",
+    });
+    const toZip = await buildZip({
+      "SKILL.md": "---\nname: my-skill\n---\n# v2\n", // modified
+      "scripts/main.js": "console.log('v2');\n",     // modified
+      "kept.txt": "same on both sides\n",            // unchanged
+      "scripts/helper.js": "export const x = 1;\n",  // added
+    });
+
+    const result = await computeVersionDiff(fromZip, toZip);
+    expect(result.files.unchangedCount).toBe(1);
+    expect(result.files.added.map((a) => a.path)).toEqual(["scripts/helper.js"]);
+    expect(result.files.removed).toEqual([]);
+    expect(result.files.modified.map((m) => m.path).sort()).toEqual([
+      "SKILL.md",
+      "scripts/main.js",
+    ]);
+  });
+
+  test("text files include both contents for modified", async () => {
+    const fromZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n# Before\n",
+    });
+    const toZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n# After\n",
+    });
+    const result = await computeVersionDiff(fromZip, toZip);
+    const modified = result.files.modified.find((m) => m.path === "SKILL.md")!;
+    expect(modified.isText).toBe(true);
+    expect(modified.fromContent).toContain("Before");
+    expect(modified.toContent).toContain("After");
+    expect(modified.truncated).toBe(false);
+  });
+
+  test("binary files omit content field", async () => {
+    const imgBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13]);
+    const fromZip = await buildZip({ "assets/logo.png": imgBytes });
+    const toZip = await buildZip({
+      "assets/logo.png": new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3]),
+    });
+    const result = await computeVersionDiff(fromZip, toZip);
+    const modified = result.files.modified[0]!;
+    expect(modified.isText).toBe(false);
+    expect(modified.fromContent).toBeUndefined();
+    expect(modified.toContent).toBeUndefined();
+    expect(modified.fromHash).not.toBe(modified.toHash);
+  });
+
+  test("removed text file includes its content (for UI rendering)", async () => {
+    const fromZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n# keep\n",
+      "scripts/old.js": "console.log('bye');\n",
+    });
+    const toZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n# keep\n",
+    });
+    const result = await computeVersionDiff(fromZip, toZip);
+    expect(result.files.removed).toHaveLength(1);
+    expect(result.files.removed[0]!.path).toBe("scripts/old.js");
+    expect(result.files.removed[0]!.content).toContain("bye");
+  });
+
+  test("added text file includes its content", async () => {
+    const fromZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n# keep\n",
+    });
+    const toZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n# keep\n",
+      "scripts/new.js": "console.log('hi');\n",
+    });
+    const result = await computeVersionDiff(fromZip, toZip);
+    expect(result.files.added).toHaveLength(1);
+    expect(result.files.added[0]!.content).toContain("hi");
+  });
+
+  test("truncates large text files and flags truncation", async () => {
+    const huge = "a".repeat(200_000);
+    const fromZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n# header\n",
+      "big.txt": huge,
+    });
+    const toZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n# header\n",
+      "big.txt": huge + "MUTATE",
+    });
+    const result = await computeVersionDiff(fromZip, toZip, { maxContentBytesPerSide: 1024 });
+    const big = result.files.modified.find((m) => m.path === "big.txt")!;
+    expect(big.truncated).toBe(true);
+    expect(big.fromContent?.length).toBe(1024);
+    expect(big.toContent?.length).toBe(1024);
+  });
+
+  test("stable deterministic path ordering", async () => {
+    const fromZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n\n# old",
+    });
+    const toZip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n\n# old",
+      "c.txt": "c",
+      "a.txt": "a",
+      "b.txt": "b",
+    });
+    const result = await computeVersionDiff(fromZip, toZip);
+    expect(result.files.added.map((a) => a.path)).toEqual(["a.txt", "b.txt", "c.txt"]);
+  });
+
+  test("SAME_VERSION edge: identical zips report all-unchanged", async () => {
+    const zip = await buildZip({
+      "SKILL.md": "---\nname: x\n---\n\n# same",
+      "scripts/main.js": "console.log(1);\n",
+    });
+    const result = await computeVersionDiff(zip, zip);
+    expect(result.files.added).toEqual([]);
+    expect(result.files.removed).toEqual([]);
+    expect(result.files.modified).toEqual([]);
+    expect(result.files.unchangedCount).toBe(2);
+  });
+});

--- a/ornn-api/src/domains/skills/crud/utils/versionDiff.ts
+++ b/ornn-api/src/domains/skills/crud/utils/versionDiff.ts
@@ -1,0 +1,223 @@
+/**
+ * Compute a structured diff between two skill-package ZIPs.
+ *
+ * The shape is intentionally UI-friendly — the frontend renders
+ * added/removed/modified lists directly, and for text files it can show
+ * side-by-side content without another fetch. Binary files get hash +
+ * byte counts only.
+ *
+ * @module domains/skills/crud/utils/versionDiff
+ */
+
+import { createHash } from "node:crypto";
+import JSZip from "jszip";
+import { resolveZipRoot } from "../../../../shared/utils/zip";
+
+export interface DiffFileAdded {
+  readonly path: string;
+  readonly bytes: number;
+  readonly hash: string;
+  /** Absent for binary. Present (possibly truncated) for text files. */
+  readonly content?: string;
+  readonly truncated?: boolean;
+  readonly isText: boolean;
+}
+
+export interface DiffFileRemoved {
+  readonly path: string;
+  readonly bytes: number;
+  readonly hash: string;
+  readonly content?: string;
+  readonly truncated?: boolean;
+  readonly isText: boolean;
+}
+
+export interface DiffFileModified {
+  readonly path: string;
+  readonly fromBytes: number;
+  readonly toBytes: number;
+  readonly fromHash: string;
+  readonly toHash: string;
+  readonly isText: boolean;
+  /** Both sides' contents for text files (truncated if large). Absent for binary. */
+  readonly fromContent?: string;
+  readonly toContent?: string;
+  readonly truncated?: boolean;
+}
+
+export interface VersionDiffResult {
+  readonly files: {
+    readonly added: ReadonlyArray<DiffFileAdded>;
+    readonly removed: ReadonlyArray<DiffFileRemoved>;
+    readonly modified: ReadonlyArray<DiffFileModified>;
+    /** Paths that exist identically in both versions. Count only — no detail needed. */
+    readonly unchangedCount: number;
+  };
+}
+
+export interface ComputeVersionDiffOptions {
+  /** Max bytes of text content to include per side per file. Default 64 KiB. */
+  readonly maxContentBytesPerSide?: number;
+}
+
+const DEFAULT_MAX_CONTENT = 64 * 1024;
+
+/** Extensions that are safe to treat as text for content inclusion. */
+const TEXT_EXTENSIONS = new Set([
+  "md", "markdown", "txt", "json", "yaml", "yml", "toml",
+  "js", "mjs", "cjs", "ts", "tsx", "jsx",
+  "py", "rb", "go", "rs", "java", "kt", "swift",
+  "sh", "bash", "zsh", "fish",
+  "html", "htm", "css", "scss", "xml", "svg",
+  "ini", "cfg", "conf", "env", "gitignore", "dockerfile",
+]);
+
+function isTextPath(path: string): boolean {
+  const lower = path.toLowerCase();
+  const lastSlash = lower.lastIndexOf("/");
+  const filename = lastSlash >= 0 ? lower.slice(lastSlash + 1) : lower;
+  // Dotfiles / no-extension common config names
+  if (filename === "dockerfile" || filename === "makefile" || filename === "readme") return true;
+  const dot = filename.lastIndexOf(".");
+  if (dot < 0) return false;
+  return TEXT_EXTENSIONS.has(filename.slice(dot + 1));
+}
+
+function sha256Hex(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Extract `path -> bytes` entries from a skill ZIP, normalizing the
+ * leading skill-root folder (`skill-name/SKILL.md` -> `SKILL.md`) so
+ * diffs are stable when the skill is renamed.
+ */
+async function extractFiles(zipBuffer: Uint8Array): Promise<Map<string, Uint8Array>> {
+  const zip = await JSZip.loadAsync(zipBuffer);
+  const allPaths = Object.keys(zip.files);
+  resolveZipRoot(zip, allPaths);
+
+  const out = new Map<string, Uint8Array>();
+  for (const path of allPaths) {
+    const entry = zip.files[path];
+    if (entry.dir) continue;
+    const parts = path.split("/");
+    let relative = path;
+    if (parts.length > 1) {
+      const rootFolder = parts[0] + "/";
+      if (zip.files[rootFolder]?.dir) {
+        relative = parts.slice(1).join("/");
+      }
+    }
+    const bytes = await entry.async("uint8array");
+    out.set(relative, bytes);
+  }
+  return out;
+}
+
+/**
+ * Decode a Uint8Array as UTF-8, replacing invalid sequences. Cap at
+ * `maxBytes` and signal truncation.
+ */
+function decodeText(bytes: Uint8Array, maxBytes: number): { content: string; truncated: boolean } {
+  const slice = bytes.byteLength > maxBytes ? bytes.subarray(0, maxBytes) : bytes;
+  const content = new TextDecoder("utf-8", { fatal: false }).decode(slice);
+  return { content, truncated: bytes.byteLength > maxBytes };
+}
+
+/**
+ * Compute a structured diff between two skill-package ZIPs.
+ */
+export async function computeVersionDiff(
+  fromZip: Uint8Array,
+  toZip: Uint8Array,
+  options: ComputeVersionDiffOptions = {},
+): Promise<VersionDiffResult> {
+  const maxContent = options.maxContentBytesPerSide ?? DEFAULT_MAX_CONTENT;
+  const from = await extractFiles(fromZip);
+  const to = await extractFiles(toZip);
+
+  const allPaths = new Set<string>([...from.keys(), ...to.keys()]);
+
+  const added: DiffFileAdded[] = [];
+  const removed: DiffFileRemoved[] = [];
+  const modified: DiffFileModified[] = [];
+  let unchangedCount = 0;
+
+  for (const path of allPaths) {
+    const fromBytes = from.get(path);
+    const toBytes = to.get(path);
+    const isText = isTextPath(path);
+
+    if (fromBytes && !toBytes) {
+      const entry: DiffFileRemoved = {
+        path,
+        bytes: fromBytes.byteLength,
+        hash: sha256Hex(fromBytes),
+        isText,
+      };
+      if (isText) {
+        const decoded = decodeText(fromBytes, maxContent);
+        Object.assign(entry, { content: decoded.content, truncated: decoded.truncated });
+      }
+      removed.push(entry);
+      continue;
+    }
+
+    if (!fromBytes && toBytes) {
+      const entry: DiffFileAdded = {
+        path,
+        bytes: toBytes.byteLength,
+        hash: sha256Hex(toBytes),
+        isText,
+      };
+      if (isText) {
+        const decoded = decodeText(toBytes, maxContent);
+        Object.assign(entry, { content: decoded.content, truncated: decoded.truncated });
+      }
+      added.push(entry);
+      continue;
+    }
+
+    if (fromBytes && toBytes) {
+      const fromHash = sha256Hex(fromBytes);
+      const toHash = sha256Hex(toBytes);
+      if (fromHash === toHash) {
+        unchangedCount++;
+        continue;
+      }
+      const entry: DiffFileModified = {
+        path,
+        fromBytes: fromBytes.byteLength,
+        toBytes: toBytes.byteLength,
+        fromHash,
+        toHash,
+        isText,
+      };
+      if (isText) {
+        const fromDecoded = decodeText(fromBytes, maxContent);
+        const toDecoded = decodeText(toBytes, maxContent);
+        Object.assign(entry, {
+          fromContent: fromDecoded.content,
+          toContent: toDecoded.content,
+          truncated: fromDecoded.truncated || toDecoded.truncated,
+        });
+      }
+      modified.push(entry);
+    }
+  }
+
+  // Deterministic ordering for stable UI render + easier testing.
+  added.sort((a, b) => a.path.localeCompare(b.path));
+  removed.sort((a, b) => a.path.localeCompare(b.path));
+  modified.sort((a, b) => a.path.localeCompare(b.path));
+
+  return {
+    files: {
+      added,
+      removed,
+      modified,
+      unchangedCount,
+    },
+  };
+}


### PR DESCRIPTION
Part of #26. First half of 'skill diff & changelog' — the diff API. Release-notes capture is a separate follow-up once a publish-time flow is agreed (SKILL.md frontmatter field vs multipart field).

## Endpoint

`GET /api/v1/skills/:idOrName/versions/:fromVersion/diff/:toVersion`

Returns:

```jsonc
{
  "skill": { "guid": "...", "name": "pdf-extract" },
  "from": { "version": "1.0", "hash": "...", "createdOn": "...", "isDeprecated": false },
  "to":   { "version": "1.1", "hash": "...", "createdOn": "...", "isDeprecated": false },
  "diff": {
    "files": {
      "added":    [{ "path": "scripts/helper.js", "bytes": 120, "hash": "...", "isText": true, "content": "...", "truncated": false }],
      "removed":  [/* same shape as added */],
      "modified": [{ "path": "SKILL.md", "fromBytes": ..., "toBytes": ..., "fromHash": ..., "toHash": ..., "isText": true, "fromContent": "...", "toContent": "...", "truncated": false }],
      "unchangedCount": 3
    }
  }
}
```

## Design notes

- **Text content on both sides** for modified text files (up to 64 KiB/side, truncation flagged). UI can render side-by-side or run any line-level differ client-side without another round-trip. Avoids bundling a diff library in the backend.
- **Binary files**: hash + size only (no content). Extension-gated text detection (`md`, `ts`, `py`, etc.; `Dockerfile` / `Makefile` / `README` treated as text too).
- **Skill-root folder stripped** before comparison so paths are stable if the skill is renamed (`pdf/SKILL.md` and `pdf-v2/SKILL.md` both present as `SKILL.md`).
- **Visibility**: optional auth; anonymous users only diff public skills; authed users go through the same `canReadSkill` gate as `GET /skills/:idOrName`.
- **Errors**: `SAME_VERSION` (400) when `v1 == v2`; `SKILL_VERSION_NOT_FOUND` (404) when either version doesn't exist; `PACKAGE_DOWNLOAD_FAILED` (500) when storage is unreachable.

## Tests

8 unit cases on `computeVersionDiff` (pure function, no network):
- Added / removed / modified / unchanged classification
- Text content inclusion on modified / added / removed
- Binary content omission
- Truncation + flag
- Deterministic path ordering
- Identical-ZIP edge (all-unchanged)

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — 0 errors, no regression
- [x] `bun run test` — 219 api (+8) + 11 web + 17 sdk = 247 pass
- [ ] Manual smoke against a real skill once merged

## Not in this PR

- Release notes field on `SkillVersionDocument` (capture, storage, surfacing). Tracked on #26 — will land once the capture path (frontmatter vs multipart) is agreed.
- Frontend 'what changed' panel on the skill detail page.