### PR TITLE
chore(web): drop dead /api/v1/openapi.json nginx bypass [closes #119]

### DIFF
--- a/.changeset/drop-dead-nginx-locations.md
+++ b/.changeset/drop-dead-nginx-locations.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Drop the `location = /api/v1/openapi.json` block from `ornn-web/nginx.conf.template` — no frontend code fetches it (the spec URL built in `ServiceDetailPage.tsx` / `GenerateSkillModal.tsx` goes through the NyxID proxy, not nginx). `/health`, SSE passthrough, gzip, static caching, SPA fallback, and NyxID X-Forwarded headers are kept.

--- a/ornn-web/nginx.conf.template
+++ b/ornn-web/nginx.conf.template
@@ -42,12 +42,6 @@ server {
         add_header Content-Type text/plain;
     }
 
-    # ── Public API route → direct to ornn-api (no auth required) ────
-    location = /api/v1/openapi.json {
-        proxy_pass ${ORNN_API_URL}/api/v1/openapi.json;
-        proxy_set_header Host $host;
-    }
-
     # ── Authenticated API routes → NyxID proxy → ornn-api ─────────
     # /api/v1/X → NyxID proxy /api/v1/proxy/s/ornn-api/api/v1/X → ornn-api /api/v1/X
     location /api/v1/ {


### PR DESCRIPTION
## Summary

Remove the `location = /api/v1/openapi.json` bypass from `ornn-web/nginx.conf.template`. It was labeled "public API route, no auth required" but no frontend code actually hits it through nginx — spec URLs are built against the NyxID proxy (`ServiceDetailPage.tsx:64`, `GenerateSkillModal.tsx:152`). If a public unauth'd spec endpoint is needed later, we can reintroduce it.

Everything else stays: `/health`, SSE passthrough, gzip, static caching, SPA fallback, NyxID X-Forwarded headers.

## Test plan

- [x] `git diff` shows only the one block removed
- [ ] CI green (typecheck, lint, test, docker-build)

Closes #119