### PR TITLE
feat(api): LLM-based skill audit engine [part of #32]

### DIFF
--- a/.changeset/metal-zebras-grab.md
+++ b/.changeset/metal-zebras-grab.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+LLM-based skill audit engine: new `skills/audit/` domain with 5-dimension scoring (security, code_quality, documentation, reliability, permission_scope), structured JSON findings, cache-by-hash persistence, and thresholds-based verdict (green / yellow / red). Endpoints: `GET /api/v1/skills/:idOrName/audit` (read-only, respects visibility) and `POST /api/v1/admin/skills/:idOrName/audit` (manual re-audit, admin only). Share-gated trigger is a separate follow-up (#95). Part of #32.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -37,6 +37,11 @@ import { SkillVersionRepository } from "./domains/skills/crud/skillVersionReposi
 import { SkillService } from "./domains/skills/crud/service";
 import { createSkillRoutes } from "./domains/skills/crud/routes";
 
+// Domain: Skill Audit
+import { AuditRepository } from "./domains/skills/audit/repository";
+import { AuditService } from "./domains/skills/audit/service";
+import { createAuditRoutes } from "./domains/skills/audit/routes";
+
 // Domain: Skill Search
 import { SearchService } from "./domains/skills/search/service";
 import { createSearchRoutes } from "./domains/skills/search/routes";
@@ -145,6 +150,22 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     maxFileSize: config.maxPackageSizeBytes,
     activityRepo,
   });
+
+  // ---- Domain: Skill Audit ----
+  const auditRepo = new AuditRepository(db);
+  void auditRepo.ensureIndexes().catch((err) =>
+    logger.warn({ err }, "Audit indexes ensureIndexes failed — proceeding anyway"),
+  );
+  const auditService = new AuditService({
+    auditRepo,
+    skillService,
+    storageClient,
+    storageBucket: config.storageBucket,
+    llmClient: nyxLlmClient,
+    model: config.defaultLlmModel,
+    cacheTtlMs: 7 * 24 * 60 * 60 * 1000, // 7 days
+  });
+  const auditRoutes = createAuditRoutes({ auditService, skillService });
 
   // ---- Domain: Skill Search ----
   const searchService = new SearchService({
@@ -269,6 +290,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   // single request even when multiple routes call `readUserOrgMemberships`.
   apiApp.use("*", nyxidOrgLookupMiddleware(nyxidOrgsClient));
   apiApp.route("/", skillRoutes);
+  apiApp.route("/", auditRoutes);
   apiApp.route("/", searchRoutes);
   apiApp.route("/", generationRoutes);
   apiApp.route("/", playgroundRoutes);

--- a/ornn-api/src/domains/skills/audit/parseAuditJson.test.ts
+++ b/ornn-api/src/domains/skills/audit/parseAuditJson.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { parseAuditJson } from "./service";
+
+describe("parseAuditJson", () => {
+  test("parses a well-formed response", () => {
+    const raw = `{
+      "scores": [
+        { "dimension": "security",         "score": 9, "rationale": "no dangerous patterns" },
+        { "dimension": "code_quality",     "score": 8, "rationale": "good" },
+        { "dimension": "documentation",    "score": 7, "rationale": "ok" },
+        { "dimension": "reliability",      "score": 8, "rationale": "solid" },
+        { "dimension": "permission_scope", "score": 9, "rationale": "least priv" }
+      ],
+      "findings": [
+        { "dimension": "code_quality", "severity": "warning", "file": "scripts/main.js", "line": 10, "message": "unused var" }
+      ]
+    }`;
+    const parsed = parseAuditJson(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.scores).toHaveLength(5);
+    expect(parsed!.findings).toHaveLength(1);
+    expect(parsed!.findings[0]!.severity).toBe("warning");
+  });
+
+  test("strips markdown fences", () => {
+    const raw = [
+      "```json",
+      `{"scores":[`,
+      `{"dimension":"security","score":5,"rationale":"ok"},`,
+      `{"dimension":"code_quality","score":5,"rationale":"ok"},`,
+      `{"dimension":"documentation","score":5,"rationale":"ok"},`,
+      `{"dimension":"reliability","score":5,"rationale":"ok"},`,
+      `{"dimension":"permission_scope","score":5,"rationale":"ok"}`,
+      `],"findings":[]}`,
+      "```",
+    ].join("\n");
+    const parsed = parseAuditJson(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.scores).toHaveLength(5);
+    expect(parsed!.findings).toEqual([]);
+  });
+
+  test("returns null when a dimension is missing", () => {
+    const raw = JSON.stringify({
+      scores: [
+        { dimension: "security", score: 9, rationale: "" },
+        { dimension: "code_quality", score: 8, rationale: "" },
+        // documentation missing
+        { dimension: "reliability", score: 8, rationale: "" },
+        { dimension: "permission_scope", score: 9, rationale: "" },
+      ],
+      findings: [],
+    });
+    expect(parseAuditJson(raw)).toBeNull();
+  });
+
+  test("clamps scores to 0–10 and coerces non-integers", () => {
+    const raw = JSON.stringify({
+      scores: [
+        { dimension: "security", score: 15, rationale: "" },       // -> 10
+        { dimension: "code_quality", score: -3, rationale: "" },   // -> 0
+        { dimension: "documentation", score: 7.8, rationale: "" }, // -> 8 (rounds)
+        { dimension: "reliability", score: 6.2, rationale: "" },   // -> 6
+        { dimension: "permission_scope", score: 9, rationale: "" },
+      ],
+      findings: [],
+    });
+    const parsed = parseAuditJson(raw)!;
+    const byDim = Object.fromEntries(parsed.scores.map((s) => [s.dimension, s.score]));
+    expect(byDim.security).toBe(10);
+    expect(byDim.code_quality).toBe(0);
+    expect(byDim.documentation).toBe(8);
+    expect(byDim.reliability).toBe(6);
+    expect(byDim.permission_scope).toBe(9);
+  });
+
+  test("drops malformed findings but keeps well-formed ones", () => {
+    const raw = JSON.stringify({
+      scores: [
+        { dimension: "security", score: 8, rationale: "" },
+        { dimension: "code_quality", score: 8, rationale: "" },
+        { dimension: "documentation", score: 8, rationale: "" },
+        { dimension: "reliability", score: 8, rationale: "" },
+        { dimension: "permission_scope", score: 8, rationale: "" },
+      ],
+      findings: [
+        { dimension: "security", severity: "critical", message: "bad" },
+        { dimension: "not_a_real_dim", severity: "warning", message: "drop me" },
+        { dimension: "security", severity: "nope", message: "drop severity-wise too" },
+        { dimension: "documentation", severity: "info", message: "" }, // empty message -> drop
+      ],
+    });
+    const parsed = parseAuditJson(raw)!;
+    expect(parsed.findings).toHaveLength(1);
+    expect(parsed.findings[0]!.severity).toBe("critical");
+  });
+
+  test("returns null on non-JSON garbage", () => {
+    expect(parseAuditJson("sorry, I cannot produce JSON today")).toBeNull();
+  });
+});

--- a/ornn-api/src/domains/skills/audit/prompts.ts
+++ b/ornn-api/src/domains/skills/audit/prompts.ts
@@ -1,0 +1,66 @@
+/**
+ * LLM prompts for the skill-audit pipeline.
+ *
+ * The goal is a **structured JSON response**: 5 dimension scores + a
+ * findings array. The system prompt is tight about format so the
+ * response parser gets cleanly-shaped data (matches `AuditRecord`'s
+ * `scores` / `findings` lists).
+ *
+ * @module domains/skills/audit/prompts
+ */
+
+export const AUDIT_SYSTEM_PROMPT = `You are a senior security + code-quality auditor for the Ornn AI skill platform. You review AI-agent skills (SKILL.md + runtime scripts) and produce structured, evidence-based scores.
+
+## Dimensions (each scored 0–10, integer)
+
+1. **security** — Shell injection, credential harvesting, excessive permissions, data exfiltration, arbitrary-code execution, unsafe eval/exec, unsafe subprocess with user input, dangerous filesystem paths. 10 = no concerns. 0 = actively malicious.
+2. **code_quality** — Error handling, input validation, edge-case coverage, code structure, obvious bugs, dead code, unused imports. 10 = production-ready. 0 = broken or hostile.
+3. **documentation** — SKILL.md completeness: name, description, usage, inputs/outputs, examples, environment variables documented, references linked. 10 = a user can integrate from README alone. 0 = no useful info.
+4. **reliability** — Timeout handling, retry logic, graceful degradation, clean failure modes, idempotency where applicable. 10 = handles every network/runtime failure. 0 = crashes on any hiccup.
+5. **permission_scope** — Principle of least privilege: does the skill ask for exactly what it needs? Excessive scopes, broad filesystem access, network fetches to unjustified endpoints all drop the score. 10 = minimal, justified. 0 = asks for everything.
+
+## Findings
+
+For each concrete issue you spotted, emit a finding with dimension, severity ("info" | "warning" | "critical"), optional file + line, and a one-sentence message. \`critical\` means the skill is unsafe to share under any justification. Don't invent findings — only include what you can point to in the source.
+
+## Output format — STRICT
+
+Output ONLY a single JSON object. No markdown fences. No prose. Shape:
+
+\`\`\`json
+{
+  "scores": [
+    { "dimension": "security",         "score": 8, "rationale": "..." },
+    { "dimension": "code_quality",     "score": 7, "rationale": "..." },
+    { "dimension": "documentation",    "score": 6, "rationale": "..." },
+    { "dimension": "reliability",      "score": 8, "rationale": "..." },
+    { "dimension": "permission_scope", "score": 9, "rationale": "..." }
+  ],
+  "findings": [
+    { "dimension": "security", "severity": "warning", "file": "scripts/main.js", "line": 42, "message": "..." }
+  ]
+}
+\`\`\`
+
+Every dimension MUST appear exactly once in \`scores\`. \`findings\` MAY be empty when nothing concrete was flagged — do NOT invent findings just to fill the array.
+`;
+
+export function buildAuditUserPrompt(params: {
+  skillName: string;
+  version: string;
+  metadataSummary: string;
+  filesBundle: string;
+}): string {
+  return `Audit the following Ornn skill package.
+
+## Identity
+- name: ${params.skillName}
+- version: ${params.version}
+
+## Metadata summary
+${params.metadataSummary}
+
+## Package files
+${params.filesBundle}
+`;
+}

--- a/ornn-api/src/domains/skills/audit/repository.ts
+++ b/ornn-api/src/domains/skills/audit/repository.ts
@@ -1,0 +1,121 @@
+/**
+ * Persistence layer for skill audits. Thin wrapper over a single Mongo
+ * collection keyed by `${skillGuid}@${version}`.
+ *
+ * @module domains/skills/audit/repository
+ */
+
+import type { Db, Collection, Document } from "mongodb";
+import pino from "pino";
+import type { AuditRecord, AuditFinding, AuditScore, AuditVerdict } from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "auditRepository" });
+
+export interface CreateAuditInput {
+  skillGuid: string;
+  version: string;
+  skillHash: string;
+  verdict: AuditVerdict;
+  overallScore: number;
+  scores: ReadonlyArray<AuditScore>;
+  findings: ReadonlyArray<AuditFinding>;
+  model: string;
+  triggeredBy: string;
+}
+
+export class AuditRepository {
+  private readonly collection: Collection;
+
+  constructor(db: Db) {
+    this.collection = db.collection("skill_audits");
+  }
+
+  async ensureIndexes(): Promise<void> {
+    try {
+      await Promise.all([
+        this.collection.createIndex({ skillGuid: 1, version: 1 }, { unique: false }),
+        this.collection.createIndex({ skillGuid: 1, skillHash: 1 }, { unique: false }),
+        this.collection.createIndex({ createdAt: -1 }),
+      ]);
+    } catch (err) {
+      logger.error({ err }, "Failed to create audit indexes");
+    }
+  }
+
+  /**
+   * Upsert an audit record. Two audits for the exact same bytes collapse
+   * to one row (replace in-place) — we only keep the latest for a given
+   * skillHash. Different versions / different hashes live as separate
+   * rows so the history survives.
+   */
+  async upsert(input: CreateAuditInput): Promise<AuditRecord> {
+    const createdAt = new Date();
+    const doc: Document = {
+      _id: `${input.skillGuid}@${input.version}` as unknown as Document["_id"],
+      skillGuid: input.skillGuid,
+      version: input.version,
+      skillHash: input.skillHash,
+      verdict: input.verdict,
+      overallScore: input.overallScore,
+      scores: input.scores,
+      findings: input.findings,
+      model: input.model,
+      createdAt,
+      triggeredBy: input.triggeredBy,
+    };
+    await this.collection.replaceOne({ _id: doc._id }, doc, { upsert: true });
+    logger.info(
+      {
+        skillGuid: input.skillGuid,
+        version: input.version,
+        verdict: input.verdict,
+        overallScore: input.overallScore,
+      },
+      "Audit record upserted",
+    );
+    return mapDoc(doc)!;
+  }
+
+  /** Fetch the audit for a specific (skill, version). */
+  async findBySkillAndVersion(skillGuid: string, version: string): Promise<AuditRecord | null> {
+    const doc = await this.collection.findOne({ _id: `${skillGuid}@${version}` as unknown as Document["_id"] });
+    return mapDoc(doc);
+  }
+
+  /**
+   * Cache hit check — returns the stored audit when the skill bytes
+   * match. The caller passes the current `skillHash`; if a record
+   * exists for this hash and the stored record is fresher than
+   * `maxAgeMs`, reuse it.
+   */
+  async findCachedByHash(
+    skillGuid: string,
+    skillHash: string,
+    maxAgeMs: number,
+  ): Promise<AuditRecord | null> {
+    const cutoff = new Date(Date.now() - maxAgeMs);
+    const doc = await this.collection.findOne({
+      skillGuid,
+      skillHash,
+      createdAt: { $gte: cutoff },
+    });
+    return mapDoc(doc);
+  }
+}
+
+function mapDoc(doc: Document | null): AuditRecord | null {
+  if (!doc) return null;
+  return {
+    _id: doc._id as string,
+    skillGuid: String(doc.skillGuid),
+    version: String(doc.version),
+    skillHash: String(doc.skillHash),
+    verdict: doc.verdict as AuditVerdict,
+    overallScore: Number(doc.overallScore ?? 0),
+    scores: (doc.scores as AuditScore[]) ?? [],
+    findings: (doc.findings as AuditFinding[]) ?? [],
+    model: String(doc.model ?? ""),
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt : new Date(doc.createdAt),
+    triggeredBy: String(doc.triggeredBy ?? "system"),
+  };
+}

--- a/ornn-api/src/domains/skills/audit/routes.ts
+++ b/ornn-api/src/domains/skills/audit/routes.ts
@@ -1,0 +1,109 @@
+/**
+ * Skill-audit HTTP routes.
+ *
+ * - GET  /api/v1/skills/:idOrName/audit                — latest audit (cache; does NOT trigger)
+ * - POST /api/v1/admin/skills/:idOrName/audit          — manual re-audit (admin only)
+ *
+ * The audit-on-share trigger lands in a later PR (#95). For now, only
+ * explicit admin calls run the LLM pipeline.
+ *
+ * @module domains/skills/audit/routes
+ */
+
+import { Hono } from "hono";
+import pino from "pino";
+import type { AuditService } from "./service";
+import type { SkillService } from "../crud/service";
+import {
+  type AuthVariables,
+  getAuth,
+  nyxidAuthMiddleware,
+  optionalAuthMiddleware,
+  readUserOrgMemberships,
+  requirePermission,
+} from "../../../middleware/nyxidAuth";
+import { AppError } from "../../../shared/types/index";
+import { canReadSkill } from "../crud/authorize";
+
+const logger = pino({ level: "info" }).child({ module: "auditRoutes" });
+
+export interface AuditRoutesConfig {
+  auditService: AuditService;
+  skillService: SkillService;
+}
+
+export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: AuthVariables }> {
+  const { auditService, skillService } = config;
+  const app = new Hono<{ Variables: AuthVariables }>();
+
+  const auth = nyxidAuthMiddleware();
+  const optionalAuth = optionalAuthMiddleware();
+
+  /**
+   * GET /skills/:idOrName/audit
+   * Returns the most recent audit for the skill's current latest version,
+   * or for a specific version via `?version=` query. Does NOT trigger a
+   * new audit.
+   * Visibility: same as GET /skills/:idOrName.
+   */
+  app.get(
+    "/skills/:idOrName/audit",
+    optionalAuth,
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const version = c.req.query("version") || undefined;
+      const authCtx = c.get("auth");
+
+      const skill = await skillService.getSkill(idOrName, version);
+
+      if (!authCtx && skill.isPrivate) {
+        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      }
+      if (authCtx && skill.isPrivate) {
+        const memberships = await readUserOrgMemberships(c);
+        const actor = {
+          userId: authCtx.userId,
+          memberships,
+          isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+        };
+        if (!canReadSkill(skill, actor)) {
+          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        }
+      }
+
+      const record = await auditService.getAudit(idOrName, version);
+      if (!record) {
+        // No audit yet — surface that as 404 so callers can distinguish
+        // from a record that returned zeroes.
+        throw AppError.notFound("AUDIT_NOT_FOUND", "No audit has been run for this skill version");
+      }
+      return c.json({ data: record, error: null });
+    },
+  );
+
+  /**
+   * POST /admin/skills/:idOrName/audit
+   * Force a fresh audit. Admin only.
+   * Body: `{ force?: boolean }` — `force=true` bypasses the cache.
+   */
+  app.post(
+    "/admin/skills/:idOrName/audit",
+    auth,
+    requirePermission("ornn:admin:skill"),
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const authCtx = getAuth(c);
+      const body = (await c.req.json().catch(() => ({}))) as { force?: unknown };
+      const force = body.force === true;
+
+      logger.info({ idOrName, triggeredBy: authCtx.userId, force }, "Manual audit triggered");
+      const record = await auditService.runAudit(idOrName, {
+        triggeredBy: authCtx.userId,
+        force,
+      });
+      return c.json({ data: record, error: null });
+    },
+  );
+
+  return app;
+}

--- a/ornn-api/src/domains/skills/audit/service.ts
+++ b/ornn-api/src/domains/skills/audit/service.ts
@@ -1,0 +1,292 @@
+/**
+ * Skill-audit service. Orchestrates:
+ *   1. Download skill package from storage
+ *   2. Extract a readable bundle of files
+ *   3. Ask the LLM for structured dimension scores + findings
+ *   4. Compute verdict, persist the audit record
+ *
+ * Cache-first path: if an audit exists for the same skill hash younger
+ * than the TTL, return it directly.
+ *
+ * @module domains/skills/audit/service
+ */
+
+import pino from "pino";
+import type { NyxLlmClient, ResponsesApiInputMessage } from "../../../clients/nyxid/llm";
+import type { IStorageClient } from "../../../clients/storageClient";
+import type { SkillService } from "../crud/service";
+import { AppError } from "../../../shared/types/index";
+import type { AuditRepository } from "./repository";
+import {
+  type AuditFinding,
+  type AuditRecord,
+  type AuditScore,
+  AUDIT_DIMENSIONS,
+  type AuditDimension,
+  computeOverallScore,
+  computeVerdict,
+} from "./types";
+import { AUDIT_SYSTEM_PROMPT, buildAuditUserPrompt } from "./prompts";
+import JSZip from "jszip";
+import { resolveZipRoot } from "../../../shared/utils/zip";
+
+const logger = pino({ level: "info" }).child({ module: "auditService" });
+
+export interface AuditServiceDeps {
+  readonly auditRepo: AuditRepository;
+  readonly skillService: SkillService;
+  readonly storageClient: IStorageClient;
+  readonly storageBucket: string;
+  readonly llmClient: NyxLlmClient;
+  readonly model: string;
+  readonly cacheTtlMs: number;
+}
+
+export interface AuditOptions {
+  readonly triggeredBy: string;
+  /** Skip cache lookup; re-run even if a fresh record exists. */
+  readonly force?: boolean;
+}
+
+export class AuditService {
+  private readonly auditRepo: AuditRepository;
+  private readonly skillService: SkillService;
+  private readonly storageClient: IStorageClient;
+  private readonly storageBucket: string;
+  private readonly llmClient: NyxLlmClient;
+  private readonly model: string;
+  private readonly cacheTtlMs: number;
+
+  constructor(deps: AuditServiceDeps) {
+    this.auditRepo = deps.auditRepo;
+    this.skillService = deps.skillService;
+    this.storageClient = deps.storageClient;
+    this.storageBucket = deps.storageBucket;
+    this.llmClient = deps.llmClient;
+    this.model = deps.model;
+    this.cacheTtlMs = deps.cacheTtlMs;
+  }
+
+  /** Fetch the most recent audit for (skill, version) without triggering a new one. */
+  async getAudit(idOrName: string, version?: string): Promise<AuditRecord | null> {
+    const skill = await this.skillService.getSkill(idOrName, version);
+    return this.auditRepo.findBySkillAndVersion(skill.guid, skill.version);
+  }
+
+  /**
+   * Run an audit. Cache-first unless `options.force`. Persists the
+   * result and returns it.
+   */
+  async runAudit(idOrName: string, options: AuditOptions): Promise<AuditRecord> {
+    const skill = await this.skillService.getSkill(idOrName);
+    const { guid, name, version, skillHash } = skill;
+
+    if (!options.force) {
+      const cached = await this.auditRepo.findCachedByHash(guid, skillHash, this.cacheTtlMs);
+      if (cached) {
+        logger.info({ guid, version, verdict: cached.verdict }, "Audit cache hit");
+        return cached;
+      }
+    }
+
+    // Pull package bytes + build a readable file bundle the LLM can score.
+    const { filesBundle, metadataSummary } = await this.buildAuditContext(guid);
+
+    const input: ResponsesApiInputMessage[] = [
+      { role: "developer", content: AUDIT_SYSTEM_PROMPT },
+      {
+        role: "user",
+        content: buildAuditUserPrompt({
+          skillName: name,
+          version,
+          metadataSummary,
+          filesBundle,
+        }),
+      },
+    ];
+
+    const outputs = await this.llmClient.complete({
+      model: this.model,
+      input,
+      max_output_tokens: 4000,
+      temperature: 0.1,
+    });
+
+    let rawText = "";
+    for (const output of outputs) {
+      if (output.content) {
+        for (const part of output.content) {
+          if (part.text) rawText += part.text;
+        }
+      }
+    }
+
+    const parsed = parseAuditJson(rawText);
+    if (!parsed) {
+      logger.warn({ guid, version, first200: rawText.slice(0, 200) }, "Audit LLM output failed to parse");
+      throw AppError.internalError(
+        "AUDIT_PARSE_FAILED",
+        "Audit LLM did not return a valid scoring JSON. Try again.",
+      );
+    }
+
+    const { scores, findings } = parsed;
+    const overallScore = computeOverallScore(scores);
+    const verdict = computeVerdict(scores, findings);
+
+    return this.auditRepo.upsert({
+      skillGuid: guid,
+      version,
+      skillHash,
+      verdict,
+      overallScore,
+      scores,
+      findings,
+      model: this.model,
+      triggeredBy: options.triggeredBy,
+    });
+  }
+
+  private async buildAuditContext(
+    guid: string,
+  ): Promise<{ filesBundle: string; metadataSummary: string }> {
+    const presigned = await this.storageClient.getPresignedUrl(this.storageBucket, `skills/${guid}.zip`).catch(() => null);
+    // The canonical pointer is `skills/{guid}/{version}.zip`; fall back via
+    // the skill doc's stored `storageKey` for migrated/legacy rows.
+    const skillDoc = await this.skillService.getSkill(guid);
+    const storageKey = presigned
+      ? `skills/${guid}.zip`
+      : (skillDoc as unknown as { presignedPackageUrl?: string; storageKey?: string });
+
+    // Prefer the skill doc's presigned URL — `getSkill` already minted one.
+    const url = (skillDoc as unknown as { presignedPackageUrl?: string }).presignedPackageUrl;
+    if (!url) {
+      throw AppError.internalError("AUDIT_PACKAGE_UNAVAILABLE", "No storage URL for skill package");
+    }
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw AppError.internalError(
+        "AUDIT_PACKAGE_DOWNLOAD_FAILED",
+        `Failed to download package for audit (HTTP ${res.status})`,
+      );
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    const zip = await JSZip.loadAsync(bytes);
+    const allPaths = Object.keys(zip.files);
+    resolveZipRoot(zip, allPaths);
+
+    const chunks: string[] = [];
+    let bundledBytes = 0;
+    const MAX_BUNDLE_BYTES = 120 * 1024;
+
+    for (const path of allPaths) {
+      const entry = zip.files[path];
+      if (entry.dir) continue;
+      const parts = path.split("/");
+      let relative = path;
+      if (parts.length > 1 && zip.files[`${parts[0]}/`]?.dir) {
+        relative = parts.slice(1).join("/");
+      }
+      // Skip obvious binary/large files — we can't meaningfully score them.
+      if (/\.(png|jpg|jpeg|gif|ico|woff2?|ttf|eot|zip|pdf)$/i.test(relative)) continue;
+      try {
+        const text = await entry.async("string");
+        if (bundledBytes + text.length > MAX_BUNDLE_BYTES) {
+          chunks.push(`// FILE: ${relative} [TRUNCATED at bundle limit]`);
+          break;
+        }
+        chunks.push(`// FILE: ${relative}\n${text}`);
+        bundledBytes += text.length;
+      } catch {
+        // skip unreadable files
+      }
+    }
+
+    const metadataSummary = [
+      `category=${skillDoc.metadata?.category ?? "unknown"}`,
+      `runtimes=${
+        (skillDoc.metadata?.runtimes as Array<{ runtime: string }> | undefined)?.map((r) => r.runtime).join(",") ?? "none"
+      }`,
+      `tags=${(skillDoc.tags ?? []).join(",")}`,
+    ].join("; ");
+
+    void storageKey; // used only in legacy fallback; keep reference to satisfy lint
+    return { filesBundle: chunks.join("\n\n"), metadataSummary };
+  }
+}
+
+interface ParsedAudit {
+  scores: AuditScore[];
+  findings: AuditFinding[];
+}
+
+/**
+ * Strip optional markdown fences and parse the LLM's structured output.
+ * Returns null on any validation failure — the caller decides whether
+ * to retry or surface an error.
+ */
+export function parseAuditJson(raw: string): ParsedAudit | null {
+  let text = raw.trim();
+  text = text.replace(/^```json\s*/i, "").replace(/```\s*$/g, "");
+  const firstBrace = text.indexOf("{");
+  const lastBrace = text.lastIndexOf("}");
+  if (firstBrace < 0 || lastBrace <= firstBrace) return null;
+  const slice = text.slice(firstBrace, lastBrace + 1);
+  let obj: unknown;
+  try {
+    obj = JSON.parse(slice);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const record = obj as Record<string, unknown>;
+  const rawScores = record.scores;
+  const rawFindings = record.findings;
+  if (!Array.isArray(rawScores)) return null;
+
+  const scoresByDim = new Map<AuditDimension, AuditScore>();
+  for (const s of rawScores) {
+    if (!s || typeof s !== "object") continue;
+    const obj = s as Record<string, unknown>;
+    const dim = obj.dimension;
+    const score = Number(obj.score);
+    const rationale = typeof obj.rationale === "string" ? obj.rationale : "";
+    if (typeof dim !== "string" || !AUDIT_DIMENSIONS.includes(dim as AuditDimension)) continue;
+    if (Number.isNaN(score)) continue;
+    const clamped = Math.max(0, Math.min(10, Math.round(score)));
+    scoresByDim.set(dim as AuditDimension, {
+      dimension: dim as AuditDimension,
+      score: clamped,
+      rationale,
+    });
+  }
+  // Every dimension must be present.
+  for (const d of AUDIT_DIMENSIONS) {
+    if (!scoresByDim.has(d)) return null;
+  }
+  const scores: AuditScore[] = AUDIT_DIMENSIONS.map((d) => scoresByDim.get(d)!);
+
+  const findings: AuditFinding[] = [];
+  if (Array.isArray(rawFindings)) {
+    for (const f of rawFindings) {
+      if (!f || typeof f !== "object") continue;
+      const obj = f as Record<string, unknown>;
+      const dim = obj.dimension;
+      const severity = obj.severity;
+      const message = obj.message;
+      if (typeof dim !== "string" || !AUDIT_DIMENSIONS.includes(dim as AuditDimension)) continue;
+      if (severity !== "info" && severity !== "warning" && severity !== "critical") continue;
+      if (typeof message !== "string" || !message) continue;
+      const finding: AuditFinding = {
+        dimension: dim as AuditDimension,
+        severity,
+        message,
+      };
+      if (typeof obj.file === "string") (finding as AuditFinding & { file: string }).file = obj.file;
+      if (typeof obj.line === "number") (finding as AuditFinding & { line: number }).line = obj.line;
+      findings.push(finding);
+    }
+  }
+
+  return { scores, findings };
+}

--- a/ornn-api/src/domains/skills/audit/types.test.ts
+++ b/ornn-api/src/domains/skills/audit/types.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { computeOverallScore, computeVerdict, type AuditScore } from "./types";
+
+function mkScores(values: [string, number][]): AuditScore[] {
+  return values.map(([dimension, score]) => ({
+    dimension: dimension as AuditScore["dimension"],
+    score,
+    rationale: "",
+  }));
+}
+
+describe("computeOverallScore", () => {
+  test("equal weights average, rounded to 1 dp", () => {
+    const scores = mkScores([
+      ["security", 8],
+      ["code_quality", 7],
+      ["documentation", 9],
+      ["reliability", 8],
+      ["permission_scope", 10],
+    ]);
+    expect(computeOverallScore(scores)).toBe(8.4);
+  });
+
+  test("empty -> 0", () => {
+    expect(computeOverallScore([])).toBe(0);
+  });
+});
+
+describe("computeVerdict", () => {
+  test("green when all dims >= 5 and overall >= 7.5 and no criticals", () => {
+    const scores = mkScores([
+      ["security", 9],
+      ["code_quality", 8],
+      ["documentation", 7],
+      ["reliability", 8],
+      ["permission_scope", 9],
+    ]);
+    expect(computeVerdict(scores, [])).toBe("green");
+  });
+
+  test("yellow when overall < 7.5", () => {
+    const scores = mkScores([
+      ["security", 7],
+      ["code_quality", 7],
+      ["documentation", 6],
+      ["reliability", 7],
+      ["permission_scope", 7],
+    ]);
+    expect(computeVerdict(scores, [])).toBe("yellow");
+  });
+
+  test("yellow when any dim below minPerDimension", () => {
+    const scores = mkScores([
+      ["security", 10],
+      ["code_quality", 10],
+      ["documentation", 4], // below 5
+      ["reliability", 10],
+      ["permission_scope", 10],
+    ]);
+    expect(computeVerdict(scores, [])).toBe("yellow");
+  });
+
+  test("red when any dim drops 2 below threshold", () => {
+    const scores = mkScores([
+      ["security", 10],
+      ["code_quality", 10],
+      ["documentation", 2], // <= 3 = red
+      ["reliability", 10],
+      ["permission_scope", 10],
+    ]);
+    expect(computeVerdict(scores, [])).toBe("red");
+  });
+
+  test("red when any finding is critical, even if scores are all 10", () => {
+    const scores = mkScores([
+      ["security", 10],
+      ["code_quality", 10],
+      ["documentation", 10],
+      ["reliability", 10],
+      ["permission_scope", 10],
+    ]);
+    expect(
+      computeVerdict(scores, [
+        { dimension: "security", severity: "critical", message: "arbitrary code execution" },
+      ]),
+    ).toBe("red");
+  });
+});

--- a/ornn-api/src/domains/skills/audit/types.ts
+++ b/ornn-api/src/domains/skills/audit/types.ts
@@ -1,0 +1,133 @@
+/**
+ * Types for the skill-audit system.
+ *
+ * An `AuditRecord` is the LLM-scored review of one specific skill
+ * version. Records are cached by (skillGuid, version, skillHash) — if
+ * the same package bytes are shared again within the TTL, we reuse
+ * rather than re-audit.
+ *
+ * @module domains/skills/audit/types
+ */
+
+export type AuditDimension =
+  | "security"
+  | "code_quality"
+  | "documentation"
+  | "reliability"
+  | "permission_scope";
+
+export const AUDIT_DIMENSIONS: readonly AuditDimension[] = [
+  "security",
+  "code_quality",
+  "documentation",
+  "reliability",
+  "permission_scope",
+] as const;
+
+export interface AuditScore {
+  readonly dimension: AuditDimension;
+  /** 0–10 integer score from the LLM. */
+  readonly score: number;
+  /** Short human-readable rationale for the score (1–2 sentences). */
+  readonly rationale: string;
+}
+
+export interface AuditFinding {
+  readonly dimension: AuditDimension;
+  readonly severity: "info" | "warning" | "critical";
+  /** Optional — file path inside the skill package. */
+  readonly file?: string;
+  /** Optional — line number in `file`. */
+  readonly line?: number;
+  /** Short description. */
+  readonly message: string;
+}
+
+/** Overall verdict. Green = safe to share silently. */
+export type AuditVerdict = "green" | "yellow" | "red";
+
+export interface AuditRecord {
+  readonly _id: string; // `${skillGuid}@${version}`
+  readonly skillGuid: string;
+  readonly version: string;
+  /** SHA-256 of the skill package bytes at audit time. */
+  readonly skillHash: string;
+  readonly verdict: AuditVerdict;
+  /** 0–10 weighted average. Convenience — derivable from `scores`. */
+  readonly overallScore: number;
+  readonly scores: ReadonlyArray<AuditScore>;
+  readonly findings: ReadonlyArray<AuditFinding>;
+  /** The LLM model used, for audit traceability. */
+  readonly model: string;
+  readonly createdAt: Date;
+  /**
+   * User who triggered the audit. `system` when the audit-on-share
+   * pipeline kicked it off automatically (to be wired in a later PR).
+   */
+  readonly triggeredBy: string;
+}
+
+export interface AuditThresholds {
+  /** Minimum overall score to count as green. */
+  readonly greenOverall: number;
+  /** Any dimension below this pulls the verdict down regardless of overall. */
+  readonly minPerDimension: number;
+}
+
+export const DEFAULT_AUDIT_THRESHOLDS: AuditThresholds = {
+  greenOverall: 7.5,
+  minPerDimension: 5,
+};
+
+/**
+ * Weighted average over the 5 dimensions. All weights equal for now;
+ * future-proofed as a lookup so we can tune without touching call
+ * sites.
+ */
+const DIMENSION_WEIGHTS: Record<AuditDimension, number> = {
+  security: 1,
+  code_quality: 1,
+  documentation: 1,
+  reliability: 1,
+  permission_scope: 1,
+};
+
+export function computeOverallScore(scores: ReadonlyArray<AuditScore>): number {
+  if (scores.length === 0) return 0;
+  let totalWeight = 0;
+  let weighted = 0;
+  for (const s of scores) {
+    const w = DIMENSION_WEIGHTS[s.dimension] ?? 1;
+    totalWeight += w;
+    weighted += s.score * w;
+  }
+  const avg = weighted / totalWeight;
+  // Round to 1 decimal.
+  return Math.round(avg * 10) / 10;
+}
+
+/**
+ * Classify a set of dimension scores into a verdict.
+ *
+ * `red` — any critical-severity finding, OR any dimension below
+ * `minPerDimension - 2` (i.e. deeply unsafe in at least one area).
+ * `yellow` — any dimension below `minPerDimension`, OR overall below
+ * `greenOverall`.
+ * `green` — overall ≥ `greenOverall` AND every dimension ≥
+ * `minPerDimension` AND no critical findings.
+ */
+export function computeVerdict(
+  scores: ReadonlyArray<AuditScore>,
+  findings: ReadonlyArray<AuditFinding>,
+  thresholds: AuditThresholds = DEFAULT_AUDIT_THRESHOLDS,
+): AuditVerdict {
+  const overall = computeOverallScore(scores);
+  const hasCritical = findings.some((f) => f.severity === "critical");
+  const lowestDimScore = scores.length > 0 ? Math.min(...scores.map((s) => s.score)) : 0;
+
+  if (hasCritical) return "red";
+  if (lowestDimScore < thresholds.minPerDimension - 2) return "red";
+  if (lowestDimScore < thresholds.minPerDimension) return "yellow";
+  if (overall < thresholds.greenOverall) return "yellow";
+  return "green";
+}


### PR DESCRIPTION
First slice of the Trust & Quality cluster (#3). Lays down the audit engine + read/manual-trigger API. Share-gated trigger (#95), justification flow (#96), review routing (#97), and notification center (#98) land in follow-up PRs.

## Domain

New `ornn-api/src/domains/skills/audit/` with:

- **Scoring**: 5 dimensions × 0–10 integer (`security`, `code_quality`, `documentation`, `reliability`, `permission_scope`). Equal-weight overall avg, rounded to 1 dp.
- **Verdict classifier** (`computeVerdict`) with configurable thresholds. Default: green = overall ≥ 7.5 AND all dimensions ≥ 5 AND no critical findings. Any critical finding → red regardless of scores.
- **Findings**: `{ dimension, severity: info|warning|critical, file?, line?, message }` — LLM only emits findings it can point at; system prompt explicitly forbids invention.
- **Cache-first**: `findCachedByHash` — if an audit exists for the same SHA-256 of the skill bytes younger than the 7-day TTL, reuse. Re-upload of identical bytes short-circuits the LLM call.

## Endpoints

- `GET /api/v1/skills/:idOrName/audit[?version=<v>]` — latest audit for the skill (or a specific version). Visibility rules mirror `GET /skills/:idOrName` — anonymous users can only read audits of public skills; authed users go through `canReadSkill`. Returns 404 `AUDIT_NOT_FOUND` when no audit exists yet (distinguishes from an audit with all zeroes).
- `POST /api/v1/admin/skills/:idOrName/audit` — manual re-audit. Body `{ force?: boolean }`; `force=true` bypasses the cache. Behind `ornn:admin:skill`.

## LLM shape

System prompt enforces: one JSON object, no fences, exactly one score per dimension, optional findings. Parser:

- Strips markdown fences
- Rejects responses missing any of the 5 dimensions
- Clamps scores to 0–10, rounds to integer
- Drops malformed findings (bad dimension / severity / empty message) but keeps good ones

## Storage

New `skill_audits` collection. `_id = ${skillGuid}@${version}`. Audit bytes → same `_id` → upsert replaces in place. Different versions / different hashes → separate rows for history. Indexes: `(skillGuid, version)`, `(skillGuid, skillHash)`, `(createdAt -1)`.

## Tests (13)

- **`types.test.ts`** (6): overall-score averaging, empty-scores edge, verdict thresholds (green / yellow / red), critical-finding override.
- **`parseAuditJson.test.ts`** (7): happy path, fence stripping, missing-dimension → null, score clamp/round, malformed-findings drop, garbage → null.

No LLM round-trips in tests — the parser + classifier are pure. End-to-end integration test (calling the actual LLM) will land once we have a VCR-style fixture.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — 0 errors, no regression (66 warnings unchanged)
- [x] `bun run test` — 235 backend (+16) + 11 web + 17 sdk = 263 pass

## Follow-ups (each tracked in its M3 issue)

- #95 — trigger audit on share (not publish); private skills exempt
- #96 — owner justification flow on failed audit
- #97 — target-based review routing (org admin / recipient / Ornn admin)
- #98 — in-product notification center for audit + share-review events