### PR TITLE
fix(web): split ornn-web NyxID token/client from ornn-api's [closes #122]

### DIFF
--- a/.changeset/ornn-web-nyxid-client-separation.md
+++ b/.changeset/ornn-web-nyxid-client-separation.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Fix `ornn-web-config` ConfigMap accidentally reusing ornn-api's `NYXID_TOKEN_URL` / `NYXID_CLIENT_ID` values. ornn-api wants internal K8s DNS + a service-account client; ornn-web needs a browser-reachable URL + a user-facing OAuth client. The ConfigMap now sources ornn-web's two vars from dedicated `.env.ornn` entries (`NYXID_WEB_TOKEN_URL`, `NYXID_WEB_CLIENT_ID`); the container env keys stay `NYXID_TOKEN_URL` / `NYXID_CLIENT_ID` so no frontend code change is needed.

--- a/deployment/.env.sample.ornn
+++ b/deployment/.env.sample.ornn
@@ -39,5 +39,8 @@ NYXID_AUTHORIZE_URL=<nyxid-authorize-url>
 NYXID_REDIRECT_URI=<oauth-redirect-uri>
 NYXID_LOGOUT_URL=<nyxid-logout-url>
 NYXID_SETTINGS_URL=<nyxid-settings-url>
-# NYXID_TOKEN_URL and NYXID_CLIENT_ID are declared in the ornn-api section
-# above and reused here (same NyxID tenant).
+# NyxID web-side OAuth — distinct from ornn-api's NYXID_TOKEN_URL / NYXID_CLIENT_ID
+# because the browser needs a public URL + user-facing OAuth client, while
+# ornn-api talks to internal K8s DNS with a service-account client.
+NYXID_WEB_TOKEN_URL=<browser-reachable-nyxid-token-url>
+NYXID_WEB_CLIENT_ID=<user-facing-oauth-client-id>

--- a/deployment/ornn-web/configmap.yaml
+++ b/deployment/ornn-web/configmap.yaml
@@ -14,10 +14,13 @@ data:
 
   # Frontend runtime config — consumed by 40-envsubst-config-js.sh,
   # injected into window.__ORNN_CONFIG__ via /config.js at page load.
+  # NYXID_TOKEN_URL / NYXID_CLIENT_ID are sourced from NYXID_WEB_* in .env.ornn
+  # because ornn-api wants internal DNS + service-account credentials while
+  # ornn-web needs browser-reachable URL + user-facing OAuth client.
   API_BASE_URL: "${API_BASE_URL}"
   NYXID_AUTHORIZE_URL: "${NYXID_AUTHORIZE_URL}"
-  NYXID_TOKEN_URL: "${NYXID_TOKEN_URL}"
-  NYXID_CLIENT_ID: "${NYXID_CLIENT_ID}"
+  NYXID_TOKEN_URL: "${NYXID_WEB_TOKEN_URL}"
+  NYXID_CLIENT_ID: "${NYXID_WEB_CLIENT_ID}"
   NYXID_REDIRECT_URI: "${NYXID_REDIRECT_URI}"
   NYXID_LOGOUT_URL: "${NYXID_LOGOUT_URL}"
   NYXID_SETTINGS_URL: "${NYXID_SETTINGS_URL}"


### PR DESCRIPTION
## Summary

The runtime-config ConfigMap in #117 collapsed two intentionally-distinct value pairs onto one `.env.ornn` variable set:

| | ornn-api | ornn-web |
|---|---|---|
| NYXID_TOKEN_URL | `http://nyxid-backend:3001/oauth/token` (internal) | `https://nyxid.ornn-cluster.local/oauth/token` (browser-reachable) |
| NYXID_CLIENT_ID | `sa_...` (service-account) | UUID (user-facing OAuth client) |

Under the buggy ConfigMap, ornn-web's browser got the unresolvable internal URL and the wrong credential flow — login broke. Caught while doing a local deploy off latest `develop`.

`deployment/ornn-web/configmap.yaml` now sources those two values from dedicated `NYXID_WEB_TOKEN_URL` / `NYXID_WEB_CLIENT_ID` entries in `.env.ornn`. Container env keys stay `NYXID_TOKEN_URL` / `NYXID_CLIENT_ID` so no frontend code change is needed.

## Test plan

- [x] `git diff` — 3 files changed, only ConfigMap + sample env + changeset
- [ ] CI green (typecheck, lint, test, docker-build)
- [ ] Local deploy: apply ConfigMap, verify `/config.js` in the pod contains the browser-reachable URL + user-facing client ID, verify login works

Closes #122