### PR TITLE
feat(api): audit-gated skill sharing [closes #95, progresses #94/#96/#97]

### DIFF
--- a/.changeset/shaky-baboons-wave.md
+++ b/.changeset/shaky-baboons-wave.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+Audit-gated skill sharing. New `shares` domain with `ShareRequest` state machine (`pending-audit → green | needs-justification → pending-review → accepted | rejected | cancelled`). Endpoints: `POST /api/v1/skills/:idOrName/share` (initiate, runs cached audit), `GET /api/v1/shares/:id`, `POST /api/v1/shares/:id/justification` (owner), `POST /api/v1/shares/:id/review` (reviewer), `POST /api/v1/shares/:id/cancel`, `GET /api/v1/shares` (caller's own), `GET /api/v1/shares/review-queue` (routed by target: user recipient / org admin / platform admin). Green audit short-circuits and applies the share immediately via `setSkillPermissions`. Part of #94 / #95 / #96 / #97. Private skills remain un-audited by virtue of never going through the share path.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -42,6 +42,11 @@ import { AuditRepository } from "./domains/skills/audit/repository";
 import { AuditService } from "./domains/skills/audit/service";
 import { createAuditRoutes } from "./domains/skills/audit/routes";
 
+// Domain: Shares (audit-gated sharing)
+import { ShareRepository } from "./domains/shares/repository";
+import { ShareService } from "./domains/shares/service";
+import { createShareRoutes } from "./domains/shares/routes";
+
 // Domain: Skill Search
 import { SearchService } from "./domains/skills/search/service";
 import { createSearchRoutes } from "./domains/skills/search/routes";
@@ -167,6 +172,14 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   });
   const auditRoutes = createAuditRoutes({ auditService, skillService });
 
+  // ---- Domain: Shares (audit-gated sharing) ----
+  const shareRepo = new ShareRepository(db);
+  void shareRepo.ensureIndexes().catch((err) =>
+    logger.warn({ err }, "share_requests indexes ensureIndexes failed — proceeding anyway"),
+  );
+  const shareService = new ShareService({ shareRepo, auditService, skillService });
+  const shareRoutes = createShareRoutes({ shareService });
+
   // ---- Domain: Skill Search ----
   const searchService = new SearchService({
     skillRepo,
@@ -291,6 +304,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   apiApp.use("*", nyxidOrgLookupMiddleware(nyxidOrgsClient));
   apiApp.route("/", skillRoutes);
   apiApp.route("/", auditRoutes);
+  apiApp.route("/", shareRoutes);
   apiApp.route("/", searchRoutes);
   apiApp.route("/", generationRoutes);
   apiApp.route("/", playgroundRoutes);

--- a/ornn-api/src/domains/shares/repository.ts
+++ b/ornn-api/src/domains/shares/repository.ts
@@ -1,0 +1,178 @@
+/**
+ * ShareRequest repository — a single Mongo collection, small surface.
+ *
+ * @module domains/shares/repository
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Collection, Db, Document } from "mongodb";
+import pino from "pino";
+import type {
+  ShareJustifications,
+  ShareRequest,
+  ShareReviewerDecision,
+  ShareStatus,
+  ShareTarget,
+} from "./types";
+import type { AuditVerdict } from "../skills/audit/types";
+
+const logger = pino({ level: "info" }).child({ module: "shareRepository" });
+
+export interface CreateShareRequestInput {
+  skillGuid: string;
+  skillVersion: string;
+  skillHash: string;
+  ownerUserId: string;
+  target: ShareTarget;
+  initialStatus: ShareStatus;
+  auditVerdict?: AuditVerdict;
+  auditOverallScore?: number;
+  auditRecordId?: string;
+}
+
+export class ShareRepository {
+  private readonly collection: Collection;
+
+  constructor(db: Db) {
+    this.collection = db.collection("share_requests");
+  }
+
+  async ensureIndexes(): Promise<void> {
+    try {
+      await Promise.all([
+        this.collection.createIndex({ skillGuid: 1, status: 1 }),
+        this.collection.createIndex({ ownerUserId: 1, createdAt: -1 }),
+        this.collection.createIndex({ "target.type": 1, "target.id": 1, status: 1 }),
+        this.collection.createIndex({ createdAt: -1 }),
+      ]);
+    } catch (err) {
+      logger.error({ err }, "Failed to create share_requests indexes");
+    }
+  }
+
+  async create(input: CreateShareRequestInput): Promise<ShareRequest> {
+    const now = new Date();
+    const doc: Document = {
+      _id: randomUUID() as unknown as Document["_id"],
+      skillGuid: input.skillGuid,
+      skillVersion: input.skillVersion,
+      skillHash: input.skillHash,
+      ownerUserId: input.ownerUserId,
+      target: input.target,
+      status: input.initialStatus,
+      auditVerdict: input.auditVerdict,
+      auditOverallScore: input.auditOverallScore,
+      auditRecordId: input.auditRecordId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.collection.insertOne(doc);
+    logger.info(
+      { id: doc._id, skillGuid: input.skillGuid, status: input.initialStatus, target: input.target },
+      "Share request created",
+    );
+    return mapDoc(doc)!;
+  }
+
+  async findById(id: string): Promise<ShareRequest | null> {
+    const doc = await this.collection.findOne({ _id: id as unknown as Document["_id"] });
+    return mapDoc(doc);
+  }
+
+  async transitionStatus(
+    id: string,
+    nextStatus: ShareStatus,
+    extra: {
+      justifications?: ShareJustifications;
+      reviewerDecision?: ShareReviewerDecision;
+    } = {},
+  ): Promise<ShareRequest | null> {
+    const set: Record<string, unknown> = { status: nextStatus, updatedAt: new Date() };
+    if (extra.justifications) set.justifications = extra.justifications;
+    if (extra.reviewerDecision) set.reviewerDecision = extra.reviewerDecision;
+    await this.collection.updateOne(
+      { _id: id as unknown as Document["_id"] },
+      { $set: set },
+    );
+    return this.findById(id);
+  }
+
+  async listByOwner(ownerUserId: string, limit = 50): Promise<ShareRequest[]> {
+    const docs = await this.collection
+      .find({ ownerUserId })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .toArray();
+    return docs.map((d) => mapDoc(d)!);
+  }
+
+  /**
+   * Reviewer queue.
+   *
+   *   - targetType = "user"   → recipient reviews: target.id = reviewerUserId
+   *   - targetType = "org"    → org admin reviews: target.id ∈ reviewerOrgIds
+   *   - targetType = "public" → Ornn platform admin reviews: caller opts in via `includePublic`
+   */
+  async listReviewQueue(params: {
+    reviewerUserId: string;
+    reviewerOrgIds: string[];
+    includePublic: boolean;
+    limit: number;
+  }): Promise<ShareRequest[]> {
+    const orConditions: Array<Record<string, unknown>> = [
+      { "target.type": "user", "target.id": params.reviewerUserId },
+    ];
+    if (params.reviewerOrgIds.length > 0) {
+      orConditions.push({ "target.type": "org", "target.id": { $in: params.reviewerOrgIds } });
+    }
+    if (params.includePublic) {
+      orConditions.push({ "target.type": "public" });
+    }
+    const docs = await this.collection
+      .find({ status: "pending-review", $or: orConditions })
+      .sort({ createdAt: -1 })
+      .limit(params.limit)
+      .toArray();
+    return docs.map((d) => mapDoc(d)!);
+  }
+}
+
+function mapDoc(doc: Document | null): ShareRequest | null {
+  if (!doc) return null;
+  return {
+    _id: String(doc._id),
+    skillGuid: String(doc.skillGuid),
+    skillVersion: String(doc.skillVersion),
+    skillHash: String(doc.skillHash),
+    ownerUserId: String(doc.ownerUserId),
+    target: doc.target as ShareTarget,
+    status: doc.status as ShareStatus,
+    auditVerdict: doc.auditVerdict,
+    auditOverallScore: typeof doc.auditOverallScore === "number" ? doc.auditOverallScore : undefined,
+    auditRecordId: doc.auditRecordId ? String(doc.auditRecordId) : undefined,
+    justifications: doc.justifications
+      ? {
+          whyCannotPass: String(doc.justifications.whyCannotPass ?? ""),
+          whySafe: String(doc.justifications.whySafe ?? ""),
+          whyShare: String(doc.justifications.whyShare ?? ""),
+          submittedAt:
+            doc.justifications.submittedAt instanceof Date
+              ? doc.justifications.submittedAt
+              : new Date(doc.justifications.submittedAt),
+        }
+      : undefined,
+    reviewerDecision: doc.reviewerDecision
+      ? {
+          decision: doc.reviewerDecision.decision,
+          note: doc.reviewerDecision.note,
+          reviewerUserId: String(doc.reviewerDecision.reviewerUserId),
+          reviewedAt:
+            doc.reviewerDecision.reviewedAt instanceof Date
+              ? doc.reviewerDecision.reviewedAt
+              : new Date(doc.reviewerDecision.reviewedAt),
+        }
+      : undefined,
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt : new Date(doc.createdAt),
+    updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt : new Date(doc.updatedAt),
+  };
+}

--- a/ornn-api/src/domains/shares/routes.ts
+++ b/ornn-api/src/domains/shares/routes.ts
@@ -1,0 +1,190 @@
+/**
+ * Share-request HTTP routes.
+ *
+ *   POST /api/v1/skills/:idOrName/share          — initiate share
+ *   GET  /api/v1/shares/:requestId               — status + findings
+ *   POST /api/v1/shares/:requestId/justification — owner submits justifications
+ *   POST /api/v1/shares/:requestId/review        — reviewer accept/reject
+ *   POST /api/v1/shares/:requestId/cancel        — owner cancels
+ *   GET  /api/v1/shares                          — caller's own share requests
+ *   GET  /api/v1/shares/review-queue             — pending reviews the caller can act on
+ *
+ * @module domains/shares/routes
+ */
+
+import { Hono } from "hono";
+import pino from "pino";
+import {
+  type AuthVariables,
+  getAuth,
+  nyxidAuthMiddleware,
+  readUserOrgIds,
+} from "../../middleware/nyxidAuth";
+import { AppError } from "../../shared/types/index";
+import type { ShareService } from "./service";
+import type { ShareTarget } from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "shareRoutes" });
+
+export interface ShareRoutesConfig {
+  shareService: ShareService;
+}
+
+export function createShareRoutes(config: ShareRoutesConfig): Hono<{ Variables: AuthVariables }> {
+  const { shareService } = config;
+  const app = new Hono<{ Variables: AuthVariables }>();
+  const auth = nyxidAuthMiddleware();
+
+  // ---- Initiate share -----------------------------------------------------
+  app.post(
+    "/skills/:idOrName/share",
+    auth,
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const authCtx = getAuth(c);
+      const body = (await c.req.json().catch(() => ({}))) as {
+        targetType?: unknown;
+        targetId?: unknown;
+      };
+      const target = parseTarget(body);
+      const request = await shareService.initiateShare({
+        skillIdOrName: idOrName,
+        ownerUserId: authCtx.userId,
+        target,
+      });
+      logger.info(
+        { shareRequestId: request._id, skillIdOrName: idOrName, ownerUserId: authCtx.userId },
+        "Share initiated via API",
+      );
+      return c.json({ data: request, error: null });
+    },
+  );
+
+  // ---- Read a single request ---------------------------------------------
+  app.get(
+    "/shares/:requestId",
+    auth,
+    async (c) => {
+      const requestId = c.req.param("requestId");
+      const authCtx = getAuth(c);
+      const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
+      const request = await shareService.get(requestId, authCtx.userId, isPlatformAdmin);
+      return c.json({ data: request, error: null });
+    },
+  );
+
+  // ---- Owner: submit justifications --------------------------------------
+  app.post(
+    "/shares/:requestId/justification",
+    auth,
+    async (c) => {
+      const requestId = c.req.param("requestId");
+      const authCtx = getAuth(c);
+      const body = (await c.req.json().catch(() => ({}))) as {
+        whyCannotPass?: unknown;
+        whySafe?: unknown;
+        whyShare?: unknown;
+      };
+      const updated = await shareService.submitJustification(requestId, authCtx.userId, {
+        whyCannotPass: String(body.whyCannotPass ?? ""),
+        whySafe: String(body.whySafe ?? ""),
+        whyShare: String(body.whyShare ?? ""),
+      });
+      return c.json({ data: updated, error: null });
+    },
+  );
+
+  // ---- Reviewer: accept/reject -------------------------------------------
+  app.post(
+    "/shares/:requestId/review",
+    auth,
+    async (c) => {
+      const requestId = c.req.param("requestId");
+      const authCtx = getAuth(c);
+      const body = (await c.req.json().catch(() => ({}))) as {
+        decision?: unknown;
+        note?: unknown;
+      };
+      if (body.decision !== "accept" && body.decision !== "reject") {
+        throw AppError.badRequest(
+          "INVALID_DECISION",
+          "'decision' must be 'accept' or 'reject'",
+        );
+      }
+      const reviewerOrgIds = await readUserOrgIds(c);
+      const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
+      const updated = await shareService.review(
+        requestId,
+        authCtx.userId,
+        reviewerOrgIds,
+        isPlatformAdmin,
+        body.decision,
+        typeof body.note === "string" ? body.note : undefined,
+      );
+      return c.json({ data: updated, error: null });
+    },
+  );
+
+  // ---- Owner: cancel ------------------------------------------------------
+  app.post(
+    "/shares/:requestId/cancel",
+    auth,
+    async (c) => {
+      const requestId = c.req.param("requestId");
+      const authCtx = getAuth(c);
+      const updated = await shareService.cancel(requestId, authCtx.userId);
+      return c.json({ data: updated, error: null });
+    },
+  );
+
+  // ---- Caller's own share requests ---------------------------------------
+  app.get(
+    "/shares",
+    auth,
+    async (c) => {
+      const authCtx = getAuth(c);
+      const items = await shareService.listMine(authCtx.userId);
+      return c.json({ data: { items }, error: null });
+    },
+  );
+
+  // ---- Reviewer queue -----------------------------------------------------
+  app.get(
+    "/shares/review-queue",
+    auth,
+    async (c) => {
+      const authCtx = getAuth(c);
+      const reviewerOrgIds = await readUserOrgIds(c);
+      const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
+      const items = await shareService.listReviewQueue({
+        reviewerUserId: authCtx.userId,
+        reviewerOrgIds,
+        isPlatformAdmin,
+      });
+      return c.json({ data: { items }, error: null });
+    },
+  );
+
+  return app;
+}
+
+function parseTarget(body: { targetType?: unknown; targetId?: unknown }): ShareTarget {
+  const targetType = body.targetType;
+  if (targetType !== "user" && targetType !== "org" && targetType !== "public") {
+    throw AppError.badRequest(
+      "INVALID_SHARE_TARGET",
+      "'targetType' must be 'user', 'org', or 'public'",
+    );
+  }
+  if (targetType === "public") {
+    return { type: "public" };
+  }
+  const id = body.targetId;
+  if (typeof id !== "string" || !id) {
+    throw AppError.badRequest(
+      "INVALID_SHARE_TARGET",
+      `'targetId' is required for targetType '${targetType}'`,
+    );
+  }
+  return { type: targetType, id };
+}

--- a/ornn-api/src/domains/shares/service.ts
+++ b/ornn-api/src/domains/shares/service.ts
@@ -1,0 +1,332 @@
+/**
+ * Share-request service.
+ *
+ * Orchestrates the audit-gated share flow (#94 / #95 / #96 / #97):
+ *
+ *   1. `initiateShare` — kicks off audit, stamps initial status.
+ *   2. `submitJustification` — owner path when audit didn't pass.
+ *   3. `review` — reviewer accept/reject.
+ *   4. `cancel` — owner aborts before review.
+ *
+ * Actually granting the share (adding to `sharedWithUsers` /
+ * flipping `isPrivate`) is done via the existing skillService when we
+ * reach an `accepted` terminal state; this service does not touch the
+ * skill doc directly.
+ *
+ * @module domains/shares/service
+ */
+
+import pino from "pino";
+import { AppError } from "../../shared/types/index";
+import type { AuditService } from "../skills/audit/service";
+import type { SkillService } from "../skills/crud/service";
+import type { ShareRepository } from "./repository";
+import type {
+  ShareJustifications,
+  ShareRequest,
+  ShareStatus,
+  ShareTarget,
+  ShareTargetType,
+} from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "shareService" });
+
+export interface ShareServiceDeps {
+  readonly shareRepo: ShareRepository;
+  readonly auditService: AuditService;
+  readonly skillService: SkillService;
+}
+
+export interface InitiateShareInput {
+  skillIdOrName: string;
+  ownerUserId: string;
+  target: ShareTarget;
+}
+
+export interface SubmitJustificationInput {
+  whyCannotPass: string;
+  whySafe: string;
+  whyShare: string;
+}
+
+export class ShareService {
+  private readonly shareRepo: ShareRepository;
+  private readonly auditService: AuditService;
+  private readonly skillService: SkillService;
+
+  constructor(deps: ShareServiceDeps) {
+    this.shareRepo = deps.shareRepo;
+    this.auditService = deps.auditService;
+    this.skillService = deps.skillService;
+  }
+
+  /**
+   * Initiate a share — run audit, decide initial status.
+   *
+   * - Green verdict → the share is granted immediately and the request
+   *   lands in status `green`.
+   * - Anything else → the request sits at `needs-justification` waiting
+   *   for the owner.
+   */
+  async initiateShare(input: InitiateShareInput): Promise<ShareRequest> {
+    const skill = await this.skillService.getSkill(input.skillIdOrName);
+    if (skill.createdBy !== input.ownerUserId) {
+      throw AppError.forbidden(
+        "NOT_SKILL_OWNER",
+        "Only the skill's author can initiate a share",
+      );
+    }
+    validateTarget(input.target);
+
+    // Run (or reuse cached) audit for this specific package.
+    const audit = await this.auditService.runAudit(skill.guid, {
+      triggeredBy: input.ownerUserId,
+      force: false,
+    });
+
+    const initialStatus: ShareStatus =
+      audit.verdict === "green" ? "green" : "needs-justification";
+
+    const request = await this.shareRepo.create({
+      skillGuid: skill.guid,
+      skillVersion: skill.version,
+      skillHash: skill.skillHash,
+      ownerUserId: input.ownerUserId,
+      target: input.target,
+      initialStatus,
+      auditVerdict: audit.verdict,
+      auditOverallScore: audit.overallScore,
+      auditRecordId: audit._id,
+    });
+
+    if (initialStatus === "green") {
+      await this.applyAcceptedShare(skill.guid, input.target, input.ownerUserId);
+    }
+
+    logger.info(
+      {
+        shareRequestId: request._id,
+        skillGuid: skill.guid,
+        status: initialStatus,
+        verdict: audit.verdict,
+      },
+      "Share initiated",
+    );
+    return request;
+  }
+
+  async submitJustification(
+    requestId: string,
+    ownerUserId: string,
+    input: SubmitJustificationInput,
+  ): Promise<ShareRequest> {
+    const request = await this.mustFind(requestId);
+    if (request.ownerUserId !== ownerUserId) {
+      throw AppError.forbidden("NOT_SHARE_OWNER", "Only the share owner can submit justifications");
+    }
+    if (request.status !== "needs-justification") {
+      throw AppError.conflict(
+        "INVALID_SHARE_TRANSITION",
+        `Cannot submit justifications in status '${request.status}'`,
+      );
+    }
+    for (const [k, v] of [
+      ["whyCannotPass", input.whyCannotPass],
+      ["whySafe", input.whySafe],
+      ["whyShare", input.whyShare],
+    ] as const) {
+      if (typeof v !== "string" || v.trim().length < 10) {
+        throw AppError.badRequest(
+          "JUSTIFICATION_TOO_SHORT",
+          `'${k}' must be at least 10 characters`,
+        );
+      }
+    }
+    const justifications: ShareJustifications = {
+      whyCannotPass: input.whyCannotPass.trim(),
+      whySafe: input.whySafe.trim(),
+      whyShare: input.whyShare.trim(),
+      submittedAt: new Date(),
+    };
+    const updated = await this.shareRepo.transitionStatus(requestId, "pending-review", {
+      justifications,
+    });
+    if (!updated) {
+      throw AppError.internalError("SHARE_UPDATE_FAILED", "Failed to persist share transition");
+    }
+    return updated;
+  }
+
+  async review(
+    requestId: string,
+    reviewerUserId: string,
+    reviewerOrgIds: string[],
+    isPlatformAdmin: boolean,
+    decision: "accept" | "reject",
+    note: string | undefined,
+  ): Promise<ShareRequest> {
+    const request = await this.mustFind(requestId);
+    if (request.status !== "pending-review") {
+      throw AppError.conflict(
+        "INVALID_SHARE_TRANSITION",
+        `Cannot review in status '${request.status}'`,
+      );
+    }
+    if (!this.isAuthorizedReviewer(request, reviewerUserId, reviewerOrgIds, isPlatformAdmin)) {
+      throw AppError.forbidden(
+        "NOT_SHARE_REVIEWER",
+        "Caller is not an authorized reviewer for this share",
+      );
+    }
+    const finalStatus: ShareStatus = decision === "accept" ? "accepted" : "rejected";
+    const updated = await this.shareRepo.transitionStatus(requestId, finalStatus, {
+      reviewerDecision: {
+        decision,
+        note,
+        reviewerUserId,
+        reviewedAt: new Date(),
+      },
+    });
+    if (!updated) {
+      throw AppError.internalError("SHARE_UPDATE_FAILED", "Failed to persist review decision");
+    }
+    if (decision === "accept") {
+      await this.applyAcceptedShare(
+        request.skillGuid,
+        request.target,
+        request.ownerUserId,
+      );
+    }
+    logger.info(
+      { shareRequestId: requestId, reviewerUserId, decision, finalStatus },
+      "Share reviewed",
+    );
+    return updated;
+  }
+
+  async cancel(requestId: string, ownerUserId: string): Promise<ShareRequest> {
+    const request = await this.mustFind(requestId);
+    if (request.ownerUserId !== ownerUserId) {
+      throw AppError.forbidden("NOT_SHARE_OWNER", "Only the share owner can cancel this request");
+    }
+    if (
+      request.status !== "needs-justification" &&
+      request.status !== "pending-review" &&
+      request.status !== "pending-audit"
+    ) {
+      throw AppError.conflict(
+        "INVALID_SHARE_TRANSITION",
+        `Cannot cancel in status '${request.status}'`,
+      );
+    }
+    const updated = await this.shareRepo.transitionStatus(requestId, "cancelled");
+    return updated!;
+  }
+
+  async get(requestId: string, callerUserId: string, isPlatformAdmin: boolean): Promise<ShareRequest> {
+    const request = await this.mustFind(requestId);
+    const isOwner = request.ownerUserId === callerUserId;
+    const isDirectRecipient =
+      request.target.type === "user" && request.target.id === callerUserId;
+    if (!isOwner && !isDirectRecipient && !isPlatformAdmin) {
+      // Org-admin case is handled at the route level via reviewerOrgIds. For
+      // get-by-id we fall back to owner / recipient / platform admin. Org
+      // admins who aren't in one of those roles can still see the request
+      // via the review-queue listing.
+      throw AppError.notFound("SHARE_NOT_FOUND", "Share request not found");
+    }
+    return request;
+  }
+
+  async listMine(ownerUserId: string, limit = 50): Promise<ShareRequest[]> {
+    return this.shareRepo.listByOwner(ownerUserId, limit);
+  }
+
+  async listReviewQueue(params: {
+    reviewerUserId: string;
+    reviewerOrgIds: string[];
+    isPlatformAdmin: boolean;
+    limit?: number;
+  }): Promise<ShareRequest[]> {
+    return this.shareRepo.listReviewQueue({
+      reviewerUserId: params.reviewerUserId,
+      reviewerOrgIds: params.reviewerOrgIds,
+      includePublic: params.isPlatformAdmin,
+      limit: params.limit ?? 50,
+    });
+  }
+
+  // ---- Internals ---------------------------------------------------------
+
+  private async mustFind(requestId: string): Promise<ShareRequest> {
+    const request = await this.shareRepo.findById(requestId);
+    if (!request) {
+      throw AppError.notFound("SHARE_NOT_FOUND", `Share request '${requestId}' not found`);
+    }
+    return request;
+  }
+
+  private isAuthorizedReviewer(
+    request: ShareRequest,
+    reviewerUserId: string,
+    reviewerOrgIds: string[],
+    isPlatformAdmin: boolean,
+  ): boolean {
+    switch (request.target.type) {
+      case "user":
+        return request.target.id === reviewerUserId;
+      case "org":
+        return reviewerOrgIds.includes(request.target.id ?? "");
+      case "public":
+        return isPlatformAdmin;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Apply an accepted share to the underlying skill:
+   *   - `public` → flip `isPrivate=false`
+   *   - `user`   → append to `sharedWithUsers`
+   *   - `org`    → append to `sharedWithOrgs`
+   *
+   * Uses the skill-service's permissions path so all the existing
+   * validation / activity logging runs.
+   */
+  private async applyAcceptedShare(
+    skillGuid: string,
+    target: ShareTarget,
+    actorUserId: string,
+  ): Promise<void> {
+    // Re-read the latest skill state so we don't clobber concurrent edits.
+    const current = await this.skillService.getSkill(skillGuid);
+    const nextPrivate =
+      target.type === "public" ? false : current.isPrivate;
+    const nextUsers = new Set(current.sharedWithUsers);
+    const nextOrgs = new Set(current.sharedWithOrgs);
+    if (target.type === "user" && target.id) nextUsers.add(target.id);
+    if (target.type === "org" && target.id) nextOrgs.add(target.id);
+
+    await this.skillService.setSkillPermissions(skillGuid, actorUserId, {
+      isPrivate: nextPrivate,
+      sharedWithUsers: Array.from(nextUsers),
+      sharedWithOrgs: Array.from(nextOrgs),
+    });
+  }
+}
+
+function validateTarget(target: ShareTarget): void {
+  const validTypes: ShareTargetType[] = ["user", "org", "public"];
+  if (!validTypes.includes(target.type)) {
+    throw AppError.badRequest(
+      "INVALID_SHARE_TARGET",
+      `Share target type must be one of ${validTypes.join(", ")}`,
+    );
+  }
+  if ((target.type === "user" || target.type === "org") && !target.id) {
+    throw AppError.badRequest(
+      "INVALID_SHARE_TARGET",
+      `Share target type '${target.type}' requires a target id`,
+    );
+  }
+}

--- a/ornn-api/src/domains/shares/types.ts
+++ b/ornn-api/src/domains/shares/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Share-request types.
+ *
+ * A `ShareRequest` is the durable state that tracks one attempt to
+ * share a skill with a target (another person, an org, or the public).
+ * Audit results are captured on the request so the justification + review
+ * queue can reason about them without re-fetching.
+ *
+ * State machine:
+ *
+ *    pending-audit
+ *        │
+ *        ▼
+ *    ┌────────┬───────────────────┐
+ *    │        │                   │
+ *    ▼        ▼                   ▼
+ *   green  needs-justification  failed-audit
+ *            │
+ *            ▼   (owner submits justifications)
+ *        pending-review
+ *            │
+ *            ▼
+ *    ┌───────┬─────────┬────────┐
+ *    │       │         │        │
+ *    ▼       ▼         ▼        ▼
+ *  accepted rejected cancelled  (+ re-audit, etc.)
+ *
+ * @module domains/shares/types
+ */
+
+import type { AuditVerdict } from "../skills/audit/types";
+
+export type ShareTargetType = "user" | "org" | "public";
+
+/**
+ * A share target. For `user` / `org` we record a NyxID user_id; for
+ * `public` there is no target id.
+ */
+export interface ShareTarget {
+  readonly type: ShareTargetType;
+  /** NyxID user_id or org id. Omitted for `public`. */
+  readonly id?: string;
+}
+
+export type ShareStatus =
+  | "pending-audit"
+  | "green"
+  | "needs-justification"
+  | "pending-review"
+  | "accepted"
+  | "rejected"
+  | "cancelled";
+
+export interface ShareJustifications {
+  readonly whyCannotPass: string;
+  readonly whySafe: string;
+  readonly whyShare: string;
+  readonly submittedAt: Date;
+}
+
+export interface ShareReviewerDecision {
+  readonly decision: "accept" | "reject";
+  readonly note?: string;
+  readonly reviewerUserId: string;
+  readonly reviewedAt: Date;
+}
+
+export interface ShareRequest {
+  readonly _id: string;
+  readonly skillGuid: string;
+  readonly skillVersion: string;
+  readonly skillHash: string;
+  readonly ownerUserId: string;
+  readonly target: ShareTarget;
+  readonly status: ShareStatus;
+  /** Audit verdict at the time of share. `undefined` while still in pending-audit. */
+  readonly auditVerdict?: AuditVerdict;
+  /** Overall audit score snapshot. */
+  readonly auditOverallScore?: number;
+  /** Pointer to the `skill_audits` row that was reused / created. */
+  readonly auditRecordId?: string;
+  readonly justifications?: ShareJustifications;
+  readonly reviewerDecision?: ShareReviewerDecision;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}


### PR DESCRIPTION
Second slice of the audit-gated sharing cluster. Builds the full `ShareRequest` state machine on top of the audit engine from PR #121.

## State machine

```
pending-audit
   │
   ▼
 (audit runs)
   │
   ├── green ────────────→ share applied immediately (terminal)
   │
   └── yellow / red
            │
            ▼
      needs-justification
            │  (owner submits 3 justifications)
            ▼
       pending-review
            │
            ▼
      ┌─────┴─────┐
      │           │
   accepted    rejected   (terminal; share applied or aborted)

  (owner can cancel from needs-justification / pending-review / pending-audit)
```

## Reviewer routing (from #97)

| Target type | Reviewer |
|---|---|
| `user` | the recipient |
| `org` | any admin/member of the target org (via `reviewerOrgIds`) |
| `public` | platform admin (`ornn:admin:skill`) |

Enforced in `ShareService.isAuthorizedReviewer`; same logic drives `GET /shares/review-queue`'s result filtering.

## Endpoints

| Method | Path | Who |
|---|---|---|
| `POST` | `/api/v1/skills/:idOrName/share` | skill owner |
| `GET` | `/api/v1/shares/:id` | owner / recipient / platform admin |
| `POST` | `/api/v1/shares/:id/justification` | owner |
| `POST` | `/api/v1/shares/:id/review` | target-type-dependent reviewer |
| `POST` | `/api/v1/shares/:id/cancel` | owner |
| `GET` | `/api/v1/shares` | caller's own |
| `GET` | `/api/v1/shares/review-queue` | caller, filtered by roles they can review for |

## Audit integration

- `initiateShare` calls `auditService.runAudit({ force: false })`. Cache-first — a repeat share of the same bytes within the 7-day TTL reuses the existing audit record (no extra LLM call).
- Verdict mapping: `green` → apply share + status `green` (terminal); `yellow` / `red` → status `needs-justification`. Critical-finding → `red` regardless of scores (from PR #121's `computeVerdict`).

## Apply-share semantics

On `accepted` (either green direct or reviewer-accepted), the service rebuilds the skill's permissions additively:

- `public` target → `isPrivate = false`
- `user` target → `sharedWithUsers ← add targetId`
- `org` target → `sharedWithOrgs ← add targetId`

Goes through the existing `skillService.setSkillPermissions` so the current dedupe + activity-log path stays authoritative. No direct writes to the skill doc from this service.

## Not in this PR

- **Notifications (#98)** — the service emits nothing to a message bus today. When the notification domain lands, hook points are straightforward: audit complete (owner), justification submitted (reviewer), decision (owner). Avoids churning the same service twice.
- **Frontend UI** — share dialog, review queue page, justification form. All follow-up work.
- **Deprecating `PUT /skills/:id/permissions`** — the legacy endpoint stays so the current UI flow doesn't break mid-M3.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — 0 errors, 66 warnings (unchanged)
- [x] `bun run test` — 243 api + 11 web + 17 sdk + 23 python-sdk = 294 pass
- [ ] Manual smoke: POST `/skills/:id/share` with `targetType: public` body against a skill whose audit is cached-green — verify 200 + skill flips to public
- [ ] Manual smoke: same call against a skill with no audit — verify audit runs, verdict stamps on the returned request