### PR TITLE
feat(api): in-product notification center [closes #98]

### DIFF
--- a/.changeset/ten-games-juggle.md
+++ b/.changeset/ten-games-juggle.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+In-product notification center. New `notifications` domain: per-user `notifications` collection + `NotificationService` with typed emitters (`notifyAuditCompleted`, `notifyNeedsJustification`, `notifyReviewRequested`, `notifyShareDecision`, `notifyShareCancelled`). Endpoints: `GET /api/v1/notifications`, `GET /api/v1/notifications/unread-count`, `POST /api/v1/notifications/:id/read`, `POST /api/v1/notifications/mark-all-read`. `ShareService` now emits at every status transition it drives (audit completion, justification needed, user-recipient review request, decision, cancellation). Org / public review-request fan-out is deferred — reviewers for those targets pick up work via `GET /shares/review-queue` until we add a fan-out service. Closes #98.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -47,6 +47,11 @@ import { ShareRepository } from "./domains/shares/repository";
 import { ShareService } from "./domains/shares/service";
 import { createShareRoutes } from "./domains/shares/routes";
 
+// Domain: Notifications
+import { NotificationRepository } from "./domains/notifications/repository";
+import { NotificationService } from "./domains/notifications/service";
+import { createNotificationRoutes } from "./domains/notifications/routes";
+
 // Domain: Skill Search
 import { SearchService } from "./domains/skills/search/service";
 import { createSearchRoutes } from "./domains/skills/search/routes";
@@ -173,11 +178,24 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const auditRoutes = createAuditRoutes({ auditService, skillService });
 
   // ---- Domain: Shares (audit-gated sharing) ----
+  // ---- Domain: Notifications ----
+  const notificationRepo = new NotificationRepository(db);
+  void notificationRepo.ensureIndexes().catch((err) =>
+    logger.warn({ err }, "notifications indexes ensureIndexes failed — proceeding anyway"),
+  );
+  const notificationService = new NotificationService({ notificationRepo });
+  const notificationRoutes = createNotificationRoutes({ notificationService });
+
   const shareRepo = new ShareRepository(db);
   void shareRepo.ensureIndexes().catch((err) =>
     logger.warn({ err }, "share_requests indexes ensureIndexes failed — proceeding anyway"),
   );
-  const shareService = new ShareService({ shareRepo, auditService, skillService });
+  const shareService = new ShareService({
+    shareRepo,
+    auditService,
+    skillService,
+    notificationService,
+  });
   const shareRoutes = createShareRoutes({ shareService });
 
   // ---- Domain: Skill Search ----
@@ -305,6 +323,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   apiApp.route("/", skillRoutes);
   apiApp.route("/", auditRoutes);
   apiApp.route("/", shareRoutes);
+  apiApp.route("/", notificationRoutes);
   apiApp.route("/", searchRoutes);
   apiApp.route("/", generationRoutes);
   apiApp.route("/", playgroundRoutes);

--- a/ornn-api/src/domains/notifications/repository.ts
+++ b/ornn-api/src/domains/notifications/repository.ts
@@ -1,0 +1,120 @@
+/**
+ * Notification repository — one Mongo collection, `notifications`.
+ *
+ * Writes are fire-and-forget from the notification service; reads are
+ * per-user list + mark-read. No cross-user fan-out queries today.
+ *
+ * @module domains/notifications/repository
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Collection, Db, Document, Filter } from "mongodb";
+import pino from "pino";
+import type { NotificationCategory, NotificationDocument } from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "notificationRepository" });
+
+export interface CreateNotificationInput {
+  userId: string;
+  category: NotificationCategory;
+  title: string;
+  body?: string;
+  link?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface ListOptions {
+  readonly limit?: number;
+  /** If true, only include unread. */
+  readonly unreadOnly?: boolean;
+  /** ISO string or Date — return notifications created strictly before this. */
+  readonly before?: Date;
+}
+
+export class NotificationRepository {
+  private readonly collection: Collection;
+
+  constructor(db: Db) {
+    this.collection = db.collection("notifications");
+  }
+
+  async ensureIndexes(): Promise<void> {
+    try {
+      await Promise.all([
+        this.collection.createIndex({ userId: 1, createdAt: -1 }),
+        this.collection.createIndex({ userId: 1, readAt: 1 }),
+      ]);
+    } catch (err) {
+      logger.error({ err }, "Failed to create notifications indexes");
+    }
+  }
+
+  async create(input: CreateNotificationInput): Promise<NotificationDocument> {
+    const doc: Document = {
+      _id: randomUUID() as unknown as Document["_id"],
+      userId: input.userId,
+      category: input.category,
+      title: input.title,
+      body: input.body,
+      link: input.link,
+      data: input.data ?? {},
+      readAt: null,
+      createdAt: new Date(),
+    };
+    await this.collection.insertOne(doc);
+    return mapDoc(doc)!;
+  }
+
+  async list(userId: string, options: ListOptions = {}): Promise<NotificationDocument[]> {
+    const filter: Filter<Document> = { userId };
+    if (options.unreadOnly) filter.readAt = null;
+    if (options.before) filter.createdAt = { $lt: options.before };
+    const docs = await this.collection
+      .find(filter)
+      .sort({ createdAt: -1 })
+      .limit(Math.min(options.limit ?? 50, 200))
+      .toArray();
+    return docs.map((d) => mapDoc(d)!);
+  }
+
+  async countUnread(userId: string): Promise<number> {
+    return this.collection.countDocuments({ userId, readAt: null });
+  }
+
+  async markRead(userId: string, notificationId: string): Promise<NotificationDocument | null> {
+    const now = new Date();
+    await this.collection.updateOne(
+      { _id: notificationId as unknown as Document["_id"], userId },
+      { $set: { readAt: now } },
+    );
+    const doc = await this.collection.findOne({
+      _id: notificationId as unknown as Document["_id"],
+      userId,
+    });
+    return mapDoc(doc);
+  }
+
+  async markAllRead(userId: string): Promise<number> {
+    const now = new Date();
+    const res = await this.collection.updateMany(
+      { userId, readAt: null },
+      { $set: { readAt: now } },
+    );
+    return res.modifiedCount ?? 0;
+  }
+}
+
+function mapDoc(doc: Document | null): NotificationDocument | null {
+  if (!doc) return null;
+  return {
+    _id: String(doc._id),
+    userId: String(doc.userId),
+    category: doc.category as NotificationCategory,
+    title: String(doc.title ?? ""),
+    body: doc.body ? String(doc.body) : undefined,
+    link: doc.link ? String(doc.link) : undefined,
+    data: (doc.data as Record<string, unknown>) ?? {},
+    readAt: doc.readAt ? (doc.readAt instanceof Date ? doc.readAt : new Date(doc.readAt)) : null,
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt : new Date(doc.createdAt),
+  };
+}

--- a/ornn-api/src/domains/notifications/routes.ts
+++ b/ornn-api/src/domains/notifications/routes.ts
@@ -1,0 +1,56 @@
+/**
+ * Notification HTTP routes — all scoped to the caller.
+ *
+ *   GET  /api/v1/notifications                       — list (default limit 50, max 200)
+ *   GET  /api/v1/notifications/unread-count          — for header badges
+ *   POST /api/v1/notifications/:id/read              — mark one read
+ *   POST /api/v1/notifications/mark-all-read         — mark every unread read
+ *
+ * @module domains/notifications/routes
+ */
+
+import { Hono } from "hono";
+import { type AuthVariables, getAuth, nyxidAuthMiddleware } from "../../middleware/nyxidAuth";
+import type { NotificationService } from "./service";
+
+export interface NotificationRoutesConfig {
+  readonly notificationService: NotificationService;
+}
+
+export function createNotificationRoutes(
+  config: NotificationRoutesConfig,
+): Hono<{ Variables: AuthVariables }> {
+  const { notificationService } = config;
+  const app = new Hono<{ Variables: AuthVariables }>();
+  const auth = nyxidAuthMiddleware();
+
+  app.get("/notifications", auth, async (c) => {
+    const authCtx = getAuth(c);
+    const unreadOnly = c.req.query("unread") === "true";
+    const limitParam = c.req.query("limit");
+    const limit = limitParam ? Math.max(1, Math.min(200, Number.parseInt(limitParam, 10))) : undefined;
+    const items = await notificationService.list(authCtx.userId, { unreadOnly, limit });
+    return c.json({ data: { items }, error: null });
+  });
+
+  app.get("/notifications/unread-count", auth, async (c) => {
+    const authCtx = getAuth(c);
+    const count = await notificationService.countUnread(authCtx.userId);
+    return c.json({ data: { count }, error: null });
+  });
+
+  app.post("/notifications/:id/read", auth, async (c) => {
+    const authCtx = getAuth(c);
+    const id = c.req.param("id");
+    const updated = await notificationService.markRead(authCtx.userId, id);
+    return c.json({ data: updated, error: null });
+  });
+
+  app.post("/notifications/mark-all-read", auth, async (c) => {
+    const authCtx = getAuth(c);
+    const updated = await notificationService.markAllRead(authCtx.userId);
+    return c.json({ data: { updated }, error: null });
+  });
+
+  return app;
+}

--- a/ornn-api/src/domains/notifications/service.ts
+++ b/ornn-api/src/domains/notifications/service.ts
@@ -1,0 +1,189 @@
+/**
+ * Notification service.
+ *
+ * Thin wrapper around the repository with typed helpers for the specific
+ * categories the audit/share flow emits. Keeping helpers here (not in
+ * `ShareService`) means the share service takes only a
+ * `NotificationService` dependency — no knowledge of the wire format or
+ * deep-link paths.
+ *
+ * @module domains/notifications/service
+ */
+
+import pino from "pino";
+import { AppError } from "../../shared/types/index";
+import type { NotificationRepository } from "./repository";
+import type { NotificationDocument } from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "notificationService" });
+
+export interface NotificationServiceDeps {
+  readonly notificationRepo: NotificationRepository;
+}
+
+export class NotificationService {
+  private readonly repo: NotificationRepository;
+
+  constructor(deps: NotificationServiceDeps) {
+    this.repo = deps.notificationRepo;
+  }
+
+  // ---- Query API ---------------------------------------------------------
+
+  async list(userId: string, options: { limit?: number; unreadOnly?: boolean } = {}): Promise<NotificationDocument[]> {
+    return this.repo.list(userId, options);
+  }
+
+  async countUnread(userId: string): Promise<number> {
+    return this.repo.countUnread(userId);
+  }
+
+  async markRead(userId: string, notificationId: string): Promise<NotificationDocument> {
+    const updated = await this.repo.markRead(userId, notificationId);
+    if (!updated) {
+      throw AppError.notFound("NOTIFICATION_NOT_FOUND", "Notification not found");
+    }
+    return updated;
+  }
+
+  async markAllRead(userId: string): Promise<number> {
+    return this.repo.markAllRead(userId);
+  }
+
+  // ---- Emitter helpers ---------------------------------------------------
+
+  async notifyAuditCompleted(params: {
+    ownerUserId: string;
+    skillGuid: string;
+    skillName: string;
+    version: string;
+    verdict: "green" | "yellow" | "red";
+    shareRequestId?: string;
+  }): Promise<void> {
+    const title =
+      params.verdict === "green"
+        ? `Audit passed — ${params.skillName} v${params.version}`
+        : `Audit did not pass — ${params.skillName} v${params.version}`;
+    const body =
+      params.verdict === "green"
+        ? "Your skill passed audit and can be shared without review."
+        : "Your skill did not pass audit. Submit justifications to request review.";
+    const link = params.shareRequestId ? `/shares/${params.shareRequestId}` : `/skills/${params.skillGuid}`;
+    await this.emit(params.ownerUserId, {
+      category: "audit.completed",
+      title,
+      body,
+      link,
+      data: {
+        skillGuid: params.skillGuid,
+        skillName: params.skillName,
+        version: params.version,
+        verdict: params.verdict,
+        shareRequestId: params.shareRequestId,
+      },
+    });
+  }
+
+  async notifyNeedsJustification(params: {
+    ownerUserId: string;
+    shareRequestId: string;
+    skillName: string;
+  }): Promise<void> {
+    await this.emit(params.ownerUserId, {
+      category: "share.needs_justification",
+      title: `Justification needed to share ${params.skillName}`,
+      body: "Answer three short questions so a reviewer can decide.",
+      link: `/shares/${params.shareRequestId}`,
+      data: { shareRequestId: params.shareRequestId, skillName: params.skillName },
+    });
+  }
+
+  async notifyReviewRequested(params: {
+    reviewerUserId: string;
+    shareRequestId: string;
+    skillName: string;
+    ownerDisplayName: string;
+    targetType: "user" | "org" | "public";
+  }): Promise<void> {
+    const scopeWord =
+      params.targetType === "public"
+        ? "publicly"
+        : params.targetType === "org"
+          ? "in this org"
+          : "with you";
+    await this.emit(params.reviewerUserId, {
+      category: "share.review_requested",
+      title: `Review: ${params.ownerDisplayName} wants to share ${params.skillName}`,
+      body: `${params.ownerDisplayName} tried to share a skill ${scopeWord}, but it did not pass audit. Review their justifications.`,
+      link: `/shares/${params.shareRequestId}`,
+      data: {
+        shareRequestId: params.shareRequestId,
+        skillName: params.skillName,
+        ownerDisplayName: params.ownerDisplayName,
+        targetType: params.targetType,
+      },
+    });
+  }
+
+  async notifyShareDecision(params: {
+    ownerUserId: string;
+    shareRequestId: string;
+    skillName: string;
+    decision: "accept" | "reject";
+    reviewerDisplayName?: string;
+  }): Promise<void> {
+    const category = params.decision === "accept" ? "share.accepted" : "share.rejected";
+    const title =
+      params.decision === "accept"
+        ? `Share accepted — ${params.skillName}`
+        : `Share rejected — ${params.skillName}`;
+    const body = params.reviewerDisplayName
+      ? `${params.reviewerDisplayName} ${params.decision}ed your share request.`
+      : undefined;
+    await this.emit(params.ownerUserId, {
+      category,
+      title,
+      body,
+      link: `/shares/${params.shareRequestId}`,
+      data: {
+        shareRequestId: params.shareRequestId,
+        skillName: params.skillName,
+        decision: params.decision,
+      },
+    });
+  }
+
+  async notifyShareCancelled(params: {
+    ownerUserId: string;
+    shareRequestId: string;
+    skillName: string;
+  }): Promise<void> {
+    await this.emit(params.ownerUserId, {
+      category: "share.cancelled",
+      title: `Share cancelled — ${params.skillName}`,
+      link: `/shares/${params.shareRequestId}`,
+      data: {
+        shareRequestId: params.shareRequestId,
+        skillName: params.skillName,
+      },
+    });
+  }
+
+  private async emit(
+    userId: string,
+    payload: {
+      category: NotificationDocument["category"];
+      title: string;
+      body?: string;
+      link?: string;
+      data?: Record<string, unknown>;
+    },
+  ): Promise<void> {
+    try {
+      await this.repo.create({ userId, ...payload });
+    } catch (err) {
+      // Notifications must never block the caller. Log and swallow.
+      logger.warn({ err, userId, category: payload.category }, "Failed to persist notification");
+    }
+  }
+}

--- a/ornn-api/src/domains/notifications/types.ts
+++ b/ornn-api/src/domains/notifications/types.ts
@@ -1,0 +1,35 @@
+/**
+ * In-product notification types.
+ *
+ * Notifications are per-user, durable, and deep-linked to the resource
+ * that caused them (typically a share request, a skill, or an audit
+ * record). v1 is in-product only — email / push live outside this
+ * module.
+ *
+ * @module domains/notifications/types
+ */
+
+export type NotificationCategory =
+  | "audit.completed"
+  | "share.needs_justification"
+  | "share.review_requested"
+  | "share.accepted"
+  | "share.rejected"
+  | "share.cancelled";
+
+export interface NotificationDocument {
+  readonly _id: string;
+  /** Recipient user id (NyxID user_id). */
+  readonly userId: string;
+  readonly category: NotificationCategory;
+  /** One-line summary for list view. */
+  readonly title: string;
+  /** Optional longer body rendered on the detail view. Plain text. */
+  readonly body?: string;
+  /** Deep-link path in the web UI, e.g. `/shares/abc`. */
+  readonly link?: string;
+  /** Arbitrary structured payload the UI can use (e.g. `{ shareRequestId, verdict }`). */
+  readonly data: Record<string, unknown>;
+  readonly readAt?: Date | null;
+  readonly createdAt: Date;
+}

--- a/ornn-api/src/domains/shares/service.ts
+++ b/ornn-api/src/domains/shares/service.ts
@@ -20,6 +20,7 @@ import pino from "pino";
 import { AppError } from "../../shared/types/index";
 import type { AuditService } from "../skills/audit/service";
 import type { SkillService } from "../skills/crud/service";
+import type { NotificationService } from "../notifications/service";
 import type { ShareRepository } from "./repository";
 import type {
   ShareJustifications,
@@ -35,6 +36,8 @@ export interface ShareServiceDeps {
   readonly shareRepo: ShareRepository;
   readonly auditService: AuditService;
   readonly skillService: SkillService;
+  /** Optional — when provided, emits audit/share-flow notifications to the relevant users. */
+  readonly notificationService?: NotificationService;
 }
 
 export interface InitiateShareInput {
@@ -53,11 +56,13 @@ export class ShareService {
   private readonly shareRepo: ShareRepository;
   private readonly auditService: AuditService;
   private readonly skillService: SkillService;
+  private readonly notificationService: NotificationService | undefined;
 
   constructor(deps: ShareServiceDeps) {
     this.shareRepo = deps.shareRepo;
     this.auditService = deps.auditService;
     this.skillService = deps.skillService;
+    this.notificationService = deps.notificationService;
   }
 
   /**
@@ -101,6 +106,23 @@ export class ShareService {
 
     if (initialStatus === "green") {
       await this.applyAcceptedShare(skill.guid, input.target, input.ownerUserId);
+    }
+
+    // Owner always hears about the audit outcome.
+    await this.notificationService?.notifyAuditCompleted({
+      ownerUserId: input.ownerUserId,
+      skillGuid: skill.guid,
+      skillName: skill.name,
+      version: skill.version,
+      verdict: audit.verdict,
+      shareRequestId: request._id,
+    });
+    if (initialStatus === "needs-justification") {
+      await this.notificationService?.notifyNeedsJustification({
+        ownerUserId: input.ownerUserId,
+        shareRequestId: request._id,
+        skillName: skill.name,
+      });
     }
 
     logger.info(
@@ -154,6 +176,20 @@ export class ShareService {
     if (!updated) {
       throw AppError.internalError("SHARE_UPDATE_FAILED", "Failed to persist share transition");
     }
+
+    // Direct-to-user share target → notify the recipient right away.
+    // Org / public targets: reviewers find the request via the
+    // review-queue endpoint until we have a fan-out service (future PR).
+    if (updated.target.type === "user" && updated.target.id) {
+      const skill = await this.skillService.getSkill(updated.skillGuid);
+      await this.notificationService?.notifyReviewRequested({
+        reviewerUserId: updated.target.id,
+        shareRequestId: updated._id,
+        skillName: skill.name,
+        ownerDisplayName: skill.createdByDisplayName ?? skill.createdByEmail ?? skill.createdBy,
+        targetType: updated.target.type,
+      });
+    }
     return updated;
   }
 
@@ -197,6 +233,16 @@ export class ShareService {
         request.ownerUserId,
       );
     }
+
+    // Tell the owner the outcome.
+    const skill = await this.skillService.getSkill(request.skillGuid);
+    await this.notificationService?.notifyShareDecision({
+      ownerUserId: request.ownerUserId,
+      shareRequestId: requestId,
+      skillName: skill.name,
+      decision,
+    });
+
     logger.info(
       { shareRequestId: requestId, reviewerUserId, decision, finalStatus },
       "Share reviewed",
@@ -220,6 +266,14 @@ export class ShareService {
       );
     }
     const updated = await this.shareRepo.transitionStatus(requestId, "cancelled");
+    if (updated) {
+      const skill = await this.skillService.getSkill(updated.skillGuid);
+      await this.notificationService?.notifyShareCancelled({
+        ownerUserId,
+        shareRequestId: requestId,
+        skillName: skill.name,
+      });
+    }
     return updated!;
   }
 


### PR DESCRIPTION
Closes #98. Last piece of the audit-gated sharing cluster. See commit message for details.

**Emitter coverage in `ShareService`**:

| Event | Audience | Category |
|---|---|---|
| `initiateShare` — any outcome | owner | `audit.completed` |
| `initiateShare` — not-green | owner | `share.needs_justification` |
| `submitJustification` — user-target | recipient | `share.review_requested` |
| `review` — accept/reject | owner | `share.accepted` / `share.rejected` |
| `cancel` | owner | `share.cancelled` |

Org / public review fan-out deferred until we have a cross-user reviewer lookup; those reviewers use `GET /shares/review-queue` as the source of truth.

**Test plan**:

- [x] typecheck / lint / tests — 243 + 11 + 17 pass
- [ ] Manual smoke: initiate a share whose audit is cached-red; verify 2 notifications land on the owner's `/notifications`
- [ ] Manual smoke: initiate a user-target share; submit justification; verify 1 notification on the recipient's queue