### PR TITLE
feat(api): author-supplied release notes per skill version [closes #26]

### DIFF
--- a/.changeset/cool-trees-drum.md
+++ b/.changeset/cool-trees-drum.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+Authors can include release notes per version via SKILL.md frontmatter (`release-notes:` or `releaseNotes:`, plain text, capped at 2000 chars). Persisted on `SkillVersionDocument.releaseNotes`, returned from `GET /api/v1/skills/:id/versions` and both `from`/`to` sides of the diff endpoint. Closes #26.

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -83,7 +83,7 @@ export class SkillService {
     }
 
     // 2. Parse SKILL.md from ZIP
-    const { name, description, version, license, compatibility, metadata } = await this.extractSkillInfo(zipBuffer);
+    const { name, description, version, license, compatibility, metadata, releaseNotes } = await this.extractSkillInfo(zipBuffer);
     const parsedVersion = parseVersion(version);
 
     // 3a. Reject reserved-verb names — would collide with `/v1/skills/{verb}`
@@ -146,6 +146,7 @@ export class SkillService {
       createdBy: userId,
       createdByEmail: options?.userEmail,
       createdByDisplayName: options?.userDisplayName,
+      releaseNotes,
     });
 
     return { guid };
@@ -185,6 +186,7 @@ export class SkillService {
     createdOn: string;
     isDeprecated: boolean;
     deprecationNote: string | null;
+    releaseNotes: string | null;
   }>> {
     const skill = await this.findSkillByIdOrName(idOrName);
     const versions = await this.skillVersionRepo.listBySkill(skill.guid);
@@ -197,6 +199,7 @@ export class SkillService {
       createdOn: v.createdOn instanceof Date ? v.createdOn.toISOString() : String(v.createdOn),
       isDeprecated: v.isDeprecated === true,
       deprecationNote: v.deprecationNote ?? null,
+      releaseNotes: v.releaseNotes ?? null,
     }));
   }
 
@@ -321,7 +324,7 @@ export class SkillService {
         }
       }
 
-      const { name, description, version, license, compatibility, metadata } = await this.extractSkillInfo(options.zipBuffer);
+      const { name, description, version, license, compatibility, metadata, releaseNotes } = await this.extractSkillInfo(options.zipBuffer);
       const parsedNewVersion = parseVersion(version);
 
       // Enforce strictly-incrementing version on every package update.
@@ -367,6 +370,7 @@ export class SkillService {
         createdBy: userId,
         createdByEmail: options.userEmail,
         createdByDisplayName: options.userDisplayName,
+        releaseNotes,
       });
 
       Object.assign(updateData, {
@@ -488,8 +492,8 @@ export class SkillService {
     toVersion: string,
   ): Promise<{
     skill: { guid: string; name: string };
-    from: { version: string; hash: string; createdOn: string; isDeprecated: boolean };
-    to: { version: string; hash: string; createdOn: string; isDeprecated: boolean };
+    from: { version: string; hash: string; createdOn: string; isDeprecated: boolean; releaseNotes: string | null };
+    to: { version: string; hash: string; createdOn: string; isDeprecated: boolean; releaseNotes: string | null };
     diff: VersionDiffResult;
   }> {
     if (fromVersion === toVersion) {
@@ -538,6 +542,7 @@ export class SkillService {
             ? fromDoc.createdOn.toISOString()
             : String(fromDoc.createdOn),
         isDeprecated: fromDoc.isDeprecated === true,
+        releaseNotes: fromDoc.releaseNotes ?? null,
       },
       to: {
         version: toDoc.version,
@@ -547,6 +552,7 @@ export class SkillService {
             ? toDoc.createdOn.toISOString()
             : String(toDoc.createdOn),
         isDeprecated: toDoc.isDeprecated === true,
+        releaseNotes: toDoc.releaseNotes ?? null,
       },
       diff,
     };
@@ -678,6 +684,8 @@ export class SkillService {
     license: string | null;
     compatibility: string | null;
     metadata: SkillMetadata;
+    /** Optional author-supplied changelog. Read from SKILL.md frontmatter `release-notes` or `releaseNotes`. Max 2000 chars. */
+    releaseNotes: string | null;
   }> {
     const zip = await JSZip.loadAsync(zipBuffer);
     const allPaths = Object.keys(zip.files);
@@ -754,6 +762,18 @@ export class SkillService {
       metadata.tags = rawMeta.tag;
     }
 
+    // Author-supplied changelog lives next to the formal frontmatter but isn't
+    // part of the Zod schema — kept permissive so missing/older SKILL.md files
+    // just report null instead of hard-failing. Accepts either `release-notes`
+    // (kebab-case to match other frontmatter fields) or `releaseNotes`.
+    const rawReleaseNotes =
+      rawFrontmatter["release-notes"] ?? rawFrontmatter["releaseNotes"];
+    let releaseNotes: string | null = null;
+    if (typeof rawReleaseNotes === "string" && rawReleaseNotes.trim().length > 0) {
+      const trimmed = rawReleaseNotes.trim();
+      releaseNotes = trimmed.length > 2000 ? trimmed.slice(0, 2000) : trimmed;
+    }
+
     return {
       name: fm.name,
       description: fm.description,
@@ -761,6 +781,7 @@ export class SkillService {
       license: fm.license ?? null,
       compatibility: fm.compatibility ?? null,
       metadata,
+      releaseNotes,
     };
   }
 

--- a/ornn-api/src/domains/skills/crud/skillVersionRepository.ts
+++ b/ornn-api/src/domains/skills/crud/skillVersionRepository.ts
@@ -29,6 +29,8 @@ export interface CreateSkillVersionData {
   createdByEmail?: string;
   createdByDisplayName?: string;
   createdOn?: Date;
+  /** Author-supplied release notes pulled from SKILL.md frontmatter. */
+  releaseNotes?: string | null;
 }
 
 export class SkillVersionRepository {
@@ -66,6 +68,7 @@ export class SkillVersionRepository {
       createdByEmail: data.createdByEmail ?? null,
       createdByDisplayName: data.createdByDisplayName ?? null,
       createdOn,
+      releaseNotes: data.releaseNotes ?? null,
     };
 
     try {
@@ -168,5 +171,6 @@ function mapDoc(doc: Document | null): SkillVersionDocument | null {
     createdOn: doc.createdOn ?? new Date(),
     isDeprecated: doc.isDeprecated === true,
     deprecationNote: doc.deprecationNote ?? null,
+    releaseNotes: typeof doc.releaseNotes === "string" ? doc.releaseNotes : null,
   };
 }

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -187,6 +187,13 @@ export interface SkillVersionDocument {
   isDeprecated?: boolean;
   /** Optional human-readable explanation surfaced with the warning. */
   deprecationNote?: string | null;
+  /**
+   * Author-supplied release notes for this specific version. Read at
+   * publish time from SKILL.md frontmatter (`release-notes` or
+   * `releaseNotes`). Plain text, max 2000 chars. Null when the author
+   * omitted it.
+   */
+  releaseNotes?: string | null;
 }
 
 export interface SkillMetadata {


### PR DESCRIPTION
Closes the changelog half of #26. Diff API was PR #118.

**Input**: SKILL.md frontmatter key `release-notes:` (or `releaseNotes:`). Plain text, trimmed, clamped at 2000 chars. Absent/older packages → `null` (no publish breakage).

**Output**:

- `GET /api/v1/skills/:idOrName/versions` — each entry now has `releaseNotes: string | null`
- `GET /api/v1/skills/:idOrName/versions/:fromVersion/diff/:toVersion` — both sides (`from` + `to`) carry `releaseNotes`

Lives outside the Zod skill-frontmatter schema on purpose: older packages without the field read back as `null` instead of hard-failing publish. The extraction is lenient: either kebab-case or camelCase accepted.

**Test plan**:

- [x] `bun run typecheck` — green
- [x] `bun run test` — 243 api + 11 web + 17 sdk = 271 pass
- [ ] Manual smoke: publish a skill with `release-notes: "Fixed pagination handling"` in SKILL.md, verify the string echoes on the versions list + diff response