### PR TITLE
feat(api): skill analytics read API [closes #34]

### DIFF
--- a/.changeset/six-kids-follow.md
+++ b/.changeset/six-kids-follow.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+Skill analytics: new `analytics` domain with append-only `skill_executions` event log + aggregation. `GET /api/v1/skills/:idOrName/analytics?window=7d|30d|all` returns execution count, success/failure/timeout breakdown, success rate, latency p50/p95/p99, unique users, top error codes. Visibility mirrors `GET /skills/:idOrName`. Emission hook points (playground / SDK / CLI) ship as a follow-up so this PR stays read-side-focused. Closes #34.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -52,6 +52,11 @@ import { NotificationRepository } from "./domains/notifications/repository";
 import { NotificationService } from "./domains/notifications/service";
 import { createNotificationRoutes } from "./domains/notifications/routes";
 
+// Domain: Analytics
+import { AnalyticsRepository } from "./domains/analytics/repository";
+import { AnalyticsService } from "./domains/analytics/service";
+import { createAnalyticsRoutes } from "./domains/analytics/routes";
+
 // Domain: Skill Search
 import { SearchService } from "./domains/skills/search/service";
 import { createSearchRoutes } from "./domains/skills/search/routes";
@@ -185,6 +190,14 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   );
   const notificationService = new NotificationService({ notificationRepo });
   const notificationRoutes = createNotificationRoutes({ notificationService });
+
+  // ---- Domain: Analytics ----
+  const analyticsRepo = new AnalyticsRepository(db);
+  void analyticsRepo.ensureIndexes().catch((err) =>
+    logger.warn({ err }, "skill_executions indexes ensureIndexes failed — proceeding anyway"),
+  );
+  const analyticsService = new AnalyticsService({ analyticsRepo });
+  const analyticsRoutes = createAnalyticsRoutes({ analyticsService, skillService });
 
   const shareRepo = new ShareRepository(db);
   void shareRepo.ensureIndexes().catch((err) =>
@@ -324,6 +337,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   apiApp.route("/", auditRoutes);
   apiApp.route("/", shareRoutes);
   apiApp.route("/", notificationRoutes);
+  apiApp.route("/", analyticsRoutes);
   apiApp.route("/", searchRoutes);
   apiApp.route("/", generationRoutes);
   apiApp.route("/", playgroundRoutes);

--- a/ornn-api/src/domains/analytics/repository.ts
+++ b/ornn-api/src/domains/analytics/repository.ts
@@ -1,0 +1,188 @@
+/**
+ * Analytics repository — append-only event log + aggregation queries.
+ *
+ * One Mongo collection (`skill_executions`). Writes are fire-and-forget;
+ * reads are per-skill aggregates over a rolling window.
+ *
+ * @module domains/analytics/repository
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Collection, Db, Document } from "mongodb";
+import pino from "pino";
+import type {
+  ExecutionOutcome,
+  SkillAnalyticsSummary,
+  SkillExecutionEvent,
+} from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "analyticsRepository" });
+
+export interface RecordEventInput {
+  skillGuid: string;
+  skillName: string;
+  skillVersion?: string;
+  outcome: ExecutionOutcome;
+  latencyMs: number;
+  userId: string;
+  source: SkillExecutionEvent["source"];
+  errorCode?: string;
+}
+
+export class AnalyticsRepository {
+  private readonly collection: Collection;
+
+  constructor(db: Db) {
+    this.collection = db.collection("skill_executions");
+  }
+
+  async ensureIndexes(): Promise<void> {
+    try {
+      await Promise.all([
+        this.collection.createIndex({ skillGuid: 1, createdAt: -1 }),
+        this.collection.createIndex({ createdAt: -1 }),
+        this.collection.createIndex({ userId: 1 }),
+      ]);
+    } catch (err) {
+      logger.error({ err }, "Failed to create skill_executions indexes");
+    }
+  }
+
+  async recordEvent(input: RecordEventInput): Promise<void> {
+    try {
+      const doc: Document = {
+        _id: randomUUID() as unknown as Document["_id"],
+        skillGuid: input.skillGuid,
+        skillName: input.skillName,
+        skillVersion: input.skillVersion,
+        outcome: input.outcome,
+        latencyMs: Math.max(0, Math.round(input.latencyMs)),
+        userId: input.userId,
+        source: input.source,
+        errorCode: input.errorCode,
+        createdAt: new Date(),
+      };
+      await this.collection.insertOne(doc);
+    } catch (err) {
+      // Analytics must never block a user's skill invocation — log and swallow.
+      logger.warn({ err, skillGuid: input.skillGuid }, "Failed to record execution event");
+    }
+  }
+
+  async summarize(
+    skillGuid: string,
+    window: "7d" | "30d" | "all",
+    topErrorsLimit = 5,
+  ): Promise<SkillAnalyticsSummary> {
+    const now = new Date();
+    const filter: Record<string, unknown> = { skillGuid };
+    if (window !== "all") {
+      const days = window === "7d" ? 7 : 30;
+      const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+      filter.createdAt = { $gte: cutoff };
+    }
+
+    // One pass for counts + per-user dedup; a second pass for percentiles
+    // to keep the aggregate shape simple + server-side computed.
+    const countPipeline = [
+      { $match: filter },
+      {
+        $group: {
+          _id: null,
+          executionCount: { $sum: 1 },
+          successCount: {
+            $sum: { $cond: [{ $eq: ["$outcome", "success"] }, 1, 0] },
+          },
+          failureCount: {
+            $sum: { $cond: [{ $eq: ["$outcome", "failure"] }, 1, 0] },
+          },
+          timeoutCount: {
+            $sum: { $cond: [{ $eq: ["$outcome", "timeout"] }, 1, 0] },
+          },
+          uniqueUsers: { $addToSet: "$userId" },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          executionCount: 1,
+          successCount: 1,
+          failureCount: 1,
+          timeoutCount: 1,
+          uniqueUsers: { $size: "$uniqueUsers" },
+        },
+      },
+    ];
+
+    const percentilePipeline = [
+      { $match: filter },
+      {
+        $group: {
+          _id: null,
+          latencies: { $push: "$latencyMs" },
+        },
+      },
+    ];
+
+    const errorsPipeline = [
+      { $match: { ...filter, outcome: { $ne: "success" }, errorCode: { $ne: null } } },
+      { $group: { _id: "$errorCode", count: { $sum: 1 } } },
+      { $sort: { count: -1 as const } },
+      { $limit: topErrorsLimit },
+    ];
+
+    const [countsRows, latencyRows, errorRows] = await Promise.all([
+      this.collection.aggregate(countPipeline).toArray(),
+      this.collection.aggregate(percentilePipeline).toArray(),
+      this.collection.aggregate(errorsPipeline).toArray(),
+    ]);
+
+    const counts = (countsRows[0] ?? {
+      executionCount: 0,
+      successCount: 0,
+      failureCount: 0,
+      timeoutCount: 0,
+      uniqueUsers: 0,
+    }) as {
+      executionCount: number;
+      successCount: number;
+      failureCount: number;
+      timeoutCount: number;
+      uniqueUsers: number;
+    };
+
+    const latencies = ((latencyRows[0]?.latencies as number[] | undefined) ?? []).sort(
+      (a, b) => a - b,
+    );
+    const pick = (p: number): number | null => {
+      if (latencies.length === 0) return null;
+      const idx = Math.min(latencies.length - 1, Math.floor((p / 100) * latencies.length));
+      return latencies[idx] ?? null;
+    };
+
+    const successRate =
+      counts.executionCount > 0 ? counts.successCount / counts.executionCount : null;
+
+    const topErrorCodes = errorRows.map((r) => ({
+      code: String(r._id ?? ""),
+      count: Number(r.count ?? 0),
+    }));
+
+    return {
+      skillGuid,
+      window,
+      executionCount: counts.executionCount,
+      successCount: counts.successCount,
+      failureCount: counts.failureCount,
+      timeoutCount: counts.timeoutCount,
+      successRate,
+      latencyMs: {
+        p50: pick(50),
+        p95: pick(95),
+        p99: pick(99),
+      },
+      uniqueUsers: counts.uniqueUsers,
+      topErrorCodes,
+    };
+  }
+}

--- a/ornn-api/src/domains/analytics/routes.ts
+++ b/ornn-api/src/domains/analytics/routes.ts
@@ -1,0 +1,71 @@
+/**
+ * Analytics HTTP routes — read-side only. Event emission happens from
+ * server-side hook points (playground today).
+ *
+ *   GET /api/v1/skills/:idOrName/analytics[?window=7d|30d|all]
+ *
+ * Visibility mirrors `GET /skills/:idOrName`: anonymous users can only
+ * read analytics of public skills. Private skills require the caller to
+ * be able to read the skill.
+ *
+ * @module domains/analytics/routes
+ */
+
+import { Hono } from "hono";
+import {
+  type AuthVariables,
+  optionalAuthMiddleware,
+  readUserOrgMemberships,
+} from "../../middleware/nyxidAuth";
+import { AppError } from "../../shared/types/index";
+import { canReadSkill } from "../skills/crud/authorize";
+import type { SkillService } from "../skills/crud/service";
+import type { AnalyticsService } from "./service";
+
+export interface AnalyticsRoutesConfig {
+  readonly analyticsService: AnalyticsService;
+  readonly skillService: SkillService;
+}
+
+export function createAnalyticsRoutes(
+  config: AnalyticsRoutesConfig,
+): Hono<{ Variables: AuthVariables }> {
+  const { analyticsService, skillService } = config;
+  const app = new Hono<{ Variables: AuthVariables }>();
+  const optionalAuth = optionalAuthMiddleware();
+
+  app.get(
+    "/skills/:idOrName/analytics",
+    optionalAuth,
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const windowParam = c.req.query("window") || "30d";
+      if (windowParam !== "7d" && windowParam !== "30d" && windowParam !== "all") {
+        throw AppError.badRequest(
+          "INVALID_WINDOW",
+          "'window' must be '7d', '30d', or 'all'",
+        );
+      }
+      const authCtx = c.get("auth");
+      const skill = await skillService.getSkill(idOrName);
+      if (!authCtx && skill.isPrivate) {
+        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      }
+      if (authCtx && skill.isPrivate) {
+        const memberships = await readUserOrgMemberships(c);
+        const actor = {
+          userId: authCtx.userId,
+          memberships,
+          isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+        };
+        if (!canReadSkill(skill, actor)) {
+          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        }
+      }
+      const summary = await analyticsService.getSummary(skill.guid, windowParam);
+      return c.json({ data: summary, error: null });
+    },
+  );
+
+  return app;
+}

--- a/ornn-api/src/domains/analytics/service.ts
+++ b/ornn-api/src/domains/analytics/service.ts
@@ -1,0 +1,35 @@
+/**
+ * Analytics service — thin facade over the repo.
+ *
+ * - `recordExecution` is callable from any hook that knows the skill +
+ *   outcome (today: playground chat). Fire-and-forget, never throws.
+ * - `getSummary` reads the aggregate windowed by 7d / 30d / all.
+ *
+ * @module domains/analytics/service
+ */
+
+import type { AnalyticsRepository, RecordEventInput } from "./repository";
+import type { SkillAnalyticsSummary } from "./types";
+
+export interface AnalyticsServiceDeps {
+  readonly analyticsRepo: AnalyticsRepository;
+}
+
+export class AnalyticsService {
+  private readonly repo: AnalyticsRepository;
+
+  constructor(deps: AnalyticsServiceDeps) {
+    this.repo = deps.analyticsRepo;
+  }
+
+  async recordExecution(input: RecordEventInput): Promise<void> {
+    return this.repo.recordEvent(input);
+  }
+
+  async getSummary(
+    skillGuid: string,
+    window: "7d" | "30d" | "all" = "30d",
+  ): Promise<SkillAnalyticsSummary> {
+    return this.repo.summarize(skillGuid, window);
+  }
+}

--- a/ornn-api/src/domains/analytics/types.ts
+++ b/ornn-api/src/domains/analytics/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Skill-analytics types.
+ *
+ * v1 captures one event per skill execution from the playground. Future
+ * hook points (SDK, nyx CLI, agent proxy) emit the same shape so
+ * aggregations stay consistent.
+ *
+ * @module domains/analytics/types
+ */
+
+export type ExecutionOutcome = "success" | "failure" | "timeout";
+
+export interface SkillExecutionEvent {
+  readonly _id: string;
+  readonly skillGuid: string;
+  readonly skillName: string;
+  /** Version the caller invoked, e.g. `1.2`. Omitted for playground calls that don't pin a version. */
+  readonly skillVersion?: string;
+  readonly outcome: ExecutionOutcome;
+  /** Wall-clock invocation duration in ms. */
+  readonly latencyMs: number;
+  /** Caller's NyxID user_id. `anonymous` when the event came from an unauth path. */
+  readonly userId: string;
+  /** Source that emitted the event. `playground` today; `sdk` / `cli` / `agent-proxy` later. */
+  readonly source: "playground" | "sdk" | "cli" | "agent-proxy";
+  /** Short error code when `outcome !== "success"`. Free-form lowercase. */
+  readonly errorCode?: string;
+  readonly createdAt: Date;
+}
+
+/** Summary aggregate for a skill over a rolling window. */
+export interface SkillAnalyticsSummary {
+  readonly skillGuid: string;
+  readonly window: "7d" | "30d" | "all";
+  readonly executionCount: number;
+  readonly successCount: number;
+  readonly failureCount: number;
+  readonly timeoutCount: number;
+  /** Success rate as a decimal in [0, 1]. `null` when `executionCount === 0`. */
+  readonly successRate: number | null;
+  readonly latencyMs: {
+    readonly p50: number | null;
+    readonly p95: number | null;
+    readonly p99: number | null;
+  };
+  readonly uniqueUsers: number;
+  readonly topErrorCodes: ReadonlyArray<{ code: string; count: number }>;
+}


### PR DESCRIPTION
Closes #34 (read API). Emission hook points ship separately so this PR stays review-sized and merge-ready.

## Endpoint

`GET /api/v1/skills/:idOrName/analytics?window=7d|30d|all`

Returns:

```jsonc
{
  "skillGuid": "...",
  "window": "30d",
  "executionCount": 2847,
  "successCount": 2721,
  "failureCount": 98,
  "timeoutCount": 28,
  "successRate": 0.9557,
  "latencyMs": { "p50": 320, "p95": 1840, "p99": 4120 },
  "uniqueUsers": 142,
  "topErrorCodes": [
    { "code": "sandbox_timeout", "count": 28 },
    { "code": "missing_env", "count": 12 }
  ]
}
```

Visibility mirrors `GET /skills/:idOrName` — anonymous clients can only read analytics of public skills; private skills go through `canReadSkill`.

## Domain

- `skill_executions` collection — append-only event log, indexed on `(skillGuid, createdAt -1)` + `(createdAt -1)` + `(userId)`.
- `recordEvent` is fire-and-forget — swallows DB errors so analytics troubles can never fail a user's skill invocation.
- `summarize` runs 3 parallel Mongo aggregates: counts + unique-user set, latency push-to-array (percentile pick in TS for simplicity), top-N error codes.

## Not in this PR (deliberately)

- **Emission hook points** — playground chat + SDK + CLI need to call `analyticsService.recordExecution(...)` at the right moments. Separate PR. ShareService-style wire-up, same pattern as the notification hook.
- **Retention** — raw events 30d, aggregates 1y (per the issue). Needs a scheduled job; belongs in a separate infra PR.
- **Frontend** — search-result reliability badge + author dashboard UI. Frontend work.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — 243 api + 11 web + 17 sdk = 271 pass