### PR TITLE
chore: test changeset for release workflow smoke test

### DIFF
--- a/.changeset/test-release-workflow.md
+++ b/.changeset/test-release-workflow.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+Smoke test for the new push-to-main release workflow (PR #130). This changeset forces a v0.3.1 patch bump with no functional change; it exists so State A → State B can be exercised end-to-end on a live release cycle.


### PR DESCRIPTION
Seeds a patch-level changeset on develop. Merging this, then promoting develop → main, is the smoke test for the new state-machine release workflow (PR #130).