### PR TITLE
release: promote develop → main (guard fix + v0.3.1 retry)

### DIFF
--- a/.changeset/dry-crews-sell.md
+++ b/.changeset/dry-crews-sell.md
@@ -1,0 +1,4 @@
+---
+---
+
+`enforce-branch-policy.yml` accepts `release/*` as a legal source branch for PRs → main (for bot release-bump PRs from the changeset-release workflow). `require-review.yml` treats the github-actions bot as a trusted author and drops the stale `aevatarAI/Aevatarians` team reference left over from the pre-transfer repo.

--- a/.github/workflows/enforce-branch-policy.yml
+++ b/.github/workflows/enforce-branch-policy.yml
@@ -9,10 +9,24 @@ jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify PR source branch is develop
+      - name: Verify PR source branch is develop or release/*
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ "${{ github.head_ref }}" != "develop" ]; then
-            echo "::error::PRs targeting main must come from the develop branch. Got: ${{ github.head_ref }}"
-            exit 1
+          # Two legal paths to main:
+          #   1. develop → main          (normal feature promote)
+          #   2. release/* → main        (bot-opened version-bump PR
+          #                               from the changeset-release
+          #                               workflow state machine)
+          if [ "$HEAD_REF" = "develop" ]; then
+            echo "Source branch is develop — OK"
+            exit 0
           fi
-          echo "Source branch is develop — OK"
+          case "$HEAD_REF" in
+            release/*)
+              echo "Source branch is $HEAD_REF (release-bump PR) — OK"
+              exit 0
+              ;;
+          esac
+          echo "::error::PRs targeting main must come from 'develop' or 'release/*'. Got: $HEAD_REF"
+          exit 1

--- a/.github/workflows/require-review.yml
+++ b/.github/workflows/require-review.yml
@@ -19,39 +19,25 @@ jobs:
             const pr = context.payload.pull_request;
             const author = pr.user.login;
 
-            // Owner can self-merge without approval
-            if (author === 'chronoai-shining') {
+            // Trusted authors can self-merge without external approval:
+            //   - chronoai-shining (maintainer)
+            //   - github-actions[bot] (release-bump + sync PRs opened by
+            //     the changeset-release workflow state machine)
+            const TRUSTED_AUTHORS = new Set([
+              'chronoai-shining',
+              'github-actions[bot]',
+              'app/github-actions',
+            ]);
+            if (TRUSTED_AUTHORS.has(author)) {
               console.log(`PR author is ${author} — no approval required`);
               return;
             }
 
-            // For other contributors, check for Aevatarians team approval
-            const reviews = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-            });
-
-            // Get Aevatarians team members
-            let teamMembers;
-            try {
-              const members = await github.rest.teams.listMembersInOrg({
-                org: 'aevatarAI',
-                team_slug: 'Aevatarians',
-              });
-              teamMembers = members.data.map(m => m.login);
-            } catch (e) {
-              core.setFailed('Could not fetch Aevatarians team members. Ensure the GITHUB_TOKEN has org:read scope.');
-              return;
-            }
-
-            // Check if any team member approved
-            const approved = reviews.data.some(
-              r => r.state === 'APPROVED' && teamMembers.includes(r.user.login)
+            // External contributors: placeholder. The original team-based
+            // gate (aevatarAI/Aevatarians) pointed at the pre-transfer org
+            // and was removed when the repo moved to ChronoAIProject. Until
+            // a ChronoAIProject team exists + there are actual external
+            // contributors to gate, fail explicitly so nothing slips through.
+            core.setFailed(
+              `PRs from '${author}' require maintainer approval — no team-review gate is configured yet for the ChronoAIProject org.`,
             );
-
-            if (!approved) {
-              core.setFailed(`PRs from external contributors require at least 1 approval from the Aevatarians team. Author: ${author}`);
-            } else {
-              console.log('Aevatarians team approval found — OK');
-            }


### PR DESCRIPTION
Carries:
- **Guard fix** (#134) — `enforce-branch-policy.yml` accepts `release/*` + `require-review.yml` whitelists the bot
- **Empty changeset** (from #130 CI-only PR)
- **Patch changeset** (from #131 smoke-test seed)
- **Empty changeset** (from #134 CI-only)

On merge, the new workflow state machine should:
1. Detect 3 pending changesets → open release/v0.3.1 → main PR (now with guard fixes baked in so CI actually runs)
2. Review + merge that
3. Tag v0.3.1 + create Release + auto-merge sync PR to develop