### PR TITLE
ci(release): CODEOWNERS + hard guard on auto-merge target

### DIFF
--- a/.changeset/cozy-loops-taste.md
+++ b/.changeset/cozy-loops-taste.md
@@ -1,0 +1,4 @@
+---
+---
+
+Harden the release-flow trust boundary. New `.github/CODEOWNERS` requires maintainer review on workflow files, CODEOWNERS itself, changeset config, package manifests, Dockerfiles, nginx config, and `deployment/`. `changeset-release.yml` adds a hard pre-merge assertion that the auto-merged PR's head branch matches `sync/post-release-v*`, base is `develop`, and author is the github-actions bot — so the auto-merge path can never drift into a different PR shape by mistake.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,41 @@
+# Code Owners — enforce maintainer review on trust-critical paths.
+#
+# Branch protection on `main` and `develop` must enable
+# "Require review from Code Owners" for these rules to actually gate.
+#
+# Pattern precedence: last-matching wins, per the CODEOWNERS format.
+
+# ---- Default owner ------------------------------------------------------
+# Nothing falls through without a maintainer review today. Relax later if
+# we add team members.
+*                                @chronoai-shining
+
+# ---- Workflow + CODEOWNERS itself --------------------------------------
+# These dictate what gets auto-approved / auto-merged / tagged by the
+# release state machine. Any change to them must come from the maintainer
+# so a malicious PR can't loosen the approval gate then auto-merge itself.
+/.github/workflows/              @chronoai-shining
+/.github/CODEOWNERS              @chronoai-shining
+
+# ---- Changeset config --------------------------------------------------
+# Determines package-version policy (fixed-linked mode, package list).
+# Opening this up would let a PR decouple ornn-api / ornn-web versions
+# without the maintainer noticing.
+/.changeset/config.json          @chronoai-shining
+
+# ---- Branch/version release surface ------------------------------------
+# Release-related scripts + top-level package manifest (workspaces,
+# versioning scripts).
+/package.json                    @chronoai-shining
+/ornn-api/package.json           @chronoai-shining
+/ornn-web/package.json           @chronoai-shining
+/ornn-sdk/package.json           @chronoai-shining
+/ornn-sdk-python/pyproject.toml  @chronoai-shining
+
+# ---- Docker + deployment -----------------------------------------------
+# Supply-chain sensitive. Changing build args or base images is a
+# backdoor-shaped footgun.
+/ornn-api/Dockerfile             @chronoai-shining
+/ornn-web/Dockerfile             @chronoai-shining
+/ornn-web/nginx.conf             @chronoai-shining
+/deployment/                     @chronoai-shining

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -179,6 +179,40 @@ jobs:
             echo "Opened sync PR #${SYNC_PR}"
           fi
 
+          # ── Hard safety rail on auto-merge ────────────────────────
+          # Code-level guarantee that this path only ever auto-merges a
+          # PR whose:
+          #   - head branch matches `sync/post-release-v*`
+          #   - base branch is `develop`
+          #   - author is github-actions[bot]
+          # even if a future edit introduces a new auto-merge call site
+          # by mistake.
+          if [ -n "$SYNC_PR" ]; then
+            PR_META=$(gh pr view "$SYNC_PR" --json headRefName,baseRefName,author --jq '.headRefName + "|" + .baseRefName + "|" + .author.login')
+            PR_HEAD="${PR_META%%|*}"
+            REST="${PR_META#*|}"
+            PR_BASE="${REST%%|*}"
+            PR_AUTHOR="${REST#*|}"
+            case "$PR_HEAD" in
+              sync/post-release-v*) ;;
+              *)
+                echo "::error::refusing to auto-merge: head '$PR_HEAD' does not match sync/post-release-v*"
+                exit 1
+                ;;
+            esac
+            if [ "$PR_BASE" != "develop" ]; then
+              echo "::error::refusing to auto-merge: base '$PR_BASE' is not 'develop'"
+              exit 1
+            fi
+            case "$PR_AUTHOR" in
+              github-actions|app/github-actions|github-actions\[bot\]) ;;
+              *)
+                echo "::error::refusing to auto-merge: author '$PR_AUTHOR' is not the github-actions bot"
+                exit 1
+                ;;
+            esac
+          fi
+
           # Auto-approve + auto-merge: the sync PR is a deterministic
           # replay of a commit that already passed CI on main. No human
           # review adds value here. Requires the org-level


### PR DESCRIPTION
Two hardenings that turn the bot-trust in the release flow from 'process habit' into 'code-level invariant'.

## 1. `.github/CODEOWNERS`

Blocks unreviewed edits to anything that could loosen the release flow or slip a supply-chain footgun:

| Path | Why |
|---|---|
| `/.github/workflows/` | contains the state machine + approval gates |
| `/.github/CODEOWNERS` | can't weaken ownership rules silently |
| `/.changeset/config.json` | fixed-mode versioning coupling |
| `*/package.json` | workspace layout + versioning scripts |
| `ornn-sdk-python/pyproject.toml` | Python SDK publish surface |
| Dockerfiles + `nginx.conf` + `/deployment/` | supply-chain sensitive |

Activation requires branch protection on `main` + `develop` to enable **Require review from Code Owners**. (Setting change — not in this PR.)

## 2. Auto-merge hard guard in `changeset-release.yml`

Before calling `gh pr merge --auto`, assert:

```
head branch = sync/post-release-v*
base branch = develop
author      = github-actions[bot]
```

If any of those don't match, the step exits non-zero with a clear error. Today the only auto-merge call site satisfies this by construction; this turns 'the workflow only auto-merges the sync PR' into an assertion, not just a habit.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [x] `bun run test` — green
- [ ] Next release cycle: observe that the State-B auto-merge step still passes (guard sees a well-formed sync PR, lets it through)

## Follow-up after merge

Flip branch-protection on `main` + `develop`: enable **Require review from Code Owners**. Without that, the CODEOWNERS file is descriptive not enforced.