### PR TITLE
fix(release): sync PR via direct merge API + merge_method=merge

### DIFF
--- a/.changeset/metal-bananas-post.md
+++ b/.changeset/metal-bananas-post.md
@@ -1,0 +1,4 @@
+---
+---
+
+Sync PR now lands as a real merge commit instead of squashing. The auto-merge step calls the GitHub merge API directly with `merge_method: merge` rather than relying on `gh pr merge --merge` (which falls back to the repo default, often squash). A squash-merged sync creates an orphan commit on develop that doesn't reference main's bump commit — merge-base walks back past it and every later `develop → main` PR shows a phantom version-bump diff. Merge-commit strategy gives develop two parents so histories stay joined. Sync PR body also updated with a bright warning for manual-merge cases.

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -172,9 +172,18 @@ jobs:
               --base develop \
               --head "${SYNC_BRANCH}" \
               --title "chore: sync main → develop after v${VERSION}" \
-              --body "Auto-opened + auto-merged after \`v${VERSION}\` was tagged on \`main\`.
+              --body "⚠️ **MUST be merged as a merge commit**, not squash.
 
-          Brings the version bump + consumed CHANGELOG entries back to \`develop\` so subsequent work starts from the right version. Only delta vs \`develop\` is the release-bump commit." \
+          Auto-opened + auto-merged after \`v${VERSION}\` was tagged on \`main\`.
+          Brings the version bump + consumed CHANGELOG entries back to \`develop\` so subsequent work starts from the right version. Only delta vs \`develop\` is the release-bump commit.
+
+          ### Why merge commit (not squash)
+
+          A merge commit gives this PR two parents: the current \`develop\` tip **and main's version-bump commit**. That makes \`git merge-base(main, develop)\` = main's HEAD, so the next \`develop → main\` PR diff is clean (no \"version change\" that's already on both sides).
+
+          A squash-merge creates a brand-new commit on \`develop\` that has no parent link to main's bump commit. The two branches then carry the same file contents but diverged histories — every subsequent \`develop → main\` PR shows a phantom version bump until the histories rejoin.
+
+          The workflow's auto-merge step calls the GitHub merge API directly with \`merge_method: merge\` to enforce this. If you're ever merging this PR manually, click **Create a merge commit**, never **Squash and merge**." \
               | tail -1 | grep -oE '[0-9]+$')
             echo "Opened sync PR #${SYNC_PR}"
           fi
@@ -219,11 +228,36 @@ jobs:
           # "Allow GitHub Actions to create and approve pull requests"
           # setting to be on; otherwise approve is rejected and the PR
           # waits for manual action.
+          #
+          # IMPORTANT — merge_method: merge is load-bearing.
+          # Squash-merging creates a new orphan commit on develop whose
+          # parent is the pre-bump develop tip, not main's bump commit.
+          # Subsequent develop → main PRs then show a phantom version
+          # bump diff because git merge-base walks back past the orphan.
+          # A proper merge commit gives develop two parents — previous
+          # develop HEAD + main's bump commit — making merge-base(main,
+          # develop) = main's HEAD after the sync. That keeps the
+          # histories joined.
           if [ -n "$SYNC_PR" ]; then
             gh pr review "$SYNC_PR" --approve \
               --body "Auto-approved: sync PR carrying the release-bump commit that was already on main." || true
-            gh pr merge "$SYNC_PR" --auto --merge || \
-              gh pr merge "$SYNC_PR" --merge || true
+
+            # Call the GitHub merge API directly with merge_method: merge.
+            # Bypasses `gh pr merge`'s auto-detection that can otherwise
+            # fall back to the repo's default strategy (often squash).
+            REPO_FULL="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+            MERGE_RESULT=$(gh api \
+              --method PUT \
+              "repos/${REPO_FULL}/pulls/${SYNC_PR}/merge" \
+              -f merge_method=merge \
+              -f commit_title="chore: sync main → develop after v${VERSION} (#${SYNC_PR})" \
+              -f commit_message="Auto-merged sync PR carrying main's v${VERSION} bump commit back onto develop." 2>&1) || {
+                echo "::warning::Direct API merge failed — sync PR left open for manual action. Output:"
+                echo "$MERGE_RESULT"
+                echo "$MERGE_RESULT" | grep -qi "Branch not mergeable\|Required status check\|pending review" && \
+                  echo "::warning::Looks like a branch-protection rule is gating the merge. Merge manually with 'Create a merge commit' (NOT squash)." || true
+              }
+            echo "$MERGE_RESULT"
           fi
 
       # ─────────────────────────── State C ─────────────────────────── #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,11 @@ Review that PR. Merge with **Squash and merge** (keeps history linear; `main` en
 1. Creates an annotated `v<version>` tag and pushes it.
 2. Extracts the `## <version>` section from each package's `CHANGELOG.md`, builds a combined body, and calls `gh release create`.
 3. Creates branch `sync/post-release-v<version>` from `main`.
-4. Opens PR `sync/post-release-v<version> → develop` — **auto-approved + auto-merged** by the same workflow (merge-commit strategy). No human action required for the sync step; the PR is a deterministic replay of a commit that already passed CI on `main`.
+4. Opens PR `sync/post-release-v<version> → develop` — **auto-approved + auto-merged** by the same workflow via a direct `PUT /repos/.../pulls/:n/merge` API call with `merge_method: merge`. No human action for the sync step; the PR is a deterministic replay of a commit that already passed CI on `main`.
 
-If branch protection blocks the auto-approve (e.g. stricter required-reviewer rules added later), the PR waits for manual merge instead of failing the workflow.
+**Load-bearing:** the sync PR **must** land as a merge commit, not a squash. A squash-merge creates an orphan commit on `develop` whose parent is the pre-bump `develop` tip, not `main`'s bump commit. Subsequent `develop → main` PRs then show a phantom version bump because `git merge-base` walks back past the orphan. A merge commit gives `develop` two parents (previous `develop` HEAD + `main`'s bump), making `merge-base(main, develop)` = `main`'s HEAD after the sync. The workflow calls the API directly so it doesn't fall back to the repo-default merge strategy (often squash).
+
+If branch protection blocks the auto-merge (e.g. stricter required-reviewer rules added later), the PR stays open with a warning log entry — **merge it manually via "Create a merge commit", never "Squash and merge"**.
 
 ### State summary (what the workflow does on every `main` push)
 


### PR DESCRIPTION
## Bug

PR #138 (sync/post-release-v0.3.1 → develop) landed as a **squash commit**, not a merge commit, because:

1. The workflow's `gh pr merge --auto --merge` didn't fire in time
2. User clicked GitHub's default 'Squash and merge' button manually

Result: develop's v0.3.1 bump commit is an orphan (single parent = pre-bump develop). `git merge-base(main, develop) = 5687e909` — before either side had v0.3.1. GitHub computes PR diffs from the merge-base, so every `develop → main` PR now shows a phantom 0.3.0 → 0.3.1 diff even though both branches hold identical content.

## Fix

Replace `gh pr merge --auto --merge` with a direct API call:

```
gh api --method PUT repos/$REPO/pulls/$N/merge -f merge_method=merge
```

Forces a proper merge commit regardless of repo default. After next sync, `merge-base(main, develop)` = main's HEAD, histories stay joined.

Also: sync PR body now has a visible warning for manual-merge cases (**Create a merge commit**, never Squash), and CLAUDE.md §Versioning spells out why.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — green
- [ ] Next release cycle: check `git show` on the sync commit — should have **two parents**. Then `git merge-base origin/main origin/develop` should equal `origin/main` HEAD.

## Caveat

This doesn't retroactively fix the current divergence. Fresh v0.3.2 release via this fixed workflow will rejoin the histories.