### PR TITLE
release: promote develop → main (v0.3.2 smoke test)

### DIFF
--- a/.changeset/cozy-loops-taste.md
+++ b/.changeset/cozy-loops-taste.md
@@ -1,0 +1,4 @@
+---
+---
+
+Harden the release-flow trust boundary. New `.github/CODEOWNERS` requires maintainer review on workflow files, CODEOWNERS itself, changeset config, package manifests, Dockerfiles, nginx config, and `deployment/`. `changeset-release.yml` adds a hard pre-merge assertion that the auto-merged PR's head branch matches `sync/post-release-v*`, base is `develop`, and author is the github-actions bot — so the auto-merge path can never drift into a different PR shape by mistake.

--- a/.changeset/dry-crews-sell.md
+++ b/.changeset/dry-crews-sell.md
@@ -1,4 +1,0 @@
----
----
-
-`enforce-branch-policy.yml` accepts `release/*` as a legal source branch for PRs → main (for bot release-bump PRs from the changeset-release workflow). `require-review.yml` treats the github-actions bot as a trusted author and drops the stale `aevatarAI/Aevatarians` team reference left over from the pre-transfer repo.

--- a/.changeset/lazy-spiders-sort.md
+++ b/.changeset/lazy-spiders-sort.md
@@ -1,4 +1,0 @@
----
----
-
-Release workflow redesign: `changeset-release.yml` becomes a state machine on `push: main` that (A) opens a release-bump PR when pending `.changeset/*.md` land on main, (B) tags + creates the GitHub Release + opens a sync PR back to develop when a bump was merged, or (C) no-ops. Removes the local `bun run release:prep` + `scripts/release-prep.sh` path. See CLAUDE.md §Versioning.

--- a/.changeset/metal-bananas-post.md
+++ b/.changeset/metal-bananas-post.md
@@ -1,0 +1,4 @@
+---
+---
+
+Sync PR now lands as a real merge commit instead of squashing. The auto-merge step calls the GitHub merge API directly with `merge_method: merge` rather than relying on `gh pr merge --merge` (which falls back to the repo default, often squash). A squash-merged sync creates an orphan commit on develop that doesn't reference main's bump commit — merge-base walks back past it and every later `develop → main` PR shows a phantom version-bump diff. Merge-commit strategy gives develop two parents so histories stay joined. Sync PR body also updated with a bright warning for manual-merge cases.

--- a/.changeset/test-release-workflow.md
+++ b/.changeset/test-release-workflow.md
@@ -1,6 +1,0 @@
----
-"ornn-api": patch
-"ornn-web": patch
----
-
-Smoke test for the new push-to-main release workflow (PR #130). This changeset forces a v0.3.1 patch bump with no functional change; it exists so State A → State B can be exercised end-to-end on a live release cycle.

--- a/.changeset/verify-sync-pr-merge-commit.md
+++ b/.changeset/verify-sync-pr-merge-commit.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+Smoke test for PR #141 — forces a v0.3.2 patch bump so the release state machine can exercise the new direct-API merge path. After this ships, `git show` on the sync commit should list two parents and `git merge-base origin/main origin/develop` should equal `origin/main`'s HEAD.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,41 @@
+# Code Owners — enforce maintainer review on trust-critical paths.
+#
+# Branch protection on `main` and `develop` must enable
+# "Require review from Code Owners" for these rules to actually gate.
+#
+# Pattern precedence: last-matching wins, per the CODEOWNERS format.
+
+# ---- Default owner ------------------------------------------------------
+# Nothing falls through without a maintainer review today. Relax later if
+# we add team members.
+*                                @chronoai-shining
+
+# ---- Workflow + CODEOWNERS itself --------------------------------------
+# These dictate what gets auto-approved / auto-merged / tagged by the
+# release state machine. Any change to them must come from the maintainer
+# so a malicious PR can't loosen the approval gate then auto-merge itself.
+/.github/workflows/              @chronoai-shining
+/.github/CODEOWNERS              @chronoai-shining
+
+# ---- Changeset config --------------------------------------------------
+# Determines package-version policy (fixed-linked mode, package list).
+# Opening this up would let a PR decouple ornn-api / ornn-web versions
+# without the maintainer noticing.
+/.changeset/config.json          @chronoai-shining
+
+# ---- Branch/version release surface ------------------------------------
+# Release-related scripts + top-level package manifest (workspaces,
+# versioning scripts).
+/package.json                    @chronoai-shining
+/ornn-api/package.json           @chronoai-shining
+/ornn-web/package.json           @chronoai-shining
+/ornn-sdk/package.json           @chronoai-shining
+/ornn-sdk-python/pyproject.toml  @chronoai-shining
+
+# ---- Docker + deployment -----------------------------------------------
+# Supply-chain sensitive. Changing build args or base images is a
+# backdoor-shaped footgun.
+/ornn-api/Dockerfile             @chronoai-shining
+/ornn-web/Dockerfile             @chronoai-shining
+/ornn-web/nginx.conf             @chronoai-shining
+/deployment/                     @chronoai-shining

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -179,6 +179,40 @@ jobs:
             echo "Opened sync PR #${SYNC_PR}"
           fi
 
+          # ── Hard safety rail on auto-merge ────────────────────────
+          # Code-level guarantee that this path only ever auto-merges a
+          # PR whose:
+          #   - head branch matches `sync/post-release-v*`
+          #   - base branch is `develop`
+          #   - author is github-actions[bot]
+          # even if a future edit introduces a new auto-merge call site
+          # by mistake.
+          if [ -n "$SYNC_PR" ]; then
+            PR_META=$(gh pr view "$SYNC_PR" --json headRefName,baseRefName,author --jq '.headRefName + "|" + .baseRefName + "|" + .author.login')
+            PR_HEAD="${PR_META%%|*}"
+            REST="${PR_META#*|}"
+            PR_BASE="${REST%%|*}"
+            PR_AUTHOR="${REST#*|}"
+            case "$PR_HEAD" in
+              sync/post-release-v*) ;;
+              *)
+                echo "::error::refusing to auto-merge: head '$PR_HEAD' does not match sync/post-release-v*"
+                exit 1
+                ;;
+            esac
+            if [ "$PR_BASE" != "develop" ]; then
+              echo "::error::refusing to auto-merge: base '$PR_BASE' is not 'develop'"
+              exit 1
+            fi
+            case "$PR_AUTHOR" in
+              github-actions|app/github-actions|github-actions\[bot\]) ;;
+              *)
+                echo "::error::refusing to auto-merge: author '$PR_AUTHOR' is not the github-actions bot"
+                exit 1
+                ;;
+            esac
+          fi
+
           # Auto-approve + auto-merge: the sync PR is a deterministic
           # replay of a commit that already passed CI on main. No human
           # review adds value here. Requires the org-level

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -172,9 +172,18 @@ jobs:
               --base develop \
               --head "${SYNC_BRANCH}" \
               --title "chore: sync main → develop after v${VERSION}" \
-              --body "Auto-opened + auto-merged after \`v${VERSION}\` was tagged on \`main\`.
+              --body "⚠️ **MUST be merged as a merge commit**, not squash.
 
-          Brings the version bump + consumed CHANGELOG entries back to \`develop\` so subsequent work starts from the right version. Only delta vs \`develop\` is the release-bump commit." \
+          Auto-opened + auto-merged after \`v${VERSION}\` was tagged on \`main\`.
+          Brings the version bump + consumed CHANGELOG entries back to \`develop\` so subsequent work starts from the right version. Only delta vs \`develop\` is the release-bump commit.
+
+          ### Why merge commit (not squash)
+
+          A merge commit gives this PR two parents: the current \`develop\` tip **and main's version-bump commit**. That makes \`git merge-base(main, develop)\` = main's HEAD, so the next \`develop → main\` PR diff is clean (no \"version change\" that's already on both sides).
+
+          A squash-merge creates a brand-new commit on \`develop\` that has no parent link to main's bump commit. The two branches then carry the same file contents but diverged histories — every subsequent \`develop → main\` PR shows a phantom version bump until the histories rejoin.
+
+          The workflow's auto-merge step calls the GitHub merge API directly with \`merge_method: merge\` to enforce this. If you're ever merging this PR manually, click **Create a merge commit**, never **Squash and merge**." \
               | tail -1 | grep -oE '[0-9]+$')
             echo "Opened sync PR #${SYNC_PR}"
           fi
@@ -219,11 +228,36 @@ jobs:
           # "Allow GitHub Actions to create and approve pull requests"
           # setting to be on; otherwise approve is rejected and the PR
           # waits for manual action.
+          #
+          # IMPORTANT — merge_method: merge is load-bearing.
+          # Squash-merging creates a new orphan commit on develop whose
+          # parent is the pre-bump develop tip, not main's bump commit.
+          # Subsequent develop → main PRs then show a phantom version
+          # bump diff because git merge-base walks back past the orphan.
+          # A proper merge commit gives develop two parents — previous
+          # develop HEAD + main's bump commit — making merge-base(main,
+          # develop) = main's HEAD after the sync. That keeps the
+          # histories joined.
           if [ -n "$SYNC_PR" ]; then
             gh pr review "$SYNC_PR" --approve \
               --body "Auto-approved: sync PR carrying the release-bump commit that was already on main." || true
-            gh pr merge "$SYNC_PR" --auto --merge || \
-              gh pr merge "$SYNC_PR" --merge || true
+
+            # Call the GitHub merge API directly with merge_method: merge.
+            # Bypasses `gh pr merge`'s auto-detection that can otherwise
+            # fall back to the repo's default strategy (often squash).
+            REPO_FULL="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+            MERGE_RESULT=$(gh api \
+              --method PUT \
+              "repos/${REPO_FULL}/pulls/${SYNC_PR}/merge" \
+              -f merge_method=merge \
+              -f commit_title="chore: sync main → develop after v${VERSION} (#${SYNC_PR})" \
+              -f commit_message="Auto-merged sync PR carrying main's v${VERSION} bump commit back onto develop." 2>&1) || {
+                echo "::warning::Direct API merge failed — sync PR left open for manual action. Output:"
+                echo "$MERGE_RESULT"
+                echo "$MERGE_RESULT" | grep -qi "Branch not mergeable\|Required status check\|pending review" && \
+                  echo "::warning::Looks like a branch-protection rule is gating the merge. Merge manually with 'Create a merge commit' (NOT squash)." || true
+              }
+            echo "$MERGE_RESULT"
           fi
 
       # ─────────────────────────── State C ─────────────────────────── #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,11 @@ Review that PR. Merge with **Squash and merge** (keeps history linear; `main` en
 1. Creates an annotated `v<version>` tag and pushes it.
 2. Extracts the `## <version>` section from each package's `CHANGELOG.md`, builds a combined body, and calls `gh release create`.
 3. Creates branch `sync/post-release-v<version>` from `main`.
-4. Opens PR `sync/post-release-v<version> → develop` — **auto-approved + auto-merged** by the same workflow (merge-commit strategy). No human action required for the sync step; the PR is a deterministic replay of a commit that already passed CI on `main`.
+4. Opens PR `sync/post-release-v<version> → develop` — **auto-approved + auto-merged** by the same workflow via a direct `PUT /repos/.../pulls/:n/merge` API call with `merge_method: merge`. No human action for the sync step; the PR is a deterministic replay of a commit that already passed CI on `main`.
 
-If branch protection blocks the auto-approve (e.g. stricter required-reviewer rules added later), the PR waits for manual merge instead of failing the workflow.
+**Load-bearing:** the sync PR **must** land as a merge commit, not a squash. A squash-merge creates an orphan commit on `develop` whose parent is the pre-bump `develop` tip, not `main`'s bump commit. Subsequent `develop → main` PRs then show a phantom version bump because `git merge-base` walks back past the orphan. A merge commit gives `develop` two parents (previous `develop` HEAD + `main`'s bump), making `merge-base(main, develop)` = `main`'s HEAD after the sync. The workflow calls the API directly so it doesn't fall back to the repo-default merge strategy (often squash).
+
+If branch protection blocks the auto-merge (e.g. stricter required-reviewer rules added later), the PR stays open with a warning log entry — **merge it manually via "Create a merge commit", never "Squash and merge"**.
 
 ### State summary (what the workflow does on every `main` push)
 

--- a/ornn-api/CHANGELOG.md
+++ b/ornn-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ornn-api
 
+## 0.3.1
+
+### Patch Changes
+
+- [#131](https://github.com/ChronoAIProject/Ornn/pull/131) [`b8fc37a`](https://github.com/ChronoAIProject/Ornn/commit/b8fc37a39d9cc1e03b3cb5aa63978bf34661fcf7) Thanks [@chronoai-shining](https://github.com/chronoai-shining)! - Smoke test for the new push-to-main release workflow (PR [#130](https://github.com/ChronoAIProject/Ornn/issues/130)). This changeset forces a v0.3.1 patch bump with no functional change; it exists so State A → State B can be exercised end-to-end on a live release cycle.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/ornn-api/package.json
+++ b/ornn-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ornn-api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ornn-web/CHANGELOG.md
+++ b/ornn-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ornn-web
 
+## 0.3.1
+
+### Patch Changes
+
+- [#131](https://github.com/ChronoAIProject/Ornn/pull/131) [`b8fc37a`](https://github.com/ChronoAIProject/Ornn/commit/b8fc37a39d9cc1e03b3cb5aa63978bf34661fcf7) Thanks [@chronoai-shining](https://github.com/chronoai-shining)! - Smoke test for the new push-to-main release workflow (PR [#130](https://github.com/ChronoAIProject/Ornn/issues/130)). This changeset forces a v0.3.1 patch bump with no functional change; it exists so State A → State B can be exercised end-to-end on a live release cycle.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/ornn-web/package.json
+++ b/ornn-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ornn-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Carries 4 pending changesets (3 empty + 1 patch bump to v0.3.2). Triggers the state-machine release workflow.

Smoke-test target for PR #141's direct-API merge fix. After the cycle:
- Bot opens `release/v0.3.2 → main` (State A)
- I review + merge that
- Bot tags v0.3.2, creates Release, opens **merge-commit** sync PR to develop (State B with #141's fix)
- Verify sync commit has two parents + merge-base(main, develop) = main's HEAD