### PR TITLE
release: promote develop → main (v0.3.3 with nginx SNI fix)

### DIFF
--- a/.changeset/nginx-ssl-sni.md
+++ b/.changeset/nginx-ssl-sni.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Fix nginx SNI when proxying to an HTTPS NyxID upstream behind a multi-tenant edge (Cloudflare et al). Without `proxy_ssl_server_name on` + a proper `proxy_ssl_name`, the upstream TLS handshake fails with alert 40 and the browser sees 502. Adds a new `NYXID_BACKEND_HOST` env var (hostname part of `NYXID_BACKEND_URL`, e.g. `nyx.chrono-ai.fun`) consumed by `nginx.conf.template` for SNI + Host header; plumbed through `deployment/ornn-web/configmap.yaml` and `deployment/.env.sample.ornn`.

--- a/deployment/.env.sample.ornn
+++ b/deployment/.env.sample.ornn
@@ -32,6 +32,11 @@ ALLOWED_ORIGINS=<comma-separated-origins, e.g. https://app.ornn.xyz,http://local
 ORNN_WEB_IMAGE=<ornn-web-image>
 # nginx upstream targets (consumed by /etc/nginx/templates/default.conf.template)
 NYXID_BACKEND_URL=<nyxid-backend-url>
+# Hostname portion of NYXID_BACKEND_URL — used for Host header + SNI.
+# Required when the upstream is behind a multi-tenant HTTPS edge (Cloudflare,
+# Vercel, etc.) — without it TLS handshake fails with alert 40.
+# e.g. NYXID_BACKEND_URL=https://nyx.chrono-ai.fun → NYXID_BACKEND_HOST=nyx.chrono-ai.fun
+NYXID_BACKEND_HOST=<nyxid-backend-host>
 ORNN_API_URL=<ornn-api-url>
 # Frontend runtime config (injected into window.__ORNN_CONFIG__ via /config.js)
 API_BASE_URL=<api-base-url-for-frontend>

--- a/deployment/ornn-web/configmap.yaml
+++ b/deployment/ornn-web/configmap.yaml
@@ -6,11 +6,17 @@ metadata:
 data:
   # nginx upstreams — consumed by /etc/nginx/templates/default.conf.template
   # via the image's built-in 20-envsubst-on-templates.sh. NGINX_ENVSUBST_FILTER
-  # narrows substitution to these two so $host / $remote_addr / $scheme etc.
-  # inside the template stay literal.
+  # narrows substitution so $host / $remote_addr / $scheme etc. inside the
+  # template stay literal.
   NYXID_BACKEND_URL: "${NYXID_BACKEND_URL}"
+  # Hostname portion of NYXID_BACKEND_URL — used for Host header + SNI when
+  # the upstream is a multi-tenant HTTPS edge (Cloudflare, Vercel, etc.).
+  # e.g. "nyx.chrono-ai.fun" when NYXID_BACKEND_URL is "https://nyx.chrono-ai.fun".
+  # For in-cluster plain-HTTP upstreams this MAY be set to $host (the nginx
+  # built-in) to fall back to standard behavior.
+  NYXID_BACKEND_HOST: "${NYXID_BACKEND_HOST}"
   ORNN_API_URL: "${ORNN_API_URL}"
-  NGINX_ENVSUBST_FILTER: "^(NYXID_BACKEND_URL|ORNN_API_URL)$"
+  NGINX_ENVSUBST_FILTER: "^(NYXID_BACKEND_URL|NYXID_BACKEND_HOST|ORNN_API_URL)$"
 
   # Frontend runtime config — consumed by 40-envsubst-config-js.sh,
   # injected into window.__ORNN_CONFIG__ via /config.js at page load.

--- a/ornn-web/nginx.conf.template
+++ b/ornn-web/nginx.conf.template
@@ -46,7 +46,18 @@ server {
     # /api/v1/X → NyxID proxy /api/v1/proxy/s/ornn-api/api/v1/X → ornn-api /api/v1/X
     location /api/v1/ {
         proxy_pass ${NYXID_BACKEND_URL}/api/v1/proxy/s/ornn-api/api/v1/;
-        proxy_set_header Host $host;
+
+        # SNI + Host alignment for HTTPS upstreams behind Cloudflare /
+        # multi-tenant edges. Without SNI, the edge can't pick the right
+        # cert and drops the TLS handshake with alert 40 (handshake_failure),
+        # surfacing as 502 here. NYXID_BACKEND_HOST is the hostname portion
+        # of NYXID_BACKEND_URL (e.g. 'nyx.chrono-ai.fun') — same-origin
+        # in-cluster deployments can leave it empty and it'll fall back to
+        # the proxy_pass target hostname, which nginx handles correctly.
+        proxy_ssl_server_name on;
+        proxy_ssl_name ${NYXID_BACKEND_HOST};
+        proxy_set_header Host ${NYXID_BACKEND_HOST};
+
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Carries **PR #146** — nginx SNI fix for the 502 that blocks every frontend API call when NyxID is behind Cloudflare. That PR has 1 patch-level changeset.

On merge, the state machine should:
1. Detect pending changeset → open release/v0.3.3 PR (State A)
2. Review + merge it
3. Tag v0.3.3, create GH Release, open sync PR to develop (State B — this time via direct API merge_method=merge, per PR #141's fix)
4. Sync PR auto-approves + auto-merges as a true merge commit this time (no human needed)

Expected verification after:
- `git show <sync-commit>` has 2 parents
- `git merge-base origin/main origin/develop` = `origin/main`'s HEAD