### PR TITLE
[Feature] Notifications UI (bell + /notifications page)

### DIFF
--- a/.changeset/notifications-ui.md
+++ b/.changeset/notifications-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+frontend: in-product notifications UI — navbar bell with unread badge, popover with latest 10 items, dedicated `/notifications` page with filter + mark-all-read. Wires up the already-shipped `/api/v1/notifications/*` endpoints; closes #157 from the phase-3 frontend catch-up umbrella (#156).

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -64,6 +64,9 @@ const MySkillsPage = lazy(() =>
 const ServiceDetailPage = lazy(() =>
   import("@/pages/ServiceDetailPage").then((m) => ({ default: m.ServiceDetailPage })),
 );
+const NotificationsPage = lazy(() =>
+  import("@/pages/NotificationsPage").then((m) => ({ default: m.NotificationsPage })),
+);
 
 // Admin pages — bundled into one chunk by virtue of sharing the barrel
 // import path; only loaded when an /admin route activates.
@@ -132,6 +135,7 @@ export function App() {
 
                   <Route path="/my-skills" element={<MySkillsPage />} />
                   <Route path="/services/:id" element={<ServiceDetailPage />} />
+                  <Route path="/notifications" element={<NotificationsPage />} />
                 </Route>
 
                 {/* Admin routes - separate layout */}

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ import { logActivity } from "@/services/activityApi";
 import { useThemeStore } from "@/stores/themeStore";
 import { useTranslation } from "react-i18next";
 import { Logo } from "@/components/brand/Logo";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { config } from "@/config";
 
 /** Admin icon */
@@ -348,6 +349,13 @@ export function Navbar({ className = "" }: NavbarProps) {
             <GitHubLink />
             <LangDropdown />
             <ThemeToggle />
+
+            {/* Notifications — authenticated users only. */}
+            {isAuthenticated && (
+              <div className="hidden sm:block">
+                <NotificationBell />
+              </div>
+            )}
 
             {/* User Menu (Desktop) */}
             {isAuthenticated && user && (

--- a/ornn-web/src/components/notifications/NotificationBell.tsx
+++ b/ornn-web/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,197 @@
+/**
+ * Navbar notification bell.
+ * Shows an unread-count badge and a popover with the most-recent items.
+ * Click an item to navigate + auto-mark-read; "View all" goes to /notifications.
+ *
+ * Mounted inside Navbar only when the caller is authenticated (the parent
+ * gates rendering). Hooks themselves also gate on auth, so a stray mount
+ * won't fire a stream of 401s.
+ *
+ * @module components/notifications/NotificationBell
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+import {
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotifications,
+  useUnreadNotificationCount,
+} from "@/hooks/useNotifications";
+import type { Notification } from "@/types/notifications";
+
+/** Size used in navbar + empty-state. */
+const POPOVER_ITEM_CAP = 10;
+
+function BellIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+      />
+    </svg>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffSec = Math.max(0, Math.round((now - then) / 1000));
+  if (diffSec < 60) return "just now";
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function NotificationBell() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const { data: unread = 0 } = useUnreadNotificationCount();
+  // Keep the popover list small — we don't want to pay for 200 items on every
+  // navbar render. The full /notifications page has its own list.
+  const { data: items = [], isLoading } = useNotifications({ limit: POPOVER_ITEM_CAP });
+  const markRead = useMarkNotificationRead();
+  const markAll = useMarkAllNotificationsRead();
+
+  const visibleItems = useMemo(
+    () => items.slice(0, POPOVER_ITEM_CAP),
+    [items],
+  );
+
+  // Close popover on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (ev: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(ev.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const handleItemClick = (n: Notification) => {
+    if (!n.readAt) {
+      markRead.mutate(n._id);
+    }
+    setOpen(false);
+    if (n.link) navigate(n.link);
+    else navigate("/notifications");
+  };
+
+  const badgeLabel = unread > 99 ? "99+" : String(unread);
+
+  return (
+    <div ref={panelRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={t("notifications.bellAria", "Notifications")}
+        className="relative flex h-10 w-10 items-center justify-center rounded-full border border-neon-cyan/20 bg-bg-surface/50 text-text-muted transition-all duration-200 hover:border-neon-cyan/60 hover:text-text-primary cursor-pointer"
+      >
+        <BellIcon className="h-5 w-5" />
+        {unread > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 min-w-[1.25rem] rounded-full border-2 border-bg-surface bg-neon-red px-1 font-heading text-[10px] font-bold leading-4 text-white">
+            {badgeLabel}
+          </span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: -10, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -10, scale: 0.95 }}
+            transition={{ duration: 0.15, ease: "easeOut" }}
+            className="absolute right-0 top-full mt-2 w-80 overflow-hidden rounded-lg glass border border-neon-cyan/20 shadow-lg shadow-neon-cyan/10"
+          >
+            <div className="flex items-center justify-between border-b border-neon-cyan/10 px-4 py-3">
+              <span className="font-heading text-sm uppercase tracking-wider text-text-primary">
+                {t("notifications.title", "Notifications")}
+              </span>
+              {unread > 0 && (
+                <button
+                  type="button"
+                  onClick={() => markAll.mutate()}
+                  disabled={markAll.isPending}
+                  className="font-body text-xs text-text-muted transition-colors hover:text-neon-cyan cursor-pointer disabled:opacity-50"
+                >
+                  {t("notifications.markAllRead", "Mark all read")}
+                </button>
+              )}
+            </div>
+
+            <div className="max-h-96 overflow-y-auto">
+              {isLoading ? (
+                <div className="px-4 py-6 text-center font-body text-sm text-text-muted">
+                  {t("notifications.loading", "Loading…")}
+                </div>
+              ) : visibleItems.length === 0 ? (
+                <div className="px-4 py-6 text-center font-body text-sm text-text-muted">
+                  {t("notifications.empty", "You're all caught up.")}
+                </div>
+              ) : (
+                visibleItems.map((n) => (
+                  <button
+                    key={n._id}
+                    type="button"
+                    onClick={() => handleItemClick(n)}
+                    className={`flex w-full flex-col gap-1 border-b border-neon-cyan/5 px-4 py-3 text-left transition-colors last:border-b-0 cursor-pointer ${
+                      n.readAt
+                        ? "hover:bg-neon-cyan/5"
+                        : "bg-neon-cyan/[0.04] hover:bg-neon-cyan/10"
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      {!n.readAt && (
+                        <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-neon-cyan" />
+                      )}
+                      <span
+                        className={`font-body text-sm leading-snug ${
+                          n.readAt ? "text-text-muted" : "text-text-primary"
+                        }`}
+                      >
+                        {n.title}
+                      </span>
+                    </div>
+                    <span className="font-mono text-xs text-text-muted pl-4">
+                      {formatRelative(n.createdAt)}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+
+            <div className="border-t border-neon-cyan/10">
+              <button
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  navigate("/notifications");
+                }}
+                className="flex w-full items-center justify-center px-4 py-2.5 font-body text-sm text-neon-cyan transition-colors hover:bg-neon-cyan/5 cursor-pointer"
+              >
+                {t("notifications.viewAll", "View all")}
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/ornn-web/src/hooks/useNotifications.ts
+++ b/ornn-web/src/hooks/useNotifications.ts
@@ -1,0 +1,69 @@
+/**
+ * React Query hooks for the in-product notification center.
+ *
+ * Caller-gated: every hook is `enabled` only when the user is authenticated.
+ * Anonymous callers short-circuit to empty data without firing a request.
+ *
+ * @module hooks/useNotifications
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchNotifications,
+  fetchUnreadCount,
+  markAllNotificationsRead,
+  markNotificationRead,
+  type ListNotificationsOptions,
+} from "@/services/notificationsApi";
+import type { Notification } from "@/types/notifications";
+import { useIsAuthenticated } from "@/stores/authStore";
+
+const NOTIFICATIONS_KEY = ["notifications"] as const;
+const UNREAD_COUNT_KEY = ["notifications", "unread-count"] as const;
+
+/** 30s polling — cheap endpoint, UX feels live without WebSocket infra. */
+const UNREAD_POLL_MS = 30_000;
+
+export function useNotifications(opts: ListNotificationsOptions = {}) {
+  const isAuthed = useIsAuthenticated();
+  return useQuery<Notification[]>({
+    queryKey: [...NOTIFICATIONS_KEY, opts] as const,
+    queryFn: () => fetchNotifications(opts),
+    enabled: isAuthed,
+    staleTime: 10_000,
+  });
+}
+
+export function useUnreadNotificationCount() {
+  const isAuthed = useIsAuthenticated();
+  return useQuery<number>({
+    queryKey: UNREAD_COUNT_KEY,
+    queryFn: fetchUnreadCount,
+    enabled: isAuthed,
+    refetchInterval: isAuthed ? UNREAD_POLL_MS : false,
+    refetchIntervalInBackground: false,
+    staleTime: 10_000,
+  });
+}
+
+export function useMarkNotificationRead() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => markNotificationRead(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_KEY });
+      queryClient.invalidateQueries({ queryKey: UNREAD_COUNT_KEY });
+    },
+  });
+}
+
+export function useMarkAllNotificationsRead() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => markAllNotificationsRead(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_KEY });
+      queryClient.invalidateQueries({ queryKey: UNREAD_COUNT_KEY });
+    },
+  });
+}

--- a/ornn-web/src/pages/NotificationsPage.tsx
+++ b/ornn-web/src/pages/NotificationsPage.tsx
@@ -1,0 +1,154 @@
+/**
+ * /notifications — full list, filter by unread, mark-all-read.
+ *
+ * @module pages/NotificationsPage
+ */
+
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import {
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotifications,
+} from "@/hooks/useNotifications";
+import type { Notification, NotificationCategory } from "@/types/notifications";
+import { PageTransition } from "@/components/layout/PageTransition";
+
+const CATEGORY_LABEL: Record<NotificationCategory, string> = {
+  "audit.completed": "Audit",
+  "share.needs_justification": "Share",
+  "share.review_requested": "Share",
+  "share.accepted": "Share",
+  "share.rejected": "Share",
+  "share.cancelled": "Share",
+};
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+export function NotificationsPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [unreadOnly, setUnreadOnly] = useState(false);
+
+  const { data: items = [], isLoading, isError } = useNotifications({
+    unread: unreadOnly,
+    limit: 200,
+  });
+  const markRead = useMarkNotificationRead();
+  const markAll = useMarkAllNotificationsRead();
+
+  const hasUnread = useMemo(() => items.some((n) => !n.readAt), [items]);
+
+  const handleOpen = (n: Notification) => {
+    if (!n.readAt) markRead.mutate(n._id);
+    if (n.link) navigate(n.link);
+  };
+
+  return (
+    <PageTransition>
+      <div className="mx-auto w-full max-w-4xl px-6 py-10">
+        <header className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="font-heading text-3xl font-bold text-text-primary">
+              {t("notifications.title", "Notifications")}
+            </h1>
+            <p className="mt-1 font-body text-sm text-text-muted">
+              {t(
+                "notifications.subtitle",
+                "Share reviews, audit verdicts, and admin actions on your skills.",
+              )}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setUnreadOnly((v) => !v)}
+              className={`rounded-lg border px-3 py-1.5 font-body text-sm transition-colors cursor-pointer ${
+                unreadOnly
+                  ? "border-neon-cyan/60 bg-neon-cyan/10 text-neon-cyan"
+                  : "border-neon-cyan/20 bg-bg-surface/50 text-text-muted hover:text-text-primary"
+              }`}
+            >
+              {unreadOnly
+                ? t("notifications.showAll", "Show all")
+                : t("notifications.showUnreadOnly", "Unread only")}
+            </button>
+            <button
+              type="button"
+              onClick={() => markAll.mutate()}
+              disabled={!hasUnread || markAll.isPending}
+              className="rounded-lg border border-neon-cyan/20 bg-bg-surface/50 px-3 py-1.5 font-body text-sm text-text-muted transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
+            >
+              {t("notifications.markAllRead", "Mark all read")}
+            </button>
+          </div>
+        </header>
+
+        {isLoading ? (
+          <div className="py-16 text-center font-body text-sm text-text-muted">
+            {t("notifications.loading", "Loading…")}
+          </div>
+        ) : isError ? (
+          <div className="py-16 text-center font-body text-sm text-neon-red">
+            {t("notifications.loadFailed", "Could not load notifications.")}
+          </div>
+        ) : items.length === 0 ? (
+          <div className="rounded-lg border border-neon-cyan/10 bg-bg-surface/30 py-16 text-center font-body text-sm text-text-muted">
+            {unreadOnly
+              ? t("notifications.noUnread", "No unread notifications.")
+              : t("notifications.empty", "You're all caught up.")}
+          </div>
+        ) : (
+          <ul className="divide-y divide-neon-cyan/10 overflow-hidden rounded-lg border border-neon-cyan/10 bg-bg-surface/30">
+            {items.map((n) => (
+              <li key={n._id}>
+                <button
+                  type="button"
+                  onClick={() => handleOpen(n)}
+                  className={`flex w-full flex-col gap-2 px-5 py-4 text-left transition-colors cursor-pointer ${
+                    n.readAt ? "hover:bg-neon-cyan/5" : "bg-neon-cyan/[0.04] hover:bg-neon-cyan/10"
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-start gap-3">
+                      {!n.readAt && (
+                        <span className="mt-2 h-2 w-2 shrink-0 rounded-full bg-neon-cyan" />
+                      )}
+                      <div className="flex flex-col gap-1">
+                        <div className="flex items-center gap-2">
+                          <span className="rounded border border-neon-cyan/20 px-2 py-0.5 font-heading text-[10px] uppercase tracking-wider text-text-muted">
+                            {CATEGORY_LABEL[n.category] ?? n.category}
+                          </span>
+                          <span
+                            className={`font-body text-sm font-medium leading-snug ${
+                              n.readAt ? "text-text-muted" : "text-text-primary"
+                            }`}
+                          >
+                            {n.title}
+                          </span>
+                        </div>
+                        {n.body && (
+                          <p className="font-body text-sm leading-snug text-text-muted">
+                            {n.body}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <span className="shrink-0 font-mono text-xs text-text-muted">
+                      {formatTimestamp(n.createdAt)}
+                    </span>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/services/notificationsApi.ts
+++ b/ornn-web/src/services/notificationsApi.ts
@@ -1,0 +1,40 @@
+/**
+ * Caller-scoped notification endpoints — /api/v1/notifications/*.
+ *
+ * @module services/notificationsApi
+ */
+
+import { apiGet, apiPost } from "./apiClient";
+import type { Notification } from "@/types/notifications";
+
+export interface ListNotificationsOptions {
+  /** When true, restrict to unread entries. Default false (all). */
+  unread?: boolean;
+  /** 1–200; backend clamps. Default 50. */
+  limit?: number;
+}
+
+export async function fetchNotifications(
+  opts: ListNotificationsOptions = {},
+): Promise<Notification[]> {
+  const params: Record<string, string | number | boolean | undefined> = {};
+  if (opts.unread) params.unread = "true";
+  if (opts.limit !== undefined) params.limit = opts.limit;
+  const res = await apiGet<{ items: Notification[] }>("/api/v1/notifications", params);
+  return res.data?.items ?? [];
+}
+
+export async function fetchUnreadCount(): Promise<number> {
+  const res = await apiGet<{ count: number }>("/api/v1/notifications/unread-count");
+  return res.data?.count ?? 0;
+}
+
+export async function markNotificationRead(id: string): Promise<Notification | null> {
+  const res = await apiPost<Notification>(`/api/v1/notifications/${id}/read`, {});
+  return res.data ?? null;
+}
+
+export async function markAllNotificationsRead(): Promise<number> {
+  const res = await apiPost<{ updated: number }>("/api/v1/notifications/mark-all-read", {});
+  return res.data?.updated ?? 0;
+}

--- a/ornn-web/src/types/notifications.ts
+++ b/ornn-web/src/types/notifications.ts
@@ -1,0 +1,33 @@
+/**
+ * In-product notification types. Shape mirrors the backend's
+ * `NotificationDocument` from `ornn-api/src/domains/notifications/types.ts`
+ * with Date fields serialized as ISO strings over the wire.
+ *
+ * @module types/notifications
+ */
+
+export type NotificationCategory =
+  | "audit.completed"
+  | "share.needs_justification"
+  | "share.review_requested"
+  | "share.accepted"
+  | "share.rejected"
+  | "share.cancelled";
+
+export interface Notification {
+  _id: string;
+  userId: string;
+  category: NotificationCategory;
+  /** One-line summary for list / popover. */
+  title: string;
+  /** Optional longer body rendered on the detail view. Plain text. */
+  body?: string;
+  /** Deep-link path within the web UI, e.g. `/shares/abc`. */
+  link?: string;
+  /** Arbitrary structured payload the UI can lean on (e.g. `{ shareRequestId, verdict }`). */
+  data: Record<string, unknown>;
+  /** ISO timestamp set when the recipient read this notification; `null`/`undefined` = unread. */
+  readAt?: string | null;
+  /** ISO timestamp of creation. */
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

Gives users a visible inbox for the audit + share-workflow events that the backend has been emitting for weeks. First PR of the phase-3 frontend catch-up umbrella (#156).

- **Navbar bell** — unread-count badge, popover with the 10 most-recent items. Click any item → marks read + navigates to the deep link if one is present. Visible only when authenticated.
- **/notifications page** — full list view with an "unread only" filter and a "mark all read" action. Pagination deliberately omitted (backend caps at 200; inbox is naturally bounded).
- **Plumbing** — new `types/notifications.ts`, `services/notificationsApi.ts`, `hooks/useNotifications.ts` (4 hooks, all auth-gated). Route registered under AuthGuard + RootLayout, code-split via `lazy()`.
- **Polling** — unread count every 30s via TanStack refetchInterval; list has 10s staleTime so popover opens feel fresh without being chatty.

Scope deliberately kept small: no WebSocket push, no preferences / muting, no bulk-by-filter actions. Those aren't needed for parity with the backend and can follow as separate PRs.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` (vitest) — 11/11 pass
- [x] `bun run lint` — 0 errors (pre-existing warnings unchanged)
- [ ] Post-merge local deploy: sign in → bell appears with badge when backend has entries → popover opens → click an item → state updates → `/notifications` page renders

## Out of scope (tracked elsewhere)

- Share-workflow UI that would emit new notifications (#160)
- Audit banner that would emit audit-completed notifications (#158)

Closes #157. Progresses #156.