### PR TITLE
[Feature] Skill audit banner on SkillDetailPage + admin rerun

### DIFF
--- a/.changeset/audit-banner-ui.md
+++ b/.changeset/audit-banner-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+frontend: skill audit banner on SkillDetailPage. Shows the cached verdict (green / yellow / red), overall 0–10 score, and a collapsible drawer with per-dimension scores and findings. Admins get a "Rerun" button (and a "Run audit" CTA for skills that have never been audited). Wires up the already-shipped `/api/v1/skills/:idOrName/audit` endpoints; closes #158 from the phase-3 frontend catch-up umbrella (#156).

--- a/ornn-web/src/components/skill/AuditBanner.tsx
+++ b/ornn-web/src/components/skill/AuditBanner.tsx
@@ -1,0 +1,287 @@
+/**
+ * Banner on `SkillDetailPage` showing the skill's audit verdict.
+ *
+ * - No audit yet → hidden (or a tiny "Run audit" CTA for admins).
+ * - Audit exists → verdict pill, overall score, timestamp; expandable to
+ *   show per-dimension scores and findings.
+ * - Admin viewers get a "Rerun" button; the mutation sync-updates the
+ *   banner state via query-cache priming in `useRerunAudit`.
+ *
+ * @module components/skill/AuditBanner
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useRerunAudit, useSkillAudit } from "@/hooks/useAudit";
+import type {
+  AuditFinding,
+  AuditRecord,
+  AuditScore,
+  AuditVerdict,
+} from "@/types/audit";
+
+interface AuditBannerProps {
+  /** Skill id or name. Empty/undefined suppresses the banner. */
+  idOrName: string | undefined;
+  /** Optional pin; omit for latest. */
+  version?: string;
+  /** Caller can rerun / trigger initial audits. */
+  isAdmin: boolean;
+  className?: string;
+}
+
+const VERDICT_STYLE: Record<
+  AuditVerdict,
+  { ring: string; dot: string; label: string; text: string; bg: string }
+> = {
+  green: {
+    ring: "border-neon-cyan/40",
+    dot: "bg-neon-cyan",
+    label: "Pass",
+    text: "text-neon-cyan",
+    bg: "bg-neon-cyan/5",
+  },
+  yellow: {
+    ring: "border-neon-yellow/40",
+    dot: "bg-neon-yellow",
+    label: "Warnings",
+    text: "text-neon-yellow",
+    bg: "bg-neon-yellow/5",
+  },
+  red: {
+    ring: "border-neon-red/40",
+    dot: "bg-neon-red",
+    label: "Fail",
+    text: "text-neon-red",
+    bg: "bg-neon-red/5",
+  },
+};
+
+function DimensionLabel({ dim }: { dim: string }) {
+  // Pretty-print the snake_case dimension names.
+  const pretty = dim
+    .split("_")
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(" ");
+  return <span className="font-heading text-xs uppercase tracking-wider text-text-muted">{pretty}</span>;
+}
+
+function ScoreCell({ score }: { score: AuditScore }) {
+  const warn = score.score < 5;
+  return (
+    <div
+      className={`rounded-lg border px-3 py-2 ${
+        warn ? "border-neon-yellow/30 bg-neon-yellow/5" : "border-neon-cyan/15 bg-bg-surface/40"
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <DimensionLabel dim={score.dimension} />
+        <span
+          className={`font-mono text-sm font-bold ${
+            warn ? "text-neon-yellow" : "text-text-primary"
+          }`}
+        >
+          {score.score}/10
+        </span>
+      </div>
+      <p className="mt-1 font-body text-xs text-text-muted leading-snug">{score.rationale}</p>
+    </div>
+  );
+}
+
+function FindingRow({ f }: { f: AuditFinding }) {
+  const severityStyle =
+    f.severity === "critical"
+      ? "text-neon-red border-neon-red/30 bg-neon-red/5"
+      : f.severity === "warning"
+        ? "text-neon-yellow border-neon-yellow/30 bg-neon-yellow/5"
+        : "text-text-muted border-neon-cyan/15 bg-bg-surface/30";
+  return (
+    <div className={`flex flex-col gap-1 rounded-lg border px-3 py-2 ${severityStyle}`}>
+      <div className="flex items-center gap-2">
+        <span className="font-heading text-[10px] uppercase tracking-wider">{f.severity}</span>
+        <DimensionLabel dim={f.dimension} />
+        {f.file && (
+          <span className="font-mono text-xs text-text-muted">
+            {f.file}
+            {typeof f.line === "number" ? `:${f.line}` : ""}
+          </span>
+        )}
+      </div>
+      <p className="font-body text-sm text-text-primary/90">{f.message}</p>
+    </div>
+  );
+}
+
+function AuditBannerInner({
+  record,
+  idOrName,
+  version,
+  isAdmin,
+  className,
+}: {
+  record: AuditRecord;
+  idOrName: string;
+  version?: string;
+  isAdmin: boolean;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const rerun = useRerunAudit();
+
+  const style = VERDICT_STYLE[record.verdict];
+  const createdAt = new Date(record.createdAt);
+  const timestampLabel = Number.isNaN(createdAt.getTime())
+    ? record.createdAt
+    : createdAt.toLocaleString();
+
+  const handleRerun = () => {
+    rerun.mutate({ idOrName, version, force: true });
+  };
+
+  return (
+    <div
+      role="status"
+      aria-label="Skill audit verdict"
+      className={`glass rounded-xl border ${style.ring} ${style.bg} ${className ?? ""}`}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-3 px-4 py-3 cursor-pointer"
+      >
+        <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${style.dot}`} />
+        <span className={`font-heading text-sm uppercase tracking-wider ${style.text}`}>
+          Audit · {style.label}
+        </span>
+        <span className="font-mono text-sm text-text-primary">
+          {record.overallScore.toFixed(1)} / 10
+        </span>
+        <span className="font-body text-xs text-text-muted hidden sm:inline">
+          · v{record.version} · {timestampLabel}
+        </span>
+        <div className="flex-1" />
+        {isAdmin && (
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!rerun.isPending) handleRerun();
+            }}
+            onKeyDown={(e) => {
+              if ((e.key === "Enter" || e.key === " ") && !rerun.isPending) {
+                e.stopPropagation();
+                handleRerun();
+              }
+            }}
+            className={`rounded-lg border border-neon-cyan/30 px-3 py-1 font-body text-xs text-text-primary transition-colors ${
+              rerun.isPending ? "opacity-50" : "hover:bg-neon-cyan/10 cursor-pointer"
+            }`}
+          >
+            {rerun.isPending ? t("audit.rerunning", "Rerunning…") : t("audit.rerun", "Rerun")}
+          </span>
+        )}
+        <svg
+          className={`h-4 w-4 shrink-0 text-text-muted transition-transform ${
+            expanded ? "rotate-180" : ""
+          }`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-neon-cyan/10 px-4 py-4 space-y-4">
+          <section>
+            <h4 className="mb-2 font-heading text-xs uppercase tracking-wider text-text-muted">
+              {t("audit.scoresHeading", "Scores by dimension")}
+            </h4>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {record.scores.map((s) => (
+                <ScoreCell key={s.dimension} score={s} />
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h4 className="mb-2 font-heading text-xs uppercase tracking-wider text-text-muted">
+              {t("audit.findingsHeading", "Findings")}
+              <span className="ml-2 font-mono text-text-muted normal-case tracking-normal">
+                ({record.findings.length})
+              </span>
+            </h4>
+            {record.findings.length === 0 ? (
+              <p className="font-body text-sm text-text-muted">
+                {t("audit.noFindings", "No findings — the auditor had nothing to flag.")}
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {record.findings.map((f, idx) => (
+                  <FindingRow key={`${f.dimension}-${idx}`} f={f} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          <p className="font-body text-xs text-text-muted">
+            {t("audit.model", "Model")}: <span className="font-mono">{record.model}</span>
+            {" · "}
+            {t("audit.triggeredBy", "Triggered by")}:{" "}
+            <span className="font-mono">{record.triggeredBy}</span>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AuditBanner({ idOrName, version, isAdmin, className }: AuditBannerProps) {
+  const { t } = useTranslation();
+  const { data: record, isLoading, isError } = useSkillAudit(idOrName, { version });
+  const rerun = useRerunAudit();
+
+  if (!idOrName || isLoading || isError) return null;
+
+  if (!record) {
+    // Not audited yet. Only admins get an affordance to kick off the first run.
+    if (!isAdmin) return null;
+    return (
+      <div
+        className={`glass flex items-center gap-3 rounded-xl border border-neon-cyan/15 bg-bg-surface/40 px-4 py-3 ${
+          className ?? ""
+        }`}
+      >
+        <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-text-muted" />
+        <span className="font-heading text-sm uppercase tracking-wider text-text-muted">
+          {t("audit.notRunYet", "Audit · not run yet")}
+        </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={() => rerun.mutate({ idOrName, version, force: true })}
+          disabled={rerun.isPending}
+          className="rounded-lg border border-neon-cyan/30 px-3 py-1 font-body text-xs text-text-primary transition-colors hover:bg-neon-cyan/10 cursor-pointer disabled:opacity-50"
+        >
+          {rerun.isPending
+            ? t("audit.running", "Running…")
+            : t("audit.runFirst", "Run audit")}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <AuditBannerInner
+      record={record}
+      idOrName={idOrName}
+      version={version}
+      isAdmin={isAdmin}
+      className={className}
+    />
+  );
+}

--- a/ornn-web/src/hooks/useAudit.ts
+++ b/ornn-web/src/hooks/useAudit.ts
@@ -1,0 +1,37 @@
+/**
+ * React Query hooks for the skill-audit endpoints.
+ *
+ * @module hooks/useAudit
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetchAudit, rerunAudit, type FetchAuditOptions } from "@/services/auditApi";
+import type { AuditRecord } from "@/types/audit";
+
+const auditKey = (idOrName: string, version?: string) =>
+  ["audit", idOrName, version ?? "__latest__"] as const;
+
+export function useSkillAudit(idOrName: string | undefined, opts: FetchAuditOptions = {}) {
+  return useQuery<AuditRecord | null>({
+    queryKey: auditKey(idOrName ?? "", opts.version),
+    queryFn: () => fetchAudit(idOrName!, opts),
+    enabled: Boolean(idOrName),
+    staleTime: 60_000,
+  });
+}
+
+export function useRerunAudit() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { idOrName: string; version?: string; force?: boolean }) =>
+      rerunAudit({ idOrName: vars.idOrName, force: vars.force }),
+    onSuccess: (record, vars) => {
+      // The server returns the fresh record synchronously — prime the
+      // cache so the banner updates immediately instead of waiting for
+      // the next refetch.
+      queryClient.setQueryData(auditKey(vars.idOrName, vars.version), record);
+      // Invalidate any related keys (notifications may reference audit events).
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+}

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/Badge";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { VersionPicker } from "@/components/skill/VersionPicker";
 import { DeprecationBanner } from "@/components/skill/DeprecationBanner";
+import { AuditBanner } from "@/components/skill/AuditBanner";
 import { SkillVersionList } from "@/components/skill/SkillVersionList";
 import { PermissionsModal } from "@/components/skill/PermissionsModal";
 import {
@@ -322,6 +323,13 @@ export function SkillDetailPage() {
           onViewLatest={() => handleVersionChange(null)}
         />
       )}
+      <AuditBanner
+        className="mb-3 shrink-0"
+        idOrName={skill.name || skill.guid}
+        version={skill.version}
+        isAdmin={isAdminUser}
+      />
+
       <div className="flex-1 min-h-0 grid gap-4 lg:grid-cols-[1fr_300px]">
         {/* Main content — Package Contents (fills available height) */}
         <Card className="flex flex-col min-h-0 overflow-hidden">

--- a/ornn-web/src/services/auditApi.ts
+++ b/ornn-web/src/services/auditApi.ts
@@ -1,0 +1,58 @@
+/**
+ * Skill audit endpoints — GET /api/v1/skills/:idOrName/audit and
+ * admin-only POST /api/v1/admin/skills/:idOrName/audit.
+ *
+ * @module services/auditApi
+ */
+
+import { apiGet, apiPost, ApiClientError } from "./apiClient";
+import type { AuditRecord } from "@/types/audit";
+
+export interface FetchAuditOptions {
+  /** Optional pin to a specific version; default = skill's latest. */
+  version?: string;
+}
+
+/**
+ * Fetch the latest cached audit. Returns `null` when the backend says
+ * AUDIT_NOT_FOUND (404) rather than throwing — the banner can then
+ * distinguish "no audit run yet" from "request failed".
+ */
+export async function fetchAudit(
+  idOrName: string,
+  opts: FetchAuditOptions = {},
+): Promise<AuditRecord | null> {
+  const params: Record<string, string | undefined> = {};
+  if (opts.version) params.version = opts.version;
+  try {
+    const res = await apiGet<AuditRecord>(
+      `/api/v1/skills/${encodeURIComponent(idOrName)}/audit`,
+      params,
+    );
+    return res.data ?? null;
+  } catch (err) {
+    if (err instanceof ApiClientError && err.code === "AUDIT_NOT_FOUND") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export interface RerunAuditInput {
+  idOrName: string;
+  /** Force cache bypass (default true — if someone clicks rerun they want a fresh run). */
+  force?: boolean;
+}
+
+/** Admin-only: force a fresh audit run. Returns the new record. */
+export async function rerunAudit({
+  idOrName,
+  force = true,
+}: RerunAuditInput): Promise<AuditRecord> {
+  const res = await apiPost<AuditRecord>(
+    `/api/v1/admin/skills/${encodeURIComponent(idOrName)}/audit`,
+    { force },
+  );
+  if (!res.data) throw new Error("Audit rerun returned no data");
+  return res.data;
+}

--- a/ornn-web/src/types/audit.ts
+++ b/ornn-web/src/types/audit.ts
@@ -1,0 +1,56 @@
+/**
+ * Skill audit types. Shape mirrors the backend's `AuditRecord` with
+ * `Date` fields serialized as ISO strings.
+ *
+ * @module types/audit
+ */
+
+export type AuditDimension =
+  | "security"
+  | "code_quality"
+  | "documentation"
+  | "reliability"
+  | "permission_scope";
+
+export const AUDIT_DIMENSIONS: readonly AuditDimension[] = [
+  "security",
+  "code_quality",
+  "documentation",
+  "reliability",
+  "permission_scope",
+] as const;
+
+export type AuditVerdict = "green" | "yellow" | "red";
+
+export type AuditSeverity = "info" | "warning" | "critical";
+
+export interface AuditScore {
+  dimension: AuditDimension;
+  /** 0–10 integer. */
+  score: number;
+  /** Short human-readable rationale (1–2 sentences). */
+  rationale: string;
+}
+
+export interface AuditFinding {
+  dimension: AuditDimension;
+  severity: AuditSeverity;
+  file?: string;
+  line?: number;
+  message: string;
+}
+
+export interface AuditRecord {
+  _id: string;
+  skillGuid: string;
+  version: string;
+  skillHash: string;
+  verdict: AuditVerdict;
+  /** 0–10 weighted average. */
+  overallScore: number;
+  scores: AuditScore[];
+  findings: AuditFinding[];
+  model: string;
+  createdAt: string;
+  triggeredBy: string;
+}


### PR DESCRIPTION
## Summary

Part two of the phase-3 frontend catch-up umbrella (#156). Surfaces the LLM-scored audit verdict the backend has been computing since #32 merged — users can finally see if a skill passed, has warnings, or was flagged.

### States

- **No audit yet** — hidden for regular users. Admins see a compact "Run audit" CTA that kicks off the first audit.
- **Audited** — verdict pill (pass / warnings / fail), overall 0–10 score, version + timestamp. Click to expand:
  - Per-dimension scores (security, code_quality, documentation, reliability, permission_scope) with the LLM's rationale.
  - Findings list grouped by severity (critical / warning / info) with file+line if provided.
- **Admin viewer** — "Rerun" button always visible. The mutation sync-primes the query cache so the banner updates immediately.

### Plumbing

- `types/audit.ts` mirrors the backend `AuditRecord` with `Date → ISO string`.
- `services/auditApi.ts` — `fetchAudit()` returns `null` on 404 AUDIT_NOT_FOUND so the banner can distinguish "not run yet" from "request failed". `rerunAudit()` posts to the admin endpoint with `force=true`.
- `hooks/useAudit.ts` — `useSkillAudit`, `useRerunAudit`. `staleTime: 60s` — audits only change on admin action.

### Visual

The banner follows the DeprecationBanner pattern (sits above the content grid, shrink-0, glass + colored ring) so the two stack cleanly when a skill is both deprecated *and* has an audit verdict.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` (vitest) — 11/11 pass
- [x] `bun run lint` — 0 errors (pre-existing warnings unchanged)
- [ ] Post-merge local deploy: open a skill with no audit → banner hidden for regular user / "Run audit" CTA for admin → click → banner flips to verdict state immediately → expand to see scores + findings

Closes #158. Progresses #156.