### PR TITLE
[Feature] GitHub import + refresh UI

### DIFF
--- a/.changeset/github-import-ui.md
+++ b/.changeset/github-import-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+frontend: GitHub import + refresh UI. Adds a fourth creation mode on `/skills/new` ("Import from GitHub") that pulls a public repo into Ornn via `POST /api/v1/skills/pull`. On `SkillDetailPage`, imported skills now show a compact origin chip (repo + commit + synced-at) with a one-click "Refresh from GitHub" action for owners/admins that calls `POST /api/v1/skills/:id/refresh`. Closes #159 from the phase-3 frontend catch-up umbrella (#156).

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -52,6 +52,9 @@ const CreateSkillFreePage = lazy(() =>
 const CreateSkillGenerativePage = lazy(() =>
   import("@/pages/CreateSkillGenerativePage").then((m) => ({ default: m.CreateSkillGenerativePage })),
 );
+const CreateSkillFromGitHubPage = lazy(() =>
+  import("@/pages/CreateSkillFromGitHubPage").then((m) => ({ default: m.CreateSkillFromGitHubPage })),
+);
 const EditSkillPage = lazy(() =>
   import("@/pages/EditSkillPage").then((m) => ({ default: m.EditSkillPage })),
 );
@@ -130,6 +133,7 @@ export function App() {
                   <Route path="/skills/new/guided" element={<CreateSkillGuidedPage />} />
                   <Route path="/skills/new/free" element={<CreateSkillFreePage />} />
                   <Route path="/skills/new/generate" element={<CreateSkillGenerativePage />} />
+                  <Route path="/skills/new/from-github" element={<CreateSkillFromGitHubPage />} />
                   <Route path="/skills/:id/edit" element={<EditSkillPage />} />
                   <Route path="/playground" element={<PlaygroundPage />} />
 

--- a/ornn-web/src/components/skill/GitHubOriginChip.tsx
+++ b/ornn-web/src/components/skill/GitHubOriginChip.tsx
@@ -1,0 +1,126 @@
+/**
+ * Chip on `SkillDetailPage` that flags "this skill was imported from GitHub"
+ * and offers owner/admin a one-click refresh.
+ *
+ * Hidden entirely for skills without a `source` pointer.
+ *
+ * @module components/skill/GitHubOriginChip
+ */
+
+import { useTranslation } from "react-i18next";
+import type { SkillSource } from "@/types/domain";
+
+interface GitHubOriginChipProps {
+  source: SkillSource | undefined;
+  /** True when the caller may trigger `/refresh` (owner or platform admin). */
+  canRefresh: boolean;
+  /** External-loading flag from the refresh mutation. */
+  isRefreshing: boolean;
+  onRefresh: () => void;
+  className?: string;
+}
+
+function GitHubMarkIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .5a11.5 11.5 0 00-3.64 22.42c.58.11.79-.25.79-.56v-2.16c-3.21.7-3.89-1.37-3.89-1.37-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.97.1-.76.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.72 0-1.26.45-2.3 1.19-3.11-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.92-.39 2.9-.39.99 0 1.98.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.11 3.06.74.81 1.19 1.85 1.19 3.11 0 4.45-2.7 5.42-5.28 5.71.41.35.78 1.05.78 2.12v3.14c0 .31.21.67.8.56A11.5 11.5 0 0012 .5z" />
+    </svg>
+  );
+}
+
+function RefreshIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M4 4v6h6M20 20v-6h-6M20 10a8 8 0 10-2.34 5.66L20 14"
+      />
+    </svg>
+  );
+}
+
+/** First 7 characters of a commit SHA; fall back to the raw input. */
+function shortSha(sha: string | undefined): string | null {
+  if (!sha) return null;
+  return sha.length > 7 ? sha.slice(0, 7) : sha;
+}
+
+export function GitHubOriginChip({
+  source,
+  canRefresh,
+  isRefreshing,
+  onRefresh,
+  className,
+}: GitHubOriginChipProps) {
+  const { t } = useTranslation();
+
+  if (!source || source.type !== "github") return null;
+
+  const sha = shortSha(source.lastSyncedCommit);
+  const refLabel = source.ref || "HEAD";
+  // Prefer the exact commit for deep-link stability; fall back to ref.
+  const treeRef = source.lastSyncedCommit || source.ref || "HEAD";
+  const pathSuffix = source.path ? `/${source.path.replace(/^\/+/, "")}` : "";
+  const repoUrl = `https://github.com/${source.repo}/tree/${treeRef}${pathSuffix}`;
+
+  const syncedAt = source.lastSyncedAt ? new Date(source.lastSyncedAt) : null;
+  const syncedLabel =
+    syncedAt && !Number.isNaN(syncedAt.getTime()) ? syncedAt.toLocaleString() : null;
+
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-3 rounded-lg border border-neon-cyan/20 bg-bg-surface/40 px-3 py-2 ${
+        className ?? ""
+      }`}
+    >
+      <GitHubMarkIcon className="h-4 w-4 text-text-primary" />
+      <span className="font-heading text-xs uppercase tracking-wider text-text-muted">
+        {t("githubOrigin.label", "Synced from GitHub")}
+      </span>
+      <a
+        href={repoUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="font-mono text-sm text-neon-cyan transition-colors hover:text-text-primary"
+        title={source.lastSyncedCommit || refLabel}
+      >
+        {source.repo}
+        {sha ? <span className="text-text-muted">@{sha}</span> : null}
+      </a>
+      <span className="font-body text-xs text-text-muted">
+        · {t("githubOrigin.ref", "ref")}:{" "}
+        <span className="font-mono">{refLabel}</span>
+        {source.path && (
+          <>
+            {" "}
+            · {t("githubOrigin.path", "path")}:{" "}
+            <span className="font-mono">{source.path}</span>
+          </>
+        )}
+      </span>
+      {syncedLabel && (
+        <span className="font-body text-xs text-text-muted">
+          · {t("githubOrigin.syncedAt", "synced")} {syncedLabel}
+        </span>
+      )}
+      <div className="flex-1" />
+      {canRefresh && (
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/30 px-3 py-1 font-body text-xs text-text-primary transition-colors hover:bg-neon-cyan/10 cursor-pointer disabled:opacity-50"
+        >
+          <RefreshIcon
+            className={`h-3.5 w-3.5 text-text-muted ${isRefreshing ? "animate-spin" : ""}`}
+          />
+          {isRefreshing
+            ? t("githubOrigin.refreshing", "Refreshing…")
+            : t("githubOrigin.refresh", "Refresh from GitHub")}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -8,6 +8,9 @@ import {
   updateSkillPackage,
   deleteSkill,
   setSkillVersionDeprecation,
+  pullSkillFromGitHub,
+  refreshSkillFromSource,
+  type PullFromGitHubInput,
 } from "@/services/skillApi";
 import { updateSkillPermissions, type SkillPermissionsInput } from "@/services/permissionsApi";
 import type { SkillSearchParams, SystemFilter } from "@/types/search";
@@ -170,6 +173,34 @@ export function useCreateSkill() {
       createSkill(zipFile, skipValidation),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
+    },
+  });
+}
+
+/** Pull a new skill from a public GitHub repo. */
+export function usePullSkillFromGitHub() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: PullFromGitHubInput) => pullSkillFromGitHub(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
+    },
+  });
+}
+
+/** Re-pull the skill's GitHub source and publish a fresh version. */
+export function useRefreshSkillFromSource(idOrName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (guid: string) => refreshSkillFromSource(guid),
+    onSuccess: (updated) => {
+      // Prime the detail cache with the refreshed payload so the chip
+      // updates in place.
+      queryClient.setQueryData([SKILLS_KEY, idOrName, undefined], updated);
+      queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [SKILL_VERSIONS_KEY, idOrName] });
       queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
     },
   });

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -145,7 +145,11 @@
     "genTitle": "Generative Mode",
     "genDesc": "Describe what you need and let AI generate a complete skill for you. Refine with chat.",
     "genBullets": ["AI-powered generation", "Real-time streaming", "Chat refinement", "Auto-structured output"],
-    "startGen": "Start Generative Mode"
+    "startGen": "Start Generative Mode",
+    "githubTitle": "Import from GitHub",
+    "githubDesc": "Pull a skill from a public GitHub repo. Later updates can be re-synced with one click.",
+    "githubBullets": ["Public repos only", "Branch / tag / commit pinning", "One-click resync", "No ZIP packaging needed"],
+    "startGithub": "Import from GitHub"
   },
   "guided": {
     "header": "CREATE SKILL",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -145,7 +145,11 @@
     "genTitle": "生成模式",
     "genDesc": "描述你的需求，让 AI 为你生成完整的技能。支持对话优化。",
     "genBullets": ["AI 驱动生成", "实时流式传输", "对话式优化", "自动结构化输出"],
-    "startGen": "开始生成模式"
+    "startGen": "开始生成模式",
+    "githubTitle": "从 GitHub 导入",
+    "githubDesc": "从公开的 GitHub 仓库拉取技能。后续更新可一键同步。",
+    "githubBullets": ["仅限公开仓库", "支持分支 / 标签 / commit", "一键重新同步", "无需手动打包"],
+    "startGithub": "从 GitHub 导入"
   },
   "guided": {
     "header": "创建技能",

--- a/ornn-web/src/pages/CreateSkillFromGitHubPage.tsx
+++ b/ornn-web/src/pages/CreateSkillFromGitHubPage.tsx
@@ -1,0 +1,231 @@
+/**
+ * /skills/new/from-github — create a skill by pulling a public GitHub repo.
+ *
+ * Thin wrapper around `POST /api/v1/skills/pull`: the backend does the
+ * cloning, zipping, and publication. This page just collects the repo
+ * coords and surfaces errors.
+ *
+ * @module pages/CreateSkillFromGitHubPage
+ */
+
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { ArrowLeftIcon } from "@/components/icons";
+import { usePullSkillFromGitHub } from "@/hooks/useSkills";
+import { useToastStore } from "@/stores/toastStore";
+
+const REPO_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?\/[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$/;
+
+function GitHubMarkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 .5a11.5 11.5 0 00-3.64 22.42c.58.11.79-.25.79-.56v-2.16c-3.21.7-3.89-1.37-3.89-1.37-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.97.1-.76.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.72 0-1.26.45-2.3 1.19-3.11-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.92-.39 2.9-.39.99 0 1.98.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.11 3.06.74.81 1.19 1.85 1.19 3.11 0 4.45-2.7 5.42-5.28 5.71.41.35.78 1.05.78 2.12v3.14c0 .31.21.67.8.56A11.5 11.5 0 0012 .5z" />
+    </svg>
+  );
+}
+
+export function CreateSkillFromGitHubPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const addToast = useToastStore((s) => s.addToast);
+  const pull = usePullSkillFromGitHub();
+
+  const [repo, setRepo] = useState("");
+  const [ref, setRef] = useState("");
+  const [path, setPath] = useState("");
+  const [skipValidation, setSkipValidation] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const repoValid = REPO_PATTERN.test(repo.trim());
+  const canSubmit = repoValid && !pull.isPending;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitted(true);
+    if (!repoValid) return;
+    try {
+      const skill = await pull.mutateAsync({
+        repo: repo.trim(),
+        ref: ref.trim() || undefined,
+        path: path.trim() || undefined,
+        skipValidation,
+      });
+      addToast({
+        type: "success",
+        message: t("githubImport.success", "Skill pulled from GitHub."),
+      });
+      navigate(`/skills/${skill.guid}`);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : t("githubImport.genericError", "Failed to pull from GitHub."),
+      });
+    }
+  };
+
+  return (
+    <PageTransition>
+      <div className="flex flex-col h-full py-2">
+        <div className="mx-auto w-full max-w-2xl">
+          <Link
+            to="/skills/new"
+            className="inline-flex items-center gap-2 font-body text-sm text-text-muted transition-colors hover:text-text-primary mb-4"
+          >
+            <ArrowLeftIcon className="h-4 w-4" />
+            {t("githubImport.backToModes", "Back to creation modes")}
+          </Link>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25 }}
+          >
+            <Card className="p-6">
+              <div className="flex items-start gap-4 mb-6">
+                <div className="rounded-2xl border border-neon-cyan/30 bg-neon-cyan/10 p-3">
+                  <GitHubMarkIcon className="h-8 w-8 text-neon-cyan" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h1 className="font-heading text-2xl text-neon-cyan">
+                    {t("githubImport.title", "Import from GitHub")}
+                  </h1>
+                  <p className="mt-1 font-body text-sm text-text-muted">
+                    {t(
+                      "githubImport.subtitle",
+                      "Publish a skill from a public GitHub repo. Later updates can be pulled in one click.",
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              <form onSubmit={handleSubmit} className="space-y-5">
+                <div>
+                  <label
+                    htmlFor="repo"
+                    className="mb-1 block font-heading text-xs uppercase tracking-wider text-text-muted"
+                  >
+                    {t("githubImport.repoLabel", "Repository")}{" "}
+                    <span className="text-neon-red">*</span>
+                  </label>
+                  <input
+                    id="repo"
+                    type="text"
+                    placeholder="owner/name"
+                    value={repo}
+                    onChange={(e) => setRepo(e.target.value)}
+                    className={`w-full rounded-lg border bg-bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 ${
+                      submitted && !repoValid
+                        ? "border-neon-red/40 focus:ring-neon-red/40"
+                        : "border-neon-cyan/20 focus:border-neon-cyan/60 focus:ring-neon-cyan/30"
+                    }`}
+                    autoComplete="off"
+                    spellCheck={false}
+                  />
+                  <p className="mt-1 font-body text-xs text-text-muted">
+                    {t(
+                      "githubImport.repoHint",
+                      "The repo must be public. Private repos are not yet supported.",
+                    )}
+                  </p>
+                  {submitted && !repoValid && (
+                    <p className="mt-1 font-body text-xs text-neon-red">
+                      {t(
+                        "githubImport.repoInvalid",
+                        "Expected format: owner/name (e.g. anthropics/claude-code).",
+                      )}
+                    </p>
+                  )}
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <label
+                      htmlFor="ref"
+                      className="mb-1 block font-heading text-xs uppercase tracking-wider text-text-muted"
+                    >
+                      {t("githubImport.refLabel", "Branch / tag / commit")}
+                    </label>
+                    <input
+                      id="ref"
+                      type="text"
+                      placeholder="main"
+                      value={ref}
+                      onChange={(e) => setRef(e.target.value)}
+                      className="w-full rounded-lg border border-neon-cyan/20 bg-bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-neon-cyan/60 focus:ring-2 focus:ring-neon-cyan/30"
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                    <p className="mt-1 font-body text-xs text-text-muted">
+                      {t("githubImport.refHint", "Leave blank to use the default branch.")}
+                    </p>
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="path"
+                      className="mb-1 block font-heading text-xs uppercase tracking-wider text-text-muted"
+                    >
+                      {t("githubImport.pathLabel", "Path in repo")}
+                    </label>
+                    <input
+                      id="path"
+                      type="text"
+                      placeholder="skills/my-skill"
+                      value={path}
+                      onChange={(e) => setPath(e.target.value)}
+                      className="w-full rounded-lg border border-neon-cyan/20 bg-bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-neon-cyan/60 focus:ring-2 focus:ring-neon-cyan/30"
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                    <p className="mt-1 font-body text-xs text-text-muted">
+                      {t(
+                        "githubImport.pathHint",
+                        "Sub-directory that contains SKILL.md. Leave blank for repo root.",
+                      )}
+                    </p>
+                  </div>
+                </div>
+
+                <label className="flex cursor-pointer items-center gap-2 font-body text-sm text-text-muted">
+                  <input
+                    type="checkbox"
+                    checked={skipValidation}
+                    onChange={(e) => setSkipValidation(e.target.checked)}
+                    className="h-4 w-4 accent-neon-cyan"
+                  />
+                  {t("githubImport.skipValidation", "Skip format validation (advanced)")}
+                </label>
+
+                <div className="flex items-center justify-end gap-3 pt-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => navigate("/skills/new")}
+                  >
+                    {t("common.cancel", "Cancel")}
+                  </Button>
+                  <Button type="submit" disabled={!canSubmit} loading={pull.isPending}>
+                    {t("githubImport.submit", "Import")}
+                  </Button>
+                </div>
+              </form>
+            </Card>
+          </motion.div>
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -11,6 +11,8 @@ import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { VersionPicker } from "@/components/skill/VersionPicker";
 import { DeprecationBanner } from "@/components/skill/DeprecationBanner";
 import { AuditBanner } from "@/components/skill/AuditBanner";
+import { GitHubOriginChip } from "@/components/skill/GitHubOriginChip";
+import { useRefreshSkillFromSource } from "@/hooks/useSkills";
 import { SkillVersionList } from "@/components/skill/SkillVersionList";
 import { PermissionsModal } from "@/components/skill/PermissionsModal";
 import {
@@ -58,6 +60,7 @@ export function SkillDetailPage() {
   const deleteMutation = useDeleteSkill();
   const updatePackageMutation = useUpdateSkillPackage(skill?.guid ?? "");
   const deprecationMutation = useSetVersionDeprecation(idOrName ?? "");
+  const refreshMutation = useRefreshSkillFromSource(idOrName ?? "");
 
   const {
     files: packageFiles,
@@ -329,6 +332,15 @@ export function SkillDetailPage() {
         version={skill.version}
         isAdmin={isAdminUser}
       />
+      {skill.source && (
+        <GitHubOriginChip
+          className="mb-3 shrink-0"
+          source={skill.source}
+          canRefresh={!!(isOwner || isAdminUser)}
+          isRefreshing={refreshMutation.isPending}
+          onRefresh={() => refreshMutation.mutate(skill.guid)}
+        />
+      )}
 
       <div className="flex-1 min-h-0 grid gap-4 lg:grid-cols-[1fr_300px]">
         {/* Main content — Package Contents (fills available height) */}

--- a/ornn-web/src/pages/UploadSkillPage.tsx
+++ b/ornn-web/src/pages/UploadSkillPage.tsx
@@ -53,6 +53,15 @@ function SparkleIcon({ className }: { className?: string }) {
   );
 }
 
+/** GitHub mark */
+function GitHubMarkIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .5a11.5 11.5 0 00-3.64 22.42c.58.11.79-.25.79-.56v-2.16c-3.21.7-3.89-1.37-3.89-1.37-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.97.1-.76.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.72 0-1.26.45-2.3 1.19-3.11-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.92-.39 2.9-.39.99 0 1.98.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.11 3.06.74.81 1.19 1.85 1.19 3.11 0 4.45-2.7 5.42-5.28 5.71.41.35.78 1.05.78 2.12v3.14c0 .31.21.67.8.56A11.5 11.5 0 0012 .5z" />
+    </svg>
+  );
+}
+
 interface ModeCardConfig {
   titleKey: string;
   descKey: string;
@@ -111,6 +120,20 @@ const MODE_CARDS: ModeCardConfig[] = [
     variant: "primary",
     delay: 0.3,
   },
+  {
+    titleKey: "upload.githubTitle",
+    descKey: "upload.githubDesc",
+    icon: GitHubMarkIcon,
+    accentColor: "text-neon-cyan",
+    accentBg: "bg-neon-cyan/10",
+    accentBorder: "border-neon-cyan/30",
+    accentGlow: "group-hover:shadow-[0_0_20px_rgba(34,211,238,0.3)]",
+    bulletsKey: "upload.githubBullets",
+    ctaKey: "upload.startGithub",
+    route: "/skills/new/from-github",
+    variant: "secondary",
+    delay: 0.4,
+  },
 ];
 
 export function UploadSkillPage() {
@@ -125,7 +148,7 @@ export function UploadSkillPage() {
           {t("upload.chooseMode")}
         </p>
 
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4">
           {MODE_CARDS.map((card) => {
             const Icon = card.icon;
             return (

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPut, apiDelete } from "./apiClient";
+import { apiGet, apiPost, apiPut, apiDelete } from "./apiClient";
 import type { UpdateSkillMetadata } from "@/types/api";
 import type { SkillDetail, SkillVersionEntry } from "@/types/domain";
 import { useAuthStore } from "@/stores/authStore";
@@ -146,4 +146,39 @@ export async function updateSkillPackage(id: string, zipFile: File, skipValidati
 /** Hard-delete a skill */
 export async function deleteSkill(id: string): Promise<void> {
   await apiDelete(`/api/v1/skills/${id}`);
+}
+
+export interface PullFromGitHubInput {
+  /** `owner/name`. */
+  repo: string;
+  /** Branch / tag / commit SHA. Omit for the repo default. */
+  ref?: string;
+  /** Subdirectory that contains `SKILL.md`. Omit for repo root. */
+  path?: string;
+  /** Skip the format-validation pass on the generated ZIP. */
+  skipValidation?: boolean;
+}
+
+/**
+ * Create a skill by cloning a public GitHub repo. Backend zips the tree,
+ * records the source pointer, and publishes as v1. Subsequent updates
+ * come via `refreshSkillFromSource`.
+ */
+export async function pullSkillFromGitHub(input: PullFromGitHubInput): Promise<SkillDetail> {
+  const res = await apiPost<SkillDetail>("/api/v1/skills/pull", {
+    repo: input.repo,
+    ref: input.ref,
+    path: input.path,
+    skip_validation: input.skipValidation ?? false,
+  });
+  return res.data!;
+}
+
+/**
+ * Re-pull the skill's GitHub source at the current ref HEAD and publish as
+ * a new version. Requires owner or platform admin.
+ */
+export async function refreshSkillFromSource(id: string): Promise<SkillDetail> {
+  const res = await apiPost<SkillDetail>(`/api/v1/skills/${id}/refresh`, {});
+  return res.data!;
 }

--- a/ornn-web/src/types/domain.ts
+++ b/ornn-web/src/types/domain.ts
@@ -12,6 +12,26 @@ export interface SkillSummary {
   updatedOn?: string;
 }
 
+/**
+ * Origin metadata for a skill that was pulled from an external source.
+ * Absent on hand-uploaded skills. `type` is a discriminator that keeps the
+ * door open for GitLab / Bitbucket variants without touching callers.
+ */
+export type SkillSource =
+  | {
+      type: "github";
+      /** `owner/name`. */
+      repo: string;
+      /** Branch, tag, or commit SHA originally requested. */
+      ref: string;
+      /** Subdirectory inside the repo that contains SKILL.md. Empty = repo root. */
+      path: string;
+      /** ISO timestamp of the most recent successful pull / refresh. */
+      lastSyncedAt: string;
+      /** Commit SHA fetched at `lastSyncedAt`. */
+      lastSyncedCommit: string;
+    };
+
 export interface SkillDetail extends SkillSummary {
   updatedOn: string;
   presignedPackageUrl: string;
@@ -26,6 +46,8 @@ export interface SkillDetail extends SkillSummary {
   sharedWithUsers: string[];
   /** Org user_ids this skill has been explicitly shared with. */
   sharedWithOrgs: string[];
+  /** Present when the skill was created (or last refreshed) by pulling from an external source. */
+  source?: SkillSource;
 }
 
 export interface SkillVersionEntry {


### PR DESCRIPTION
## Summary

Third PR of the phase-3 frontend catch-up umbrella (#156). Exposes the GitHub-sync backend (#57) in the web UI — users can now import a skill from a public repo and re-sync later with one click.

### Import path
- Fourth card on `/skills/new`: **Import from GitHub**. Accent-cyan, sits alongside Guided / Free / Generative. Grid switched to `xl:grid-cols-4` so the four modes line up on wide screens.
- New page `/skills/new/from-github`: simple form with `repo` (required, `owner/name` validated client-side), optional `ref` (branch / tag / commit; blank = default branch), optional `path` (sub-dir that contains `SKILL.md`; blank = repo root), and a "skip format validation" advanced toggle. Submit → `POST /api/v1/skills/pull` → toast + redirect to the new skill.

### Refresh path on SkillDetailPage
- `GitHubOriginChip` renders for any skill whose `source` is GitHub: repo link deep-linked to the exact commit SHA, plus ref / path / last-synced timestamp.
- Owner or platform admin also see a **Refresh from GitHub** action that calls `POST /api/v1/skills/:id/refresh`. The mutation primes the skill-detail cache so the chip updates in place (new commit SHA) without a manual refetch.

### Plumbing
- `SkillDetail` gains optional `source: SkillSource` (discriminated union — `type: "github"` today).
- `skillApi.ts` exports `pullSkillFromGitHub(input)` and `refreshSkillFromSource(id)`.
- `useSkills.ts` exports `usePullSkillFromGitHub` and `useRefreshSkillFromSource` (invalidates detail + versions on success, primes detail cache).
- i18n keys in `en.json` + `zh.json` for the new mode card and the form labels.

### Out of scope
- Private repo auth (needs a product decision on token handling).
- Scheduled / webhook auto-refresh.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` (vitest) — 11/11 pass
- [x] `bun run lint` — 0 errors (pre-existing warnings unchanged)
- [ ] Post-merge local deploy:
  - [ ] `/skills/new` shows four cards; fourth = Import from GitHub
  - [ ] Form validates repo as \`owner/name\`
  - [ ] Successful import redirects to new skill; origin chip visible
  - [ ] As owner, "Refresh from GitHub" pulls a new version; chip updates to new commit SHA

Closes #159. Progresses #156.