### PR TITLE
[Feature] Per-skill analytics card on SkillDetailPage

### DIFF
--- a/.changeset/analytics-ui.md
+++ b/.changeset/analytics-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+frontend: per-skill analytics card on `SkillDetailPage`. Shows execution count, success rate with outcome breakdown (ok / fail / timeout), p50 + p95 latency (p99 in hint), unique users, and top error codes for a rolling window (7d / 30d / all). Graceful empty state for skills with no executions yet. Wires up the already-shipped `GET /api/v1/skills/:idOrName/analytics` endpoint; closes #161 from the phase-3 frontend catch-up umbrella (#156).

--- a/ornn-web/src/components/skill/AnalyticsCard.tsx
+++ b/ornn-web/src/components/skill/AnalyticsCard.tsx
@@ -1,0 +1,173 @@
+/**
+ * Per-skill analytics card for `SkillDetailPage`.
+ *
+ * Renders execution count, success rate, p50/p95 latency, unique users,
+ * outcome breakdown, and top error codes for a chosen rolling window
+ * (7d / 30d / all). Gracefully shows an empty state for skills that
+ * haven't been invoked yet.
+ *
+ * @module components/skill/AnalyticsCard
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSkillAnalytics } from "@/hooks/useAnalytics";
+import type { AnalyticsWindow } from "@/types/analytics";
+
+const WINDOWS: ReadonlyArray<{ key: AnalyticsWindow; labelKey: string; fallback: string }> = [
+  { key: "7d", labelKey: "analytics.window7d", fallback: "7d" },
+  { key: "30d", labelKey: "analytics.window30d", fallback: "30d" },
+  { key: "all", labelKey: "analytics.windowAll", fallback: "All time" },
+];
+
+function formatMs(ms: number | null): string {
+  if (ms === null) return "—";
+  if (ms >= 1000) return `${(ms / 1000).toFixed(ms >= 10_000 ? 1 : 2)} s`;
+  return `${Math.round(ms)} ms`;
+}
+
+function formatPercent(rate: number | null): string {
+  if (rate === null) return "—";
+  return `${(rate * 100).toFixed(rate >= 0.995 ? 0 : 1)}%`;
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string | number;
+  hint?: string;
+}) {
+  return (
+    <div>
+      <p className="font-heading text-[11px] uppercase tracking-wider text-text-muted mb-0.5">
+        {label}
+      </p>
+      <p className="font-heading text-lg text-text-primary leading-tight">{value}</p>
+      {hint && <p className="font-body text-xs text-text-muted mt-0.5">{hint}</p>}
+    </div>
+  );
+}
+
+interface AnalyticsCardProps {
+  idOrName: string | undefined;
+  className?: string;
+}
+
+export function AnalyticsCard({ idOrName, className }: AnalyticsCardProps) {
+  const { t } = useTranslation();
+  const [windowChoice, setWindowChoice] = useState<AnalyticsWindow>("30d");
+  const { data, isLoading, isError } = useSkillAnalytics(idOrName, windowChoice);
+
+  if (!idOrName) return null;
+
+  const showEmpty = !isLoading && !isError && data && data.executionCount === 0;
+
+  return (
+    <div className={`glass rounded-xl p-5 space-y-4 ${className ?? ""}`}>
+      <div className="flex items-center justify-between gap-3">
+        <p className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+          {t("analytics.heading", "Usage")}
+        </p>
+        <div className="flex overflow-hidden rounded-md border border-neon-cyan/20">
+          {WINDOWS.map((w) => (
+            <button
+              key={w.key}
+              type="button"
+              onClick={() => setWindowChoice(w.key)}
+              className={`px-2 py-0.5 font-mono text-[11px] transition-colors cursor-pointer ${
+                windowChoice === w.key
+                  ? "bg-neon-cyan/15 text-neon-cyan"
+                  : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              {t(w.labelKey, w.fallback)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <p className="font-body text-sm text-text-muted">{t("analytics.loading", "Loading…")}</p>
+      ) : isError ? (
+        <p className="font-body text-sm text-neon-red">
+          {t("analytics.loadFailed", "Could not load analytics.")}
+        </p>
+      ) : !data ? (
+        <p className="font-body text-sm text-text-muted">
+          {t("analytics.unavailable", "Analytics unavailable for this skill.")}
+        </p>
+      ) : showEmpty ? (
+        <p className="font-body text-sm text-text-muted">
+          {t(
+            "analytics.empty",
+            "No executions recorded in this window yet.",
+          )}
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+            <Stat
+              label={t("analytics.executions", "Executions")}
+              value={data.executionCount.toLocaleString()}
+              hint={
+                data.uniqueUsers > 0
+                  ? t("analytics.uniqueUsers", "{{count}} unique users", {
+                      count: data.uniqueUsers,
+                    })
+                  : undefined
+              }
+            />
+            <Stat
+              label={t("analytics.successRate", "Success rate")}
+              value={formatPercent(data.successRate)}
+              hint={t("analytics.outcomeBreakdown", "{{ok}} ok · {{fail}} fail · {{to}} timeout", {
+                ok: data.successCount,
+                fail: data.failureCount,
+                to: data.timeoutCount,
+              })}
+            />
+            <Stat
+              label={t("analytics.p50", "p50 latency")}
+              value={formatMs(data.latencyMs.p50)}
+            />
+            <Stat
+              label={t("analytics.p95", "p95 latency")}
+              value={formatMs(data.latencyMs.p95)}
+              hint={
+                data.latencyMs.p99 !== null
+                  ? t("analytics.p99Hint", "p99 {{value}}", {
+                      value: formatMs(data.latencyMs.p99),
+                    })
+                  : undefined
+              }
+            />
+          </div>
+
+          {data.topErrorCodes.length > 0 && (
+            <div>
+              <p className="font-heading text-[11px] uppercase tracking-wider text-text-muted mb-1.5">
+                {t("analytics.topErrors", "Top errors")}
+              </p>
+              <ul className="space-y-1">
+                {data.topErrorCodes.slice(0, 5).map((e) => (
+                  <li
+                    key={e.code}
+                    className="flex items-center justify-between gap-3 rounded-md border border-neon-red/20 bg-neon-red/5 px-2 py-1"
+                  >
+                    <span className="font-mono text-xs text-neon-red truncate">{e.code}</span>
+                    <span className="font-mono text-xs text-text-muted shrink-0">
+                      ×{e.count}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/ornn-web/src/hooks/useAnalytics.ts
+++ b/ornn-web/src/hooks/useAnalytics.ts
@@ -1,0 +1,21 @@
+/**
+ * React Query hook for per-skill analytics.
+ *
+ * @module hooks/useAnalytics
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchSkillAnalytics } from "@/services/analyticsApi";
+import type { AnalyticsWindow, SkillAnalyticsSummary } from "@/types/analytics";
+
+export function useSkillAnalytics(
+  idOrName: string | undefined,
+  window: AnalyticsWindow = "30d",
+) {
+  return useQuery<SkillAnalyticsSummary | null>({
+    queryKey: ["analytics", idOrName ?? "", window] as const,
+    queryFn: () => fetchSkillAnalytics(idOrName!, { window }),
+    enabled: Boolean(idOrName),
+    staleTime: 60_000,
+  });
+}

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -12,6 +12,7 @@ import { VersionPicker } from "@/components/skill/VersionPicker";
 import { DeprecationBanner } from "@/components/skill/DeprecationBanner";
 import { AuditBanner } from "@/components/skill/AuditBanner";
 import { GitHubOriginChip } from "@/components/skill/GitHubOriginChip";
+import { AnalyticsCard } from "@/components/skill/AnalyticsCard";
 import { useRefreshSkillFromSource } from "@/hooks/useSkills";
 import { SkillVersionList } from "@/components/skill/SkillVersionList";
 import { PermissionsModal } from "@/components/skill/PermissionsModal";
@@ -552,6 +553,8 @@ export function SkillDetailPage() {
               isMutating={deprecationMutation.isPending}
             />
           )}
+
+          <AnalyticsCard idOrName={skill.name || skill.guid} />
         </div>
       </div>
 

--- a/ornn-web/src/services/analyticsApi.ts
+++ b/ornn-web/src/services/analyticsApi.ts
@@ -1,0 +1,25 @@
+/**
+ * Skill analytics endpoints — `/api/v1/skills/:idOrName/analytics`.
+ *
+ * @module services/analyticsApi
+ */
+
+import { apiGet } from "./apiClient";
+import type { AnalyticsWindow, SkillAnalyticsSummary } from "@/types/analytics";
+
+export interface FetchAnalyticsOptions {
+  window?: AnalyticsWindow;
+}
+
+export async function fetchSkillAnalytics(
+  idOrName: string,
+  opts: FetchAnalyticsOptions = {},
+): Promise<SkillAnalyticsSummary | null> {
+  const params: Record<string, string | undefined> = {};
+  if (opts.window) params.window = opts.window;
+  const res = await apiGet<SkillAnalyticsSummary>(
+    `/api/v1/skills/${encodeURIComponent(idOrName)}/analytics`,
+    params,
+  );
+  return res.data ?? null;
+}

--- a/ornn-web/src/types/analytics.ts
+++ b/ornn-web/src/types/analytics.ts
@@ -1,0 +1,27 @@
+/**
+ * Skill-analytics types. Mirrors the backend `SkillAnalyticsSummary`.
+ *
+ * @module types/analytics
+ */
+
+export type AnalyticsWindow = "7d" | "30d" | "all";
+
+export interface SkillAnalyticsLatency {
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+}
+
+export interface SkillAnalyticsSummary {
+  skillGuid: string;
+  window: AnalyticsWindow;
+  executionCount: number;
+  successCount: number;
+  failureCount: number;
+  timeoutCount: number;
+  /** Decimal in [0, 1]; `null` when no executions. */
+  successRate: number | null;
+  latencyMs: SkillAnalyticsLatency;
+  uniqueUsers: number;
+  topErrorCodes: Array<{ code: string; count: number }>;
+}


### PR DESCRIPTION
## Summary

Fourth PR of the phase-3 frontend catch-up umbrella (#156). Exposes the already-shipped analytics backend (#34) on SkillDetailPage — authors and readers can finally see how a skill has been used.

### Card content

Sidebar column, below the version list. Stats for the selected rolling window:

- **Executions** — total count, with unique-users count as a hint.
- **Success rate** — rendered as `%` with decimal precision tuned to how close to 100%; outcome breakdown (`ok · fail · timeout`) as hint.
- **p50 latency** and **p95 latency**; p99 piggybacks as a hint under p95.
- **Top 5 error codes** — list only shown when backend returns non-empty `topErrorCodes`.

Window toggle: **7d / 30d / all** — maps 1:1 to the backend's `?window=` param.

### Empty / failure states

- `executionCount === 0` → "No executions recorded in this window yet."
- `isError` → "Could not load analytics."
- Anonymous user viewing a private skill → backend returns 404, which `fetchSkillAnalytics` normalizes to `null`; card renders "Analytics unavailable for this skill."

### Plumbing

- `types/analytics.ts` mirrors `SkillAnalyticsSummary` 1:1 (p50/p95/p99 nullable, successRate nullable).
- `services/analyticsApi.ts` — `fetchSkillAnalytics(idOrName, { window })`.
- `hooks/useAnalytics.ts` — `useSkillAnalytics(idOrName, window)`. `staleTime: 60s` — usage counts don't need sub-minute freshness.

### Out of scope

- Time-series chart (backend returns aggregate counters only).
- CSV export.
- Admin rollup / top-skills board (separate future work).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` (vitest) — 11/11 pass
- [x] `bun run lint` — 0 errors (pre-existing warnings unchanged)
- [ ] Post-merge local deploy:
  - [ ] Open a skill with playground usage → card shows numbers
  - [ ] Toggle window between 7d / 30d / all → values change
  - [ ] Open a skill with no executions → graceful empty state

Closes #161. Progresses #156.