### PR TITLE
[Feature] Audit-gated share workflow — PR 1/3 (modal + inline status)

### DIFF
--- a/.changeset/shares-modal-ui.md
+++ b/.changeset/shares-modal-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+frontend: audit-gated share workflow — PR 1/3. Adds a "Share (audit-gated)" button on `SkillDetailPage` that opens a target picker (user / org / public), fires `POST /api/v1/skills/:idOrName/share`, and surfaces the caller's in-flight requests for this skill inline with status badges and a cancel action. The `/shares/:requestId` detail view and reviewer queue land in follow-up PRs (#160b / #160c). Progresses #160 from the phase-3 frontend catch-up umbrella (#156).

--- a/ornn-web/src/components/skill/InFlightShareRequests.tsx
+++ b/ornn-web/src/components/skill/InFlightShareRequests.tsx
@@ -1,0 +1,168 @@
+/**
+ * Inline list of the caller's share requests for the current skill.
+ * Renders under the metadata column on `SkillDetailPage`. Each row shows
+ * the request's target, status, and offers a Cancel button while the
+ * request is still pending.
+ *
+ * Full detail view (audit findings + justification + reviewer decision)
+ * lives at `/shares/:requestId` — this component just links there.
+ *
+ * @module components/skill/InFlightShareRequests
+ */
+
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useCancelShareRequest, useMyShareRequests } from "@/hooks/useShares";
+import { CANCELLABLE_STATUSES, type ShareRequest, type ShareStatus } from "@/types/shares";
+import { useToastStore } from "@/stores/toastStore";
+
+const STATUS_STYLE: Record<
+  ShareStatus,
+  { label: string; text: string; bg: string; ring: string }
+> = {
+  "pending-audit": {
+    label: "Auditing",
+    text: "text-neon-cyan",
+    bg: "bg-neon-cyan/10",
+    ring: "border-neon-cyan/30",
+  },
+  green: {
+    label: "Green — awaiting apply",
+    text: "text-neon-cyan",
+    bg: "bg-neon-cyan/10",
+    ring: "border-neon-cyan/30",
+  },
+  "needs-justification": {
+    label: "Needs justification",
+    text: "text-neon-yellow",
+    bg: "bg-neon-yellow/10",
+    ring: "border-neon-yellow/30",
+  },
+  "pending-review": {
+    label: "Pending review",
+    text: "text-neon-yellow",
+    bg: "bg-neon-yellow/10",
+    ring: "border-neon-yellow/30",
+  },
+  accepted: {
+    label: "Accepted",
+    text: "text-neon-cyan",
+    bg: "bg-neon-cyan/5",
+    ring: "border-neon-cyan/20",
+  },
+  rejected: {
+    label: "Rejected",
+    text: "text-neon-red",
+    bg: "bg-neon-red/5",
+    ring: "border-neon-red/20",
+  },
+  cancelled: {
+    label: "Cancelled",
+    text: "text-text-muted",
+    bg: "bg-bg-surface/40",
+    ring: "border-neon-cyan/10",
+  },
+};
+
+function targetLabel(req: ShareRequest): string {
+  if (req.target.type === "public") return "Public";
+  if (req.target.type === "org") return `Org ${req.target.id ?? ""}`.trim();
+  return `User ${req.target.id ?? ""}`.trim();
+}
+
+interface InFlightShareRequestsProps {
+  /** Current skill's guid — used to filter the caller's request list. */
+  skillGuid: string;
+  className?: string;
+}
+
+export function InFlightShareRequests({ skillGuid, className }: InFlightShareRequestsProps) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+  const { data: requests = [], isLoading } = useMyShareRequests();
+  const cancelMutation = useCancelShareRequest();
+
+  const forThisSkill = useMemo(
+    () =>
+      requests
+        .filter((r) => r.skillGuid === skillGuid)
+        // Newest first so the active request is always on top.
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
+    [requests, skillGuid],
+  );
+
+  if (isLoading || forThisSkill.length === 0) return null;
+
+  const handleCancel = async (req: ShareRequest) => {
+    try {
+      await cancelMutation.mutateAsync(req._id);
+      addToast({
+        type: "success",
+        message: t("share.cancelled", "Share request cancelled."),
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : t("share.cancelFailed", "Failed to cancel."),
+      });
+    }
+  };
+
+  return (
+    <div className={`glass rounded-xl p-5 space-y-3 ${className ?? ""}`}>
+      <p className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+        {t("share.myRequestsHeading", "Your share requests for this skill")}
+      </p>
+      <ul className="space-y-2">
+        {forThisSkill.map((req) => {
+          const style = STATUS_STYLE[req.status];
+          const canCancel = CANCELLABLE_STATUSES.has(req.status);
+          return (
+            <li
+              key={req._id}
+              className={`flex flex-wrap items-center justify-between gap-2 rounded-lg border ${style.ring} ${style.bg} px-3 py-2`}
+            >
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`font-heading text-[10px] uppercase tracking-wider ${style.text}`}
+                  >
+                    {style.label}
+                  </span>
+                  <span className="font-body text-xs text-text-muted truncate">
+                    · {targetLabel(req)}
+                  </span>
+                </div>
+                <span className="font-mono text-xs text-text-muted">
+                  {new Date(req.createdAt).toLocaleString()}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Link
+                  to={`/shares/${req._id}`}
+                  className="rounded-md border border-neon-cyan/20 px-2 py-1 font-body text-xs text-text-muted transition-colors hover:text-text-primary"
+                >
+                  {t("share.viewDetails", "Details")}
+                </Link>
+                {canCancel && (
+                  <button
+                    type="button"
+                    onClick={() => handleCancel(req)}
+                    disabled={cancelMutation.isPending}
+                    className="rounded-md border border-neon-red/30 px-2 py-1 font-body text-xs text-neon-red transition-colors hover:bg-neon-red/10 cursor-pointer disabled:opacity-50"
+                  >
+                    {t("share.cancel", "Cancel")}
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/ornn-web/src/components/skill/ShareModal.tsx
+++ b/ornn-web/src/components/skill/ShareModal.tsx
@@ -1,0 +1,290 @@
+/**
+ * ShareModal — opens from SkillDetailPage to start an audit-gated share
+ * request. Distinct from `PermissionsModal`, which edits the static
+ * `sharedWithUsers` / `sharedWithOrgs` allow-list without audit.
+ *
+ * Target types:
+ *   - user:   single NyxID user_id, selected via email typeahead.
+ *   - org:    dropdown of caller's NyxID orgs (admin / member).
+ *   - public: no picker; warns that the audit engine will run.
+ *
+ * Submit fires `POST /api/v1/skills/:idOrName/share`. After success the
+ * modal closes; the caller's inline in-flight request list picks the
+ * new row up on the next poll.
+ *
+ * @module components/skill/ShareModal
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { useMyOrgs } from "@/hooks/useMe";
+import { useInitiateShare } from "@/hooks/useShares";
+import { useToastStore } from "@/stores/toastStore";
+import {
+  searchUsersByEmail,
+  type UserDirectoryEntry,
+} from "@/services/usersApi";
+import type { ShareTargetType } from "@/types/shares";
+
+interface ShareModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  skillIdOrName: string;
+  skillName: string;
+}
+
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(t);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+type TargetChoice =
+  | { type: "user"; user: UserDirectoryEntry | null }
+  | { type: "org"; orgId: string }
+  | { type: "public" };
+
+export function ShareModal({
+  isOpen,
+  onClose,
+  skillIdOrName,
+  skillName,
+}: ShareModalProps) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+  const { data: myOrgs = [] } = useMyOrgs();
+  const mutation = useInitiateShare();
+
+  const [tab, setTab] = useState<ShareTargetType>("user");
+  const [pickedUser, setPickedUser] = useState<UserDirectoryEntry | null>(null);
+  const [userQuery, setUserQuery] = useState("");
+  const [orgId, setOrgId] = useState<string>("");
+
+  // Reset on (re)open so the form doesn't carry state from a prior skill.
+  useEffect(() => {
+    if (!isOpen) return;
+    setTab("user");
+    setPickedUser(null);
+    setUserQuery("");
+    setOrgId(myOrgs[0]?.userId ?? "");
+  }, [isOpen, myOrgs]);
+
+  const debouncedQuery = useDebouncedValue(userQuery.trim(), 200);
+  const userResults = useQuery<UserDirectoryEntry[]>({
+    queryKey: ["users", "search", debouncedQuery] as const,
+    queryFn: () => searchUsersByEmail(debouncedQuery, 8),
+    enabled: tab === "user" && debouncedQuery.length >= 2,
+    staleTime: 30_000,
+  });
+
+  const choice = useMemo<TargetChoice>(() => {
+    if (tab === "public") return { type: "public" };
+    if (tab === "org") return { type: "org", orgId };
+    return { type: "user", user: pickedUser };
+  }, [tab, orgId, pickedUser]);
+
+  const canSubmit =
+    (choice.type === "public") ||
+    (choice.type === "org" && choice.orgId !== "") ||
+    (choice.type === "user" && choice.user !== null);
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    try {
+      const input =
+        choice.type === "public"
+          ? { targetType: "public" as const }
+          : choice.type === "org"
+            ? { targetType: "org" as const, targetId: choice.orgId }
+            : { targetType: "user" as const, targetId: choice.user!.userId };
+
+      await mutation.mutateAsync({ skillIdOrName, input });
+      addToast({
+        type: "success",
+        message: t("share.initiated", "Share request initiated."),
+      });
+      onClose();
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : t("share.initiateFailed", "Failed to initiate share."),
+      });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t("share.title", "Share skill")}>
+      <p className="font-body text-sm text-text-muted mb-5">
+        {t(
+          "share.subtitle",
+          "Share '{{skillName}}' with a user, an org, or the public. Audit findings (if any) will be surfaced and reviewed before access is granted.",
+          { skillName },
+        )}
+      </p>
+
+      {/* Target-type segmented control */}
+      <div className="mb-4 grid grid-cols-3 overflow-hidden rounded-lg border border-neon-cyan/20 bg-bg-surface/40">
+        {([
+          ["user", t("share.targetUser", "A user")],
+          ["org", t("share.targetOrg", "An org")],
+          ["public", t("share.targetPublic", "Public")],
+        ] as const).map(([key, label]) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setTab(key)}
+            className={`px-3 py-2 font-body text-sm transition-colors cursor-pointer ${
+              tab === key
+                ? "bg-neon-cyan/15 text-neon-cyan"
+                : "text-text-muted hover:text-text-primary"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Target picker */}
+      <div className="mb-6 space-y-2">
+        {tab === "user" && (
+          <>
+            <label
+              htmlFor="share-user"
+              className="block font-heading text-[11px] uppercase tracking-wider text-text-muted"
+            >
+              {t("share.pickUser", "Pick a user")}
+            </label>
+            {pickedUser ? (
+              <div className="flex items-center justify-between rounded-lg border border-neon-cyan/20 bg-bg-surface/40 px-3 py-2">
+                <div className="min-w-0">
+                  <p className="font-body text-sm text-text-primary truncate">
+                    {pickedUser.displayName || pickedUser.email}
+                  </p>
+                  <p className="font-mono text-xs text-text-muted truncate">
+                    {pickedUser.email || pickedUser.userId}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPickedUser(null);
+                    setUserQuery("");
+                  }}
+                  className="font-body text-xs text-text-muted transition-colors hover:text-neon-red cursor-pointer"
+                >
+                  {t("share.removeUser", "Remove")}
+                </button>
+              </div>
+            ) : (
+              <>
+                <input
+                  id="share-user"
+                  type="text"
+                  placeholder={t("share.userPlaceholder", "Start typing an email…") as string}
+                  value={userQuery}
+                  onChange={(e) => setUserQuery(e.target.value)}
+                  className="w-full rounded-lg border border-neon-cyan/20 bg-bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-neon-cyan/60 focus:ring-2 focus:ring-neon-cyan/30"
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                {debouncedQuery.length >= 2 && (
+                  <div className="max-h-48 overflow-y-auto rounded-lg border border-neon-cyan/15 bg-bg-surface/40">
+                    {userResults.isLoading ? (
+                      <p className="px-3 py-2 font-body text-xs text-text-muted">
+                        {t("share.userSearching", "Searching…")}
+                      </p>
+                    ) : userResults.data && userResults.data.length > 0 ? (
+                      userResults.data.map((u) => (
+                        <button
+                          key={u.userId}
+                          type="button"
+                          onClick={() => setPickedUser(u)}
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-neon-cyan/5 cursor-pointer"
+                        >
+                          <span className="font-body text-sm text-text-primary truncate">
+                            {u.displayName || u.email}
+                          </span>
+                          <span className="font-mono text-xs text-text-muted truncate">
+                            {u.email}
+                          </span>
+                        </button>
+                      ))
+                    ) : (
+                      <p className="px-3 py-2 font-body text-xs text-text-muted">
+                        {t("share.userNoMatch", "No users matched.")}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+
+        {tab === "org" && (
+          <>
+            <label
+              htmlFor="share-org"
+              className="block font-heading text-[11px] uppercase tracking-wider text-text-muted"
+            >
+              {t("share.pickOrg", "Pick an org")}
+            </label>
+            {myOrgs.length === 0 ? (
+              <p className="rounded-lg border border-neon-yellow/30 bg-neon-yellow/5 px-3 py-2 font-body text-sm text-text-muted">
+                {t(
+                  "share.noOrgs",
+                  "You're not a member of any orgs. Join an org on NyxID first.",
+                )}
+              </p>
+            ) : (
+              <select
+                id="share-org"
+                value={orgId}
+                onChange={(e) => setOrgId(e.target.value)}
+                className="w-full rounded-lg border border-neon-cyan/20 bg-bg-surface px-3 py-2 font-body text-sm text-text-primary focus:outline-none focus:border-neon-cyan/60 focus:ring-2 focus:ring-neon-cyan/30"
+              >
+                {myOrgs.map((o) => (
+                  <option key={o.userId} value={o.userId}>
+                    {o.displayName} ({o.role})
+                  </option>
+                ))}
+              </select>
+            )}
+          </>
+        )}
+
+        {tab === "public" && (
+          <div className="rounded-lg border border-neon-yellow/30 bg-neon-yellow/5 px-3 py-3 font-body text-sm text-text-primary">
+            {t(
+              "share.publicWarning",
+              "Publishing to the public triggers an audit. If the verdict is anything other than green, you'll need to submit justifications and an Ornn admin reviews before access is granted.",
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-3">
+        <Button variant="secondary" size="sm" onClick={onClose}>
+          {t("common.cancel", "Cancel")}
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!canSubmit || mutation.isPending}
+          loading={mutation.isPending}
+        >
+          {t("share.submit", "Initiate share")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/ornn-web/src/hooks/useShares.ts
+++ b/ornn-web/src/hooks/useShares.ts
@@ -1,0 +1,110 @@
+/**
+ * React Query hooks for the audit-gated sharing workflow.
+ *
+ * @module hooks/useShares
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  cancelShareRequest,
+  fetchMyShareRequests,
+  fetchShareRequest,
+  fetchShareReviewQueue,
+  initiateShare,
+  reviewShareRequest,
+  submitShareJustification,
+} from "@/services/sharesApi";
+import type {
+  InitiateShareInput,
+  ReviewDecisionInput,
+  ShareRequest,
+  SubmitJustificationInput,
+} from "@/types/shares";
+import { useIsAuthenticated } from "@/stores/authStore";
+
+const MY_SHARES_KEY = ["shares", "mine"] as const;
+const REVIEW_QUEUE_KEY = ["shares", "review-queue"] as const;
+const shareKey = (requestId: string) => ["shares", "one", requestId] as const;
+
+export function useMyShareRequests() {
+  const isAuthed = useIsAuthenticated();
+  return useQuery<ShareRequest[]>({
+    queryKey: MY_SHARES_KEY,
+    queryFn: fetchMyShareRequests,
+    enabled: isAuthed,
+    staleTime: 15_000,
+  });
+}
+
+export function useShareReviewQueue() {
+  const isAuthed = useIsAuthenticated();
+  return useQuery<ShareRequest[]>({
+    queryKey: REVIEW_QUEUE_KEY,
+    queryFn: fetchShareReviewQueue,
+    enabled: isAuthed,
+    staleTime: 15_000,
+  });
+}
+
+export function useShareRequest(requestId: string | undefined) {
+  return useQuery<ShareRequest | null>({
+    queryKey: shareKey(requestId ?? ""),
+    queryFn: () => fetchShareRequest(requestId!),
+    enabled: Boolean(requestId),
+    staleTime: 15_000,
+  });
+}
+
+export function useInitiateShare() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { skillIdOrName: string; input: InitiateShareInput }) =>
+      initiateShare(vars.skillIdOrName, vars.input),
+    onSuccess: (created) => {
+      queryClient.setQueryData(shareKey(created._id), created);
+      queryClient.invalidateQueries({ queryKey: MY_SHARES_KEY });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+}
+
+export function useCancelShareRequest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (requestId: string) => cancelShareRequest(requestId),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(shareKey(updated._id), updated);
+      queryClient.invalidateQueries({ queryKey: MY_SHARES_KEY });
+      queryClient.invalidateQueries({ queryKey: REVIEW_QUEUE_KEY });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+}
+
+export function useSubmitShareJustification() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { requestId: string; input: SubmitJustificationInput }) =>
+      submitShareJustification(vars.requestId, vars.input),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(shareKey(updated._id), updated);
+      queryClient.invalidateQueries({ queryKey: MY_SHARES_KEY });
+      queryClient.invalidateQueries({ queryKey: REVIEW_QUEUE_KEY });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+}
+
+export function useReviewShareRequest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { requestId: string; input: ReviewDecisionInput }) =>
+      reviewShareRequest(vars.requestId, vars.input),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(shareKey(updated._id), updated);
+      queryClient.invalidateQueries({ queryKey: MY_SHARES_KEY });
+      queryClient.invalidateQueries({ queryKey: REVIEW_QUEUE_KEY });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+}

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -16,6 +16,8 @@ import { AnalyticsCard } from "@/components/skill/AnalyticsCard";
 import { useRefreshSkillFromSource } from "@/hooks/useSkills";
 import { SkillVersionList } from "@/components/skill/SkillVersionList";
 import { PermissionsModal } from "@/components/skill/PermissionsModal";
+import { ShareModal } from "@/components/skill/ShareModal";
+import { InFlightShareRequests } from "@/components/skill/InFlightShareRequests";
 import {
   useSkill,
   useDeleteSkill,
@@ -115,6 +117,7 @@ export function SkillDetailPage() {
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showPermissionsModal, setShowPermissionsModal] = useState(false);
+  const [showShareModal, setShowShareModal] = useState(false);
   const [showSaveConfirm, setShowSaveConfirm] = useState(false);
   const [editedContents, setEditedContents] = useState<Map<string, string>>(new Map());
   const [addedPaths, setAddedPaths] = useState<FileTreeEntry[]>([]);
@@ -530,6 +533,16 @@ export function SkillDetailPage() {
                   )}
                   {isOwner && (
                     <Button
+                      variant="secondary"
+                      size="sm"
+                      className="w-full"
+                      onClick={() => setShowShareModal(true)}
+                    >
+                      {t("skillDetail.shareSkill", "Share (audit-gated)")}
+                    </Button>
+                  )}
+                  {isOwner && (
+                    <Button
                       variant="danger"
                       size="sm"
                       className="w-full"
@@ -555,6 +568,8 @@ export function SkillDetailPage() {
           )}
 
           <AnalyticsCard idOrName={skill.name || skill.guid} />
+
+          {isOwner && <InFlightShareRequests skillGuid={skill.guid} />}
         </div>
       </div>
 
@@ -624,6 +639,16 @@ export function SkillDetailPage() {
           isOpen={showPermissionsModal}
           onClose={() => setShowPermissionsModal(false)}
           skill={skill}
+        />
+      )}
+
+      {/* Share modal — owner-initiated audit-gated share request. */}
+      {isOwner && (
+        <ShareModal
+          isOpen={showShareModal}
+          onClose={() => setShowShareModal(false)}
+          skillIdOrName={skill.name || skill.guid}
+          skillName={skill.name}
         />
       )}
       </div>

--- a/ornn-web/src/services/sharesApi.ts
+++ b/ornn-web/src/services/sharesApi.ts
@@ -1,0 +1,80 @@
+/**
+ * Share-request endpoints — `/api/v1/skills/:idOrName/share`,
+ * `/api/v1/shares/*`. Covers the full audit-gated sharing workflow.
+ *
+ * @module services/sharesApi
+ */
+
+import { apiGet, apiPost } from "./apiClient";
+import type {
+  InitiateShareInput,
+  ReviewDecisionInput,
+  ShareRequest,
+  SubmitJustificationInput,
+} from "@/types/shares";
+
+export async function initiateShare(
+  skillIdOrName: string,
+  input: InitiateShareInput,
+): Promise<ShareRequest> {
+  const body: { targetType: string; targetId?: string } = {
+    targetType: input.targetType,
+  };
+  if (input.targetId) body.targetId = input.targetId;
+  const res = await apiPost<ShareRequest>(
+    `/api/v1/skills/${encodeURIComponent(skillIdOrName)}/share`,
+    body,
+  );
+  if (!res.data) throw new Error("initiateShare returned no data");
+  return res.data;
+}
+
+export async function fetchShareRequest(requestId: string): Promise<ShareRequest | null> {
+  const res = await apiGet<ShareRequest>(
+    `/api/v1/shares/${encodeURIComponent(requestId)}`,
+  );
+  return res.data ?? null;
+}
+
+export async function submitShareJustification(
+  requestId: string,
+  input: SubmitJustificationInput,
+): Promise<ShareRequest> {
+  const res = await apiPost<ShareRequest>(
+    `/api/v1/shares/${encodeURIComponent(requestId)}/justification`,
+    input,
+  );
+  if (!res.data) throw new Error("submitShareJustification returned no data");
+  return res.data;
+}
+
+export async function reviewShareRequest(
+  requestId: string,
+  input: ReviewDecisionInput,
+): Promise<ShareRequest> {
+  const res = await apiPost<ShareRequest>(
+    `/api/v1/shares/${encodeURIComponent(requestId)}/review`,
+    input,
+  );
+  if (!res.data) throw new Error("reviewShareRequest returned no data");
+  return res.data;
+}
+
+export async function cancelShareRequest(requestId: string): Promise<ShareRequest> {
+  const res = await apiPost<ShareRequest>(
+    `/api/v1/shares/${encodeURIComponent(requestId)}/cancel`,
+    {},
+  );
+  if (!res.data) throw new Error("cancelShareRequest returned no data");
+  return res.data;
+}
+
+export async function fetchMyShareRequests(): Promise<ShareRequest[]> {
+  const res = await apiGet<{ items: ShareRequest[] }>("/api/v1/shares");
+  return res.data?.items ?? [];
+}
+
+export async function fetchShareReviewQueue(): Promise<ShareRequest[]> {
+  const res = await apiGet<{ items: ShareRequest[] }>("/api/v1/shares/review-queue");
+  return res.data?.items ?? [];
+}

--- a/ornn-web/src/types/shares.ts
+++ b/ornn-web/src/types/shares.ts
@@ -1,0 +1,93 @@
+/**
+ * Share-request TS types mirroring the backend state machine.
+ *
+ * State progression:
+ *
+ *    pending-audit → { green · needs-justification · failed-audit }
+ *                    ↓
+ *              pending-review → { accepted · rejected · cancelled }
+ *
+ * @module types/shares
+ */
+
+import type { AuditVerdict } from "./audit";
+
+export type ShareTargetType = "user" | "org" | "public";
+
+export interface ShareTarget {
+  type: ShareTargetType;
+  /** NyxID user_id / org user_id. Omitted for `public`. */
+  id?: string;
+}
+
+export type ShareStatus =
+  | "pending-audit"
+  | "green"
+  | "needs-justification"
+  | "pending-review"
+  | "accepted"
+  | "rejected"
+  | "cancelled";
+
+export interface ShareJustifications {
+  whyCannotPass: string;
+  whySafe: string;
+  whyShare: string;
+  submittedAt: string;
+}
+
+export interface ShareReviewerDecision {
+  decision: "accept" | "reject";
+  note?: string;
+  reviewerUserId: string;
+  reviewedAt: string;
+}
+
+export interface ShareRequest {
+  _id: string;
+  skillGuid: string;
+  skillVersion: string;
+  skillHash: string;
+  ownerUserId: string;
+  target: ShareTarget;
+  status: ShareStatus;
+  auditVerdict?: AuditVerdict;
+  auditOverallScore?: number;
+  auditRecordId?: string;
+  justifications?: ShareJustifications;
+  reviewerDecision?: ShareReviewerDecision;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** The backend accepts this shape on `POST /skills/:idOrName/share`. */
+export interface InitiateShareInput {
+  targetType: ShareTargetType;
+  /** Required for `user` / `org`; omit for `public`. */
+  targetId?: string;
+}
+
+export interface SubmitJustificationInput {
+  whyCannotPass: string;
+  whySafe: string;
+  whyShare: string;
+}
+
+export interface ReviewDecisionInput {
+  decision: "accept" | "reject";
+  note?: string;
+}
+
+/** Statuses that the owner can still cancel out of. */
+export const CANCELLABLE_STATUSES: ReadonlySet<ShareStatus> = new Set([
+  "pending-audit",
+  "needs-justification",
+  "pending-review",
+]);
+
+/** Statuses that are a final outcome, for UI styling. */
+export const TERMINAL_STATUSES: ReadonlySet<ShareStatus> = new Set([
+  "accepted",
+  "rejected",
+  "cancelled",
+]);


### PR DESCRIPTION
## Summary

First slice of the Shares UI umbrella (#160), the last outstanding item in the phase-3 frontend catch-up (#156). Lets owners kick off an audit-gated share and watch the request lifecycle inline on `SkillDetailPage`.

### Share modal

Distinct from the existing `PermissionsModal` (which writes the static `sharedWithUsers` / `sharedWithOrgs` allow-list with no audit). `ShareModal` fires `POST /api/v1/skills/:idOrName/share` and triggers the audit pipeline.

- Segmented control — **User / Org / Public**.
- **User** target: email typeahead, reuses `searchUsersByEmail` + same debouncing pattern as `PermissionsModal`.
- **Org** target: dropdown populated from `useMyOrgs`.
- **Public** target: no picker; prominent yellow warning that the audit engine will run and a reviewer decision will be required if the verdict isn't green.

### In-flight request list (sidebar column)

`InFlightShareRequests` lives under the Analytics card. It:

- Reads the caller's `/shares` list, filters to `skillGuid === currentSkill.guid`, sorts newest-first.
- Renders a status pill (pending-audit / needs-justification / pending-review / accepted / rejected / cancelled) using the design-system colour scale.
- Offers a `Cancel` button whenever the status is in `CANCELLABLE_STATUSES`.
- Links to `/shares/:requestId` for full detail.

### Plumbing (all 7 endpoints wired up-front)

- `types/shares.ts` mirrors `ShareRequest`, `ShareStatus`, etc. with `Date → ISO string`. Exports `CANCELLABLE_STATUSES` / `TERMINAL_STATUSES` for downstream reuse.
- `services/sharesApi.ts` exposes all seven endpoints: `initiateShare`, `fetchShareRequest`, `submitShareJustification`, `reviewShareRequest`, `cancelShareRequest`, `fetchMyShareRequests`, `fetchShareReviewQueue`.
- `hooks/useShares.ts` — seven matching hooks. Mutations also invalidate `notifications` since share events emit notifications the bell + list need to pick up.

PR 160b and PR 160c will only touch pages + components; the API + hook layer is finalized here.

## Known gap

The `Details` link currently 404s because `/shares/:requestId` is added in PR 160b. Acceptable 1–2 day gap while the Shares UI ships incrementally.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` (vitest) — 11/11 pass
- [x] `bun run lint` — 0 errors (pre-existing warnings unchanged; 1 new warning I'll clean up if it's worth a whole commit)
- [ ] Post-merge local deploy:
  - [ ] Open own skill → "Share (audit-gated)" button appears
  - [ ] Modal segmented control switches between User / Org / Public
  - [ ] Pick a user by email → initiate → success toast → request shows up in the inline list with "pending-audit" status
  - [ ] Cancel the request → status flips to "cancelled"; button disappears
  - [ ] Non-owners don't see the button and never see the inline list

Progresses #160.