### PR TITLE
[Infra] Local minio ingress + browser-reachable presigned URLs

### DIFF
--- a/.changeset/minio-ingress.md
+++ b/.changeset/minio-ingress.md
@@ -1,0 +1,4 @@
+---
+---
+
+infra: local deploy — re-add the minio ingress and move chrono-storage to sign presigned URLs with `http://minio.ornn-cluster.local` so browsers can actually fetch skill packages. Adds port 80 on the minio Service (targetPort 9000) and a `hostAliases` entry on the chrono-storage deployment so both in-cluster and in-browser traffic hit the same host. Local-only; production uses real S3 where the endpoint is already browser-reachable.

--- a/deployment/dependencies/chrono-storage/deployment.yaml
+++ b/deployment/dependencies/chrono-storage/deployment.yaml
@@ -15,6 +15,16 @@ spec:
       labels:
         app: chrono-storage
     spec:
+      # Make `minio.ornn-cluster.local` resolvable in-cluster so
+      # chrono-storage can sign presigned URLs with the same hostname
+      # the browser uses. Without this, presigned URLs point to an
+      # in-cluster hostname (`minio:9000`) the browser can't reach.
+      # The alias target IP comes from the cluster's minio Service
+      # ClusterIP at deploy time; update if the service is recreated.
+      hostAliases:
+        - ip: ${MINIO_HOST_ALIAS_IP}
+          hostnames:
+            - minio.ornn-cluster.local
       initContainers:
         - name: wait-for-minio
           image: busybox:1.37

--- a/deployment/dependencies/minio/service.yaml
+++ b/deployment/dependencies/minio/service.yaml
@@ -7,6 +7,15 @@ spec:
   selector:
     app: minio
   ports:
+    # Port 80 maps to the S3 API so callers can address minio as
+    # http://minio.ornn-cluster.local (port 80 implicit) both via the
+    # ingress (external) and via hostAliases on peer pods (internal).
+    # Having a stable, well-known port means presigned URLs can be
+    # signed and validated against the same Host without baking a
+    # non-standard port into the signature.
+    - name: http
+      port: 80
+      targetPort: 9000
     - name: api
       port: 9000
       targetPort: 9000


### PR DESCRIPTION
## Problem

Opening a skill's detail page in the local cluster shows "Failed to load package contents". Root cause: chrono-storage signs presigned URLs with the in-cluster hostname `http://minio:9000`, which the browser can't resolve.

## Fix

Route both in-cluster and browser traffic through the same host:

- **minio Service** — add a `port: 80 → targetPort: 9000` entry so the signing endpoint can be a plain http URL. Baking a non-standard port into the signature was the other option but complicates ingress routing and /etc/hosts setup.
- **minio Ingress** — already templated at `deployment/dependencies/minio/ingress.yaml` but was missing from the live local cluster; the deploy loop now re-applies it. `minio.ornn-cluster.local` resolves through the ingress to the minio Service.
- **chrono-storage Deployment** — add `hostAliases` so `minio.ornn-cluster.local` resolves inside the pod too, pointed at the minio Service ClusterIP. Parametrised via `MINIO_HOST_ALIAS_IP` in `.env.dependencies`.
- **`.env.dependencies` sample** — `CHRONO_STORAGE_S3_ENDPOINT` moves from `http://minio:9000` to `http://minio.ornn-cluster.local`.

End-to-end, same hostname from both sides:
- Browser → /etc/hosts → `127.0.0.1:80` → docker-desktop → ingress-nginx → minio Service → minio:9000.
- chrono-storage pod → hostAliases → minio Service ClusterIP:80 → minio:9000.

Presigned URL shape verified in-pod:
```
http://minio.ornn-cluster.local/ornn/<key>?X-Amz-Algorithm=...&X-Amz-Signature=...
```

## Operator notes

Add `minio.ornn-cluster.local` to `/etc/hosts` alongside the existing ornn / nyxid entries:

```
127.0.0.1 nyxid.ornn-cluster.local nyxid-api.ornn-cluster.local ornn.ornn-cluster.local minio.ornn-cluster.local
```

If the minio Service is recreated, its ClusterIP changes — update `MINIO_HOST_ALIAS_IP` in `.env.dependencies` and re-apply the chrono-storage Deployment.

## Production

Unaffected. Prod uses real S3 whose endpoint is already browser-reachable. Only the local `.env.dependencies` drives `CHRONO_STORAGE_S3_ENDPOINT`.

## Test plan

- [x] `kubectl apply` of service + ingress + chrono-storage clean
- [x] chrono-storage bootstrap logs show `endpoint: http://minio.ornn-cluster.local`
- [x] `fetch('http://localhost:3805/api/buckets/ornn/presigned-url?key=test')` from chrono-storage pod returns a URL with the new host
- [ ] Browser test: open an existing skill detail page → package contents render