### PR TITLE
[Feature] Audit-gated share workflow — PR 3/3 (review queue + decisions)

### DIFF
--- a/.changeset/shares-review-queue-ui.md
+++ b/.changeset/shares-review-queue-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+frontend: audit-gated share workflow — PR 3/3 (the final slice). Adds a `/reviews` page listing share requests awaiting the caller's decision, a matching "Reviews" nav link, and accept/reject controls (with optional note) on the `/shares/:requestId` detail page for non-owner reviewers. Closes #160, wrapping up the phase-3 frontend catch-up umbrella (#156).

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -73,6 +73,9 @@ const NotificationsPage = lazy(() =>
 const ShareRequestPage = lazy(() =>
   import("@/pages/ShareRequestPage").then((m) => ({ default: m.ShareRequestPage })),
 );
+const ReviewsPage = lazy(() =>
+  import("@/pages/ReviewsPage").then((m) => ({ default: m.ReviewsPage })),
+);
 
 // Admin pages — bundled into one chunk by virtue of sharing the barrel
 // import path; only loaded when an /admin route activates.
@@ -144,6 +147,7 @@ export function App() {
                   <Route path="/services/:id" element={<ServiceDetailPage />} />
                   <Route path="/notifications" element={<NotificationsPage />} />
                   <Route path="/shares/:requestId" element={<ShareRequestPage />} />
+                  <Route path="/reviews" element={<ReviewsPage />} />
                 </Route>
 
                 {/* Admin routes - separate layout */}

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -239,6 +239,7 @@ const NAV_ITEMS = [
   { i18nKey: "nav.home", path: "/", requiresAuth: false, exact: true },
   { i18nKey: "nav.registry", path: "/registry", requiresAuth: false, exact: true },
   { i18nKey: "nav.build", path: "/skills/new", requiresAuth: true },
+  { i18nKey: "nav.reviews", path: "/reviews", requiresAuth: true },
   { i18nKey: "nav.docs", path: "/docs", requiresAuth: false },
 ] as const;
 

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -22,6 +22,7 @@
     "home": "Home",
     "registry": "Registry",
     "build": "Build",
+    "reviews": "Reviews",
     "docs": "Docs",
     "signIn": "Sign In",
     "signOut": "Sign Out",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -22,6 +22,7 @@
     "home": "首页",
     "registry": "技能库",
     "build": "构建",
+    "reviews": "审核",
     "docs": "文档",
     "signIn": "登录",
     "signOut": "退出",

--- a/ornn-web/src/pages/ReviewsPage.tsx
+++ b/ornn-web/src/pages/ReviewsPage.tsx
@@ -1,0 +1,133 @@
+/**
+ * /reviews — share-request queue for the caller.
+ *
+ * Backend scopes the list via `/shares/review-queue`: requests that are
+ * pending-review where the caller is either the target user, an admin of
+ * the target org, or a platform admin. This page just lists them — the
+ * actual decision UI lives on `/shares/:requestId` (see ShareRequestPage
+ * reviewer block).
+ *
+ * @module pages/ReviewsPage
+ */
+
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { useShareReviewQueue } from "@/hooks/useShares";
+import type { ShareRequest } from "@/types/shares";
+
+function targetLabel(req: ShareRequest): string {
+  if (req.target.type === "public") return "Public";
+  const prefix = req.target.type === "org" ? "Org" : "User";
+  return `${prefix} ${req.target.id ?? ""}`.trim();
+}
+
+function verdictTone(verdict?: string): string {
+  if (verdict === "green") return "text-neon-cyan";
+  if (verdict === "yellow") return "text-neon-yellow";
+  if (verdict === "red") return "text-neon-red";
+  return "text-text-muted";
+}
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (diffSec < 60) return "just now";
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function ReviewsPage() {
+  const { t } = useTranslation();
+  const { data: queue = [], isLoading, isError } = useShareReviewQueue();
+
+  const sorted = useMemo(
+    () => [...queue].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+    [queue],
+  );
+
+  return (
+    <PageTransition>
+      <div className="mx-auto w-full max-w-4xl px-6 py-10">
+        <header className="mb-6">
+          <h1 className="font-heading text-3xl text-text-primary">
+            {t("reviews.title", "Review queue")}
+          </h1>
+          <p className="mt-1 font-body text-sm text-text-muted">
+            {t(
+              "reviews.subtitle",
+              "Share requests awaiting your decision. Click one to see the audit findings and the owner's justifications.",
+            )}
+          </p>
+        </header>
+
+        {isLoading ? (
+          <p className="py-16 text-center font-body text-sm text-text-muted">
+            {t("reviews.loading", "Loading…")}
+          </p>
+        ) : isError ? (
+          <p className="py-16 text-center font-body text-sm text-neon-red">
+            {t("reviews.loadFailed", "Could not load the review queue.")}
+          </p>
+        ) : sorted.length === 0 ? (
+          <div className="rounded-lg border border-neon-cyan/10 bg-bg-surface/30 py-16 text-center">
+            <p className="font-body text-sm text-text-muted">
+              {t("reviews.empty", "No share requests awaiting your review.")}
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-neon-cyan/10 overflow-hidden rounded-lg border border-neon-cyan/10 bg-bg-surface/30">
+            {sorted.map((req) => (
+              <li key={req._id}>
+                <Link
+                  to={`/shares/${encodeURIComponent(req._id)}`}
+                  className="flex flex-wrap items-center justify-between gap-3 px-5 py-4 transition-colors hover:bg-neon-cyan/5 cursor-pointer"
+                >
+                  <div className="min-w-0 flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <span className="rounded border border-neon-yellow/30 bg-neon-yellow/10 px-2 py-0.5 font-heading text-[10px] uppercase tracking-wider text-neon-yellow">
+                        {t("reviews.pending", "Pending review")}
+                      </span>
+                      <span className="font-body text-sm text-text-primary">
+                        {t("reviews.target", "To")}: {targetLabel(req)}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 font-mono text-xs text-text-muted">
+                      <span>
+                        {t("reviews.skill", "skill")}: {req.skillGuid.slice(0, 8)}… ·{" "}
+                        v{req.skillVersion}
+                      </span>
+                      {req.auditVerdict && (
+                        <span>
+                          {t("reviews.audit", "audit")}:{" "}
+                          <span className={verdictTone(req.auditVerdict)}>
+                            {req.auditVerdict}
+                          </span>
+                          {typeof req.auditOverallScore === "number" && (
+                            <> · {req.auditOverallScore.toFixed(1)}/10</>
+                          )}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-1 shrink-0">
+                    <span className="font-mono text-xs text-text-muted">
+                      {formatRelative(req.createdAt)}
+                    </span>
+                    <span className="font-body text-xs text-neon-cyan">
+                      {t("reviews.review", "Review →")}
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/pages/ShareRequestPage.tsx
+++ b/ornn-web/src/pages/ShareRequestPage.tsx
@@ -1,10 +1,14 @@
 /**
- * /shares/:requestId — share-request detail + justification form.
+ * /shares/:requestId — share-request detail + justification form +
+ * reviewer accept/reject controls.
  *
- * Accessible to the owner and to reviewers authorised by the backend
- * (the `GET /shares/:requestId` endpoint does the access check). This PR
- * renders the full state + audit findings + justification flow; reviewer
- * accept/reject controls are added by PR #160c.
+ * Access-controlled by the backend (`GET /shares/:requestId` rejects
+ * non-owners / non-reviewers). The page shows:
+ *   - Audit findings from the cached audit record
+ *   - Owner's justification form (while `needs-justification`) → read-only
+ *     once submitted
+ *   - Reviewer's accept/reject controls (while `pending-review` and the
+ *     caller isn't the owner) → read-only decision once recorded
  *
  * @module pages/ShareRequestPage
  */
@@ -19,6 +23,7 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { ArrowLeftIcon } from "@/components/icons";
 import {
   useCancelShareRequest,
+  useReviewShareRequest,
   useShareRequest,
   useSubmitShareJustification,
 } from "@/hooks/useShares";
@@ -292,6 +297,96 @@ function JustificationForm({ request }: { request: ShareRequest }) {
   );
 }
 
+function ReviewerActions({ request }: { request: ShareRequest }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const addToast = useToastStore((s) => s.addToast);
+  const review = useReviewShareRequest();
+
+  const [note, setNote] = useState("");
+
+  const handleDecision = async (decision: "accept" | "reject") => {
+    try {
+      await review.mutateAsync({
+        requestId: request._id,
+        input: { decision, note: note.trim() || undefined },
+      });
+      addToast({
+        type: "success",
+        message:
+          decision === "accept"
+            ? t("shareDetail.acceptedToast", "Share accepted.")
+            : t("shareDetail.rejectedToast", "Share rejected."),
+      });
+      // Kick the caller back to their queue; the request will no longer
+      // be pending-review there.
+      navigate("/reviews");
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : t("shareDetail.reviewFailed", "Review failed."),
+      });
+    }
+  };
+
+  return (
+    <Card className="space-y-4 p-5">
+      <div>
+        <h3 className="font-heading text-sm uppercase tracking-wider text-text-primary">
+          {t("shareDetail.reviewHeading", "Your decision")}
+        </h3>
+        <p className="mt-1 font-body text-sm text-text-muted">
+          {t(
+            "shareDetail.reviewHint",
+            "Accept grants access to the target. Reject keeps the skill private. Either decision notifies the owner.",
+          )}
+        </p>
+      </div>
+      <div>
+        <label
+          htmlFor="review-note"
+          className="mb-1 block font-heading text-[11px] uppercase tracking-wider text-text-muted"
+        >
+          {t("shareDetail.reviewNote", "Note (optional)")}
+        </label>
+        <textarea
+          id="review-note"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+          className="w-full rounded-lg border border-neon-cyan/20 bg-bg-surface px-3 py-2 font-body text-sm text-text-primary focus:outline-none focus:border-neon-cyan/60 focus:ring-2 focus:ring-neon-cyan/30"
+          placeholder={
+            t(
+              "shareDetail.reviewNotePlaceholder",
+              "Short explanation shared with the owner.",
+            ) as string
+          }
+        />
+      </div>
+      <div className="flex flex-wrap items-center justify-end gap-3">
+        <Button
+          variant="danger"
+          onClick={() => handleDecision("reject")}
+          disabled={review.isPending}
+          loading={review.isPending && review.variables?.input.decision === "reject"}
+        >
+          {t("shareDetail.reject", "Reject")}
+        </Button>
+        <Button
+          onClick={() => handleDecision("accept")}
+          disabled={review.isPending}
+          loading={review.isPending && review.variables?.input.decision === "accept"}
+        >
+          {t("shareDetail.accept", "Accept")}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
 function ReviewerDecisionReadonly({
   decision,
 }: {
@@ -513,7 +608,15 @@ export function ShareRequestPage() {
           <JustificationReadonly j={request.justifications} />
         ) : null}
 
-        {/* Reviewer decision */}
+        {/* Reviewer controls — shown for non-owners when the request is
+            pending review. The backend re-checks authorization; we just
+            gate on obvious signals client-side to avoid showing controls
+            to the owner. */}
+        {request.status === "pending-review" && !isOwner && (
+          <ReviewerActions request={request} />
+        )}
+
+        {/* Reviewer decision (read-only once recorded) */}
         {request.reviewerDecision && (
           <ReviewerDecisionReadonly decision={request.reviewerDecision} />
         )}


### PR DESCRIPTION
## Summary

Final slice of the Shares UI umbrella (#160) and the last open item in the phase-3 frontend catch-up (#156). Reviewers can now discover and act on pending share requests from the web UI.

### New surface

- **\`/reviews\` page** — lists share requests awaiting the caller's decision, sourced from \`GET /shares/review-queue\`. Per-row: target (user / org / public), skill guid + version, audit verdict + score, age. Click → \`/shares/:requestId\` for full context.
- **Navbar** — new "Reviews" link, authenticated-only.
- **\`/shares/:requestId\` reviewer controls** — when status === \`pending-review\` AND caller !== owner, the detail page renders a ReviewerActions card with an optional-note textarea and Accept / Reject buttons. On submit, fires \`POST /shares/:id/review\`, toasts, and routes back to \`/reviews\`. The backend re-checks reviewer eligibility; we gate client-side on obvious signals to avoid showing controls to the owner.

### Plumbing

No new service or hook surface — \`useShareReviewQueue\` and \`useReviewShareRequest\` were laid down up-front in PR 160a. i18n adds \`nav.reviews\` in both locales.

### Umbrella status

With this PR the three-slice Shares workflow ships end-to-end:

| Flow | PR |
|------|----|
| Initiate share + inline lifecycle tracking | #166 (160a) — merged |
| Detail page + audit findings + justification form | #169 (160b) — merged |
| Review queue + accept/reject | #170 (this one, 160c) |

And all five phase-3 frontend catch-up PRs are landed: notifications (#162), audit banner (#163), GitHub import/refresh (#164), analytics (#165), and shares 1–3. Umbrella #156 can close once this merges.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test\` (vitest) — 11/11 pass
- [x] \`bun run lint\` — 0 errors (pre-existing warnings unchanged)
- [ ] Post-merge local deploy:
  - [ ] As a reviewer (org admin of the share target, or platform admin) → navbar shows "Reviews" → queue lists pending items → click → detail page shows Accept / Reject
  - [ ] Accept → toast + routed back to /reviews → item removed → owner's notification fires + their detail page shows "Accepted"
  - [ ] Reject with a note → shows up on owner's detail page under "Rejected"
  - [ ] As the owner (same request) → no reviewer controls shown — read-only status block instead

Closes #160. Completes #156.