### PR TITLE
[Bug] /shares/review-queue 404 — route ordering

### DIFF
--- a/.changeset/shares-route-ordering.md
+++ b/.changeset/shares-route-ordering.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+fix(api): `GET /shares/review-queue` was 404 because the wildcard `/shares/:requestId` route was registered first and captured the literal segment as a `requestId`. Reorder so static paths (`/shares`, `/shares/review-queue`) are registered ahead of the dynamic one.

--- a/ornn-api/src/domains/shares/routes.ts
+++ b/ornn-api/src/domains/shares/routes.ts
@@ -60,6 +60,39 @@ export function createShareRoutes(config: ShareRoutesConfig): Hono<{ Variables: 
     },
   );
 
+  // Order matters: the specific paths (`/shares`, `/shares/review-queue`)
+  // MUST be registered before the wildcard `/shares/:requestId`. Hono
+  // matches in definition order, so putting the dynamic one first makes
+  // it swallow `review-queue` as if it were a requestId and 404.
+
+  // ---- Caller's own share requests ---------------------------------------
+  app.get(
+    "/shares",
+    auth,
+    async (c) => {
+      const authCtx = getAuth(c);
+      const items = await shareService.listMine(authCtx.userId);
+      return c.json({ data: { items }, error: null });
+    },
+  );
+
+  // ---- Reviewer queue -----------------------------------------------------
+  app.get(
+    "/shares/review-queue",
+    auth,
+    async (c) => {
+      const authCtx = getAuth(c);
+      const reviewerOrgIds = await readUserOrgIds(c);
+      const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
+      const items = await shareService.listReviewQueue({
+        reviewerUserId: authCtx.userId,
+        reviewerOrgIds,
+        isPlatformAdmin,
+      });
+      return c.json({ data: { items }, error: null });
+    },
+  );
+
   // ---- Read a single request ---------------------------------------------
   app.get(
     "/shares/:requestId",
@@ -134,34 +167,6 @@ export function createShareRoutes(config: ShareRoutesConfig): Hono<{ Variables: 
       const authCtx = getAuth(c);
       const updated = await shareService.cancel(requestId, authCtx.userId);
       return c.json({ data: updated, error: null });
-    },
-  );
-
-  // ---- Caller's own share requests ---------------------------------------
-  app.get(
-    "/shares",
-    auth,
-    async (c) => {
-      const authCtx = getAuth(c);
-      const items = await shareService.listMine(authCtx.userId);
-      return c.json({ data: { items }, error: null });
-    },
-  );
-
-  // ---- Reviewer queue -----------------------------------------------------
-  app.get(
-    "/shares/review-queue",
-    auth,
-    async (c) => {
-      const authCtx = getAuth(c);
-      const reviewerOrgIds = await readUserOrgIds(c);
-      const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
-      const items = await shareService.listReviewQueue({
-        reviewerUserId: authCtx.userId,
-        reviewerOrgIds,
-        isPlatformAdmin,
-      });
-      return c.json({ data: { items }, error: null });
     },
   );
 


### PR DESCRIPTION
## Symptom

\`GET /api/v1/shares/review-queue\` returns 404 instead of the caller's pending-review list. Surfaced while testing the \`/reviews\` page from PR #170.

## Root cause

Hono matches routes in definition order. In \`ornn-api/src/domains/shares/routes.ts\`, \`GET /shares/:requestId\` was registered before \`GET /shares/review-queue\`, so hits on the static path were captured by the wildcard with \`requestId = "review-queue"\`. The handler then called \`shareService.get("review-queue", ...)\` which 404'd.

## Fix

Reorder so the two static paths (\`/shares\` and \`/shares/review-queue\`) are registered above the dynamic \`/shares/:requestId\`. The POST variants under \`/shares/:requestId/*\` stay grouped with the wildcard — they don't collide with any static suffix.

A short comment at the top of the route registrations explains the ordering invariant so this doesn't regress the next time someone alphabetises or moves blocks around.

## Test plan

- [x] \`bun test\` — 243/243 pass locally
- [x] Local docker rebuild + rollout — /reviews page now loads the queue instead of 404
- [ ] After merge: PR #170's test-plan row ("queue lists pending items") now passes end-to-end