### PR TITLE
[Bug] Drop redundant Share (audit-gated) button

### DIFF
--- a/.changeset/consolidate-share-button.md
+++ b/.changeset/consolidate-share-button.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+fix(web): remove the redundant "Share (audit-gated)" button from `SkillDetailPage`. The existing "Manage permissions" entry stays; the broader UX of wiring audit-gated share initiation into that modal is tracked separately.

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -16,7 +16,6 @@ import { AnalyticsCard } from "@/components/skill/AnalyticsCard";
 import { useRefreshSkillFromSource } from "@/hooks/useSkills";
 import { SkillVersionList } from "@/components/skill/SkillVersionList";
 import { PermissionsModal } from "@/components/skill/PermissionsModal";
-import { ShareModal } from "@/components/skill/ShareModal";
 import { InFlightShareRequests } from "@/components/skill/InFlightShareRequests";
 import {
   useSkill,
@@ -117,7 +116,6 @@ export function SkillDetailPage() {
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showPermissionsModal, setShowPermissionsModal] = useState(false);
-  const [showShareModal, setShowShareModal] = useState(false);
   const [showSaveConfirm, setShowSaveConfirm] = useState(false);
   const [editedContents, setEditedContents] = useState<Map<string, string>>(new Map());
   const [addedPaths, setAddedPaths] = useState<FileTreeEntry[]>([]);
@@ -533,16 +531,6 @@ export function SkillDetailPage() {
                   )}
                   {isOwner && (
                     <Button
-                      variant="secondary"
-                      size="sm"
-                      className="w-full"
-                      onClick={() => setShowShareModal(true)}
-                    >
-                      {t("skillDetail.shareSkill", "Share (audit-gated)")}
-                    </Button>
-                  )}
-                  {isOwner && (
-                    <Button
                       variant="danger"
                       size="sm"
                       className="w-full"
@@ -642,15 +630,6 @@ export function SkillDetailPage() {
         />
       )}
 
-      {/* Share modal — owner-initiated audit-gated share request. */}
-      {isOwner && (
-        <ShareModal
-          isOpen={showShareModal}
-          onClose={() => setShowShareModal(false)}
-          skillIdOrName={skill.name || skill.guid}
-          skillName={skill.name}
-        />
-      )}
       </div>
     </PageTransition>
   );


### PR DESCRIPTION
## Problem

SkillDetailPage showed two side-by-side owner buttons that looked nearly identical:

- Manage permissions — direct allow-list editor (isPrivate + sharedWithUsers/Orgs, no audit)
- Share (audit-gated) — initiates a share request through the audit pipeline

Users (reasonably) asked why both exist.

## Fix

Remove the new "Share (audit-gated)" button and its ShareModal mount from `SkillDetailPage`.

- The \`ShareModal\` component stays in the tree for future reuse once the properly-merged flow lands.
- \`InFlightShareRequests\` also stays; a share request created by any other path (API, CLI, future merged modal) still deserves inline visibility on the skill page.

## Follow-up

Proper UX — fold audit-gated share initiation into \`PermissionsModal\`'s save path so additions route through \`POST /share\` and removals continue to use \`PUT /permissions\` — is tracked as #172.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] Rebuild + local rollout — only "Manage permissions" button appears in the owner action strip
- [x] \`InFlightShareRequests\` card still renders when the caller has an active request on the skill