### PR TITLE
[Feature] Audit-gated permissions save + owner-triggered audit

### DIFF
--- a/.changeset/consolidate-share-button.md
+++ b/.changeset/consolidate-share-button.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+fix(web): remove the redundant "Share (audit-gated)" button from `SkillDetailPage`. The existing "Manage permissions" entry stays; the broader UX of wiring audit-gated share initiation into that modal is tracked separately.

--- a/.changeset/permissions-audit-gated.md
+++ b/.changeset/permissions-audit-gated.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+feat: audit-gated permissions save — when a skill owner adds a new user / org grant or flips a skill to public in the PermissionsModal, each added target now routes through `POST /api/v1/skills/:idOrName/share` instead of the direct `PUT /permissions` path, so the audit engine runs before access is granted. Removes and flip-to-private continue to be applied immediately. Adds a new owner-facing `POST /api/v1/skills/:idOrName/audit` so owners can also pre-flight an audit from the AuditBanner; the admin `POST /admin/skills/:idOrName/audit` endpoint stays for any-skill admin reach.

--- a/ornn-api/src/domains/skills/audit/routes.ts
+++ b/ornn-api/src/domains/skills/audit/routes.ts
@@ -82,8 +82,45 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
   );
 
   /**
+   * POST /skills/:idOrName/audit
+   * Owner-triggered audit. The skill's author (or a platform admin) can
+   * kick off an audit ahead of initiating a share so they see the
+   * verdict before committing to a share request. Same service path as
+   * the admin endpoint below; differs only in auth gate.
+   * Body: `{ force?: boolean }` — `force=true` bypasses the cache.
+   */
+  app.post(
+    "/skills/:idOrName/audit",
+    auth,
+    requirePermission("ornn:skill:update"),
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const authCtx = getAuth(c);
+      const body = (await c.req.json().catch(() => ({}))) as { force?: unknown };
+      const force = body.force === true;
+
+      const skill = await skillService.getSkill(idOrName);
+      const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
+      if (skill.createdBy !== authCtx.userId && !isPlatformAdmin) {
+        throw AppError.forbidden(
+          "NOT_SKILL_OWNER",
+          "Only the skill's author or a platform admin can trigger an audit",
+        );
+      }
+
+      logger.info({ idOrName, triggeredBy: authCtx.userId, force }, "Owner audit triggered");
+      const record = await auditService.runAudit(idOrName, {
+        triggeredBy: authCtx.userId,
+        force,
+      });
+      return c.json({ data: record, error: null });
+    },
+  );
+
+  /**
    * POST /admin/skills/:idOrName/audit
-   * Force a fresh audit. Admin only.
+   * Force a fresh audit. Admin only. Same underlying path as the owner
+   * endpoint above but keyed on the admin permission for any-skill reach.
    * Body: `{ force?: boolean }` — `force=true` bypasses the cache.
    */
   app.post(

--- a/ornn-web/src/components/skill/AuditBanner.tsx
+++ b/ornn-web/src/components/skill/AuditBanner.tsx
@@ -1,11 +1,12 @@
 /**
  * Banner on `SkillDetailPage` showing the skill's audit verdict.
  *
- * - No audit yet → hidden (or a tiny "Run audit" CTA for admins).
+ * - No audit yet → hidden for readers; compact "Run audit" CTA for
+ *   anyone with `canTriggerAudit` (owners + platform admins).
  * - Audit exists → verdict pill, overall score, timestamp; expandable to
- *   show per-dimension scores and findings.
- * - Admin viewers get a "Rerun" button; the mutation sync-updates the
- *   banner state via query-cache priming in `useRerunAudit`.
+ *   show per-dimension scores and findings. Triggerers get a "Rerun"
+ *   button; the mutation sync-updates the banner state via query-cache
+ *   priming in `useRerunAudit`.
  *
  * @module components/skill/AuditBanner
  */
@@ -26,7 +27,7 @@ interface AuditBannerProps {
   /** Optional pin; omit for latest. */
   version?: string;
   /** Caller can rerun / trigger initial audits. */
-  isAdmin: boolean;
+  canTriggerAudit: boolean;
   className?: string;
 }
 
@@ -117,13 +118,13 @@ function AuditBannerInner({
   record,
   idOrName,
   version,
-  isAdmin,
+  canTriggerAudit,
   className,
 }: {
   record: AuditRecord;
   idOrName: string;
   version?: string;
-  isAdmin: boolean;
+  canTriggerAudit: boolean;
   className?: string;
 }) {
   const { t } = useTranslation();
@@ -162,7 +163,7 @@ function AuditBannerInner({
           · v{record.version} · {timestampLabel}
         </span>
         <div className="flex-1" />
-        {isAdmin && (
+        {canTriggerAudit && (
           <span
             role="button"
             tabIndex={0}
@@ -240,7 +241,7 @@ function AuditBannerInner({
   );
 }
 
-export function AuditBanner({ idOrName, version, isAdmin, className }: AuditBannerProps) {
+export function AuditBanner({ idOrName, version, canTriggerAudit, className }: AuditBannerProps) {
   const { t } = useTranslation();
   const { data: record, isLoading, isError } = useSkillAudit(idOrName, { version });
   const rerun = useRerunAudit();
@@ -249,7 +250,7 @@ export function AuditBanner({ idOrName, version, isAdmin, className }: AuditBann
 
   if (!record) {
     // Not audited yet. Only admins get an affordance to kick off the first run.
-    if (!isAdmin) return null;
+    if (!canTriggerAudit) return null;
     return (
       <div
         className={`glass flex items-center gap-3 rounded-xl border border-neon-cyan/15 bg-bg-surface/40 px-4 py-3 ${
@@ -280,7 +281,7 @@ export function AuditBanner({ idOrName, version, isAdmin, className }: AuditBann
       record={record}
       idOrName={idOrName}
       version={version}
-      isAdmin={isAdmin}
+      canTriggerAudit={canTriggerAudit}
       className={className}
     />
   );

--- a/ornn-web/src/components/skill/PermissionsModal.tsx
+++ b/ornn-web/src/components/skill/PermissionsModal.tsx
@@ -28,9 +28,11 @@ import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
 import { useMyOrgs } from "@/hooks/useMe";
 import { useUpdateSkillPermissions } from "@/hooks/useSkills";
+import { useInitiateShare } from "@/hooks/useShares";
 import { useToastStore } from "@/stores/toastStore";
 import { searchUsersByEmail, resolveUsers, fetchOrgSummary, type UserDirectoryEntry } from "@/services/usersApi";
 import type { SkillDetail } from "@/types/domain";
+import type { InitiateShareInput } from "@/types/shares";
 
 interface PermissionsModalProps {
   isOpen: boolean;
@@ -63,7 +65,9 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
   const [sharedOrgIds, setSharedOrgIds] = useState<string[]>(skill.sharedWithOrgs);
   const [userQuery, setUserQuery] = useState("");
   const [userInputFocused, setUserInputFocused] = useState(false);
+  const [savingShares, setSavingShares] = useState(false);
   const userInputRef = useRef<HTMLInputElement>(null);
+  const initiateShareMutation = useInitiateShare();
 
   // Reset form whenever the modal re-opens on a different skill version.
   useEffect(() => {
@@ -176,20 +180,117 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
   const privateActive = !isPublic && !orgsActive && !usersActive;
 
   const handleSave = async () => {
-    const payload = isPublic
-      ? { isPrivate: false, sharedWithOrgs: [], sharedWithUsers: [] }
-      : {
-        isPrivate: true,
-        sharedWithOrgs: sharedOrgIds,
-        sharedWithUsers: sharedUsers.map((u) => u.userId),
-      };
+    // Diff between current skill state and form state.
+    // New grants (user / org adds + flip-to-public) are audit-gated and
+    // routed through `POST /api/v1/skills/:idOrName/share`. The actual
+    // ACL only moves once the audit lands green or a reviewer accepts,
+    // so we don't include new grants in the direct PUT below.
+    // Removes + flip-to-private don't need audit — access is being taken
+    // away — so they go through `PUT /api/v1/skills/:id/permissions` as
+    // before.
+    const beforePrivate = skill.isPrivate;
+    const beforeUsers = new Set(skill.sharedWithUsers);
+    const beforeOrgs = new Set(skill.sharedWithOrgs);
+    const afterPrivate = !isPublic;
+    const afterUsers = new Set(sharedUsers.map((u) => u.userId));
+    const afterOrgs = new Set(sharedOrgIds);
+
+    const goingPublic = beforePrivate && !afterPrivate;
+    const goingPrivate = !beforePrivate && afterPrivate;
+
+    // When flipping to public, skip per-user / per-org share requests —
+    // public supersedes them and creating redundant requests is noise.
+    const addedUsers = goingPublic
+      ? []
+      : sharedUsers.map((u) => u.userId).filter((id) => !beforeUsers.has(id));
+    const addedOrgs = goingPublic
+      ? []
+      : sharedOrgIds.filter((id) => !beforeOrgs.has(id));
+
+    const removedUsers = skill.sharedWithUsers.filter((id) => !afterUsers.has(id));
+    const removedOrgs = skill.sharedWithOrgs.filter((id) => !afterOrgs.has(id));
+
+    const shareTargets: InitiateShareInput[] = [
+      ...(goingPublic ? [{ targetType: "public" as const }] : []),
+      ...addedUsers.map((id) => ({ targetType: "user" as const, targetId: id })),
+      ...addedOrgs.map((id) => ({ targetType: "org" as const, targetId: id })),
+    ];
+
+    const needsPut =
+      removedUsers.length > 0 || removedOrgs.length > 0 || goingPrivate;
+
+    if (!needsPut && shareTargets.length === 0) {
+      addToast({
+        type: "info",
+        message: t("permissions.noChanges", "No changes to save."),
+      });
+      onClose();
+      return;
+    }
+
+    setSavingShares(true);
     try {
-      await permissionsMutation.mutateAsync(payload);
-      addToast({ type: "success", message: t("permissions.saveSuccess", "Permissions updated") });
+      // 1. Removes (or flip-to-private) — immediate effect, no audit.
+      if (needsPut) {
+        await permissionsMutation.mutateAsync({
+          isPrivate: goingPrivate ? true : beforePrivate,
+          sharedWithUsers: skill.sharedWithUsers.filter(
+            (id) => !removedUsers.includes(id),
+          ),
+          sharedWithOrgs: skill.sharedWithOrgs.filter(
+            (id) => !removedOrgs.includes(id),
+          ),
+        });
+      }
+
+      // 2. Adds — each one opens an audit-gated share request. Sequential
+      //    rather than Promise.all so the backend's audit cache (shared
+      //    per skill version) only runs once and later targets reuse.
+      let shareOk = 0;
+      let shareFail = 0;
+      for (const input of shareTargets) {
+        try {
+          await initiateShareMutation.mutateAsync({
+            skillIdOrName: skill.guid,
+            input,
+          });
+          shareOk += 1;
+        } catch (err) {
+          shareFail += 1;
+          console.warn("Share request failed", input, err);
+        }
+      }
+
+      const parts: string[] = [];
+      if (needsPut) {
+        parts.push(t("permissions.partRemoves", "permissions updated"));
+      }
+      if (shareOk > 0) {
+        parts.push(
+          t("permissions.partSharesOk", "{{n}} share request(s) submitted for audit", {
+            n: shareOk,
+          }),
+        );
+      }
+      if (shareFail > 0) {
+        parts.push(
+          t("permissions.partSharesFail", "{{n}} share request(s) failed", {
+            n: shareFail,
+          }),
+        );
+      }
+      addToast({
+        type: shareFail > 0 ? "warning" : "success",
+        message: parts.length > 0
+          ? parts.join(" · ")
+          : t("permissions.saveSuccess", "Permissions updated"),
+      });
       onClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       addToast({ type: "error", message });
+    } finally {
+      setSavingShares(false);
     }
   };
 
@@ -376,7 +477,10 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
         <Button variant="secondary" onClick={onClose}>
           {t("common.cancel", "Cancel")}
         </Button>
-        <Button onClick={handleSave} loading={permissionsMutation.isPending}>
+        <Button
+          onClick={handleSave}
+          loading={permissionsMutation.isPending || savingShares}
+        >
           {t("common.save", "Save")}
         </Button>
       </div>

--- a/ornn-web/src/components/skill/PermissionsModal.tsx
+++ b/ornn-web/src/components/skill/PermissionsModal.tsx
@@ -22,6 +22,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { Modal } from "@/components/ui/Modal";
@@ -32,7 +33,21 @@ import { useInitiateShare } from "@/hooks/useShares";
 import { useToastStore } from "@/stores/toastStore";
 import { searchUsersByEmail, resolveUsers, fetchOrgSummary, type UserDirectoryEntry } from "@/services/usersApi";
 import type { SkillDetail } from "@/types/domain";
-import type { InitiateShareInput } from "@/types/shares";
+import type { InitiateShareInput, ShareRequest } from "@/types/shares";
+
+type SavePhase = "form" | "running" | "results";
+
+interface SaveResult {
+  label: string;
+  kind:
+    | "direct-remove"
+    | "share-green"
+    | "share-needs-justification"
+    | "share-failed-audit"
+    | "share-failed";
+  shareRequestId?: string;
+  errorMessage?: string;
+}
 
 interface PermissionsModalProps {
   isOpen: boolean;
@@ -65,7 +80,9 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
   const [sharedOrgIds, setSharedOrgIds] = useState<string[]>(skill.sharedWithOrgs);
   const [userQuery, setUserQuery] = useState("");
   const [userInputFocused, setUserInputFocused] = useState(false);
-  const [savingShares, setSavingShares] = useState(false);
+  const [phase, setPhase] = useState<SavePhase>("form");
+  const [progressLabel, setProgressLabel] = useState<string>("");
+  const [saveResults, setSaveResults] = useState<SaveResult[]>([]);
   const userInputRef = useRef<HTMLInputElement>(null);
   const initiateShareMutation = useInitiateShare();
 
@@ -82,6 +99,9 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
         displayName: id,
       })),
     );
+    setPhase("form");
+    setProgressLabel("");
+    setSaveResults([]);
   }, [isOpen, skill]);
 
   // Resolve saved user_ids into email/displayName so the chip list
@@ -179,6 +199,15 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
   const usersActive = !isPublic && sharedUsers.length > 0;
   const privateActive = !isPublic && !orgsActive && !usersActive;
 
+  const labelForOrg = (orgId: string): string => {
+    const hit = allOrgOptions.find((o) => o.userId === orgId);
+    return hit?.displayName || orgId;
+  };
+  const labelForUser = (userId: string): string => {
+    const hit = sharedUsers.find((u) => u.userId === userId);
+    return hit?.displayName || hit?.email || userId;
+  };
+
   const handleSave = async () => {
     // Diff between current skill state and form state.
     // New grants (user / org adds + flip-to-public) are audit-gated and
@@ -186,8 +215,7 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
     // ACL only moves once the audit lands green or a reviewer accepts,
     // so we don't include new grants in the direct PUT below.
     // Removes + flip-to-private don't need audit — access is being taken
-    // away — so they go through `PUT /api/v1/skills/:id/permissions` as
-    // before.
+    // away — so they go through `PUT /api/v1/skills/:id/permissions`.
     const beforePrivate = skill.isPrivate;
     const beforeUsers = new Set(skill.sharedWithUsers);
     const beforeOrgs = new Set(skill.sharedWithOrgs);
@@ -210,10 +238,19 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
     const removedUsers = skill.sharedWithUsers.filter((id) => !afterUsers.has(id));
     const removedOrgs = skill.sharedWithOrgs.filter((id) => !afterOrgs.has(id));
 
-    const shareTargets: InitiateShareInput[] = [
-      ...(goingPublic ? [{ targetType: "public" as const }] : []),
-      ...addedUsers.map((id) => ({ targetType: "user" as const, targetId: id })),
-      ...addedOrgs.map((id) => ({ targetType: "org" as const, targetId: id })),
+    type LabeledTarget = { label: string; input: InitiateShareInput };
+    const shareTargets: LabeledTarget[] = [
+      ...(goingPublic
+        ? [{ label: t("permissions.targetPublic", "Public"), input: { targetType: "public" as const } }]
+        : []),
+      ...addedUsers.map((id) => ({
+        label: labelForUser(id),
+        input: { targetType: "user" as const, targetId: id },
+      })),
+      ...addedOrgs.map((id) => ({
+        label: labelForOrg(id),
+        input: { targetType: "org" as const, targetId: id },
+      })),
     ];
 
     const needsPut =
@@ -228,10 +265,16 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
       return;
     }
 
-    setSavingShares(true);
+    setPhase("running");
+    setSaveResults([]);
+    const collected: SaveResult[] = [];
+
     try {
       // 1. Removes (or flip-to-private) — immediate effect, no audit.
       if (needsPut) {
+        setProgressLabel(
+          t("permissions.progressApplying", "Applying permission changes…"),
+        );
         await permissionsMutation.mutateAsync({
           isPrivate: goingPrivate ? true : beforePrivate,
           sharedWithUsers: skill.sharedWithUsers.filter(
@@ -241,58 +284,238 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
             (id) => !removedOrgs.includes(id),
           ),
         });
-      }
-
-      // 2. Adds — each one opens an audit-gated share request. Sequential
-      //    rather than Promise.all so the backend's audit cache (shared
-      //    per skill version) only runs once and later targets reuse.
-      let shareOk = 0;
-      let shareFail = 0;
-      for (const input of shareTargets) {
-        try {
-          await initiateShareMutation.mutateAsync({
-            skillIdOrName: skill.guid,
-            input,
+        const removedCount = removedUsers.length + removedOrgs.length + (goingPrivate ? 1 : 0);
+        if (removedCount > 0) {
+          collected.push({
+            kind: "direct-remove",
+            label: t("permissions.revokedSummary", "{{n}} grant(s) revoked", {
+              n: removedCount,
+            }),
           });
-          shareOk += 1;
-        } catch (err) {
-          shareFail += 1;
-          console.warn("Share request failed", input, err);
         }
       }
 
-      const parts: string[] = [];
-      if (needsPut) {
-        parts.push(t("permissions.partRemoves", "permissions updated"));
-      }
-      if (shareOk > 0) {
-        parts.push(
-          t("permissions.partSharesOk", "{{n}} share request(s) submitted for audit", {
-            n: shareOk,
+      // 2. Adds — each one opens an audit-gated share request. Sequential
+      //    rather than Promise.all so the backend's audit cache (per skill
+      //    version) only runs once and subsequent targets reuse it.
+      for (let i = 0; i < shareTargets.length; i++) {
+        const t0 = shareTargets[i];
+        setProgressLabel(
+          t("permissions.progressAuditing", "Running audit for {{label}} ({{i}}/{{total}})…", {
+            label: t0.label,
+            i: i + 1,
+            total: shareTargets.length,
           }),
         );
+        try {
+          const result: ShareRequest = await initiateShareMutation.mutateAsync({
+            skillIdOrName: skill.guid,
+            input: t0.input,
+          });
+          let kind: SaveResult["kind"];
+          if (result.status === "green") kind = "share-green";
+          else if (result.status === "needs-justification") kind = "share-needs-justification";
+          else kind = "share-failed-audit";
+          collected.push({
+            kind,
+            label: t0.label,
+            shareRequestId: result._id,
+          });
+        } catch (err) {
+          collected.push({
+            kind: "share-failed",
+            label: t0.label,
+            errorMessage: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
-      if (shareFail > 0) {
-        parts.push(
-          t("permissions.partSharesFail", "{{n}} share request(s) failed", {
-            n: shareFail,
-          }),
-        );
+
+      // Decide: if any target needs further action, stay in modal and
+      // show the results view. Otherwise toast + close (current flow).
+      const needsFollowup = collected.some(
+        (r) => r.kind === "share-needs-justification" || r.kind === "share-failed-audit" || r.kind === "share-failed",
+      );
+
+      if (needsFollowup) {
+        setSaveResults(collected);
+        setPhase("results");
+      } else {
+        const ok = collected.filter((r) => r.kind === "share-green").length;
+        const parts: string[] = [];
+        if (needsPut) parts.push(t("permissions.partRemoves", "permissions updated"));
+        if (ok > 0) {
+          parts.push(
+            t("permissions.partSharesAccepted", "{{n}} share(s) auto-approved (audit green)", {
+              n: ok,
+            }),
+          );
+        }
+        addToast({
+          type: "success",
+          message: parts.length > 0
+            ? parts.join(" · ")
+            : t("permissions.saveSuccess", "Permissions updated"),
+        });
+        onClose();
       }
-      addToast({
-        type: shareFail > 0 ? "warning" : "success",
-        message: parts.length > 0
-          ? parts.join(" · ")
-          : t("permissions.saveSuccess", "Permissions updated"),
-      });
-      onClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       addToast({ type: "error", message });
-    } finally {
-      setSavingShares(false);
+      setPhase("form");
     }
   };
+
+  if (phase === "running") {
+    return (
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        title={t("permissions.runningTitle", "Running audit…") as string}
+        className="!max-w-xl"
+      >
+        <div className="flex flex-col items-center gap-4 py-10 text-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-2 border-neon-cyan/20 border-t-neon-cyan" aria-hidden />
+          <div className="space-y-1">
+            <p className="font-heading text-sm uppercase tracking-wider text-text-primary">
+              {t("permissions.runningHeading", "Auditing new share targets")}
+            </p>
+            <p className="font-body text-sm text-text-muted min-h-5">
+              {progressLabel}
+            </p>
+          </div>
+          <p className="max-w-md font-body text-xs text-text-muted">
+            {t(
+              "permissions.runningHint",
+              "The audit engine reviews the skill against security, quality, documentation, reliability, and permission-scope dimensions. Keep this window open — it typically takes 20–60 seconds per target.",
+            )}
+          </p>
+        </div>
+      </Modal>
+    );
+  }
+
+  if (phase === "results") {
+    const allOk = saveResults.every((r) => r.kind === "direct-remove" || r.kind === "share-green");
+    const flaggedCount = saveResults.filter(
+      (r) => r.kind === "share-needs-justification" || r.kind === "share-failed-audit" || r.kind === "share-failed",
+    ).length;
+    return (
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        title={t("permissions.resultsTitle", "Audit results") as string}
+        className="!max-w-xl"
+      >
+        <div className="space-y-4">
+          <p className="font-body text-sm text-text-muted">
+            {allOk
+              ? t(
+                  "permissions.resultsAllOk",
+                  "All changes applied cleanly. You can close this dialog.",
+                )
+              : t(
+                  "permissions.resultsHeading",
+                  "{{n}} target(s) need your attention — the audit flagged findings that require a justification before a reviewer can decide.",
+                  { n: flaggedCount },
+                )}
+          </p>
+          <ul className="space-y-2">
+            {saveResults.map((r, idx) => {
+              const iconBase = "h-6 w-6 shrink-0 rounded-full border flex items-center justify-center font-mono text-xs";
+              const rowBase = "flex items-start gap-3 rounded-lg border px-3 py-2";
+              if (r.kind === "direct-remove" || r.kind === "share-green") {
+                return (
+                  <li
+                    key={idx}
+                    className={`${rowBase} border-neon-cyan/30 bg-neon-cyan/5`}
+                  >
+                    <span
+                      aria-hidden
+                      className={`${iconBase} border-neon-cyan/40 text-neon-cyan`}
+                    >
+                      ✓
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-body text-sm text-text-primary">
+                        {r.label}
+                      </p>
+                      <p className="font-body text-xs text-text-muted">
+                        {r.kind === "direct-remove"
+                          ? t("permissions.resultDirect", "Applied immediately.")
+                          : t("permissions.resultGreen", "Audit passed — access granted.")}
+                      </p>
+                    </div>
+                  </li>
+                );
+              }
+              if (r.kind === "share-needs-justification") {
+                return (
+                  <li
+                    key={idx}
+                    className={`${rowBase} border-neon-yellow/30 bg-neon-yellow/5`}
+                  >
+                    <span
+                      aria-hidden
+                      className={`${iconBase} border-neon-yellow/40 text-neon-yellow`}
+                    >
+                      ⚠
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-body text-sm text-text-primary">
+                        {r.label}
+                      </p>
+                      <p className="font-body text-xs text-text-muted">
+                        {t(
+                          "permissions.resultNeedsJustification",
+                          "Audit flagged findings. Submit a justification for a reviewer to consider.",
+                        )}
+                      </p>
+                    </div>
+                    {r.shareRequestId && (
+                      <Link
+                        to={`/shares/${encodeURIComponent(r.shareRequestId)}`}
+                        onClick={onClose}
+                        className="shrink-0 rounded-md border border-neon-yellow/30 px-3 py-1 font-body text-xs text-neon-yellow transition-colors hover:bg-neon-yellow/10"
+                      >
+                        {t("permissions.addJustification", "Add justification →")}
+                      </Link>
+                    )}
+                  </li>
+                );
+              }
+              // failed-audit or failed (HTTP error)
+              return (
+                <li
+                  key={idx}
+                  className={`${rowBase} border-neon-red/30 bg-neon-red/5`}
+                >
+                  <span
+                    aria-hidden
+                    className={`${iconBase} border-neon-red/40 text-neon-red`}
+                  >
+                    ✗
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="font-body text-sm text-text-primary">{r.label}</p>
+                    <p className="font-body text-xs text-text-muted">
+                      {r.errorMessage ??
+                        t(
+                          "permissions.resultFailedAudit",
+                          "Audit failed outright — contact a platform admin.",
+                        )}
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="flex justify-end pt-2">
+            <Button onClick={onClose}>{t("common.close", "Close")}</Button>
+          </div>
+        </div>
+      </Modal>
+    );
+  }
 
   return (
     <Modal
@@ -479,7 +702,7 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
         </Button>
         <Button
           onClick={handleSave}
-          loading={permissionsMutation.isPending || savingShares}
+          loading={permissionsMutation.isPending || initiateShareMutation.isPending}
         >
           {t("common.save", "Save")}
         </Button>

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -332,7 +332,7 @@ export function SkillDetailPage() {
         className="mb-3 shrink-0"
         idOrName={skill.name || skill.guid}
         version={skill.version}
-        isAdmin={isAdminUser}
+        canTriggerAudit={!!(isOwner || isAdminUser)}
       />
       {skill.source && (
         <GitHubOriginChip

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -16,7 +16,6 @@ import { AnalyticsCard } from "@/components/skill/AnalyticsCard";
 import { useRefreshSkillFromSource } from "@/hooks/useSkills";
 import { SkillVersionList } from "@/components/skill/SkillVersionList";
 import { PermissionsModal } from "@/components/skill/PermissionsModal";
-import { ShareModal } from "@/components/skill/ShareModal";
 import { InFlightShareRequests } from "@/components/skill/InFlightShareRequests";
 import {
   useSkill,
@@ -117,7 +116,6 @@ export function SkillDetailPage() {
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showPermissionsModal, setShowPermissionsModal] = useState(false);
-  const [showShareModal, setShowShareModal] = useState(false);
   const [showSaveConfirm, setShowSaveConfirm] = useState(false);
   const [editedContents, setEditedContents] = useState<Map<string, string>>(new Map());
   const [addedPaths, setAddedPaths] = useState<FileTreeEntry[]>([]);
@@ -533,16 +531,6 @@ export function SkillDetailPage() {
                   )}
                   {isOwner && (
                     <Button
-                      variant="secondary"
-                      size="sm"
-                      className="w-full"
-                      onClick={() => setShowShareModal(true)}
-                    >
-                      {t("skillDetail.shareSkill", "Share (audit-gated)")}
-                    </Button>
-                  )}
-                  {isOwner && (
-                    <Button
                       variant="danger"
                       size="sm"
                       className="w-full"
@@ -642,15 +630,6 @@ export function SkillDetailPage() {
         />
       )}
 
-      {/* Share modal — owner-initiated audit-gated share request. */}
-      {isOwner && (
-        <ShareModal
-          isOpen={showShareModal}
-          onClose={() => setShowShareModal(false)}
-          skillIdOrName={skill.name || skill.guid}
-          skillName={skill.name}
-        />
-      )}
       </div>
     </PageTransition>
   );

--- a/ornn-web/src/services/auditApi.ts
+++ b/ornn-web/src/services/auditApi.ts
@@ -44,15 +44,20 @@ export interface RerunAuditInput {
   force?: boolean;
 }
 
-/** Admin-only: force a fresh audit run. Returns the new record. */
+/**
+ * Trigger an audit for a skill. Backend accepts the skill's author OR a
+ * platform admin; in both cases it hits the owner-facing endpoint. The
+ * admin-only `/admin/skills/:idOrName/audit` path is reserved for
+ * any-skill admin reach and isn't needed by the UI today.
+ */
 export async function rerunAudit({
   idOrName,
   force = true,
 }: RerunAuditInput): Promise<AuditRecord> {
   const res = await apiPost<AuditRecord>(
-    `/api/v1/admin/skills/${encodeURIComponent(idOrName)}/audit`,
+    `/api/v1/skills/${encodeURIComponent(idOrName)}/audit`,
     { force },
   );
-  if (!res.data) throw new Error("Audit rerun returned no data");
+  if (!res.data) throw new Error("Audit trigger returned no data");
   return res.data;
 }


### PR DESCRIPTION
## Problem

Two gaps in the current flow, both noticed while manually testing the share UI:

1. **Save in PermissionsModal bypasses audit.** The modal called \`PUT /permissions\` directly, so adding an org grant or flipping the skill to public silently granted access with no audit. That's the opposite of the intent set up by #95 ("audit triggers on share, private skills exempt").
2. **Owners can't run audits themselves.** Only \`POST /admin/skills/:idOrName/audit\` exists, and it requires \`ornn:admin:skill\`. There's no way for the skill's author to pre-flight an audit before initiating a share.

## Fix

### Backend

- New route \`POST /api/v1/skills/:idOrName/audit\` under \`ornn:skill:update\` + ownership check (owner or platform admin). Reuses \`auditService.runAudit\`; same \`{ force?: boolean }\` body shape as the admin endpoint.
- The existing \`POST /api/v1/admin/skills/:idOrName/audit\` route stays put for any-skill admin reach; only the auth gate differs.

### Frontend

- \`auditApi.rerunAudit\` targets the new owner path; admins fall through via the platform-admin bypass on the backend.
- \`AuditBanner\` prop renamed \`isAdmin\` → \`canTriggerAudit\`. The "Run audit" / "Rerun" action now shows for owners, not only platform admins. SkillDetailPage passes \`canTriggerAudit={!!(isOwner || isAdminUser)}\`.
- \`PermissionsModal.handleSave\` now diffs before vs after and splits the save across two paths:
  - **Removes** (user / org grants taken away, flip-to-private) → \`PUT /permissions\` with the post-remove state. Immediate effect.
  - **Adds** (new user grant, new org grant, flip-to-public) → \`POST /skills/:idOrName/share\` per target. The actual ACL only moves once the audit lands green or a reviewer accepts. Targets run sequentially so the audit cache warms once per skill version and subsequent targets reuse it.
  - Toast summarises both: "permissions updated · N share request(s) submitted for audit".
  - Save-without-edits short-circuits with an "info" toast.

## Out of scope

- Showing the audit-in-progress animation on the Save button. The backend audit is synchronous within \`POST /share\`, so the button's existing loading spinner covers it.
- Per-target failure UX beyond the aggregate toast. If one of many share requests fails, the others still land; the toast reports the count.

## Test plan

- [x] \`bun test --filter ornn-api\` — 243/243 pass
- [x] \`bun run test\` in ornn-web — 11/11 pass
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run lint\` — 0 errors (baseline warnings)
- [x] Local rebuild + rollout of both images succeeds
- [ ] Manual test loop:
  - [ ] Own private skill → Manage permissions → add an org → Save → audit runs, InFlightShareRequests card shows the new request
  - [ ] Own public skill → Manage permissions → flip to private → Save → direct PUT, immediate effect, no share request
  - [ ] Own private skill → Manage permissions → add user AND remove a different user → Save → remove PUTs immediately, add creates a share request
  - [ ] Non-admin owner → AuditBanner shows "Run audit" button (no audit exists yet) → click → audit runs, banner redraws with verdict

Part of #172.