### PR TITLE
[Feature] Sharing history surfaces — my requests + admin review history

### DIFF
--- a/.changeset/sharing-history-pages.md
+++ b/.changeset/sharing-history-pages.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+feat: two history surfaces for the sharing workflow. Adds `/my-shares` (linked from the profile dropdown) showing every share request the caller initiated — pending, decided, cancelled — with an Active/Decided filter. Adds `/admin/review-history` (linked from the admin sidebar) showing every share request the caller has accepted or rejected, sourced from the new `GET /api/v1/shares/reviewed-history` endpoint on the backend.

--- a/ornn-api/src/domains/shares/repository.ts
+++ b/ornn-api/src/domains/shares/repository.ts
@@ -135,6 +135,20 @@ export class ShareRepository {
       .toArray();
     return docs.map((d) => mapDoc(d)!);
   }
+
+  /**
+   * Historical review log — every share request where the caller is the
+   * recorded reviewer. Used by the "Review History" admin page so a
+   * reviewer can see their past decisions.
+   */
+  async listByReviewer(reviewerUserId: string, limit = 100): Promise<ShareRequest[]> {
+    const docs = await this.collection
+      .find({ "reviewerDecision.reviewerUserId": reviewerUserId })
+      .sort({ "reviewerDecision.reviewedAt": -1 })
+      .limit(limit)
+      .toArray();
+    return docs.map((d) => mapDoc(d)!);
+  }
 }
 
 function mapDoc(doc: Document | null): ShareRequest | null {

--- a/ornn-api/src/domains/shares/routes.ts
+++ b/ornn-api/src/domains/shares/routes.ts
@@ -8,6 +8,7 @@
  *   POST /api/v1/shares/:requestId/cancel        — owner cancels
  *   GET  /api/v1/shares                          — caller's own share requests
  *   GET  /api/v1/shares/review-queue             — pending reviews the caller can act on
+ *   GET  /api/v1/shares/reviewed-history         — past review decisions by the caller
  *
  * @module domains/shares/routes
  */
@@ -89,6 +90,17 @@ export function createShareRoutes(config: ShareRoutesConfig): Hono<{ Variables: 
         reviewerOrgIds,
         isPlatformAdmin,
       });
+      return c.json({ data: { items }, error: null });
+    },
+  );
+
+  // ---- Reviewer history — past decisions the caller has made -------------
+  app.get(
+    "/shares/reviewed-history",
+    auth,
+    async (c) => {
+      const authCtx = getAuth(c);
+      const items = await shareService.listReviewedHistory(authCtx.userId);
       return c.json({ data: { items }, error: null });
     },
   );

--- a/ornn-api/src/domains/shares/service.ts
+++ b/ornn-api/src/domains/shares/service.ts
@@ -310,6 +310,11 @@ export class ShareService {
     });
   }
 
+  /** Past review decisions made by this user. Terminal states only. */
+  async listReviewedHistory(reviewerUserId: string, limit = 100): Promise<ShareRequest[]> {
+    return this.shareRepo.listByReviewer(reviewerUserId, limit);
+  }
+
   // ---- Internals ---------------------------------------------------------
 
   private async mustFind(requestId: string): Promise<ShareRequest> {

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -76,6 +76,9 @@ const ShareRequestPage = lazy(() =>
 const ReviewsPage = lazy(() =>
   import("@/pages/ReviewsPage").then((m) => ({ default: m.ReviewsPage })),
 );
+const MySharesPage = lazy(() =>
+  import("@/pages/MySharesPage").then((m) => ({ default: m.MySharesPage })),
+);
 
 // Admin pages — bundled into one chunk by virtue of sharing the barrel
 // import path; only loaded when an /admin route activates.
@@ -96,6 +99,9 @@ const AdminCategoriesPage = lazy(() =>
 );
 const AdminTagsPage = lazy(() =>
   import("@/pages/admin").then((m) => ({ default: m.TagsPage })),
+);
+const AdminReviewHistoryPage = lazy(() =>
+  import("@/pages/admin").then((m) => ({ default: m.ReviewHistoryPage })),
 );
 
 const queryClient = new QueryClient({
@@ -148,6 +154,7 @@ export function App() {
                   <Route path="/notifications" element={<NotificationsPage />} />
                   <Route path="/shares/:requestId" element={<ShareRequestPage />} />
                   <Route path="/reviews" element={<ReviewsPage />} />
+                  <Route path="/my-shares" element={<MySharesPage />} />
                 </Route>
 
                 {/* Admin routes - separate layout */}
@@ -160,6 +167,7 @@ export function App() {
                     <Route path="/admin/skills" element={<AdminSkillsPage />} />
                     <Route path="/admin/categories" element={<AdminCategoriesPage />} />
                     <Route path="/admin/tags" element={<AdminTagsPage />} />
+                    <Route path="/admin/review-history" element={<AdminReviewHistoryPage />} />
                   </Route>
                 </Route>
               </Route>

--- a/ornn-web/src/components/layout/AdminLayout.tsx
+++ b/ornn-web/src/components/layout/AdminLayout.tsx
@@ -70,6 +70,15 @@ const NAV_ITEMS: NavItem[] = [
       </svg>
     ),
   },
+  {
+    path: "/admin/review-history",
+    label: "Review History",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+      </svg>
+    ),
+  },
 ];
 
 function getBreadcrumbs(pathname: string): Array<{ label: string; path?: string }> {

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -239,7 +239,6 @@ const NAV_ITEMS = [
   { i18nKey: "nav.home", path: "/", requiresAuth: false, exact: true },
   { i18nKey: "nav.registry", path: "/registry", requiresAuth: false, exact: true },
   { i18nKey: "nav.build", path: "/skills/new", requiresAuth: true },
-  { i18nKey: "nav.reviews", path: "/reviews", requiresAuth: true },
   { i18nKey: "nav.docs", path: "/docs", requiresAuth: false },
 ] as const;
 
@@ -463,6 +462,15 @@ export function Navbar({ className = "" }: NavbarProps) {
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
                           </svg>
                           {t("nav.mySharingRequests", "My Sharing Requests")}
+                        </Link>
+                        <Link
+                          to="/reviews"
+                          className="flex items-center gap-3 px-4 py-2.5 font-body text-sm text-text-primary transition-colors hover:bg-neon-cyan/5"
+                        >
+                          <svg className="h-4 w-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 13l4 4L19 7" />
+                          </svg>
+                          {t("nav.reviewQueue", "Review Queue")}
                         </Link>
                         <a
                           href={getNyxIdUrl()}

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -455,6 +455,15 @@ export function Navbar({ className = "" }: NavbarProps) {
                           </svg>
                           {t("nav.myOrgs", "My Organizations")}
                         </a>
+                        <Link
+                          to="/my-shares"
+                          className="flex items-center gap-3 px-4 py-2.5 font-body text-sm text-text-primary transition-colors hover:bg-neon-cyan/5"
+                        >
+                          <svg className="h-4 w-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                          </svg>
+                          {t("nav.mySharingRequests", "My Sharing Requests")}
+                        </Link>
                         <a
                           href={getNyxIdUrl()}
                           target="_blank"

--- a/ornn-web/src/hooks/useShares.ts
+++ b/ornn-web/src/hooks/useShares.ts
@@ -7,6 +7,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   cancelShareRequest,
+  fetchMyReviewedShareHistory,
   fetchMyShareRequests,
   fetchShareRequest,
   fetchShareReviewQueue,
@@ -24,6 +25,7 @@ import { useIsAuthenticated } from "@/stores/authStore";
 
 const MY_SHARES_KEY = ["shares", "mine"] as const;
 const REVIEW_QUEUE_KEY = ["shares", "review-queue"] as const;
+const REVIEWED_HISTORY_KEY = ["shares", "reviewed-history"] as const;
 const shareKey = (requestId: string) => ["shares", "one", requestId] as const;
 
 export function useMyShareRequests() {
@@ -43,6 +45,17 @@ export function useShareReviewQueue() {
     queryFn: fetchShareReviewQueue,
     enabled: isAuthed,
     staleTime: 15_000,
+  });
+}
+
+/** Past decisions by the caller — feeds the admin "Review history" page. */
+export function useMyReviewedShareHistory() {
+  const isAuthed = useIsAuthenticated();
+  return useQuery<ShareRequest[]>({
+    queryKey: REVIEWED_HISTORY_KEY,
+    queryFn: fetchMyReviewedShareHistory,
+    enabled: isAuthed,
+    staleTime: 60_000,
   });
 }
 
@@ -76,6 +89,7 @@ export function useCancelShareRequest() {
       queryClient.setQueryData(shareKey(updated._id), updated);
       queryClient.invalidateQueries({ queryKey: MY_SHARES_KEY });
       queryClient.invalidateQueries({ queryKey: REVIEW_QUEUE_KEY });
+      queryClient.invalidateQueries({ queryKey: REVIEWED_HISTORY_KEY });
       queryClient.invalidateQueries({ queryKey: ["notifications"] });
     },
   });

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -24,6 +24,7 @@
     "build": "Build",
     "reviews": "Reviews",
     "docs": "Docs",
+    "mySharingRequests": "My Sharing Requests",
     "signIn": "Sign In",
     "signOut": "Sign Out",
     "settings": "Settings",

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -25,6 +25,7 @@
     "reviews": "Reviews",
     "docs": "Docs",
     "mySharingRequests": "My Sharing Requests",
+    "reviewQueue": "Review Queue",
     "signIn": "Sign In",
     "signOut": "Sign Out",
     "settings": "Settings",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -24,6 +24,7 @@
     "build": "构建",
     "reviews": "审核",
     "docs": "文档",
+    "mySharingRequests": "我的分享申请",
     "signIn": "登录",
     "signOut": "退出",
     "settings": "设置",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -25,6 +25,7 @@
     "reviews": "审核",
     "docs": "文档",
     "mySharingRequests": "我的分享申请",
+    "reviewQueue": "审核队列",
     "signIn": "登录",
     "signOut": "退出",
     "settings": "设置",

--- a/ornn-web/src/pages/MySharesPage.tsx
+++ b/ornn-web/src/pages/MySharesPage.tsx
@@ -1,0 +1,174 @@
+/**
+ * /my-shares — caller's full share-request history.
+ *
+ * Shows every request the caller initiated, across all statuses:
+ * pending-audit / needs-justification / pending-review / accepted /
+ * rejected / cancelled. Rows link to the detail page for follow-up.
+ *
+ * @module pages/MySharesPage
+ */
+
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { useMyShareRequests } from "@/hooks/useShares";
+import type { ShareRequest, ShareStatus } from "@/types/shares";
+
+type StatusFilter = "all" | "active" | "decided";
+
+const STATUS_LABEL: Record<ShareStatus, string> = {
+  "pending-audit": "Auditing",
+  green: "Green",
+  "needs-justification": "Needs justification",
+  "pending-review": "Pending review",
+  accepted: "Accepted",
+  rejected: "Rejected",
+  cancelled: "Cancelled",
+};
+
+const STATUS_TONE: Record<ShareStatus, string> = {
+  "pending-audit": "border-neon-cyan/30 bg-neon-cyan/5 text-neon-cyan",
+  green: "border-neon-cyan/30 bg-neon-cyan/5 text-neon-cyan",
+  "needs-justification": "border-neon-yellow/30 bg-neon-yellow/5 text-neon-yellow",
+  "pending-review": "border-neon-yellow/30 bg-neon-yellow/5 text-neon-yellow",
+  accepted: "border-neon-cyan/20 bg-neon-cyan/5 text-neon-cyan",
+  rejected: "border-neon-red/20 bg-neon-red/5 text-neon-red",
+  cancelled: "border-neon-cyan/10 bg-bg-surface/40 text-text-muted",
+};
+
+const DECIDED: ReadonlySet<ShareStatus> = new Set([
+  "accepted",
+  "rejected",
+  "cancelled",
+]);
+
+function targetLabel(req: ShareRequest): string {
+  if (req.target.type === "public") return "Public";
+  const prefix = req.target.type === "org" ? "Org" : "User";
+  return `${prefix} ${req.target.id ?? ""}`.trim();
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+export function MySharesPage() {
+  const { t } = useTranslation();
+  const { data: requests = [], isLoading, isError } = useMyShareRequests();
+  const [filter, setFilter] = useState<StatusFilter>("all");
+
+  const filtered = useMemo(() => {
+    const sorted = [...requests].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    if (filter === "active") return sorted.filter((r) => !DECIDED.has(r.status));
+    if (filter === "decided") return sorted.filter((r) => DECIDED.has(r.status));
+    return sorted;
+  }, [requests, filter]);
+
+  return (
+    <PageTransition>
+      <div className="mx-auto w-full max-w-4xl px-6 py-10">
+        <header className="mb-6 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1 className="font-heading text-3xl text-text-primary">
+              {t("myShares.title", "My sharing requests")}
+            </h1>
+            <p className="mt-1 font-body text-sm text-text-muted">
+              {t(
+                "myShares.subtitle",
+                "Every audit-gated share you've initiated — active, decided, and cancelled.",
+              )}
+            </p>
+          </div>
+          <div className="flex overflow-hidden rounded-lg border border-neon-cyan/20 bg-bg-surface/40">
+            {([
+              ["all", t("myShares.filterAll", "All")],
+              ["active", t("myShares.filterActive", "Active")],
+              ["decided", t("myShares.filterDecided", "Decided")],
+            ] as const).map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setFilter(key)}
+                className={`px-3 py-1.5 font-body text-sm transition-colors cursor-pointer ${
+                  filter === key
+                    ? "bg-neon-cyan/15 text-neon-cyan"
+                    : "text-text-muted hover:text-text-primary"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        {isLoading ? (
+          <p className="py-16 text-center font-body text-sm text-text-muted">
+            {t("myShares.loading", "Loading…")}
+          </p>
+        ) : isError ? (
+          <p className="py-16 text-center font-body text-sm text-neon-red">
+            {t("myShares.loadFailed", "Could not load share requests.")}
+          </p>
+        ) : filtered.length === 0 ? (
+          <div className="rounded-lg border border-neon-cyan/10 bg-bg-surface/30 py-16 text-center">
+            <p className="font-body text-sm text-text-muted">
+              {filter === "all"
+                ? t("myShares.empty", "You haven't initiated any share requests yet.")
+                : filter === "active"
+                  ? t("myShares.emptyActive", "No active share requests.")
+                  : t("myShares.emptyDecided", "No decided share requests yet.")}
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-neon-cyan/10 overflow-hidden rounded-lg border border-neon-cyan/10 bg-bg-surface/30">
+            {filtered.map((req) => (
+              <li key={req._id}>
+                <Link
+                  to={`/shares/${encodeURIComponent(req._id)}`}
+                  className="flex flex-wrap items-center justify-between gap-3 px-5 py-4 transition-colors hover:bg-neon-cyan/5 cursor-pointer"
+                >
+                  <div className="min-w-0 flex flex-col gap-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span
+                        className={`rounded border px-2 py-0.5 font-heading text-[10px] uppercase tracking-wider ${STATUS_TONE[req.status]}`}
+                      >
+                        {STATUS_LABEL[req.status]}
+                      </span>
+                      <span className="font-body text-sm text-text-primary">
+                        {t("myShares.to", "To")}: {targetLabel(req)}
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3 font-mono text-xs text-text-muted">
+                      <span>
+                        {t("myShares.skill", "skill")}: {req.skillGuid.slice(0, 8)}… · v{req.skillVersion}
+                      </span>
+                      {req.auditVerdict && (
+                        <span>
+                          {t("myShares.audit", "audit")}: {req.auditVerdict}
+                          {typeof req.auditOverallScore === "number" && (
+                            <> · {req.auditOverallScore.toFixed(1)}/10</>
+                          )}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-1 shrink-0">
+                    <span className="font-mono text-xs text-text-muted">
+                      {formatTimestamp(req.createdAt)}
+                    </span>
+                    <span className="font-body text-xs text-neon-cyan">
+                      {t("myShares.view", "View →")}
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/pages/admin/ReviewHistoryPage.tsx
+++ b/ornn-web/src/pages/admin/ReviewHistoryPage.tsx
@@ -1,0 +1,139 @@
+/**
+ * /admin/review-history — past review decisions by the caller.
+ *
+ * Shows every share request where the caller is the recorded reviewer
+ * (`reviewerDecision.reviewerUserId`). Complements `/reviews` (pending
+ * queue); together they give an org admin / platform admin a full
+ * before-and-after view of their review workload.
+ *
+ * @module pages/admin/ReviewHistoryPage
+ */
+
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { useMyReviewedShareHistory } from "@/hooks/useShares";
+import type { ShareRequest } from "@/types/shares";
+
+function targetLabel(req: ShareRequest): string {
+  if (req.target.type === "public") return "Public";
+  const prefix = req.target.type === "org" ? "Org" : "User";
+  return `${prefix} ${req.target.id ?? ""}`.trim();
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+export function ReviewHistoryPage() {
+  const { t } = useTranslation();
+  const { data: history = [], isLoading, isError } = useMyReviewedShareHistory();
+
+  const sorted = useMemo(
+    () =>
+      [...history].sort((a, b) => {
+        const ad = a.reviewerDecision?.reviewedAt ?? a.updatedAt;
+        const bd = b.reviewerDecision?.reviewedAt ?? b.updatedAt;
+        return bd.localeCompare(ad);
+      }),
+    [history],
+  );
+
+  return (
+    <PageTransition>
+      <div className="mx-auto w-full max-w-4xl px-6 py-10">
+        <header className="mb-6">
+          <h1 className="font-heading text-3xl text-text-primary">
+            {t("reviewHistory.title", "Review history")}
+          </h1>
+          <p className="mt-1 font-body text-sm text-text-muted">
+            {t(
+              "reviewHistory.subtitle",
+              "Share requests you've accepted or rejected. Use the review queue for anything still pending.",
+            )}
+          </p>
+        </header>
+
+        {isLoading ? (
+          <p className="py-16 text-center font-body text-sm text-text-muted">
+            {t("reviewHistory.loading", "Loading…")}
+          </p>
+        ) : isError ? (
+          <p className="py-16 text-center font-body text-sm text-neon-red">
+            {t("reviewHistory.loadFailed", "Could not load review history.")}
+          </p>
+        ) : sorted.length === 0 ? (
+          <div className="rounded-lg border border-neon-cyan/10 bg-bg-surface/30 py-16 text-center">
+            <p className="font-body text-sm text-text-muted">
+              {t("reviewHistory.empty", "You haven't reviewed any share requests yet.")}
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-neon-cyan/10 overflow-hidden rounded-lg border border-neon-cyan/10 bg-bg-surface/30">
+            {sorted.map((req) => {
+              const decision = req.reviewerDecision?.decision;
+              const tone =
+                decision === "accept"
+                  ? "border-neon-cyan/30 bg-neon-cyan/5 text-neon-cyan"
+                  : "border-neon-red/30 bg-neon-red/5 text-neon-red";
+              return (
+                <li key={req._id}>
+                  <Link
+                    to={`/shares/${encodeURIComponent(req._id)}`}
+                    className="flex flex-wrap items-center justify-between gap-3 px-5 py-4 transition-colors hover:bg-neon-cyan/5 cursor-pointer"
+                  >
+                    <div className="min-w-0 flex flex-col gap-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span
+                          className={`rounded border px-2 py-0.5 font-heading text-[10px] uppercase tracking-wider ${tone}`}
+                        >
+                          {decision === "accept"
+                            ? t("reviewHistory.accepted", "Accepted")
+                            : t("reviewHistory.rejected", "Rejected")}
+                        </span>
+                        <span className="font-body text-sm text-text-primary">
+                          {t("reviewHistory.target", "To")}: {targetLabel(req)}
+                        </span>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-3 font-mono text-xs text-text-muted">
+                        <span>
+                          {t("reviewHistory.skill", "skill")}: {req.skillGuid.slice(0, 8)}… · v{req.skillVersion}
+                        </span>
+                        {req.auditVerdict && (
+                          <span>
+                            {t("reviewHistory.audit", "audit")}: {req.auditVerdict}
+                            {typeof req.auditOverallScore === "number" && (
+                              <> · {req.auditOverallScore.toFixed(1)}/10</>
+                            )}
+                          </span>
+                        )}
+                      </div>
+                      {req.reviewerDecision?.note && (
+                        <p className="font-body text-xs text-text-muted italic">
+                          "{req.reviewerDecision.note}"
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex flex-col items-end gap-1 shrink-0">
+                      <span className="font-mono text-xs text-text-muted">
+                        {formatTimestamp(
+                          req.reviewerDecision?.reviewedAt ?? req.updatedAt,
+                        )}
+                      </span>
+                      <span className="font-body text-xs text-neon-cyan">
+                        {t("reviewHistory.view", "Open →")}
+                      </span>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/pages/admin/index.ts
+++ b/ornn-web/src/pages/admin/index.ts
@@ -9,3 +9,4 @@ export { DashboardPage } from "./DashboardPage";
 export { ActivitiesPage } from "./ActivitiesPage";
 export { UsersPage } from "./UsersPage";
 export { AdminSkillsPage } from "./AdminSkillsPage";
+export { ReviewHistoryPage } from "./ReviewHistoryPage";

--- a/ornn-web/src/services/sharesApi.ts
+++ b/ornn-web/src/services/sharesApi.ts
@@ -78,3 +78,8 @@ export async function fetchShareReviewQueue(): Promise<ShareRequest[]> {
   const res = await apiGet<{ items: ShareRequest[] }>("/api/v1/shares/review-queue");
   return res.data?.items ?? [];
 }
+
+export async function fetchMyReviewedShareHistory(): Promise<ShareRequest[]> {
+  const res = await apiGet<{ items: ShareRequest[] }>("/api/v1/shares/reviewed-history");
+  return res.data?.items ?? [];
+}


### PR DESCRIPTION
## Summary

Two standalone history pages that bracket the existing /reviews queue so owners and reviewers can see their full share lifecycle without combing through notifications.

### /my-shares — caller's own requests

- Linked from the profile dropdown ("My Sharing Requests").
- Lists every share request the caller initiated across all statuses (pending-audit / needs-justification / pending-review / accepted / rejected / cancelled).
- All / Active / Decided filter tabs.
- Each row links to /shares/:requestId for follow-up.

### /admin/review-history — caller's past decisions

- Linked from the admin sidebar ("Review History").
- Lists every share request where the caller is the recorded reviewer.
- Shows accept/reject tone, target, skill snapshot, audit verdict + score, reviewer note, reviewed-at timestamp.
- Sorted by decision time (most recent first).

### Backend

- New GET /api/v1/shares/reviewed-history, registered before the :requestId wildcard (same ordering invariant that tripped up #171).
- shareService.listReviewedHistory + shareRepo.listByReviewer — filter on reviewerDecision.reviewerUserId, sort by reviewedAt desc, limit 100.

### Frontend plumbing

- fetchMyReviewedShareHistory in sharesApi.
- useMyReviewedShareHistory hook (60s staleTime — decisions don't change after the fact).
- useReviewShareRequest invalidates the new history key on success so a fresh decision lands in the list without a manual refresh.
- i18n: nav.mySharingRequests + per-page label keys in both locales.

## Test plan

- [x] bun test --filter ornn-api — 243/243 pass
- [x] bun run test in ornn-web — 11/11 pass
- [x] bunx tsc --noEmit — clean
- [x] bun run lint — 0 errors (baseline warnings)
- [x] Local rebuild + rollout succeeds
- [ ] Manual: profile dropdown shows "My Sharing Requests", admin sidebar shows "Review History", accepting a share from /shares/:id lands in both the queue-cleared and history-gained states.