### PR TITLE
[CI/CD] Auto-pass check-approval for repo collaborators

### DIFF
--- a/.changeset/collab-auto-approve.md
+++ b/.changeset/collab-auto-approve.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: check-approval now auto-passes for repo collaborators (not just the hardcoded TRUSTED_AUTHORS list), so PRs from added contributors don't block on maintainer approval. CI-only — no product behavior change.

--- a/.github/workflows/require-review.yml
+++ b/.github/workflows/require-review.yml
@@ -10,6 +10,12 @@ on:
 jobs:
   check-approval:
     runs-on: ubuntu-latest
+    # checkCollaborator is a read-only metadata call; the default
+    # GITHUB_TOKEN scope already covers it, but we name it here so the
+    # intent is explicit and fork PRs can't silently lose access.
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Check if team approval is required
         uses: actions/github-script@v7
@@ -33,11 +39,31 @@ jobs:
               return;
             }
 
-            // External contributors: placeholder. The original team-based
-            // gate (aevatarAI/Aevatarians) pointed at the pre-transfer org
-            // and was removed when the repo moved to ChronoAIProject. Until
-            // a ChronoAIProject team exists + there are actual external
-            // contributors to gate, fail explicitly so nothing slips through.
+            // Anyone explicitly invited as a collaborator on the repo (any
+            // permission level — read, triage, write, maintain, admin)
+            // passes without an additional maintainer approval gate. The
+            // act of accepting the collaborator invite is the vetting.
+            try {
+              await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              console.log(`PR author '${author}' is a repo collaborator — no approval required`);
+              return;
+            } catch (err) {
+              if (err.status !== 404) {
+                // Any non-404 error (rate limit, auth, transient) should
+                // surface rather than be silently treated as "not a
+                // collaborator" — that would mask token-scope regressions.
+                throw err;
+              }
+              // 404 = not a collaborator. Fall through to the gate below.
+            }
+
+            // External contributors fall through to the explicit fail. Add
+            // them as repo collaborators (Settings → Collaborators) if you
+            // want them to pass this check automatically.
             core.setFailed(
-              `PRs from '${author}' require maintainer approval — no team-review gate is configured yet for the ChronoAIProject org.`,
+              `PRs from '${author}' require maintainer approval. Add them as a repo collaborator to auto-pass this check.`,
             );


### PR DESCRIPTION
## Summary

Today any author not in a tiny hard-coded allow-list (\`chronoai-shining\` + bot accounts) hard-fails the \`check-approval\` job regardless of how much access they have on the repo. People we've explicitly invited as collaborators — e.g. \`ctkm-aelf\` on #143 — shouldn't need an additional maintainer approval gate on top of the invitation.

## Fix

Extend \`.github/workflows/require-review.yml\` with one extra branch:

1. If the author is in \`TRUSTED_AUTHORS\` (maintainer / bot) → pass (existing behaviour).
2. Else call \`github.rest.repos.checkCollaborator\` — 204 means the author is a collaborator at any permission level → pass.
3. Else fail with the existing "requires maintainer approval" message (now points the reader at Settings → Collaborators as the fix).

Non-404 API errors surface rather than being silently treated as "not a collaborator" so a token-scope regression can't downgrade the gate unnoticed.

Also pins the job to \`contents: read\` + \`pull-requests: read\` so fork PRs keep the scopes they need and nothing more.

## Test plan

- [x] Workflow YAML lints locally
- [ ] After merge: the same PR (#143) should re-run and pass without any action on the collaborator's side
- [ ] An author that is neither maintainer nor collaborator still fails (nothing regressed)