### PR TITLE
[Feature] Delete non-latest skill version

### DIFF
--- a/.changeset/delete-non-latest-skill-version.md
+++ b/.changeset/delete-non-latest-skill-version.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+feat: delete a non-latest skill version (#183). New endpoint `DELETE /api/v1/skills/:idOrName/versions/:version` (owner or `ornn:admin:skill`). Refuses to delete the only remaining version (use `DELETE /skills/:id`) or the current latest (publish a newer version first). The version's package zip is best-effort cleaned from storage; the row is removed from `skill_versions`. Frontend: per-row Delete button on `SkillVersionList` (owner / admin only, hidden for the latest row), confirmation modal, and a SkillDetailPage handler that toasts the result and snaps back to latest if the user was viewing the deleted version.

--- a/ornn-api/src/domains/admin/activityRepository.ts
+++ b/ornn-api/src/domains/admin/activityRepository.ts
@@ -15,6 +15,7 @@ export type ActivityAction =
   | "skill:create"
   | "skill:update"
   | "skill:delete"
+  | "skill:version_delete"
   | "skill:visibility_change"
   | "skill:permissions_change"
   | "skill:refresh";

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -730,5 +730,58 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     },
   );
 
+  /**
+   * DELETE /skills/:idOrName/versions/:version — Delete one non-latest
+   * version of a skill. The skill itself + every other version are
+   * preserved. Cannot remove the only remaining version (use
+   * DELETE /skills/:id) or the current latest (publish a newer one first).
+   * Requires: ornn:skill:delete + owner or admin.
+   */
+  app.delete(
+    "/skills/:idOrName/versions/:version",
+    auth,
+    requirePermission("ornn:skill:delete"),
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const version = c.req.param("version");
+      const authCtx = getAuth(c);
+
+      let skill = await skillRepo.findByGuid(idOrName);
+      if (!skill) skill = await skillRepo.findByName(idOrName);
+      if (!skill) {
+        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      }
+      const memberships = await readUserOrgMemberships(c);
+      const actor = {
+        userId: authCtx.userId,
+        memberships,
+        isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+      };
+      if (!canManageSkill(skill, actor)) {
+        throw AppError.forbidden(
+          "FORBIDDEN",
+          "You do not have permission to delete this skill version",
+        );
+      }
+      logger.info(
+        { skillGuid: skill.guid, version, userId: authCtx.userId },
+        "Skill version delete via API",
+      );
+      await skillService.deleteVersion(skill.guid, version);
+
+      activityRepo
+        ?.log(authCtx.userId, authCtx.email, authCtx.displayName, "skill:version_delete", {
+          skillId: skill.guid,
+          skillName: skill.name,
+          version,
+        })
+        .catch((err) =>
+          logger.warn({ err }, "Failed to log skill:version_delete activity"),
+        );
+
+      return c.json({ data: { success: true }, error: null });
+    },
+  );
+
   return app;
 }

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -573,6 +573,63 @@ export class SkillService {
     return new Uint8Array(await res.arrayBuffer());
   }
 
+  /**
+   * Delete a single non-latest version. Constraints:
+   *   - The version must exist.
+   *   - Cannot delete the **only** version on the skill — the caller should
+   *     use `DELETE /skills/:id` for that.
+   *   - Cannot delete the **current latest** version — moving the latest
+   *     pointer is a write that touches the skill doc and isn't worth the
+   *     complexity for a UI prune; ask the owner to publish a new latest
+   *     first if they really need to remove what's currently latest.
+   * Storage is best-effort cleaned up; failures are logged but do not roll
+   * back the version row deletion.
+   */
+  async deleteVersion(idOrName: string, version: string): Promise<void> {
+    let skill = await this.skillRepo.findByGuid(idOrName);
+    if (!skill) skill = await this.skillRepo.findByName(idOrName);
+    if (!skill) {
+      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+    }
+    const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, version);
+    if (!versionDoc) {
+      throw AppError.notFound(
+        "SKILL_VERSION_NOT_FOUND",
+        `Version '${version}' not found for skill '${skill.name}'`,
+      );
+    }
+    const allVersions = await this.skillVersionRepo.listBySkill(skill.guid);
+    if (allVersions.length <= 1) {
+      throw AppError.conflict(
+        "SKILL_VERSION_LAST",
+        `Cannot delete the only remaining version of '${skill.name}'. Delete the whole skill instead.`,
+      );
+    }
+    // `listBySkill` returns versions sorted latest-first, so index 0 is the
+    // current latest pointer. Forbid deleting it; owner must publish a
+    // newer version first.
+    const latest = allVersions[0]!;
+    if (latest.version === version) {
+      throw AppError.conflict(
+        "SKILL_VERSION_LATEST",
+        `Cannot delete v${version}: it is the current latest. Publish a newer version first, then delete v${version}.`,
+      );
+    }
+
+    if (versionDoc.storageKey) {
+      try {
+        await this.storageClient.delete(this.storageBucket, versionDoc.storageKey);
+      } catch (err) {
+        logger.warn(
+          { skillGuid: skill.guid, version, storageKey: versionDoc.storageKey, err },
+          "Best-effort version-storage cleanup failed",
+        );
+      }
+    }
+    await this.skillVersionRepo.deleteOne(skill.guid, version);
+    logger.info({ skillGuid: skill.guid, version }, "Skill version deleted");
+  }
+
   async deleteSkill(guid: string): Promise<void> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {

--- a/ornn-api/src/domains/skills/crud/skillVersionRepository.ts
+++ b/ornn-api/src/domains/skills/crud/skillVersionRepository.ts
@@ -115,6 +115,18 @@ export class SkillVersionRepository {
     return result.deletedCount ?? 0;
   }
 
+  /** Delete one version row. Returns true when the row existed. */
+  async deleteOne(skillGuid: string, version: string): Promise<boolean> {
+    const result = await this.collection.deleteOne({
+      _id: `${skillGuid}@${version}` as never,
+    });
+    const deleted = (result.deletedCount ?? 0) > 0;
+    if (deleted) {
+      logger.info({ skillGuid, version }, "Skill version deleted");
+    }
+    return deleted;
+  }
+
   /**
    * Toggle the deprecation flag on a single version. When `isDeprecated` is
    * false the `deprecationNote` is cleared (empty note is never sticky).

--- a/ornn-web/src/components/skill/SkillVersionList.tsx
+++ b/ornn-web/src/components/skill/SkillVersionList.tsx
@@ -24,7 +24,7 @@ export interface SkillVersionListProps {
   currentVersion: string;
   /** Fire when the user clicks a version row to switch to it. */
   onSelect: (version: string) => void;
-  /** Show owner-only controls (deprecation toggle). */
+  /** Show owner-only controls (deprecation toggle, delete). */
   canManage: boolean;
   /** Fire when the deprecation flag changes; receives the target version. */
   onToggleDeprecation?: (args: {
@@ -34,6 +34,10 @@ export interface SkillVersionListProps {
   }) => Promise<void> | void;
   /** Whether a deprecation mutation is currently in flight (for loading state). */
   isMutating?: boolean;
+  /** Fire when the user confirms a non-latest version delete. */
+  onDeleteVersion?: (version: string) => Promise<void> | void;
+  /** Whether a delete mutation is currently in flight (for loading state). */
+  isDeleting?: boolean;
   className?: string;
 }
 
@@ -50,11 +54,14 @@ export function SkillVersionList({
   canManage,
   onToggleDeprecation,
   isMutating = false,
+  onDeleteVersion,
+  isDeleting = false,
   className = "",
 }: SkillVersionListProps) {
   const { t } = useTranslation();
   const [modalTarget, setModalTarget] = useState<SkillVersionEntry | null>(null);
   const [noteDraft, setNoteDraft] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<SkillVersionEntry | null>(null);
   const latestVersion = versions[0]?.version;
 
   const openDeprecationModal = (entry: SkillVersionEntry) => {
@@ -74,6 +81,12 @@ export function SkillVersionList({
       deprecationNote: modalTarget.isDeprecated ? undefined : noteDraft.trim() || undefined,
     });
     closeModal();
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget || !onDeleteVersion) return;
+    await onDeleteVersion(deleteTarget.version);
+    setDeleteTarget(null);
   };
 
   if (versions.length === 0) {
@@ -147,6 +160,26 @@ export function SkillVersionList({
                       : t("skillDetail.markDeprecated")}
                   </button>
                 )}
+                {canManage &&
+                  onDeleteVersion &&
+                  !isLatest &&
+                  versions.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setDeleteTarget(v)}
+                      disabled={isDeleting}
+                      title={t("skillDetail.deleteVersion", "Delete this version")}
+                      className="
+                        shrink-0 rounded border border-transparent px-2 py-1
+                        font-body text-xs text-text-muted
+                        hover:text-neon-red hover:border-neon-red/40
+                        disabled:opacity-50 disabled:cursor-not-allowed
+                        transition-colors cursor-pointer
+                      "
+                    >
+                      {t("common.delete")}
+                    </button>
+                  )}
               </div>
             </li>
           );
@@ -193,6 +226,42 @@ export function SkillVersionList({
             {modalTarget?.isDeprecated
               ? t("skillDetail.unmarkDeprecated")
               : t("skillDetail.markDeprecated")}
+          </Button>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        title={
+          t("skillDetail.deleteVersionTitle", {
+            defaultValue: "Delete v{{version}}?",
+            version: deleteTarget?.version ?? "",
+          }) as string
+        }
+      >
+        <p className="font-body text-sm text-text-muted">
+          {t("skillDetail.deleteVersionConfirm", {
+            defaultValue:
+              "Are you sure you want to delete v{{version}}? The version's package zip and audit history are removed and this cannot be undone.",
+            version: deleteTarget?.version ?? "",
+          })}
+        </p>
+        <div className="mt-6 flex justify-end gap-3">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setDeleteTarget(null)}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            loading={isDeleting}
+            onClick={confirmDelete}
+          >
+            {t("common.delete")}
           </Button>
         </div>
       </Modal>

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -7,6 +7,7 @@ import {
   updateSkill,
   updateSkillPackage,
   deleteSkill,
+  deleteSkillVersion,
   setSkillVersionDeprecation,
   pullSkillFromGitHub,
   refreshSkillFromSource,
@@ -261,6 +262,28 @@ export function useDeleteSkill() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
+    },
+  });
+}
+
+/**
+ * Delete one non-latest version of a skill. Refreshes the skill itself,
+ * its versions list, and the audit history (which is keyed per version).
+ */
+export function useDeleteSkillVersion(idOrName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (version: string) => deleteSkillVersion(idOrName, version),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SKILLS_KEY, idOrName] });
+      queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
+      queryClient.invalidateQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === "audit" &&
+          q.queryKey[1] === idOrName,
+      });
     },
   });
 }

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -135,7 +135,12 @@
     "deprecationNoteLabel": "Note (optional)",
     "deprecationNotePlaceholder": "Reason, migration path, or replacement version…",
     "deprecationUpdated": "Deprecation status updated",
-    "deprecationFailed": "Failed to update deprecation status"
+    "deprecationFailed": "Failed to update deprecation status",
+    "deleteVersion": "Delete this version",
+    "deleteVersionTitle": "Delete v{{version}}?",
+    "deleteVersionConfirm": "Are you sure you want to delete v{{version}}? The version's package zip and audit history are removed and this cannot be undone.",
+    "versionDeleted": "Version v{{version}} deleted",
+    "versionDeleteFailed": "Failed to delete version"
   },
   "editSkill": {
     "backToSkill": "Back to {{name}}",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -135,7 +135,12 @@
     "deprecationNoteLabel": "说明（可选）",
     "deprecationNotePlaceholder": "原因、迁移路径或替代版本…",
     "deprecationUpdated": "废弃状态已更新",
-    "deprecationFailed": "更新废弃状态失败"
+    "deprecationFailed": "更新废弃状态失败",
+    "deleteVersion": "删除此版本",
+    "deleteVersionTitle": "删除 v{{version}}？",
+    "deleteVersionConfirm": "确定要删除 v{{version}} 吗？该版本的安装包和审计历史会一并移除，此操作不可撤销。",
+    "versionDeleted": "版本 v{{version}} 已删除",
+    "versionDeleteFailed": "删除版本失败"
   },
   "editSkill": {
     "backToSkill": "返回 {{name}}",

--- a/ornn-web/src/pages/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/SkillDetailPage.tsx
@@ -21,6 +21,7 @@ import { PermissionsModal } from "@/components/skill/PermissionsModal";
 import {
   useSkill,
   useDeleteSkill,
+  useDeleteSkillVersion,
   useUpdateSkillPackage,
   useSkillVersions,
   useSetVersionDeprecation,
@@ -63,6 +64,7 @@ export function SkillDetailPage() {
   const deleteMutation = useDeleteSkill();
   const updatePackageMutation = useUpdateSkillPackage(skill?.guid ?? "");
   const deprecationMutation = useSetVersionDeprecation(idOrName ?? "");
+  const deleteVersionMutation = useDeleteSkillVersion(idOrName ?? "");
   const refreshMutation = useRefreshSkillFromSource(idOrName ?? "");
   const startAuditMutation = useStartAudit();
 
@@ -590,6 +592,36 @@ export function SkillDetailPage() {
               canManage={canManageVersions}
               onToggleDeprecation={handleToggleDeprecation}
               isMutating={deprecationMutation.isPending}
+              isDeleting={deleteVersionMutation.isPending}
+              onDeleteVersion={async (version) => {
+                try {
+                  await deleteVersionMutation.mutateAsync(version);
+                  // If the user was viewing the now-deleted version, snap
+                  // back to latest so the page doesn't 404.
+                  if (skill.version === version) {
+                    handleVersionChange(null);
+                  }
+                  addToast({
+                    type: "success",
+                    message: t(
+                      "skillDetail.versionDeleted",
+                      "Version v{{version}} deleted",
+                      { version },
+                    ),
+                  });
+                } catch (err) {
+                  addToast({
+                    type: "error",
+                    message:
+                      err instanceof Error
+                        ? err.message
+                        : t(
+                            "skillDetail.versionDeleteFailed",
+                            "Failed to delete version",
+                          ),
+                  });
+                }
+              }}
             />
           )}
 

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -148,6 +148,20 @@ export async function deleteSkill(id: string): Promise<void> {
   await apiDelete(`/api/v1/skills/${id}`);
 }
 
+/**
+ * Hard-delete one non-latest version of a skill. Backend forbids deleting
+ * the only version (use `deleteSkill`) or the current latest (publish a
+ * newer version first).
+ */
+export async function deleteSkillVersion(
+  idOrName: string,
+  version: string,
+): Promise<void> {
+  await apiDelete(
+    `/api/v1/skills/${encodeURIComponent(idOrName)}/versions/${encodeURIComponent(version)}`,
+  );
+}
+
 export interface PullFromGitHubInput {
   /** `owner/name`. */
   repo: string;


### PR DESCRIPTION
## Summary

Closes #183. Owners can prune old versions of a skill (broken / superseded / deprecated-and-retired) without nuking the entire skill.

## Backend
- \`DELETE /api/v1/skills/:idOrName/versions/:version\`
  - Permission: \`ornn:skill:delete\` + owner-or-admin (same gate as full skill delete)
  - **Refuses** if it's the only remaining version (use the existing \`DELETE /skills/:id\`) or the current latest (publish a newer version first)
  - Best-effort storage zip cleanup; logs but does not roll back the row delete on storage failures
  - Logs \`skill:version_delete\` to the activity collection
- \`SkillVersionRepository.deleteOne\`, \`SkillService.deleteVersion\`

## Frontend
- New \`deleteSkillVersion\` service + \`useDeleteSkillVersion\` hook (invalidates skill / versions list / audit-history caches)
- \`SkillVersionList\` gains a per-row Delete button (owner/admin only, hidden on the latest row, hidden when only one version remains)
- Confirmation modal before commit; the SkillDetailPage handler toasts the outcome and snaps back to latest if the user was viewing the deleted version
- en/zh translations for the new copy

## Test plan
- [x] \`bunx tsc --noEmit\` clean for both packages
- [x] \`bun test --filter ornn-api\` 243 pass
- [ ] Manual: own a skill with v0.1 and v0.2, view v0.1 → click Delete on v0.1 row → confirm → toast says deleted, version list refreshes, audit-history card no longer shows v0.1's audits
- [ ] Manual: try to delete v0.2 (latest) → button hidden
- [ ] Manual: skill with one version → delete button hidden

## Closes
- Closes #183