### PR TITLE
[Feature] SkillDetailPage usage chart at the top

### DIFF
--- a/.changeset/skill-detail-pulls-chart.md
+++ b/.changeset/skill-detail-pulls-chart.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+feat: SkillDetailPage gets a full-width "Skill pulls" chart at the top (#187). New `UsagePullsCard` component renders a stacked bar chart (recharts) of pull counts over a user-controlled time range (datetime-local from / to inputs) with a Hour / Day / Month bucket toggle, broken down by source (api / web / playground). Default window: last 7 days, day buckets. Empty / invalid-range states render gracefully. Wired into SkillDetailPage between the GitHub origin chip and the Package Contents grid; respects the currently selected skill version. Added `recharts@3.x` as a dependency. en/zh i18n keys added.

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "ornn-api": {
       "name": "ornn-api",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@xenova/transformers": "^2.17.0",
         "hono": "^4.7.0",
@@ -46,7 +46,7 @@
     },
     "ornn-web": {
       "name": "ornn-web",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@tanstack/react-query": "^5.62.0",
@@ -62,6 +62,7 @@
         "react-markdown": "^9.0.0",
         "react-router": "^7.1.0",
         "react-router-dom": "^7.1.0",
+        "recharts": "^3.8.1",
         "rehype-highlight": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.0",
@@ -342,6 +343,8 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
@@ -395,6 +398,8 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
 
@@ -548,6 +553,8 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
+
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
     "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
@@ -690,6 +697,8 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -808,6 +817,8 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
+
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
@@ -846,6 +857,8 @@
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
+    "es-toolkit": ["es-toolkit@1.46.0", "", {}, "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -877,6 +890,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
@@ -987,6 +1002,8 @@
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -1380,6 +1397,8 @@
 
     "react-markdown": ["react-markdown@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "react-router": ["react-router@7.13.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA=="],
@@ -1392,7 +1411,13 @@
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
 
@@ -1407,6 +1432,8 @@
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
@@ -1514,6 +1541,8 @@
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
@@ -1585,6 +1614,8 @@
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
@@ -1663,6 +1694,8 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 

--- a/ornn-web/package.json
+++ b/ornn-web/package.json
@@ -26,6 +26,7 @@
     "react-markdown": "^9.0.0",
     "react-router": "^7.1.0",
     "react-router-dom": "^7.1.0",
+    "recharts": "^3.8.1",
     "rehype-highlight": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",

--- a/ornn-web/src/components/skill/UsagePullsCard.tsx
+++ b/ornn-web/src/components/skill/UsagePullsCard.tsx
@@ -1,0 +1,257 @@
+/**
+ * UsagePullsCard — primary "how much is this skill being used" visual on
+ * `SkillDetailPage`. Renders a stacked bar chart of skill-pull counts
+ * over a user-controlled time range and bucket size, broken down by
+ * source (api / web / playground).
+ *
+ * Data shape is fed by `useSkillPulls(idOrName, { bucket, from, to,
+ * version })`. Empty result → muted "no pulls in this range" empty state.
+ *
+ * @module components/skill/UsagePullsCard
+ */
+
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { useSkillPulls } from "@/hooks/useAnalytics";
+import type { PullBucket, PullBucketCount } from "@/types/analytics";
+
+interface UsagePullsCardProps {
+  idOrName: string | undefined;
+  /** Optional version filter; matches the SkillDetailPage selected version. */
+  version?: string;
+  className?: string;
+}
+
+const BUCKETS: ReadonlyArray<{ key: PullBucket; labelKey: string; fallback: string }> = [
+  { key: "hour", labelKey: "analytics.bucketHour", fallback: "Hour" },
+  { key: "day", labelKey: "analytics.bucketDay", fallback: "Day" },
+  { key: "month", labelKey: "analytics.bucketMonth", fallback: "Month" },
+];
+
+/** ISO-truncate a Date to `YYYY-MM-DDTHH:mm` so an `<input type=datetime-local>` accepts it. */
+function toLocalInput(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const y = d.getFullYear();
+  const m = pad(d.getMonth() + 1);
+  const day = pad(d.getDate());
+  const h = pad(d.getHours());
+  const min = pad(d.getMinutes());
+  return `${y}-${m}-${day}T${h}:${min}`;
+}
+
+/** Convert the local-input string back into an ISO-8601 instant. */
+function fromLocalInput(value: string): string | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toISOString();
+}
+
+/** Default range: last 7 days, ending now. */
+function defaultRange(): { from: string; to: string } {
+  const now = new Date();
+  const from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  return { from: toLocalInput(from), to: toLocalInput(now) };
+}
+
+/** Pretty-print bucket timestamp based on the chosen bucket size. */
+function formatBucket(iso: string, bucket: PullBucket): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  if (bucket === "hour") {
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      hour12: false,
+    });
+  }
+  if (bucket === "day") {
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short" });
+}
+
+/** Project the wire shape into recharts-friendly rows: { bucketLabel, api, web, playground }. */
+function rowsFor(items: ReadonlyArray<PullBucketCount>, bucket: PullBucket) {
+  return items.map((p) => ({
+    bucketLabel: formatBucket(p.bucket, bucket),
+    bucketRaw: p.bucket,
+    api: p.bySource.api ?? 0,
+    web: p.bySource.web ?? 0,
+    playground: p.bySource.playground ?? 0,
+    total: p.total,
+  }));
+}
+
+export function UsagePullsCard({
+  idOrName,
+  version,
+  className,
+}: UsagePullsCardProps) {
+  const { t } = useTranslation();
+  const [bucket, setBucket] = useState<PullBucket>("day");
+  const [{ from, to }, setRange] = useState<{ from: string; to: string }>(
+    defaultRange,
+  );
+
+  const fromIso = fromLocalInput(from);
+  const toIso = fromLocalInput(to);
+  const valid = !!fromIso && !!toIso && new Date(fromIso) < new Date(toIso);
+
+  const { data: items = [], isLoading, isError } = useSkillPulls(idOrName, {
+    bucket,
+    from: valid ? fromIso : undefined,
+    to: valid ? toIso : undefined,
+    version,
+  });
+
+  const rows = useMemo(() => rowsFor(items, bucket), [items, bucket]);
+  const totals = useMemo(() => {
+    let api = 0;
+    let web = 0;
+    let pg = 0;
+    for (const r of rows) {
+      api += r.api;
+      web += r.web;
+      pg += r.playground;
+    }
+    return { api, web, playground: pg, total: api + web + pg };
+  }, [rows]);
+
+  if (!idOrName) return null;
+
+  return (
+    <section
+      className={`glass rounded-xl border border-neon-cyan/15 p-4 ${className ?? ""}`}
+    >
+      <header className="mb-3 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h3 className="font-heading text-sm uppercase tracking-wider text-text-primary">
+            {t("analytics.pullsHeading", "Skill pulls")}
+          </h3>
+          <p className="mt-0.5 font-body text-xs text-text-muted">
+            {t(
+              "analytics.pullsSubtitle",
+              "Stacked by source. api = SDK / CLI / agent · web = detail-page download · playground = in-product trial.",
+            )}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex overflow-hidden rounded-md border border-neon-cyan/20">
+            {BUCKETS.map((b) => (
+              <button
+                key={b.key}
+                type="button"
+                onClick={() => setBucket(b.key)}
+                className={`px-3 py-1 font-mono text-xs uppercase tracking-wider transition-colors ${
+                  bucket === b.key
+                    ? "bg-neon-cyan/15 text-neon-cyan"
+                    : "text-text-muted hover:bg-neon-cyan/5"
+                }`}
+              >
+                {t(b.labelKey, b.fallback)}
+              </button>
+            ))}
+          </div>
+          <label className="flex flex-col gap-1">
+            <span className="font-heading text-[10px] uppercase tracking-wider text-text-muted">
+              {t("analytics.from", "From")}
+            </span>
+            <input
+              type="datetime-local"
+              value={from}
+              onChange={(e) => setRange((r) => ({ ...r, from: e.target.value }))}
+              className="rounded border border-neon-cyan/20 bg-bg-surface px-2 py-1 font-mono text-xs text-text-primary focus:outline-none focus:border-neon-cyan/60"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="font-heading text-[10px] uppercase tracking-wider text-text-muted">
+              {t("analytics.to", "To")}
+            </span>
+            <input
+              type="datetime-local"
+              value={to}
+              onChange={(e) => setRange((r) => ({ ...r, to: e.target.value }))}
+              className="rounded border border-neon-cyan/20 bg-bg-surface px-2 py-1 font-mono text-xs text-text-primary focus:outline-none focus:border-neon-cyan/60"
+            />
+          </label>
+        </div>
+      </header>
+
+      <div className="mb-3 flex flex-wrap gap-x-6 gap-y-1 font-mono text-xs">
+        <span className="text-text-muted">
+          {t("analytics.totalPulls", "Total")}:{" "}
+          <span className="text-text-primary">{totals.total}</span>
+        </span>
+        <span className="text-text-muted">api: <span className="text-neon-cyan">{totals.api}</span></span>
+        <span className="text-text-muted">web: <span className="text-neon-yellow">{totals.web}</span></span>
+        <span className="text-text-muted">playground: <span className="text-neon-magenta">{totals.playground}</span></span>
+      </div>
+
+      {!valid ? (
+        <p className="py-12 text-center font-body text-xs text-neon-red">
+          {t("analytics.invalidRange", "Invalid range — 'from' must be earlier than 'to'.")}
+        </p>
+      ) : isLoading ? (
+        <p className="py-12 text-center font-body text-xs text-text-muted">
+          {t("analytics.loading", "Loading analytics…")}
+        </p>
+      ) : isError ? (
+        <p className="py-12 text-center font-body text-xs text-neon-red">
+          {t("analytics.loadFailed", "Could not load analytics.")}
+        </p>
+      ) : rows.length === 0 ? (
+        <p className="py-12 text-center font-body text-xs text-text-muted">
+          {t("analytics.noPulls", "No pulls recorded in this range.")}
+        </p>
+      ) : (
+        <div className="h-64 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={rows} margin={{ top: 10, right: 12, bottom: 10, left: 0 }}>
+              <CartesianGrid stroke="rgba(255,255,255,0.04)" vertical={false} />
+              <XAxis
+                dataKey="bucketLabel"
+                tick={{ fontSize: 11, fill: "currentColor" }}
+                axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
+                tickLine={false}
+                className="text-text-muted"
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 11, fill: "currentColor" }}
+                axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
+                tickLine={false}
+                className="text-text-muted"
+              />
+              <Tooltip
+                cursor={{ fill: "rgba(255,255,255,0.04)" }}
+                contentStyle={{
+                  background: "rgba(20, 24, 32, 0.96)",
+                  border: "1px solid rgba(0, 255, 255, 0.25)",
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+                labelStyle={{ color: "#cbd5e1" }}
+              />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Bar dataKey="api" name="api" stackId="src" fill="#22d3ee" />
+              <Bar dataKey="web" name="web" stackId="src" fill="#facc15" />
+              <Bar dataKey="playground" name="playground" stackId="src" fill="#f472b6" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -204,7 +204,17 @@
     "topErrors": "Top errors",
     "loading": "Loading analytics…",
     "loadFailed": "Could not load analytics.",
-    "unavailable": "Usage analytics are not available yet."
+    "unavailable": "Usage analytics are not available yet.",
+    "pullsHeading": "Skill pulls",
+    "pullsSubtitle": "Stacked by source. api = SDK / CLI / agent · web = detail-page download · playground = in-product trial.",
+    "bucketHour": "Hour",
+    "bucketDay": "Day",
+    "bucketMonth": "Month",
+    "from": "From",
+    "to": "To",
+    "totalPulls": "Total",
+    "invalidRange": "Invalid range — 'from' must be earlier than 'to'.",
+    "noPulls": "No pulls recorded in this range."
   },
   "notifications": {
     "bellAria": "Notifications",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -204,7 +204,17 @@
     "topErrors": "主要错误",
     "loading": "加载分析数据…",
     "loadFailed": "无法加载使用分析。",
-    "unavailable": "使用分析暂不可用。"
+    "unavailable": "使用分析暂不可用。",
+    "pullsHeading": "Skill 拉取数",
+    "pullsSubtitle": "按来源堆叠：api = SDK / CLI / agent · web = 详情页下载 · playground = 平台内试用。",
+    "bucketHour": "小时",
+    "bucketDay": "天",
+    "bucketMonth": "月",
+    "from": "从",
+    "to": "到",
+    "totalPulls": "总计",
+    "invalidRange": "区间不合法 —— 起始时间必须早于结束时间。",
+    "noPulls": "此区间内没有拉取记录。"
   },
   "notifications": {
     "bellAria": "通知",

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -12,6 +12,7 @@ import { VersionPicker } from "@/components/skill/VersionPicker";
 import { DeprecationBanner } from "@/components/skill/DeprecationBanner";
 import { GitHubOriginChip } from "@/components/skill/GitHubOriginChip";
 import { AnalyticsCard } from "@/components/skill/AnalyticsCard";
+import { UsagePullsCard } from "@/components/skill/UsagePullsCard";
 import { AuditHistoryCard } from "@/components/skill/AuditHistoryCard";
 import { BackLink } from "@/components/layout/BackLink";
 import { useRefreshSkillFromSource } from "@/hooks/useSkills";
@@ -394,6 +395,13 @@ export function SkillDetailPage() {
           </div>
         );
       })()}
+
+      {/* Usage row — full-width chart at the top, ahead of Package Contents. */}
+      <UsagePullsCard
+        idOrName={skill.name || skill.guid}
+        version={skill.version}
+        className="mb-4 shrink-0"
+      />
 
       <div className="flex-1 min-h-0 grid gap-4 lg:grid-cols-[minmax(0,1fr)_380px] xl:grid-cols-[minmax(0,1fr)_440px]">
         {/* Main content — Package Contents (fills available height) */}


### PR DESCRIPTION
Closes #187.

## Summary

Lifts \"Usage analytics\" from the cramped right-sidebar card into a full-width chart row at the top of the page. New \`UsagePullsCard\` component renders a stacked bar chart of skill-pull counts (recharts) over a user-controlled time range and bucket size.

## What's in the chart
- **Y axis**: pull count.
- **X axis**: time bucket (label format adapts to the bucket size).
- **Stack** by source: \`api\` / \`web\` / \`playground\` — same enum as \`/analytics/pulls\` returns.
- **Header controls**: bucket toggle (Hour / Day / Month) + \`from\` / \`to\` datetime-local inputs.
- **Default window**: last 7 days, day buckets.
- **Inline totals row** above the chart shows total + per-source counts for the chosen window.
- Empty / invalid-range / loading / error states render distinct copy.

## Layout
- New row mounted as a \`shrink-0\` block between the GitHub origin chip and the existing main grid (Package Contents + sidebar). Package Contents now naturally takes \`flex-1\` of remaining vertical space — visibly shorter than before, which was the goal.
- Sidebar (Description / Author / Manage permissions / Analytics summary / Audit history) is unchanged.

## Other
- Added \`recharts@3.x\` (the standard React chart lib in this stack).
- en/zh i18n keys added.

## Test plan
- [x] \`bunx tsc --noEmit -p ornn-web/tsconfig.json\` clean
- [ ] Manual: open SkillDetailPage on a skill with pulls — chart renders, bucket toggle re-fetches, range picker re-fetches.
- [ ] Manual: switch version selector — chart narrows correctly.
- [ ] Manual: skill with no pulls in range — empty state.

## Closes
- Closes #187