### PR TITLE
docs: encode "agent-API not marketplace" positioning

### DIFF
--- a/.changeset/agent-api-positioning.md
+++ b/.changeset/agent-api-positioning.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+docs: encode the "Ornn is an agent-facing skill-lifecycle API, not a marketplace" positioning into CLAUDE.md, the landing page hero, and the docs site `what-is-ornn` page (EN + zh). Also drops the stale "audit-gated sharing" bullet — replaced by the audit-as-public-risk-label framing shipped in #197. Closes #199.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,17 @@
 # CLAUDE.md — chrono-ornn
 
+## Product Positioning
+
+**Ornn is an agent-facing skill-lifecycle API, not a human marketplace.**
+
+The primary customer is the AI agent developer / agentic-system builder. Agents call Ornn directly — over HTTP or MCP — to manage their own skill lifecycle: search → pull → install → execute → build → upload → share. Closest analog: **npm registry + npm CLI fused, model-agnostic** (works for Claude / GPT / Gemini / custom — not locked to one model runtime).
+
+Implications when proposing or building features:
+
+- Lead with the **agent-API contract** (REST / MCP ergonomics, stable schemas, model-agnostic guarantees) before any human-UX angle.
+- `ornn-web` is a *secondary* surface for skill owners and platform admins — it is not the primary product. UI features that don't translate into agent-API value are deprioritized.
+- Avoid feature framing that drifts toward "another skill marketplace" (social ranking, browse-style discovery, recommendation feeds, leaderboards) unless we deliberately decide to. When a feature looks marketplace-shaped, surface that tension before building.
+
 ## Tech Stack
 
 TypeScript, Bun workspace monorepo

--- a/ornn-web/src/docs/site/en/what-is-ornn.md
+++ b/ornn-web/src/docs/site/en/what-is-ornn.md
@@ -4,28 +4,30 @@
 
 ## Overview
 
-Ornn is the industry-standard skill platform for AI agents. It provides a standardized way to create, publish, discover, verify, and test AI capabilities (skills) across any environment.
+**Ornn is an agent-facing skill-lifecycle API.** AI agents call Ornn directly — over HTTP or MCP — to search, pull, run, build, upload, and share skills. The closest analog is **npm registry + npm CLI fused, model-agnostic**: works with Claude, GPT, Gemini, or any custom agent runtime, with no model lock-in.
 
-The ultimate goal of Ornn is **Skill-as-a-Service** — providing plug-and-play skill integration for any AI agent.
+The product framing is **Skill-as-a-Service** — plug-and-play skill integration for any AI agent.
+
+> Ornn is *not* a human-facing skill marketplace. The web UI exists as a secondary surface for skill owners and platform admins; the primary product is the API contract.
 
 ## Key Concepts
 
 ### Skills
 
-A **skill** is a packaged AI capability — a combination of prompts, scripts, and metadata that an AI agent can discover and execute. Skills are versioned, validated, and stored in the Ornn skill library.
+A **skill** is a packaged AI capability — a combination of prompts, scripts, and metadata that an AI agent can discover and execute. Skills are versioned, validated, and stored in the Ornn skill registry.
 
-### The Skill Library
+### The Skill Registry
 
-The Ornn skill library is a centralized hub where skills are published and discovered. It supports:
+The Ornn registry is the central store every agent calls into. It supports:
 
 - **Semantic search** — find skills by meaning, not just keywords
 - **Keyword search** — traditional text-based search
 - **Category browsing** — explore skills by type (plain, tool-based, runtime-based, mixed)
-- **Audit-gated sharing** — skills are reviewed before crossing org or public boundaries
+- **Audit as a public risk label** — every skill carries a verdict (`green` / `yellow` / `red`); consumers of a skill are notified when its audit flips to risky
 
 ### Sandbox Playground
 
-The Ornn platform provides a sandbox playground for users to test any skill interactively. In the playground, an AI agent executes skills by injecting them into its context. When a skill involves code or script execution, the playground integrates with **chrono-sandbox** to run the scripts and return results.
+Ornn provides a sandbox playground that lets an agent (or a human stand-in) try any skill end-to-end before committing to it. The playground injects the skill into an LLM context; for skills with code or scripts, it integrates with **chrono-sandbox** to execute them and return results.
 
 - Isolated, secure execution environment
 - Node.js and Python runtimes
@@ -37,6 +39,6 @@ The Ornn platform provides a sandbox playground for users to test any skill inte
 
 | Audience | Where to start |
 |----------|---------------|
-| **Web Users** — browse, create, and test skills via the web UI | [Quick Start as a Web User](/docs?section=qs-web-user) |
-| **AI Agents** — operate every Ornn capability via the `nyxid` CLI | [Agent Manual](/docs?section=agent-manual) |
-| **Developers & Operators** — understand what runs where | [System Architecture](/docs?section=system-architecture) · [External Integrations](/docs?section=external-integrations) |
+| **AI Agents** *(primary)* — call Ornn over HTTP / MCP to manage their own skill lifecycle | [Agent Manual](/docs?section=agent-manual) |
+| **Skill Owners & Admins** — manage skills, permissions, and audits via the GUI | [Quick Start as a Web User](/docs?section=qs-web-user) |
+| **Platform Operators** — understand what runs where | [System Architecture](/docs?section=system-architecture) · [External Integrations](/docs?section=external-integrations) |

--- a/ornn-web/src/docs/site/zh/what-is-ornn.md
+++ b/ornn-web/src/docs/site/zh/what-is-ornn.md
@@ -2,27 +2,30 @@
 
 ## 概述
 
-Ornn 是 AI Agent 的行业标准技能平台。它提供了一种标准化的方式来创建、发布、发现、验证和测试 AI 能力（技能）。
+**Ornn 是一个面向 AI agent 的技能生命周期 API。** AI agent 通过 HTTP 或 MCP 直接调用 Ornn 来搜索、拉取、运行、构建、上传和分享技能。最接近的类比是 **npm registry + npm CLI 融为一体，model-agnostic** —— Claude、GPT、Gemini 或任意自研 agent 运行时都能用，不绑定特定模型。
 
-Ornn 的终极目标是 **Skill-as-a-Service** — 为任何 AI Agent 提供即插即用的技能集成。
+产品定位是 **Skill-as-a-Service** —— 为任何 AI agent 提供即插即用的技能集成。
+
+> Ornn 不是给人逛的技能 marketplace。Web UI 是次要 surface，给 skill owner 和平台管理员使用；主产品是 API 契约本身。
 
 ## 核心概念
 
 ### 技能
 
-**技能**是一个打包的 AI 能力 — 由提示词、脚本和元数据组合而成，AI Agent 可以发现并执行它。技能是版本化的、经过验证的，并存储在 Ornn 技能库中。
+**技能**是一个打包的 AI 能力 —— 由提示词、脚本和元数据组合而成，AI agent 可以发现并执行它。技能是版本化的、经过验证的，并存储在 Ornn 技能 registry 中。
 
-### 技能库
+### 技能 Registry
 
-Ornn 技能库是技能发布和发现的中心枢纽。它支持：
+Ornn registry 是每个 agent 调用的中央存储，它支持：
 
 - **语义搜索** — 按含义查找技能，而不仅仅是关键词
 - **关键词搜索** — 传统的文本搜索
 - **分类浏览** — 按类型浏览技能（plain、tool-based、runtime-based、mixed）
+- **审计作为公开风险标签** — 每个技能都带有 verdict（`green` / `yellow` / `red`），当某个 skill 的审计结果变成有风险时，使用者会收到通知
 
 ### 沙箱试验场
 
-Ornn 平台提供沙箱试验场，供用户针对任意技能进行交互式测试。在试验场中，AI Agent 通过将技能注入上下文的方式执行 Skill。当技能涉及代码与脚本执行时，试验场 Agent 将与 **chrono-sandbox** 进行集成，完成脚本的执行与结果返回。
+Ornn 提供沙箱试验场，让 agent（或代为操作的人类）在投入使用前完整试用任意技能。试验场会把技能注入 LLM 上下文；对于带代码或脚本的技能，会集成 **chrono-sandbox** 执行并返回结果。
 
 - 隔离、安全的执行环境
 - Node.js 和 Python 运行时
@@ -34,5 +37,6 @@ Ornn 平台提供沙箱试验场，供用户针对任意技能进行交互式测
 
 | 用户类型 | 使用场景 |
 |----------|----------|
-| **Web 用户** | 通过 Web UI 浏览、创建和测试技能 |
-| **AI Agent 开发者** | 通过 Ornn MCP Tool 将技能发现、执行、打造的工具集成到自主 Agent 中 |
+| **AI Agent**（主要客户） | 通过 HTTP / MCP 直接调用 Ornn 管理自己的技能生命周期 — [Agent 手册](/docs?section=agent-manual) |
+| **Skill Owner / 管理员** | 通过 GUI 管理自己的技能、权限和审计 — [Web 用户快速入门](/docs?section=qs-web-user) |
+| **平台运维** | 了解各个组件运行在哪里 — [系统架构](/docs?section=system-architecture) · [外部集成](/docs?section=external-integrations) |

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -459,7 +459,7 @@
     "bannerSkills": "Core Skills for Claude Code, Codex, Cursor & Antigravity",
     "heroTitle1": "Forge the Future of",
     "heroTitle2": "AI Capabilities",
-    "heroDesc": "Ornn is the industry-standard skill registry for AI agents. Standardized, verifiable, and executable capabilities for the next generation of autonomous intelligence.",
+    "heroDesc": "The skill-lifecycle API your AI agent calls. Search, pull, run, build, and share skills through one HTTP / MCP surface — npm for agents, model-agnostic by design.",
     "exploreBtn": "Explore Skills",
     "registerBtn": "Register Agent",
     "navRegistry": "Registry",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -459,7 +459,7 @@
     "bannerSkills": "为 Claude Code、Codex、Cursor、Antigravity 准备的核心技能",
     "heroTitle1": "锻造",
     "heroTitle2": "AI 能力的未来",
-    "heroDesc": "Ornn 是面向 AI agent 的工业级技能注册中心，为下一代自主智能提供标准化、可验证、可执行的能力。",
+    "heroDesc": "为 AI agent 准备的技能生命周期 API。一个 HTTP / MCP 接口，让你的 agent 完成搜索、拉取、运行、构建、分享的全过程 —— 面向 agent 的 npm，model-agnostic。",
     "exploreBtn": "浏览技能",
     "registerBtn": "注册 Agent",
     "navRegistry": "Registry",


### PR DESCRIPTION
## Summary

Encode the "Ornn is an agent-facing skill-lifecycle API, not a human marketplace" framing into the durable surfaces so neither code nor copy drifts back to "another marketplace". Closes #199.

## What changed

- **`CLAUDE.md`** — new **Product Positioning** section near the top: one-line framing + the implications it has on feature work (lead with API contract, `ornn-web` is secondary, avoid marketplace-shaped features without deliberate intent).
- **LandingPage hero** (`landing.heroDesc`, EN + zh i18n) — rewritten:
  - EN: "The skill-lifecycle API your AI agent calls. Search, pull, run, build, and share skills through one HTTP / MCP surface — npm for agents, model-agnostic by design."
  - zh: 等价的中文版本。
- **Docs site `what-is-ornn`** (EN + zh):
  - Overview rewritten to lead with the agent-API framing + a callout that Ornn is not a marketplace.
  - "Who is Ornn for?" reordered so AI agents come first, owners/admins second, operators third.
  - The stale "Audit-gated sharing" bullet replaced by the audit-as-public-risk-label model shipped in #197.

## Non-goals

- In-app screens (skill detail, my-skills, admin) intentionally untouched — those are owner-facing utilities, not positioning real estate.
- No code, endpoints, or API contracts renamed.

## Test plan

- [x] Frontend typecheck (`tsc --noEmit -p ornn-web/tsconfig.json`)
- [x] i18n JSON validates (`jq empty`)
- [ ] Local visual check: landing page hero copy renders correctly in both languages, docs site `what-is-ornn` renders with new structure.