### PR TITLE
refactor(web): Editorial Forge migration — Phase A, shared UI primitives

### DIFF
--- a/.changeset/forge-primitives.md
+++ b/.changeset/forge-primitives.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+refactor(web): Editorial Forge migration — Phase A, shared UI primitives (#203). API surfaces unchanged; only internal styling migrates from legacy `neon-*` tokens to Editorial Forge semantic tokens (`bg-card`, `bg-accent`, `text-strong`, `border-subtle`, etc.). Affects `Button`, `Card`, `Modal`, `Badge`, `Input`, `Select`, `Toast`, `Pagination`, `EmptyState`, `NeonSkeleton`, `CategoryTooltip`. Foundation for the rest of the migration.

--- a/ornn-web/src/components/ui/Badge.tsx
+++ b/ornn-web/src/components/ui/Badge.tsx
@@ -1,3 +1,18 @@
+/**
+ * Badge — Editorial Forge stamp / micro-label.
+ *
+ * Mono uppercase, 2px radius, hairline border, soft tinted background.
+ * Color names are the legacy palette mapped to Editorial Forge semantics:
+ *   cyan    → ember accent
+ *   magenta → accent support (molten)
+ *   yellow  → warning (brass)
+ *   green   → success (oxidized)
+ *   red     → danger (kiln)
+ *   muted   → meta
+ *
+ * @module components/ui/Badge
+ */
+
 import type { ReactNode } from "react";
 
 export interface BadgeProps {
@@ -7,20 +22,20 @@ export interface BadgeProps {
 }
 
 const COLOR_MAP = {
-  cyan: "bg-neon-cyan/10 text-neon-cyan border-neon-cyan/30",
-  magenta: "bg-neon-magenta/10 text-neon-magenta border-neon-magenta/30",
-  yellow: "bg-neon-yellow/10 text-neon-yellow border-neon-yellow/30",
-  green: "bg-neon-green/10 text-neon-green border-neon-green/30",
-  red: "bg-neon-red/10 text-neon-red border-neon-red/30",
-  muted: "bg-text-muted/10 text-text-muted border-text-muted/30",
+  cyan: "border-accent/40 bg-accent/10 text-accent",
+  magenta: "border-accent-support/40 bg-warning-soft text-accent-support",
+  yellow: "border-warning/40 bg-warning-soft text-warning",
+  green: "border-success/40 bg-success-soft text-success",
+  red: "border-danger/40 bg-danger-soft text-danger",
+  muted: "border-strong-edge bg-elevated text-meta",
 } as const;
 
 export function Badge({ children, color = "cyan", className = "" }: BadgeProps) {
   return (
     <span
       className={`
-        inline-flex items-center rounded-full border px-2.5 py-0.5
-        font-body text-xs font-semibold
+        inline-flex items-center rounded-sm border px-2 py-0.5
+        font-mono text-[10px] font-semibold uppercase tracking-[0.1em]
         ${COLOR_MAP[color]}
         ${className}
       `}

--- a/ornn-web/src/components/ui/Button.tsx
+++ b/ornn-web/src/components/ui/Button.tsx
@@ -1,3 +1,14 @@
+/**
+ * Button — Editorial Forge primitive.
+ *
+ * Three variants per DESIGN.md:
+ *   primary    — ember fill, page-bg text, mono uppercase label
+ *   secondary  — outline, strong border, body text
+ *   danger     — outline, danger color, kiln-red on hover
+ *
+ * @module components/ui/Button
+ */
+
 import { motion } from "framer-motion";
 import type { ReactNode } from "react";
 
@@ -13,15 +24,18 @@ export interface ButtonProps {
 }
 
 const VARIANT_STYLES = {
-  primary: "border-neon-cyan/50 text-neon-cyan hover:border-neon-cyan hover:shadow-[0_0_15px_rgba(255,107,0,0.3)]",
-  secondary: "border-neon-magenta/50 text-neon-magenta hover:border-neon-magenta hover:shadow-[0_0_15px_rgba(255,140,56,0.3)]",
-  danger: "border-neon-red/50 text-neon-red hover:border-neon-red hover:shadow-[0_0_15px_rgba(255,0,60,0.3)]",
+  primary:
+    "bg-accent text-page hover:bg-accent-muted border border-accent",
+  secondary:
+    "bg-transparent text-strong border border-strong-edge hover:bg-elevated hover:border-strong",
+  danger:
+    "bg-transparent text-danger border border-danger/40 hover:bg-danger-soft hover:border-danger",
 } as const;
 
 const SIZE_STYLES = {
-  sm: "px-3 py-1.5 text-sm",
-  md: "px-5 py-2.5 text-base",
-  lg: "px-7 py-3 text-lg",
+  sm: "px-3 py-1.5 text-[11px] tracking-[0.1em]",
+  md: "px-5 py-2.5 text-xs tracking-[0.12em]",
+  lg: "px-6 py-3 text-sm tracking-[0.12em]",
 } as const;
 
 export function Button({
@@ -41,12 +55,13 @@ export function Button({
       type={type}
       onClick={onClick}
       disabled={isDisabled}
-      whileTap={isDisabled ? undefined : { scale: 0.97 }}
-      whileHover={isDisabled ? undefined : { scale: 1.02 }}
-      transition={{ duration: 0.1, ease: "easeIn" }}
+      whileTap={isDisabled ? undefined : { y: 0 }}
+      whileHover={isDisabled ? undefined : { y: -1 }}
+      transition={{ duration: 0.12, ease: "easeOut" }}
       className={`
-        glass cursor-pointer rounded-lg font-body font-semibold
-        transition-all duration-200
+        cursor-pointer rounded-sm font-mono font-semibold uppercase
+        transition-colors duration-150
+        focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent
         ${VARIANT_STYLES[variant]}
         ${SIZE_STYLES[size]}
         ${isDisabled ? "opacity-50 cursor-not-allowed" : ""}
@@ -54,9 +69,9 @@ export function Button({
       `}
     >
       {loading ? (
-        <span className="flex items-center gap-2">
-          <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-          Loading...
+        <span className="flex items-center justify-center gap-2">
+          <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-[1.5px] border-current border-t-transparent" />
+          <span>Loading…</span>
         </span>
       ) : (
         children

--- a/ornn-web/src/components/ui/Card.tsx
+++ b/ornn-web/src/components/ui/Card.tsx
@@ -1,3 +1,12 @@
+/**
+ * Card — Editorial Forge primitive.
+ *
+ * Paper / forged-metal surface, hairline border, 4px radius. Default
+ * padding `p-6`. Hover state strengthens edge and lifts 1px.
+ *
+ * @module components/ui/Card
+ */
+
 import { motion } from "framer-motion";
 import type { ReactNode } from "react";
 
@@ -11,14 +20,17 @@ export interface CardProps {
 export function Card({ children, className = "", hoverable = false, onClick }: CardProps) {
   return (
     <motion.div
-      initial={{ opacity: 0, scale: 0.95 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
-      whileHover={hoverable ? { scale: 1.02, transition: { duration: 0.2 } } : undefined}
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+      whileHover={hoverable ? { y: -1 } : undefined}
       onClick={onClick}
       className={`
-        glass rounded-xl p-6
-        ${hoverable ? "cursor-pointer glass-hover" : ""}
+        rounded-md border border-subtle bg-card p-6
+        shadow-[0_2px_8px_-4px_rgba(26,24,18,0.06)]
+        dark:shadow-[0_2px_12px_-6px_rgba(0,0,0,0.45)]
+        transition-colors duration-150
+        ${hoverable ? "cursor-pointer hover:border-strong-edge" : ""}
         ${className}
       `}
     >

--- a/ornn-web/src/components/ui/CategoryTooltip.tsx
+++ b/ornn-web/src/components/ui/CategoryTooltip.tsx
@@ -27,10 +27,10 @@ function InfoIcon({ className }: { className?: string }) {
 }
 
 const CATEGORY_COLORS: Record<SkillCategory, string> = {
-  plain: "text-neon-cyan",
-  "tool-based": "text-neon-magenta",
-  "runtime-based": "text-neon-yellow",
-  mixed: "text-neon-green",
+  plain: "text-accent",
+  "tool-based": "text-accent-support",
+  "runtime-based": "text-warning",
+  mixed: "text-success",
 };
 
 export function CategoryTooltip({ className = "" }: CategoryTooltipProps) {
@@ -54,7 +54,7 @@ export function CategoryTooltip({ className = "" }: CategoryTooltipProps) {
         onMouseEnter={() => setIsOpen(true)}
         onMouseLeave={() => setIsOpen(false)}
         onClick={() => setIsOpen((prev) => !prev)}
-        className="p-1 text-text-muted hover:text-neon-cyan transition-colors cursor-pointer"
+        className="p-1 text-meta hover:text-accent transition-colors cursor-pointer"
         aria-label="Category descriptions"
       >
         <InfoIcon className="h-4 w-4" />
@@ -67,19 +67,19 @@ export function CategoryTooltip({ className = "" }: CategoryTooltipProps) {
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.95 }}
             transition={{ duration: 0.15 }}
-            className="absolute left-6 top-0 z-50 w-72 glass rounded-lg border border-neon-cyan/12 p-4 shadow-lg"
+            className="absolute left-6 top-0 z-50 w-72 rounded-md border border-strong-edge bg-card p-4 shadow-[0_18px_40px_-18px_rgba(0,0,0,0.35)]"
           >
-            <p className="font-heading text-xs uppercase tracking-wider text-text-muted mb-3">
+            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-meta mb-3">
               Skill Categories
             </p>
             <div className="space-y-3">
               {(Object.entries(SKILL_CATEGORY_INFO) as [SkillCategory, { label: string; description: string }][]).map(
                 ([key, info]) => (
                   <div key={key}>
-                    <p className={`font-heading text-xs uppercase ${CATEGORY_COLORS[key]}`}>
+                    <p className={`font-mono text-[10px] font-semibold uppercase tracking-[0.12em] ${CATEGORY_COLORS[key]}`}>
                       {info.label}
                     </p>
-                    <p className="text-text-muted text-xs mt-0.5 font-body leading-relaxed">
+                    <p className="font-reading text-xs leading-relaxed text-body mt-0.5">
                       {info.description}
                     </p>
                   </div>

--- a/ornn-web/src/components/ui/EmptyState.tsx
+++ b/ornn-web/src/components/ui/EmptyState.tsx
@@ -10,9 +10,8 @@ export interface EmptyStateProps {
 export function EmptyState({ title, description, action, className = "" }: EmptyStateProps) {
   return (
     <div className={`flex flex-col items-center justify-center py-16 text-center ${className}`}>
-      {/* Simple geometric icon */}
-      <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full border border-neon-cyan/20 bg-neon-cyan/5">
-        <svg width="32" height="32" viewBox="0 0 32 32" fill="none" className="text-neon-cyan/40">
+      <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-sm border border-strong-edge bg-warning-soft text-accent/60">
+        <svg width="28" height="28" viewBox="0 0 32 32" fill="none">
           <path
             d="M16 2L4 8v16l12 6 12-6V8L16 2z"
             stroke="currentColor"
@@ -22,8 +21,8 @@ export function EmptyState({ title, description, action, className = "" }: Empty
           <path d="M16 14v8M12 18h8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
         </svg>
       </div>
-      <h3 className="mb-2 font-heading text-lg text-text-primary">{title}</h3>
-      {description && <p className="mb-6 max-w-md font-body text-sm text-text-muted">{description}</p>}
+      <h3 className="mb-2 font-display text-xl font-semibold tracking-tight text-strong">{title}</h3>
+      {description && <p className="mb-6 max-w-md font-reading text-sm text-body">{description}</p>}
       {action}
     </div>
   );

--- a/ornn-web/src/components/ui/Input.tsx
+++ b/ornn-web/src/components/ui/Input.tsx
@@ -1,3 +1,11 @@
+/**
+ * Input — Editorial Forge form primitive.
+ *
+ * Drafted, instrument-like. Hairline edge, focus tightens to ember.
+ *
+ * @module components/ui/Input
+ */
+
 import { forwardRef } from "react";
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -10,21 +18,26 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className="flex flex-col gap-1.5">
         {label && (
-          <label className="font-heading text-xs uppercase tracking-wider text-text-muted">
+          <label className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
             {label}
           </label>
         )}
         <input
           ref={ref}
           className={`
-            neon-input rounded-lg px-4 py-2.5 font-body text-text-primary
-            placeholder:text-text-muted/50
-            ${error ? "border-b-neon-red!" : ""}
+            w-full rounded-sm border border-subtle bg-elevated/40 px-3 py-2
+            font-reading text-sm text-strong
+            placeholder:text-meta/70
+            transition-colors duration-150
+            focus:border-accent focus:outline-none focus:bg-card
+            ${error ? "border-danger! focus:border-danger!" : ""}
             ${className}
           `}
           {...props}
         />
-        {error && <span className="text-xs text-neon-red">{error}</span>}
+        {error && (
+          <span className="font-mono text-[11px] text-danger">{error}</span>
+        )}
       </div>
     );
   }

--- a/ornn-web/src/components/ui/Modal.tsx
+++ b/ornn-web/src/components/ui/Modal.tsx
@@ -1,3 +1,12 @@
+/**
+ * Modal — Editorial Forge primitive.
+ *
+ * Backdrop fades in, dialog springs in. Surface is paper / forged metal
+ * with a hairline border. Title uses Fraunces (display).
+ *
+ * @module components/ui/Modal
+ */
+
 import { motion, AnimatePresence } from "framer-motion";
 import { createPortal } from "react-dom";
 import type { ReactNode } from "react";
@@ -19,24 +28,26 @@ export function Modal({ isOpen, onClose, title, children, className = "" }: Moda
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            transition={{ duration: 0.18 }}
+            className="absolute inset-0 bg-black/55 backdrop-blur-[2px]"
             onClick={onClose}
           />
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.9 }}
-            transition={{ type: "spring", stiffness: 80, damping: 10, mass: 1 }}
+            initial={{ opacity: 0, y: 8, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.98 }}
+            transition={{ type: "spring", stiffness: 220, damping: 22, mass: 0.9 }}
             className={`
-              relative z-10 glass rounded-xl p-6
-              max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto
-              border border-neon-cyan/20
+              relative z-10 mx-4 w-full max-w-lg max-h-[80vh] overflow-y-auto
+              rounded-md border border-strong-edge bg-card p-6
+              shadow-[0_24px_48px_-16px_rgba(0,0,0,0.35)]
               ${className}
             `}
           >
             {title && (
-              <h2 className="mb-4 font-heading text-xl text-neon-cyan">{title}</h2>
+              <h2 className="mb-4 font-display text-xl font-semibold tracking-tight text-strong">
+                {title}
+              </h2>
             )}
             {children}
           </motion.div>

--- a/ornn-web/src/components/ui/NeonSkeleton.tsx
+++ b/ornn-web/src/components/ui/NeonSkeleton.tsx
@@ -83,7 +83,7 @@ export function NeonSkeleton({
   return (
     <div
       className={`
-        ${animate ? "skeleton-shimmer" : "bg-neon-cyan/5"}
+        ${animate ? "skeleton-shimmer" : "bg-elevated/40"}
         ${VARIANT_STYLES[variant]}
         ${className}
       `}
@@ -101,7 +101,7 @@ export function SkillCardSkeleton({ className = "" }: { className?: string }) {
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className={`glass rounded-xl p-6 ${className}`}
+      className={`rounded-md border border-subtle bg-card p-6 ${className}`}
     >
       {/* Header */}
       <div className="flex items-start justify-between mb-4">
@@ -120,7 +120,7 @@ export function SkillCardSkeleton({ className = "" }: { className?: string }) {
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-between pt-4 border-t border-neon-cyan/10">
+      <div className="flex items-center justify-between pt-4 border-t border-subtle">
         <NeonSkeleton variant="text" width="6rem" height="1rem" />
         <NeonSkeleton variant="text" width="4rem" height="1rem" />
       </div>
@@ -210,7 +210,7 @@ export function DetailPageSkeleton({ className = "" }: { className?: string }) {
       </div>
 
       {/* Main content card */}
-      <div className="glass rounded-xl p-6 space-y-4">
+      <div className="rounded-md border border-subtle bg-card p-6 space-y-4">
         <NeonSkeleton variant="text" width="30%" height="1.25rem" />
         <NeonSkeleton variant="text" lines={4} size="full" />
         <NeonSkeleton variant="rounded" width="100%" height="12rem" />
@@ -218,11 +218,11 @@ export function DetailPageSkeleton({ className = "" }: { className?: string }) {
 
       {/* Secondary cards */}
       <div className="grid gap-6 md:grid-cols-2">
-        <div className="glass rounded-xl p-6 space-y-3">
+        <div className="rounded-md border border-subtle bg-card p-6 space-y-3">
           <NeonSkeleton variant="text" width="40%" height="1.25rem" />
           <NeonSkeleton variant="text" lines={3} size="full" />
         </div>
-        <div className="glass rounded-xl p-6 space-y-3">
+        <div className="rounded-md border border-subtle bg-card p-6 space-y-3">
           <NeonSkeleton variant="text" width="40%" height="1.25rem" />
           <NeonSkeleton variant="text" lines={3} size="full" />
         </div>
@@ -237,7 +237,7 @@ export function DetailPageSkeleton({ className = "" }: { className?: string }) {
  */
 export function StatsCardSkeleton({ className = "" }: { className?: string }) {
   return (
-    <div className={`glass rounded-xl p-6 ${className}`}>
+    <div className={`rounded-md border border-subtle bg-card p-6 ${className}`}>
       <div className="flex items-center justify-between mb-4">
         <NeonSkeleton variant="text" width="40%" height="1rem" />
         <NeonSkeleton variant="circular" width={32} height={32} />

--- a/ornn-web/src/components/ui/Pagination.tsx
+++ b/ornn-web/src/components/ui/Pagination.tsx
@@ -25,8 +25,8 @@ export function Pagination({ page, totalPages, onPageChange, className = "" }: P
 
       {pages.map((p, i) =>
         p === null ? (
-          <span key={`ellipsis-${i}`} className="px-1 text-text-muted">
-            ...
+          <span key={`ellipsis-${i}`} className="px-1 font-mono text-meta">
+            …
           </span>
         ) : (
           <Button
@@ -34,7 +34,6 @@ export function Pagination({ page, totalPages, onPageChange, className = "" }: P
             size="sm"
             variant={p === page ? "primary" : "secondary"}
             onClick={() => onPageChange(p)}
-            className={p === page ? "neon-border-cyan" : ""}
           >
             {p}
           </Button>

--- a/ornn-web/src/components/ui/Select.tsx
+++ b/ornn-web/src/components/ui/Select.tsx
@@ -1,3 +1,11 @@
+/**
+ * Select — Editorial Forge form primitive.
+ *
+ * Mirrors Input styling. Custom chevron icon in ember, no native arrow.
+ *
+ * @module components/ui/Select
+ */
+
 import { forwardRef } from "react";
 
 export interface SelectOption {
@@ -12,39 +20,49 @@ export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElemen
   placeholder?: string;
 }
 
+// Inline ember chevron — strokes the var(--color-accent) at runtime.
+const CHEVRON_BG =
+  "url(\"data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%2712%27%20height%3D%2712%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23C94A0E%27%20stroke-width%3D%272.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpolyline%20points%3D%276%209%2012%2015%2018%209%27%2F%3E%3C%2Fsvg%3E\")";
+
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   ({ label, error, options, placeholder, className = "", ...props }, ref) => {
     return (
       <div className="flex flex-col gap-1.5">
         {label && (
-          <label className="font-heading text-xs uppercase tracking-wider text-text-muted">
+          <label className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
             {label}
           </label>
         )}
         <select
           ref={ref}
+          style={{ backgroundImage: CHEVRON_BG }}
           className={`
-            neon-input rounded-lg px-4 py-2.5 font-body text-text-primary
-            appearance-none cursor-pointer
-            bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%3E%3Cpath%20fill%3D%22%2300f0ff%22%20d%3D%22M6%208L1%203h10z%22%2F%3E%3C%2Fsvg%3E')]
-            bg-[position:right_12px_center] bg-no-repeat
-            ${error ? "border-b-neon-red!" : ""}
+            w-full appearance-none cursor-pointer rounded-sm
+            border border-subtle bg-elevated/40 px-3 py-2 pr-9
+            font-reading text-sm text-strong
+            transition-colors duration-150
+            focus:border-accent focus:outline-none focus:bg-card
+            bg-no-repeat
+            [background-position:right_10px_center]
+            ${error ? "border-danger! focus:border-danger!" : ""}
             ${className}
           `}
           {...props}
         >
           {placeholder && (
-            <option value="" className="bg-bg-deep">
+            <option value="" className="bg-card text-strong">
               {placeholder}
             </option>
           )}
           {options.map((opt) => (
-            <option key={opt.value} value={opt.value} className="bg-bg-deep">
+            <option key={opt.value} value={opt.value} className="bg-card text-strong">
               {opt.label}
             </option>
           ))}
         </select>
-        {error && <span className="text-xs text-neon-red">{error}</span>}
+        {error && (
+          <span className="font-mono text-[11px] text-danger">{error}</span>
+        )}
       </div>
     );
   }

--- a/ornn-web/src/components/ui/Toast.tsx
+++ b/ornn-web/src/components/ui/Toast.tsx
@@ -1,38 +1,23 @@
 /**
- * Toast Component.
- * Cyberpunk-styled notification toasts with glass morphism and neon accents.
- * Features slide-in/out animations and severity-based color coding.
+ * Toast — Editorial Forge notification primitive.
+ *
+ * Card surface with a left accent bar (mineral state colors), Inter
+ * body, mono dismiss icon. Slide-in from the right, auto-dismiss
+ * progress bar at the bottom.
+ *
  * @module components/ui/Toast
  */
 
 import { motion, AnimatePresence } from "framer-motion";
 import { useToastStore, type Toast as ToastType } from "@/stores/toastStore";
 
-/** Accent colors mapped to toast types */
 const ACCENT_STYLES = {
-  success: {
-    bar: "bg-neon-green",
-    icon: "text-neon-green",
-    glow: "shadow-[0_0_15px_rgba(57,255,20,0.3)]",
-  },
-  error: {
-    bar: "bg-neon-red",
-    icon: "text-neon-red",
-    glow: "shadow-[0_0_15px_rgba(255,0,60,0.3)]",
-  },
-  warning: {
-    bar: "bg-neon-yellow",
-    icon: "text-neon-yellow",
-    glow: "shadow-[0_0_15px_rgba(255,184,0,0.3)]",
-  },
-  info: {
-    bar: "bg-neon-cyan",
-    icon: "text-neon-cyan",
-    glow: "shadow-[0_0_15px_rgba(255,107,0,0.3)]",
-  },
+  success: { bar: "bg-success", icon: "text-success" },
+  error: { bar: "bg-danger", icon: "text-danger" },
+  warning: { bar: "bg-warning", icon: "text-warning" },
+  info: { bar: "bg-accent", icon: "text-accent" },
 } as const;
 
-/** Success icon */
 function SuccessIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -46,7 +31,6 @@ function SuccessIcon({ className }: { className?: string }) {
   );
 }
 
-/** Error icon */
 function ErrorIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -60,7 +44,6 @@ function ErrorIcon({ className }: { className?: string }) {
   );
 }
 
-/** Warning icon */
 function WarningIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -74,7 +57,6 @@ function WarningIcon({ className }: { className?: string }) {
   );
 }
 
-/** Info icon */
 function InfoIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -88,7 +70,6 @@ function InfoIcon({ className }: { className?: string }) {
   );
 }
 
-/** Close icon */
 function CloseIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -121,48 +102,30 @@ function ToastItem({ toast }: ToastItemProps) {
   return (
     <motion.div
       layout
-      initial={{ opacity: 0, x: 100, scale: 0.9 }}
+      initial={{ opacity: 0, x: 80, scale: 0.96 }}
       animate={{ opacity: 1, x: 0, scale: 1 }}
-      exit={{ opacity: 0, x: 100, scale: 0.9 }}
-      transition={{
-        type: "spring",
-        stiffness: 200,
-        damping: 20,
-      }}
-      className={`
-        glass overflow-hidden rounded-lg
-        border border-neon-cyan/10
-        ${styles.glow}
-      `}
+      exit={{ opacity: 0, x: 80, scale: 0.96 }}
+      transition={{ type: "spring", stiffness: 200, damping: 22 }}
+      className="overflow-hidden rounded-md border border-strong-edge bg-card shadow-[0_18px_40px_-18px_rgba(0,0,0,0.35)]"
     >
       <div className="flex">
-        {/* Left accent bar */}
-        <div className={`w-1.5 shrink-0 ${styles.bar}`} />
-
-        {/* Content */}
+        <div className={`w-1 shrink-0 ${styles.bar}`} />
         <div className="flex flex-1 items-start gap-3 px-4 py-3">
-          {/* Icon */}
           <div className={`shrink-0 mt-0.5 ${styles.icon}`}>
             <Icon className="h-5 w-5" />
           </div>
-
-          {/* Message */}
-          <p className="flex-1 font-body text-sm text-text-primary leading-relaxed">
+          <p className="flex-1 font-reading text-sm leading-relaxed text-strong">
             {toast.message}
           </p>
-
-          {/* Close button */}
           <button
             onClick={() => removeToast(toast.id)}
-            className="shrink-0 -mt-1 -mr-1 p-1 rounded-md text-text-muted transition-colors hover:text-text-primary hover:bg-bg-elevated cursor-pointer"
+            className="-mt-1 -mr-1 shrink-0 cursor-pointer rounded-sm p-1 text-meta transition-colors hover:bg-elevated hover:text-strong"
             aria-label="Dismiss notification"
           >
             <CloseIcon className="h-4 w-4" />
           </button>
         </div>
       </div>
-
-      {/* Progress bar (optional, shows time remaining) */}
       {toast.duration && toast.duration > 0 && (
         <motion.div
           initial={{ scaleX: 1 }}
@@ -176,9 +139,7 @@ function ToastItem({ toast }: ToastItemProps) {
 }
 
 export interface ToastContainerProps {
-  /** Position of the toast container */
   position?: "top-right" | "top-left" | "bottom-right" | "bottom-left" | "top-center" | "bottom-center";
-  /** Maximum number of toasts to show */
   maxToasts?: number;
   className?: string;
 }
@@ -192,7 +153,6 @@ const POSITION_STYLES = {
   "bottom-center": "bottom-4 left-1/2 -translate-x-1/2",
 } as const;
 
-/** Global toast container -- mount once in the app root */
 export function ToastContainer({
   position = "bottom-right",
   maxToasts = 5,
@@ -203,12 +163,7 @@ export function ToastContainer({
 
   return (
     <div
-      className={`
-        pointer-events-none fixed z-50
-        flex flex-col gap-3
-        ${POSITION_STYLES[position]}
-        ${className}
-      `}
+      className={`pointer-events-none fixed z-50 flex flex-col gap-3 ${POSITION_STYLES[position]} ${className}`}
       role="region"
       aria-label="Notifications"
     >
@@ -223,13 +178,8 @@ export function ToastContainer({
   );
 }
 
-/**
- * Hook to show toasts programmatically.
- * Convenience wrapper around the toast store.
- */
 export function useToast() {
   const addToast = useToastStore((s) => s.addToast);
-
   return {
     success: (message: string, duration?: number) =>
       addToast({ type: "success", message, duration }),


### PR DESCRIPTION
## Summary

Migrates 11 shared UI primitives from legacy `neon-*` tokens to Editorial Forge semantic tokens. **API surfaces are unchanged** — every consumer still imports `<Button>`, `<Card>`, `<Modal>` etc. with the same props. Only internal styling moves to the new design language. Closes #203.

This is **Phase A** of the multi-PR Editorial Forge migration that started with #202 (SkillDetailPage redesign).

## Components migrated

| Primitive | What changed |
|---|---|
| `Button` | Ember fill primary / outline secondary / outline danger; mono uppercase labels; 2px radius; 1px hover lift |
| `Card` | Paper surface, hairline border, 4px radius, subtle shadow; \`hoverable\` strengthens edge |
| `Modal` | Hairline-edge dialog, Fraunces title (no ember coloring), springy entry |
| `Badge` | Mono uppercase stamps; legacy color names mapped to semantic state colors |
| `Input` + `Select` | Drafted instrument feel; focus tightens to ember edge |
| `Toast` | Left accent bar in mineral state colors; no glass; Inter body |
| `Pagination` | Uses Button so inherits changes; ellipsis uses meta tone |
| `EmptyState` | Restrained icon, Fraunces heading |
| `NeonSkeleton` | Shimmer kept; surfaces moved to `bg-card` / `border-subtle` |
| `CategoryTooltip` | Surface + category color palette migrated |

## Out of scope (next PRs)

- Phase B: global chrome (Navbar, RootLayout, AdminLayout) + remaining CSS in \`neon.css\` (\`.glass\`, scrollbar, focus ring, markdown body)
- Phases C–H: per-page content migration

## Test plan

- [x] Frontend typecheck (\`tsc --noEmit -p ornn-web\`)
- [x] Vite production build succeeds
- [ ] Visual smoke: open SkillDetailPage (already migrated), Registry, Playground, Notifications. Buttons / Cards / Toasts should all read Editorial Forge — no neon glow, mono uppercase action labels, parchment surfaces in light, forged metal in dark.