### PR TITLE
refactor(web): Editorial Forge migration — Phase C, auth + 404 pages

### DIFF
--- a/.changeset/forge-auth-pages.md
+++ b/.changeset/forge-auth-pages.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+refactor(web): Editorial Forge migration — Phase C, auth + 404 pages. LoginPage / OAuthCallbackPage / NotFoundPage now use the migrated `Button` primitive + `bg-card` / `border-subtle` surfaces; Fraunces display / Inter body / mineral state colors. No behavior changes. (Builds on #205.)

--- a/ornn-web/src/pages/LoginPage.tsx
+++ b/ornn-web/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 /**
  * Login Page.
  * NyxID OAuth login - redirects to NyxID authorize page.
+ *
  * @module pages/LoginPage
  */
 
@@ -10,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { useAuthStore } from "@/stores/authStore";
 import { Logo } from "@/components/brand/Logo";
+import { Button } from "@/components/ui/Button";
 
 export function LoginPage() {
   const { t } = useTranslation();
@@ -18,7 +20,6 @@ export function LoginPage() {
 
   const { isAuthenticated, loginWithNyxID } = useAuthStore();
 
-  // Redirect if already authenticated
   useEffect(() => {
     if (isAuthenticated) {
       const redirectTo = (location.state as { from?: string })?.from || "/registry";
@@ -27,7 +28,6 @@ export function LoginPage() {
   }, [isAuthenticated, navigate, location.state]);
 
   const handleLogin = () => {
-    // Store intended destination so we can redirect after callback
     const from = (location.state as { from?: string })?.from;
     if (from) {
       sessionStorage.setItem("login_redirect", from);
@@ -36,45 +36,34 @@ export function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-bg-deep bg-grid">
+    <div className="min-h-screen bg-page bg-grid">
       <div className="flex min-h-screen flex-col items-center justify-center px-4 py-12">
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.3 }}
+          transition={{ duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
           className="w-full max-w-md"
         >
-          {/* Logo */}
           <div className="mb-8 text-center">
             <h1 className="sr-only">ORNN</h1>
-            <Logo className="mx-auto h-14 w-auto mb-4" />
-            <p className="mt-2 font-body text-text-muted">
+            <Logo className="mx-auto mb-4 h-14 w-auto" />
+            <p className="font-reading text-sm text-meta">
               {t("login.tagline")}
             </p>
           </div>
 
-          {/* Glass Card */}
-          <div className="glass rounded-xl p-8 border border-neon-cyan/20">
-            <div className="text-center space-y-6">
-              <p className="font-body text-text-primary">
+          <div className="rounded-md border border-subtle bg-card p-8 shadow-[0_2px_12px_-6px_rgba(0,0,0,0.18)]">
+            <div className="space-y-6 text-center">
+              <p className="font-reading text-sm leading-relaxed text-body">
                 {t("login.desc")}
               </p>
-
-              <motion.button
-                type="button"
-                onClick={handleLogin}
-                whileTap={{ scale: 0.97 }}
-                whileHover={{ scale: 1.02 }}
-                transition={{ duration: 0.1, ease: "easeIn" }}
-                className="w-full glass cursor-pointer rounded-lg border border-neon-cyan/50 px-6 py-3.5 font-body text-base font-semibold text-neon-cyan transition-all duration-200 hover:border-neon-cyan hover:shadow-[0_0_20px_rgba(255,107,0,0.3)]"
-              >
+              <Button onClick={handleLogin} className="w-full" size="lg">
                 {t("login.loginBtn")}
-              </motion.button>
+              </Button>
             </div>
           </div>
 
-          {/* Footer */}
-          <p className="mt-8 text-center font-body text-xs text-text-muted">
+          <p className="mt-8 text-center font-mono text-[10px] uppercase tracking-[0.12em] text-meta">
             {t("login.terms")}
           </p>
         </motion.div>

--- a/ornn-web/src/pages/NotFoundPage.tsx
+++ b/ornn-web/src/pages/NotFoundPage.tsx
@@ -1,3 +1,12 @@
+/**
+ * 404 Page — Editorial Forge.
+ *
+ * Big Fraunces numeric, ember accent, Inter explanation, mono "go home"
+ * button via the Button primitive.
+ *
+ * @module pages/NotFoundPage
+ */
+
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { PageTransition } from "@/components/layout/PageTransition";
@@ -10,8 +19,10 @@ export function NotFoundPage() {
   return (
     <PageTransition>
       <div className="flex flex-col items-center justify-center py-24 text-center">
-        <h1 className="neon-magenta mb-4 font-heading text-6xl font-bold text-neon-magenta">{t("notFound.code")}</h1>
-        <p className="mb-8 font-body text-lg text-text-muted">
+        <h1 className="mb-4 font-display text-7xl font-semibold tracking-tight text-accent">
+          {t("notFound.code")}
+        </h1>
+        <p className="mb-8 max-w-md font-reading text-base leading-relaxed text-body">
           {t("notFound.message")}
         </p>
         <Button onClick={() => navigate("/")}>{t("notFound.goHome")}</Button>

--- a/ornn-web/src/pages/OAuthCallbackPage.tsx
+++ b/ornn-web/src/pages/OAuthCallbackPage.tsx
@@ -1,6 +1,7 @@
 /**
  * OAuth Callback Page.
  * Handles NyxID OAuth callback by exchanging the authorization code for tokens.
+ *
  * @module pages/OAuthCallbackPage
  */
 
@@ -31,28 +32,21 @@ export function OAuthCallbackPage() {
       const stateParam = searchParams.get("state");
       const storedState = sessionStorage.getItem("nyxid_oauth_state");
 
-      // Clear stored state
       sessionStorage.removeItem("nyxid_oauth_state");
 
-      // Validate params
       if (!code) {
         setState({ status: "error", message: "Missing authorization code" });
         return;
       }
 
-      // Validate state to prevent CSRF
       if (!stateParam || stateParam !== storedState) {
-        setState({ status: "error", message: "OAuth state mismatch - possible CSRF attack" });
+        setState({ status: "error", message: "OAuth state mismatch — possible CSRF attack" });
         return;
       }
 
       try {
         await useAuthStore.getState().handleNyxIDCallback(code);
-
-        // Log login activity (fire-and-forget)
         logActivity("login");
-
-        // Redirect to intended destination or home
         const redirectTo = sessionStorage.getItem("login_redirect") || "/registry";
         sessionStorage.removeItem("login_redirect");
         navigate(redirectTo, { replace: true });
@@ -66,32 +60,33 @@ export function OAuthCallbackPage() {
   }, [searchParams, navigate]);
 
   return (
-    <div className="min-h-screen bg-bg-deep bg-grid flex items-center justify-center px-4">
+    <div className="flex min-h-screen items-center justify-center bg-page bg-grid px-4">
       <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.22 }}
         className="w-full max-w-md"
       >
         {state.status === "loading" && (
-          <div className="glass rounded-xl p-8 text-center">
+          <div className="rounded-md border border-subtle bg-card p-8 text-center shadow-[0_2px_12px_-6px_rgba(0,0,0,0.18)]">
             <div className="mb-4 flex justify-center">
-              <span className="inline-block h-12 w-12 animate-spin rounded-full border-4 border-neon-cyan border-t-transparent" />
+              <span className="inline-block h-10 w-10 animate-spin rounded-full border-2 border-accent border-t-transparent" />
             </div>
-            <h2 className="font-heading text-xl text-neon-cyan">
-              Completing Authentication
+            <h2 className="font-display text-xl font-semibold tracking-tight text-strong">
+              Completing authentication
             </h2>
-            <p className="mt-2 font-body text-text-muted">
-              Please wait while we verify your account...
+            <p className="mt-2 font-reading text-sm text-body">
+              Please wait while we verify your account.
             </p>
           </div>
         )}
 
         {state.status === "error" && (
-          <div className="glass rounded-xl p-8 text-center">
+          <div className="rounded-md border border-danger/40 bg-card p-8 text-center shadow-[0_2px_12px_-6px_rgba(0,0,0,0.18)]">
             <div className="mb-4 flex justify-center">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-neon-red">
+              <div className="flex h-12 w-12 items-center justify-center rounded-sm border border-danger bg-danger-soft">
                 <svg
-                  className="h-6 w-6 text-neon-red"
+                  className="h-6 w-6 text-danger"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -105,16 +100,16 @@ export function OAuthCallbackPage() {
                 </svg>
               </div>
             </div>
-            <h2 className="font-heading text-xl text-neon-red">
-              Authentication Failed
+            <h2 className="font-display text-xl font-semibold tracking-tight text-danger">
+              Authentication failed
             </h2>
-            <p className="mt-2 font-body text-text-muted">{state.message}</p>
+            <p className="mt-2 font-reading text-sm leading-relaxed text-body">{state.message}</p>
             <Button
               variant="primary"
               onClick={() => navigate("/login", { replace: true })}
               className="mt-6 w-full"
             >
-              Back to Login
+              Back to login
             </Button>
           </div>
         )}


### PR DESCRIPTION
Phase C of the Editorial Forge migration. Polishes `LoginPage` / `OAuthCallbackPage` / `NotFoundPage` — replaces hand-rolled buttons / glass cards with the migrated `<Button>` primitive + `bg-card` / `border-subtle` surfaces; typography moves to Fraunces display + Inter body + mineral state colors. No behavior changes. Closes #207. (Builds on #205.)

## What changed

- **LoginPage**: glass card → bg-card; hand-rolled neon-cyan login button → `<Button size="lg">`; tagline / terms in mono micro-label
- **NotFoundPage**: bigger Fraunces 404 in ember accent (was Orbitron neon-magenta with text-shadow); Inter body; `<Button>` for go-home
- **OAuthCallbackPage**: status cards swapped to bg-card + danger-soft; spinner uses ember; error icon uses kiln-red on danger-soft tile; titles use Fraunces display
