### PR TITLE
refactor(web): Editorial Forge migration — Phase D, Landing + Docs

### DIFF
--- a/.changeset/forge-landing-docs.md
+++ b/.changeset/forge-landing-docs.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+refactor(web): Editorial Forge migration — Phase D, Landing + Docs. LandingPage hero rewritten with Fraunces display + italic ember accent + mono uppercase CTAs. DocsPage sidebar / TOC micro-labels switch from font-heading to font-mono so they read as forge stamps rather than Fraunces uppercase. Builds on #208.

--- a/ornn-web/src/pages/DocsPage.tsx
+++ b/ornn-web/src/pages/DocsPage.tsx
@@ -130,7 +130,7 @@ function ReleaseAccordion({ lang }: { lang: Lang }) {
                     — {release.title}
                   </span>
                   {isLatest && (
-                    <span className="ml-2 inline-block px-2 py-0.5 rounded text-xs font-heading bg-neon-cyan/10 text-neon-cyan border border-neon-cyan/30">
+                    <span className="ml-2 inline-block px-2 py-0.5 rounded-sm text-[10px] font-mono uppercase tracking-[0.12em] bg-accent/10 text-accent border border-accent/40">
                       {lang === "zh" ? "当前版本" : "Current"}
                     </span>
                   )}
@@ -164,7 +164,7 @@ function VersionBadge() {
   const releasesUrl = "https://github.com/ChronoAIProject/Ornn/releases";
   return (
     <div className="my-6 inline-flex flex-wrap items-center gap-3 rounded-lg border border-neon-cyan/20 bg-bg-elevated px-4 py-2">
-      <span className="font-heading text-xs uppercase tracking-wider text-text-muted">
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
         Current version
       </span>
       <span className="font-mono text-base text-neon-cyan">v{__APP_VERSION__}</span>
@@ -530,7 +530,7 @@ function Sidebar({
                 open={isExpanded}
                 className="h-4 w-4 shrink-0 text-text-muted group-hover:text-text-primary transition-colors"
               />
-              <span className="font-heading text-sm uppercase tracking-wider text-text-muted group-hover:text-text-primary transition-colors">
+              <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-meta group-hover:text-strong transition-colors">
                 {section.label}
               </span>
             </button>
@@ -585,7 +585,7 @@ function TableOfContents({
 
   return (
     <nav className="w-56 shrink-0 sticky top-0 self-start overflow-y-auto max-h-[calc(100vh-8rem)] py-4 pl-4">
-      <h4 className="font-heading text-sm uppercase tracking-wider text-text-muted px-2 py-1.5 mb-2">
+      <h4 className="font-mono text-[10px] uppercase tracking-[0.16em] text-meta px-2 py-1.5 mb-2">
         {t("docs.onThisPage")}
       </h4>
       <div className="space-y-0.5 border-l border-neon-cyan/10">

--- a/ornn-web/src/pages/LandingPage.tsx
+++ b/ornn-web/src/pages/LandingPage.tsx
@@ -141,12 +141,12 @@ function AnnouncementBanner() {
   const text = `${t("landing.bannerNew")}  Ornn v${latest.version} — ${latest.title}`;
 
   return (
-    <div className="shrink-0 relative z-10 overflow-hidden border-b border-neon-cyan/15 bg-neon-cyan/5">
+    <div className="shrink-0 relative z-10 overflow-hidden border-b border-subtle bg-elevated/40">
       <div className="inline-flex whitespace-nowrap" style={{ animation: "marquee 30s linear infinite" }}>
         {[0, 1].map((g) => (
           <span key={g} className="inline-flex items-center py-1.5 shrink-0 min-w-[100vw] justify-around">
-            <span className="font-mono text-xs text-neon-cyan/80">{text}</span>
-            <span className="font-mono text-xs text-neon-cyan/80">{text}</span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent/80">{text}</span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent/80">{text}</span>
           </span>
         ))}
       </div>
@@ -168,14 +168,14 @@ export function LandingPage() {
       {/* Center content */}
       <div className="flex-1 flex items-center justify-center relative z-10">
         <div className="text-center max-w-3xl px-6">
-          <h1 className="font-heading text-4xl sm:text-5xl lg:text-6xl font-bold tracking-wide leading-tight mb-6">
-            <span className="text-text-primary">{t("landing.heroTitle1")} </span>
-            <span className="text-neon-cyan">{t("landing.heroTitle2")}</span>
+          <h1 className="font-display text-5xl sm:text-6xl lg:text-7xl font-semibold tracking-tight leading-[1.05] mb-5">
+            <span className="text-strong">{t("landing.heroTitle1")} </span>
+            <span className="text-accent italic">{t("landing.heroTitle2")}</span>
           </h1>
-          <p className="font-heading text-xl sm:text-2xl font-bold text-neon-cyan tracking-widest uppercase mb-6 drop-shadow-[0_0_10px_rgba(255,107,0,0.6)]">
-            Skill-as-a-Service
+          <p className="font-mono text-xs sm:text-sm font-semibold text-accent tracking-[0.24em] uppercase mb-7">
+            · Skill-as-a-Service ·
           </p>
-          <p className="font-body text-lg sm:text-xl text-text-muted max-w-2xl mx-auto leading-relaxed mb-10">
+          <p className="font-reading text-lg sm:text-xl text-body max-w-2xl mx-auto leading-relaxed mb-10">
             {t("landing.heroDesc")}
           </p>
 
@@ -183,7 +183,7 @@ export function LandingPage() {
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <Link
               to="/registry"
-              className="inline-flex items-center gap-2 rounded-lg bg-neon-cyan/15 border border-neon-cyan px-6 py-3 font-body text-base font-semibold text-neon-cyan transition-all duration-200 hover:bg-neon-cyan/25 hover:shadow-[0_0_20px_rgba(255,107,0,0.3)]"
+              className="inline-flex items-center gap-2 rounded-sm bg-accent px-6 py-3 font-mono text-xs font-semibold uppercase tracking-[0.14em] text-page transition-colors duration-150 hover:bg-accent-muted"
             >
               {t("landing.exploreBtn")}
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -192,7 +192,7 @@ export function LandingPage() {
             </Link>
             <Link
               to="/docs"
-              className="inline-flex items-center gap-2 rounded-lg border border-text-muted/30 bg-bg-surface/50 px-6 py-3 font-body text-base font-semibold text-text-primary transition-all duration-200 hover:border-text-muted/60 hover:bg-bg-elevated"
+              className="inline-flex items-center gap-2 rounded-sm border border-strong-edge bg-elevated/40 px-6 py-3 font-mono text-xs font-semibold uppercase tracking-[0.14em] text-strong transition-colors duration-150 hover:bg-elevated hover:border-strong"
             >
               {t("landing.viewDocs")}
             </Link>
@@ -202,8 +202,8 @@ export function LandingPage() {
 
       {/* Footer */}
       <div className="shrink-0 text-center py-4 relative z-10">
-        <p className="font-body text-xs text-text-muted/50">
-          &copy; 2026 Ornn. All rights reserved.
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta opacity-60">
+          &copy; 2026 Ornn · All rights reserved
         </p>
       </div>
     </div>


### PR DESCRIPTION
Phase D — flagship marketing surfaces. Closes #209.

- **LandingPage**: Fraunces display title + italic ember accent (per DESIGN.md "Italic Fraunces combined with ember is a brand-level treatment"); subtitle as mono uppercase band; CTA buttons ember-fill / outline (no glow); announcement banner uses subtle Editorial Forge tones.
- **DocsPage**: sidebar / TOC / nav micro-labels switch `font-heading` (which now resolves to Fraunces) to `font-mono` so they read as forge stamps. Real headings stay Fraunces.