### PR TITLE
refactor(web): Editorial Forge migration — Phase E, registry/audit/edit polish

### DIFF
--- a/.changeset/forge-registry-myskills.md
+++ b/.changeset/forge-registry-myskills.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+refactor(web): Editorial Forge migration — Phase E, registry / my-skills / audit history / edit pages. Targeted polish: switches `font-heading` micro-labels to `font-mono` so they render as forge stamps (uppercase mono tracking) rather than Fraunces uppercase. EditSkillPage hero gets a Fraunces title with a small ember overline. Builds on #210.

--- a/ornn-web/src/pages/skill/EditSkillPage.tsx
+++ b/ornn-web/src/pages/skill/EditSkillPage.tsx
@@ -93,14 +93,17 @@ export function EditSkillPage() {
           />
         </nav>
 
-        <h1 className="neon-cyan mb-8 font-heading text-2xl font-bold tracking-wider text-neon-cyan sm:text-3xl">
-          {t("editSkill.titlePrefix", "EDIT")}: {skill.name}
+        <h1 className="mb-8 font-display text-3xl font-semibold tracking-tight text-strong sm:text-4xl">
+          <span className="font-mono text-xs uppercase tracking-[0.18em] text-accent block mb-1.5">
+            {t("editSkill.titlePrefix", "EDIT")}
+          </span>
+          {skill.name}
         </h1>
 
         <div className="mx-auto max-w-2xl space-y-6">
           {/* Visibility toggle */}
           <Card>
-            <h3 className="mb-4 font-heading text-sm uppercase tracking-wider text-neon-cyan">
+            <h3 className="mb-4 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-meta border-b border-dashed border-subtle pb-3">
               {t("editSkill.visibilityHeading", "Visibility")}
             </h3>
             <div className="flex items-center justify-between">
@@ -140,7 +143,7 @@ export function EditSkillPage() {
 
           {/* Upload new package */}
           <Card>
-            <h3 className="mb-4 font-heading text-sm uppercase tracking-wider text-neon-cyan">
+            <h3 className="mb-4 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-meta border-b border-dashed border-subtle pb-3">
               {t("editSkill.updatePackageHeading", "Update Package")}
             </h3>
             <p className="mb-4 font-body text-xs text-text-muted">

--- a/ornn-web/src/pages/skill/SkillAuditHistoryPage.tsx
+++ b/ornn-web/src/pages/skill/SkillAuditHistoryPage.tsx
@@ -65,7 +65,7 @@ function ScoreCell({ score }: { score: AuditScore }) {
       }`}
     >
       <div className="flex items-center justify-between">
-        <span className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
           {prettyDim(score.dimension)}
         </span>
         <span
@@ -91,8 +91,8 @@ function FindingRow({ f }: { f: AuditFinding }) {
   return (
     <div className={`flex flex-col gap-1 rounded-lg border px-3 py-2 ${severityStyle}`}>
       <div className="flex items-center gap-2">
-        <span className="font-heading text-[10px] uppercase tracking-wider">{f.severity}</span>
-        <span className="font-heading text-[10px] uppercase tracking-wider text-text-muted">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em]">{f.severity}</span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
           {prettyDim(f.dimension)}
         </span>
         {f.file && (
@@ -119,7 +119,7 @@ function RunningRow({ record }: { record: AuditRecord }) {
         aria-hidden
         className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-neon-cyan/30 border-t-neon-cyan"
       />
-      <span className="font-heading text-xs uppercase tracking-wider text-neon-cyan">
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-neon-cyan">
         {t("audit.statusRunning", "Running")}
       </span>
       <span className="font-mono text-xs text-text-muted">v{record.version}</span>
@@ -144,7 +144,7 @@ function FailedRow({ record }: { record: AuditRecord }) {
     <div className="flex flex-col gap-1 rounded-lg border border-neon-red/30 bg-neon-red/5 px-4 py-3">
       <div className="flex items-center gap-3">
         <span aria-hidden className="h-2.5 w-2.5 shrink-0 rounded-full bg-neon-red" />
-        <span className="font-heading text-xs uppercase tracking-wider text-neon-red">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-neon-red">
           {t("audit.statusFailed", "Failed")}
         </span>
         <span className="font-mono text-xs text-text-muted">v{record.version}</span>
@@ -180,7 +180,7 @@ function HistoryRow({ record, defaultOpen }: { record: AuditRecord; defaultOpen:
         className="flex w-full items-center gap-3 px-4 py-3 cursor-pointer"
       >
         <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${style.dot}`} />
-        <span className={`font-heading text-xs uppercase tracking-wider ${style.text}`}>
+        <span className={`font-mono text-[10px] uppercase tracking-[0.14em] ${style.text}`}>
           {style.label}
         </span>
         <span className="font-mono text-sm text-text-primary">
@@ -212,7 +212,7 @@ function HistoryRow({ record, defaultOpen }: { record: AuditRecord; defaultOpen:
       {expanded && (
         <div className="border-t border-neon-cyan/10 px-4 py-4 space-y-4">
           <section>
-            <h4 className="mb-2 font-heading text-[11px] uppercase tracking-wider text-text-muted">
+            <h4 className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
               {t("audit.scoresHeading", "Scores by dimension")}
             </h4>
             <div className="grid gap-2 sm:grid-cols-2">
@@ -223,7 +223,7 @@ function HistoryRow({ record, defaultOpen }: { record: AuditRecord; defaultOpen:
           </section>
 
           <section>
-            <h4 className="mb-2 font-heading text-[11px] uppercase tracking-wider text-text-muted">
+            <h4 className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
               {t("audit.findingsHeading", "Findings")}
               <span className="ml-2 font-mono text-text-muted normal-case tracking-normal">
                 ({record.findings.length})
@@ -292,7 +292,7 @@ export function SkillAuditHistoryPage() {
             <h1 className="font-heading text-2xl text-text-primary truncate">
               {displayName}
             </h1>
-            <p className="mt-1 font-heading text-xs uppercase tracking-wider text-text-muted">
+            <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
               {versionFilter
                 ? t("audit.historyHeadingForVersion", "Audit history · v{{v}}", {
                     v: versionFilter,


### PR DESCRIPTION
Phase E. Most pages already auto-migrated via the Phase B @theme remap. This PR fixes the remaining hand-rolled bits where `font-heading` was used on micro-labels — those now render as Fraunces uppercase, which doesn't read as a stamp; switch to `font-mono` for the forge-stamp texture.

- SkillAuditHistoryPage: ~10 micro-labels → font-mono
- EditSkillPage: section labels → font-mono with dashed underline; hero title rebuilt as Fraunces display with small ember uppercase overline (replaces neon-cyan glowing Orbitron heading)
- ExplorePage / MySkillsPage: no edits — already use migrated primitives

Closes #211.