### PR TITLE
refactor(web): Editorial Forge migration — Phase F, remaining pages sweep

### DIFF
--- a/.changeset/forge-remaining-pages.md
+++ b/.changeset/forge-remaining-pages.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+refactor(web): Editorial Forge migration — Phase F, remaining pages sweep. Mechanical conversion of `font-heading` micro-labels (uppercase tracking-wider) → `font-mono` (forge stamps) across NotificationsPage / PlaygroundPage / SettingsPage / 4 admin pages / CreateSkillFromGitHubPage. Closes the migration started in #201/#202.

--- a/ornn-web/src/pages/NotificationsPage.tsx
+++ b/ornn-web/src/pages/NotificationsPage.tsx
@@ -117,7 +117,7 @@ export function NotificationsPage() {
                       )}
                       <div className="flex flex-col gap-1">
                         <div className="flex items-center gap-2">
-                          <span className="rounded border border-neon-cyan/20 px-2 py-0.5 font-heading text-[10px] uppercase tracking-wider text-text-muted">
+                          <span className="rounded border border-neon-cyan/20 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                             {CATEGORY_LABEL[n.category] ?? n.category}
                           </span>
                           <span

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -235,7 +235,7 @@ export function PlaygroundPage() {
             {/* Env vars form (only for runtime-based skills with env vars) */}
             {needsEnvVars && (
               <Card>
-                <h3 className="font-heading text-sm uppercase tracking-wider text-neon-cyan mb-3">
+                <h3 className="font-mono text-[11px] uppercase tracking-[0.16em] text-neon-cyan mb-3">
                   {t("playground.envVars")}
                 </h3>
                 <p className="font-body text-xs text-text-muted mb-3">

--- a/ornn-web/src/pages/SettingsPage.tsx
+++ b/ornn-web/src/pages/SettingsPage.tsx
@@ -112,7 +112,7 @@ export function SettingsPage() {
             transition={{ duration: 0.3, delay: 0.1 }}
             className="glass rounded-xl border border-neon-cyan/20 p-6"
           >
-            <h3 className="font-heading text-sm uppercase tracking-wider text-text-primary mb-3">
+            <h3 className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-primary mb-3">
               {t("settings.accountMgmt")}
             </h3>
             <p className="font-body text-sm text-text-muted mb-4">

--- a/ornn-web/src/pages/admin/ActivitiesPage.tsx
+++ b/ornn-web/src/pages/admin/ActivitiesPage.tsx
@@ -118,7 +118,7 @@ export function ActivitiesPage() {
 
       {/* Filter */}
       <div className="flex items-center gap-4">
-        <label className="font-heading text-xs uppercase tracking-wider text-text-muted">
+        <label className="font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
           Filter by Action
         </label>
         <select
@@ -158,16 +158,16 @@ export function ActivitiesPage() {
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-neon-cyan/20">
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Time
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       User
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Action
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Details
                     </th>
                   </tr>

--- a/ornn-web/src/pages/admin/AdminSkillsPage.tsx
+++ b/ornn-web/src/pages/admin/AdminSkillsPage.tsx
@@ -191,22 +191,22 @@ export function AdminSkillsPage() {
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-neon-cyan/20">
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Name
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Author
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Visibility
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Tags
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Created
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Actions
                     </th>
                   </tr>

--- a/ornn-web/src/pages/admin/PlatformSettingsPage.tsx
+++ b/ornn-web/src/pages/admin/PlatformSettingsPage.tsx
@@ -79,7 +79,7 @@ export function PlatformSettingsPage() {
             <section className="space-y-2">
               <label
                 htmlFor="auditWaiverThreshold"
-                className="block font-heading text-[11px] uppercase tracking-wider text-text-muted"
+                className="block font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted"
               >
                 {t("platformSettings.auditThresholdLabel", "Audit waiver threshold")}
               </label>

--- a/ornn-web/src/pages/admin/UsersPage.tsx
+++ b/ornn-web/src/pages/admin/UsersPage.tsx
@@ -104,19 +104,19 @@ export function UsersPage() {
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-neon-cyan/20">
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       User
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Email
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Skills
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Activities
                     </th>
-                    <th className="px-4 py-3 text-left font-heading text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
                       Last Active
                     </th>
                   </tr>

--- a/ornn-web/src/pages/skill/CreateSkillFromGitHubPage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillFromGitHubPage.tsx
@@ -115,7 +115,7 @@ export function CreateSkillFromGitHubPage() {
                 <div>
                   <label
                     htmlFor="repo"
-                    className="mb-1 block font-heading text-xs uppercase tracking-wider text-text-muted"
+                    className="mb-1 block font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted"
                   >
                     {t("githubImport.repoLabel", "Repository")}{" "}
                     <span className="text-neon-red">*</span>
@@ -154,7 +154,7 @@ export function CreateSkillFromGitHubPage() {
                   <div>
                     <label
                       htmlFor="ref"
-                      className="mb-1 block font-heading text-xs uppercase tracking-wider text-text-muted"
+                      className="mb-1 block font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted"
                     >
                       {t("githubImport.refLabel", "Branch / tag / commit")}
                     </label>
@@ -176,7 +176,7 @@ export function CreateSkillFromGitHubPage() {
                   <div>
                     <label
                       htmlFor="path"
-                      className="mb-1 block font-heading text-xs uppercase tracking-wider text-text-muted"
+                      className="mb-1 block font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted"
                     >
                       {t("githubImport.pathLabel", "Path in repo")}
                     </label>


### PR DESCRIPTION
Final phase of the Editorial Forge migration sequence. Mechanical sweep across 8 remaining pages: replaces every `font-heading` micro-label (uppercase tracking-wider) with `font-mono` uppercase `tracking-[0.14em]` so they read as forge stamps instead of Fraunces uppercase letterforms.

Pages touched:
- NotificationsPage
- PlaygroundPage
- SettingsPage
- skill/CreateSkillFromGitHubPage
- admin/ActivitiesPage / UsersPage / AdminSkillsPage / PlatformSettingsPage

(Other create-flow + admin pages either had no font-heading micro-labels or already migrated via primitive tokens. Closes #213.)

This closes out the migration sequence started in #201/#202: every page in `ornn-web` now reads Editorial Forge — Fraunces display, Inter body, JetBrains Mono operational, ember accent, parchment / forged-metal surfaces, hairline borders, mineral state colors.