### PR TITLE
docs(web): site restructure + per-domain API Reference + copy-as-skill agent manual

### DIFF
--- a/.changeset/docs-site-restructure.md
+++ b/.changeset/docs-site-restructure.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+docs: restructure in-product docs site (About / Quick Start / Technical References), add 4 new About pages (Why Ornn? + 3 comparison pages), split API Reference into per-domain pages (14 pages), make Agent Manual a paste-installable skill (SKILL.md frontmatter prepended), add Copy-as-markdown button to every doc.

--- a/ornn-web/src/docs/site/en/agent-manual.md
+++ b/ornn-web/src/docs/site/en/agent-manual.md
@@ -1,8 +1,20 @@
+---
+name: ornn-agent-manual
+description: Operational manual for AI agents using the Ornn skill-lifecycle API. Loads as a skill so that, once installed, the host agent can search / pull / execute / build / upload / share skills via the NyxID CLI without further setup. Authoritative contract between Ornn and the agent.
+metadata:
+  category: plain
+  tags:
+    - ornn
+    - agent
+    - manual
+    - skill-lifecycle
+---
+
 # Agent Manual
 
-> **This document is designed to be loaded as context into an AI agent.** Once loaded, the agent can operate every Ornn capability end-to-end via the `nyxid` CLI — discover skills, pull skills, execute skills, create new skills, manage its own skill library, and participate in the sharing workflow. No SDK. No MCP. Just the CLI.
+> **Paste this whole document into an AI agent's system context.** It is structured as an Ornn skill (`category: plain`) — the `SKILL.md` frontmatter above + the body below are the entire skill. Once loaded, the agent can operate every Ornn capability end-to-end via the `nyxid` CLI — discover skills, pull skills, execute skills, create new skills, manage its own skill library, and participate in the sharing workflow. No SDK. No MCP. Just the CLI.
 >
-> Ornn's core product is **Skill-as-a-Service for AI agents.** Skills are packaged AI capabilities (a `SKILL.md` prompt + optional scripts + YAML metadata) that any agent can pull and execute. This manual is the contract between Ornn and you.
+> Ornn's product is **Skill-as-a-Service for AI agents.** Skills are packaged AI capabilities (a `SKILL.md` prompt + optional scripts + YAML metadata) that any agent can pull and execute. This manual is the contract between Ornn and you.
 
 ## §1. Prerequisites
 

--- a/ornn-web/src/docs/site/en/api-admin.md
+++ b/ornn-web/src/docs/site/en/api-admin.md
@@ -1,0 +1,314 @@
+# API Reference — Admin
+
+Mounted under `/api/v1/admin`. Most endpoints require `ornn:admin:skill`. Category endpoints require `ornn:admin:category`.
+
+## `GET /api/v1/admin/stats`
+
+**Platform-wide totals for the dashboard.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+```jsonc
+{
+  "data": {
+    "totalSkills": 42,
+    "totalUsers": 15,
+    "totalActivities": 1234,
+    "skillsByCategory": { "plain": 10, "tool-based": 15, "runtime-based": 12, "mixed": 5 }
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `GET /api/v1/admin/activities`
+
+**Paginated activity log.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `page` | int ≥ 1 | `1` | — |
+| `pageSize` | int 1–100 | `20` | — |
+| `action` | activity action | — | Filter (see Appendix B in original API doc) |
+| `userId` | string | — | Filter by actor |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      {
+        "id": "...",
+        "userId": "...",
+        "userEmail": "...",
+        "userDisplayName": "...",
+        "action": "skill:create",
+        "details": { "skillId": "...", "skillName": "ornn-api" },
+        "createdAt": "..."
+      }
+    ],
+    "total": 1234,
+    "page": 1,
+    "pageSize": 20,
+    "totalPages": 62
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `GET /api/v1/admin/users`
+
+**Paginated user directory (aggregated from activities).**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Query
+
+| Param | Type | Default |
+|---|---|---|
+| `page` | int ≥ 1 | `1` |
+| `pageSize` | int 1–100 | `20` |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "userId": "...", "email": "...", "displayName": "...", "skillCount": 5, "lastActivityAt": "..." }
+    ],
+    "total": 15,
+    "page": 1,
+    "pageSize": 20,
+    "totalPages": 1
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `GET /api/v1/admin/skills`
+
+**Registry-wide skill browser. Admins see every skill, public or private, regardless of authorship.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `page` | int ≥ 1 | `1` | — |
+| `pageSize` | int 1–100 | `20` | — |
+| `q` | string | — | Search by name / description |
+| `userId` | string | — | Filter by author |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [ /* SkillSummary[] with createdByEmail / createdByDisplayName populated */ ],
+    "total": 42, "page": 1, "pageSize": 20, "totalPages": 3
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `DELETE /api/v1/admin/skills/:id`
+
+**Force-delete any skill (no ownership check).**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Response 200
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+
+Activity logged: `skill:delete` with `details.adminAction = true`.
+
+---
+
+## `GET /api/v1/admin/categories`
+
+**List all skill categories.**
+
+> **Auth required.** Permission: `ornn:admin:category`.
+
+```jsonc
+{
+  "data": [
+    { "id": "...", "name": "plain", "slug": "plain", "description": "Pure prompts", "order": 0 }
+  ],
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/admin/categories`
+
+**Create a category.**
+
+> **Auth required.** Permission: `ornn:admin:category`.
+
+### Request body
+
+```jsonc
+{ "name": "plain", "slug": "plain", "description": "...", "order": 0 }
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | One of `plain`, `tool-based`, `runtime-based`, `mixed` |
+| `slug` | yes | Kebab-case |
+| `description` | yes | — |
+| `order` | no | Default 0 |
+
+### Response 201
+
+The created category document.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Body validation failed |
+
+---
+
+## `PUT /api/v1/admin/categories/:id`
+
+**Patch category metadata. `name` and `slug` are immutable.**
+
+> **Auth required.** Permission: `ornn:admin:category`.
+
+### Request body
+
+```jsonc
+{ "description": "Updated", "order": 1 }
+```
+
+Both fields optional.
+
+### Response 200
+
+Updated category.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `CATEGORY_NOT_FOUND` | — |
+| 400 | `VALIDATION_ERROR` | — |
+
+---
+
+## `DELETE /api/v1/admin/categories/:id`
+
+**Delete a category.**
+
+> **Auth required.** Permission: `ornn:admin:category`.
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `CATEGORY_NOT_FOUND` | — |
+
+---
+
+## `GET /api/v1/admin/tags`
+
+**List skill tags.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Query
+
+| Param | Type | Notes |
+|---|---|---|
+| `type` | `predefined` \| `custom` | Optional filter |
+
+```jsonc
+{ "data": [ { "id": "...", "name": "api", "type": "predefined" } ], "error": null }
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/admin/tags`
+
+**Create a custom tag.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Request body
+
+```jsonc
+{ "name": "agent" }
+```
+
+`name` is ≤ 30 chars, lowercase alphanumerics with `-` / `_`.
+
+### Response 201
+
+Created tag document.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | — |
+| 409 | `TAG_EXISTS` | Tag with that name already exists |
+
+---
+
+## `DELETE /api/v1/admin/tags/:id`
+
+**Delete a tag.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `TAG_NOT_FOUND` | — |

--- a/ornn-web/src/docs/site/en/api-analytics.md
+++ b/ornn-web/src/docs/site/en/api-analytics.md
@@ -1,0 +1,82 @@
+# API Reference — Analytics
+
+Both endpoints follow skill visibility — anonymous callers can analyze public skills only.
+
+## `GET /api/v1/skills/:idOrName/analytics`
+
+**Execution summary for a skill.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `window` | `7d` \| `30d` \| `all` | `30d` | — |
+| `version` | `<major>.<minor>` | all | Aggregate one version |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "skillGuid": "...",
+    "skillName": "ornn-api",
+    "window": "30d",
+    "totalPulls": 14,
+    "uniqueUsers": 8,
+    "lastPull": "2026-04-28T...",
+    "pullsBySource": { "api": 0, "web": 13, "playground": 1 },
+    "executions": { "count": 42, "successRate": 0.95, "p50LatencyMs": 220, "p95LatencyMs": 1200, "p99LatencyMs": 3300, "topErrors": [] }
+  },
+  "error": null
+}
+```
+
+`executions` is omitted when no execution data exists in the window.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_WINDOW` | `window` not in 7d/30d/all |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `GET /api/v1/skills/:idOrName/analytics/pulls`
+
+**Pull time-series, bucketed.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `bucket` | `hour` \| `day` \| `month` | `day` | — |
+| `from` | ISO timestamp | now − 7d | — |
+| `to` | ISO timestamp | now | — |
+| `version` | `<major>.<minor>` | all | — |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "bucket": "2026-04-22T00:00:00Z", "total": 14, "bySource": { "api": 0, "web": 13, "playground": 1 } },
+      { "bucket": "2026-04-23T00:00:00Z", "total": 0, "bySource": { "api": 0, "web": 0, "playground": 0 } }
+    ]
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_BUCKET` | `bucket` not in hour/day/month |
+| 400 | `INVALID_RANGE` | `from`/`to` invalid ISO or `from >= to` |
+| 404 | `SKILL_NOT_FOUND` | — |

--- a/ornn-web/src/docs/site/en/api-audit.md
+++ b/ornn-web/src/docs/site/en/api-audit.md
@@ -1,0 +1,167 @@
+# API Reference — Skill Audit
+
+Audit verdicts are computed asynchronously and stored per-version. Verdicts are advisory: they appear on the skill detail UI, drive consumer notifications when risky, but never block sharing or use.
+
+## `GET /api/v1/skills/:idOrName/audit`
+
+**Most recent completed audit for the version (cache hit; never triggers).**
+
+> **Auth optional.** Visibility rules apply.
+
+### Query
+
+| Param | Type | Notes |
+|---|---|---|
+| `version` | string | `<major>.<minor>`; defaults to latest |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "_id": "01J...",
+    "skillGuid": "...",
+    "version": "0.1",
+    "status": "completed",
+    "verdict": "green",
+    "overallScore": 7.8,
+    "scores": [ { "dimension": "security", "score": 8, "rationale": "..." } ],
+    "findings": [ { "severity": "info", "dimension": "documentation", "message": "...", "file": "SKILL.md", "line": 12 } ],
+    "completedAt": "...",
+    "triggeredBy": "<userId>"
+  },
+  "error": null
+}
+```
+
+`verdict` is one of `green`, `yellow`, `red`. `status` is one of `running`, `completed`, `failed` — only `completed` rows are surfaced here. `findings[*].severity` is `info` / `warning` / `critical`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+| 404 | `AUDIT_NOT_FOUND` | No completed audit for that (skill, version) |
+
+---
+
+## `GET /api/v1/skills/:idOrName/audit/summary-by-version`
+
+**Latest completed audit per version (powers per-version badges).**
+
+> **Auth optional.** Visibility rules apply.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "byVersion": {
+      "0.1": { "verdict": "green", "overallScore": 7.8, "completedAt": "...", "status": "completed" },
+      "0.2": { "verdict": "yellow", "overallScore": 6.2, "completedAt": "...", "status": "completed" }
+    }
+  },
+  "error": null
+}
+```
+
+Versions without a completed audit are absent from the map.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `GET /api/v1/skills/:idOrName/audit/history`
+
+**All audit records, newest first. Optionally narrow to a single version.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Query
+
+| Param | Type | Notes |
+|---|---|---|
+| `version` | string | Narrow to one version |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "_id": "...", "version": "0.2", "status": "completed", "verdict": "yellow", "overallScore": 6.2 },
+      { "_id": "...", "version": "0.1", "status": "completed", "verdict": "green" }
+    ]
+  },
+  "error": null
+}
+```
+
+`running` rows are included so the UI can render in-flight badges.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `POST /api/v1/skills/:idOrName/audit`
+
+**Owner-triggered audit (Start Auditing).**
+
+> **Auth required.** Owner-or-admin only. Ownership is the gate; no permission string required.
+
+Returns immediately with the `running` row; clients poll `audit/history` (or wait for the `audit.completed` notification).
+
+### Request body
+
+```jsonc
+{ "force": false }
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `force` | boolean | Bypass the 30-day same-bytes cache |
+
+### Response 200
+
+Initial running record:
+
+```jsonc
+{
+  "data": {
+    "_id": "...",
+    "skillGuid": "...",
+    "version": "0.1",
+    "status": "running",
+    "triggeredBy": "<userId>"
+  },
+  "error": null
+}
+```
+
+If the cache is hit (`force=false` and a completed audit exists with the same skill hash within TTL) the existing record is returned with `status: "completed"`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `POST /api/v1/admin/skills/:idOrName/audit`
+
+**Force-rerun audit as platform admin (bypasses ownership).**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+Same body / response shape as the owner endpoint. `force: true` is honoured.

--- a/ornn-web/src/docs/site/en/api-format.md
+++ b/ornn-web/src/docs/site/en/api-format.md
@@ -1,0 +1,61 @@
+# API Reference — Skill Format
+
+## `GET /api/v1/skill-format/rules`
+
+**Canonical SKILL.md / package format spec, in Markdown.**
+
+> **Auth: anonymous.**
+
+### Response 200
+
+```json
+{ "data": { "rules": "# Skill format\n\n..." }, "error": null }
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/skill-format/validate`
+
+**Validate a ZIP without uploading it.**
+
+> **Auth required.** Permission: `ornn:skill:read`.
+
+### Request
+
+| In | Header / Body | Notes |
+|---|---|---|
+| Header | `Content-Type: application/zip` (or `application/octet-stream`) | Required |
+| Body | binary ZIP | Required |
+
+### Response 200 (valid)
+
+```json
+{ "data": { "valid": true }, "error": null }
+```
+
+### Response 200 (invalid — not an HTTP error)
+
+```jsonc
+{
+  "data": {
+    "valid": false,
+    "violations": [
+      { "rule": "FRONTMATTER_VALIDATION_FAILED", "message": "name must not contain 'claude'" }
+    ]
+  },
+  "error": null
+}
+```
+
+This intentionally returns 200; validation failures are content, not faults.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_CONTENT_TYPE` | — |
+| 400 | `EMPTY_BODY` | — |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:read` |

--- a/ornn-web/src/docs/site/en/api-generation.md
+++ b/ornn-web/src/docs/site/en/api-generation.md
@@ -1,0 +1,132 @@
+# API Reference — Skill Generation (SSE)
+
+These three endpoints stream Server-Sent Events. All set:
+
+```
+Cache-Control: no-cache
+Connection: keep-alive
+X-Accel-Buffering: no
+```
+
+Each SSE event is a `data: <json>` line; consumers JSON-parse the body.
+
+| Event payload | Meaning |
+|---|---|
+| `{ "type": "start" }` | Generation started |
+| `{ "type": "chunk", "delta": "<text>" }` | Incremental text |
+| `{ "type": "complete", "content": "<full>", "skillPackage": {...} }` | Generation finished. `skillPackage` present when the generator produced files |
+| `{ "type": "error", "message": "<text>" }` | Generation aborted; stream closes after this |
+| `{ "type": "keepalive" }` | Heartbeat |
+
+---
+
+## `POST /api/v1/skills/generate`
+
+**Generate a brand-new skill from a prompt.**
+
+> **Auth required.** Permission: `ornn:skill:build`.
+
+### Request
+
+Two body shapes are accepted; the discriminator is `Content-Type`.
+
+**Multipart (single-shot)** `Content-Type: multipart/form-data`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `prompt` | string | yes | Natural-language description |
+| `package` | File | no | Existing ZIP for context (iterative refinement) |
+
+**JSON (multi-turn)** `Content-Type: application/json`
+
+```jsonc
+{
+  "prompt": "Build a skill that ...",
+  "messages": [
+    { "role": "user", "content": "..." },
+    { "role": "assistant", "content": "..." }
+  ]
+}
+```
+
+`prompt` is required when `messages` is omitted; with `messages`, the array is the source of truth.
+
+### Response
+
+`200 OK` with `Content-Type: text/event-stream`. Events as above.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `MISSING_PROMPT` | Multipart body without `prompt` field |
+| 400 | `INVALID_CONTENT_TYPE` | Body type isn't multipart or JSON |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:build` |
+
+---
+
+## `POST /api/v1/skills/generate/from-source`
+
+**Generate a skill from an inline code snippet or a public GitHub URL.**
+
+> **Auth required.** Permission: `ornn:skill:build`.
+
+### Request body (`application/json`)
+
+```jsonc
+{
+  "code": "<inline source>",          // exactly one of code / repoUrl
+  "repoUrl": "https://github.com/owner/repo",
+  "path": "src/routes",                // optional; subpath inside repo
+  "framework": "hono",                 // optional; framework hint
+  "description": "Wraps the v1 routes" // optional; free-form context
+}
+```
+
+### Response
+
+SSE stream as in `/skills/generate`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `MISSING_SOURCE` | Neither `code` nor `repoUrl` |
+| 400 | `AMBIGUOUS_SOURCE` | Both `code` and `repoUrl` |
+| 400 | `EMPTY_SOURCE` | `code` empty after strip |
+| 400 | `INVALID_BODY` | JSON parse failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:build` |
+| 502 | `REPO_FETCH_FAILED` | Repo fetch failed |
+
+---
+
+## `POST /api/v1/skills/generate/from-openapi`
+
+**Generate a skill from an OpenAPI 3 specification.**
+
+> **Auth required.** Permission: `ornn:skill:build`.
+
+### Request body (`application/json`)
+
+```jsonc
+{
+  "spec": "<openapi yaml or json as a single string>",
+  "endpoints": ["GET /users", "POST /users"], // optional allow-list
+  "description": "..."                        // optional
+}
+```
+
+### Response
+
+SSE stream as in `/skills/generate`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `MISSING_SPEC` | `spec` missing or not a string |
+| 400 | `INVALID_BODY` | JSON parse failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:build` |

--- a/ornn-web/src/docs/site/en/api-me.md
+++ b/ornn-web/src/docs/site/en/api-me.md
@@ -1,0 +1,143 @@
+# API Reference — Me / Caller scope
+
+Every route below requires authentication. There is no permission gate beyond identity.
+
+## `GET /api/v1/me`
+
+**Snapshot of the authenticated caller.**
+
+```jsonc
+{
+  "data": {
+    "userId": "<sub>",
+    "email": "<email>",
+    "displayName": "<name>",
+    "roles": ["ornn-user"],
+    "permissions": ["ornn:skill:read", "ornn:skill:create", "ornn:playground:use"]
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/activity/login`
+
+**Record a session-opened event.**
+
+> **Auth required.** Fire-and-forget from the frontend after the OAuth callback completes.
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+Activity logged: `login`.
+
+---
+
+## `POST /api/v1/activity/logout`
+
+**Record a session-closed event.**
+
+> **Auth required.** Called by the frontend before clearing local auth state.
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+Activity logged: `logout`.
+
+---
+
+## `GET /api/v1/me/orgs`
+
+**Caller's NyxID org memberships (admin + member roles only).**
+
+> **Auth required.**
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "userId": "<orgId>", "role": "admin", "displayName": "Acme Corp" }
+    ]
+  },
+  "error": null
+}
+```
+
+Fail-soft: NyxID outage returns `items: []` rather than 5xx. Diagnosis: response duration ≈ 0 ms is the giveaway.
+
+No errors.
+
+---
+
+## `GET /api/v1/me/orgs/:orgId`
+
+**Resolve a single org (useful even after the caller leaves it).**
+
+> **Auth required.**
+
+```jsonc
+{
+  "data": { "userId": "<orgId>", "displayName": "Acme Corp", "avatarUrl": "https://..." },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `ORG_NOT_FOUND` | NyxID does not return that org or the caller cannot resolve it |
+
+---
+
+## `GET /api/v1/me/nyxid-services`
+
+**Caller's NyxID user-services (personal + org-inherited).**
+
+> **Auth required.**
+
+Used to power the system-skill filter on the registry.
+
+```jsonc
+{
+  "data": { "items": [ { "id": "...", "slug": "ornn-api", "label": "ornn-api" } ] },
+  "error": null
+}
+```
+
+Fail-soft: returns `items: []` when NyxID is unreachable or no proxy token is set.
+
+---
+
+## `GET /api/v1/me/skills/grants-summary`
+
+**Caller's outbound shares — orgs and users they've granted access to.**
+
+> **Auth required.**
+
+```jsonc
+{
+  "data": {
+    "orgs":  [ { "id": "<orgId>", "displayName": "Acme",     "skillCount": 5 } ],
+    "users": [ { "userId": "<userId>", "email": "...", "displayName": "...", "skillCount": 2 } ]
+  },
+  "error": null
+}
+```
+
+Display names are best-effort: orgs resolved via NyxID, users via Ornn activity directory; missing values fall back to the raw id.
+
+---
+
+## `GET /api/v1/me/shared-skills/sources-summary`
+
+**Caller's inbound shares — orgs and users that have granted them access.**
+
+> **Auth required.**
+
+Same shape as `grants-summary`. `orgs` are bridge memberships (orgs caller is in where someone has shared a skill); `users` are authors who shared directly.

--- a/ornn-web/src/docs/site/en/api-notifications.md
+++ b/ornn-web/src/docs/site/en/api-notifications.md
@@ -1,0 +1,96 @@
+# API Reference — Notifications
+
+All four endpoints are scoped to the caller's own notifications. There is no admin override.
+
+## `GET /api/v1/notifications`
+
+**List notifications, newest first.**
+
+> **Auth required.** No specific permission; identity is the gate.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `unread` | `"true"` | — | Filter to unread only |
+| `limit` | int 1–200 | `50` | — |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      {
+        "_id": "...",
+        "userId": "<self>",
+        "category": "audit.completed",
+        "title": "Skill audit passed — ornn-api v0.1 · score 7.8/10",
+        "body": "...",
+        "link": "/skills/<guid>/audits?version=0.1",
+        "data": { "skillGuid": "...", "version": "0.1", "verdict": "green", "overallScore": 7.8 },
+        "readAt": null,
+        "createdAt": "..."
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+Two categories are emitted today:
+
+| Category | Recipient | Trigger |
+|---|---|---|
+| `audit.completed` | Skill owner | Every audit completion |
+| `audit.risky_for_consumer` | Every consumer of a `yellow` / `red` skill | Same audit completion; `green` skipped |
+
+No errors.
+
+---
+
+## `GET /api/v1/notifications/unread-count`
+
+**Badge count for the bell.**
+
+> **Auth required.**
+
+```json
+{ "data": { "count": 5 }, "error": null }
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/notifications/:id/read`
+
+**Mark a single notification read.**
+
+> **Auth required.** Caller must own the notification.
+
+### Response 200
+
+Updated notification document.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `NOTIFICATION_NOT_FOUND` | Unknown id or not the caller's |
+
+---
+
+## `POST /api/v1/notifications/mark-all-read`
+
+**Mark every unread notification read.**
+
+> **Auth required.**
+
+### Response 200
+
+```json
+{ "data": { "updated": 5 }, "error": null }
+```
+
+No errors.

--- a/ornn-web/src/docs/site/en/api-out-of-band.md
+++ b/ornn-web/src/docs/site/en/api-out-of-band.md
@@ -1,0 +1,73 @@
+# API Reference — Out-of-band Endpoints
+
+These four routes live outside `/api/v1` and are intended for infrastructure (k8s probes, OpenAPI tooling).
+
+## `GET /health`
+
+**Liveness probe (alias of `/livez`).**
+
+> **Auth: anonymous.**
+
+Used by k8s liveness checks and uptime monitors.
+
+**Response 200**
+
+```json
+{
+  "status": "ok",
+  "service": "ornn-api",
+  "version": "0.4.0",
+  "timestamp": "2026-04-28T07:00:00.000Z"
+}
+```
+
+No errors.
+
+---
+
+## `GET /livez`
+
+**k8s liveness probe.**
+
+> **Auth: anonymous.**
+
+Identical body to `/health`.
+
+---
+
+## `GET /readyz`
+
+**k8s readiness probe.**
+
+> **Auth: anonymous.**
+
+Pings MongoDB with a 2-second timeout.
+
+**Response 200 (ready)**
+
+```json
+{
+  "status": "ready",
+  "service": "ornn-api",
+  "mongoLatencyMs": 8
+}
+```
+
+**Response 503 (not ready)**
+
+```json
+{
+  "status": "not_ready",
+  "reason": "mongo_unreachable"
+}
+```
+
+---
+
+## `GET /api/v1/openapi.json`
+
+**Auto-generated OpenAPI 3 spec.**
+
+> **Auth: anonymous.**
+
+Generated from the Zod schemas attached to each route (Hono `@hono/zod-openapi` integration). Useful for SDK generators and IDE tooling. The document is regenerated per process start.

--- a/ornn-web/src/docs/site/en/api-overview.md
+++ b/ornn-web/src/docs/site/en/api-overview.md
@@ -1,0 +1,158 @@
+# API Reference — Overview & Conventions
+
+Ornn exposes one HTTP surface — `https://<host>/api/v1/*` — that AI agents and the web UI both consume. Every endpoint lives under `/api/v1` unless explicitly marked **out-of-band**. This page captures the conventions every domain shares; per-domain pages cover the actual endpoints.
+
+## Base URL and versioning
+
+| Environment | Base URL |
+|---|---|
+| Local k8s | `https://ornn.ornn-cluster.local/api/v1` |
+| Production | `https://ornn.<domain>/api/v1` (from `ORNN_API_URL` env) |
+
+`/api/v1` is the only mounted version.
+
+## Authentication model
+
+Ornn does not verify NyxID tokens itself. Every request goes through the NyxID proxy, which:
+
+1. Validates the user's NyxID OAuth session.
+2. Decodes the user's identity into a JWT.
+3. Forwards the request with `X-NyxID-Identity-Token: <jwt>` (and a few legacy `X-NyxID-*` headers for backwards compat).
+
+`ornn-api`'s middleware decodes that JWT *without re-verifying signatures* (the proxy already verified) and populates `c.var.auth` for the rest of the handler chain.
+
+| Field | Source | Notes |
+|---|---|---|
+| `userId` | JWT `sub` | Required. Used for ownership / authorship checks. |
+| `email` | JWT `email` | Optional; defaults to empty string. |
+| `displayName` | JWT `name` | Optional; falls back to `email`, then `userId`. |
+| `roles` | JWT `roles` | Array of role strings. |
+| `permissions` | JWT `permissions` | Array of permission strings (see catalogue below). |
+
+Endpoints fall into three auth tiers:
+
+| Tier | Behaviour |
+|---|---|
+| **Anonymous** | No identity token required. Used for public health / spec / public skill reads. |
+| **Optional** | Token decoded if present; handler observes `c.var.auth` may be `null`. Used for visibility-gated reads where unauthenticated callers see only public data. |
+| **Required** | Token must be present and well-formed; otherwise the request fails with `401 AUTH_MISSING`. |
+
+## Permission catalogue
+
+Required permissions are encoded as colon-separated namespaced strings on the JWT's `permissions` array. Missing the permission yields `403 FORBIDDEN`.
+
+| Permission | Typical role | What it grants |
+|---|---|---|
+| `ornn:skill:read` | `ornn-user` | Fetch skill packages as JSON, validate skill packages |
+| `ornn:skill:create` | `ornn-user` | Upload new skills, pull from GitHub |
+| `ornn:skill:update` | `ornn-user` | Change skills you own |
+| `ornn:skill:delete` | `ornn-user` | Delete skills / versions you own |
+| `ornn:skill:build` | `ornn-user` | Use the AI generation endpoints |
+| `ornn:playground:use` | `ornn-user` | Run the playground chat |
+| `ornn:admin:skill` | `ornn-admin` | Read and act on every skill regardless of ownership; admin stats / activities / users; force-audit / force-delete; tag CRUD |
+| `ornn:admin:category` | `ornn-admin` | Skill-category CRUD |
+
+Several endpoints add an **ownership** check on top of the permission gate (e.g. only the skill author can `PUT /skills/:id`, unless the caller also holds `ornn:admin:skill`). Each endpoint section calls those out explicitly.
+
+## Visibility rules for skills
+
+Most read paths use the same visibility rule, applied server-side:
+
+| Caller | Sees |
+|---|---|
+| Anonymous | Public skills only |
+| Authenticated, non-owner | Public + skills directly shared with their `userId` + skills shared with any org they belong to (admin or member role; viewer doesn't count) |
+| Authenticated, owner | All of the above + their own skills, including private |
+| Platform admin (`ornn:admin:skill`) | All skills |
+
+If a caller asks for a skill they cannot see, the response is `404 SKILL_NOT_FOUND` — never `403`. This avoids leaking the existence of private skills.
+
+> **Sharing is unconditional.** Editing the allow-list (`PUT /skills/:id/permissions`) applies the new state immediately. There is no audit gate, no waiver, no reviewer queue. Audit results travel separately as a passive label and notification.
+
+## Response envelope
+
+Every JSON response (success and error) uses the same envelope:
+
+```jsonc
+{
+  "data": <T> | null,
+  "error": { "code": "<MACHINE_CODE>", "message": "<human-readable>" } | null
+}
+```
+
+Streaming endpoints (SSE) do **not** wrap each event in this envelope.
+
+## HTTP status codes
+
+| Code | Meaning |
+|---|---|
+| `200 OK` | Successful GET / PUT / PATCH / DELETE |
+| `201 Created` | `POST /skills`, `POST /skills/pull`, `POST /admin/categories`, `POST /admin/tags` |
+| `400 Bad Request` | Validation failure, malformed body, missing required field, invalid query enum |
+| `401 Unauthorized` | Auth required but no usable identity token |
+| `403 Forbidden` | Authenticated but missing the permission, or failed an ownership check |
+| `404 Not Found` | Resource does not exist or is not visible to the caller |
+| `409 Conflict` | State conflict (rare) |
+| `413 Payload Too Large` | ZIP exceeds `MAX_PACKAGE_SIZE_BYTES` (default ~50 MiB) |
+| `500 Internal Server Error` | Unhandled exception; correlate via `X-Request-ID` |
+| `503 Service Unavailable` | Hard dependency (Mongo, NyxID) unreachable. `/readyz` only. |
+| `504 Gateway Timeout` | Upstream timed out |
+
+## Common error codes
+
+Codes are stable identifiers — branch on `error.code`, not on the HTTP status alone.
+
+| Code | Meaning |
+|---|---|
+| `AUTH_MISSING` | No usable NyxID identity token |
+| `FORBIDDEN` | Authenticated, but lacks permission or ownership |
+| `VALIDATION_ERROR` | Generic Zod validation failure |
+| `INVALID_BODY` | Body could not be parsed as JSON or was empty when required |
+| `EMPTY_BODY` | ZIP-upload route received empty bytes |
+| `INVALID_CONTENT_TYPE` | Content-Type was not `application/zip` / `application/octet-stream` / `multipart/form-data` |
+| `PAYLOAD_TOO_LARGE` | ZIP exceeds size cap |
+| `SKILL_NOT_FOUND` | Skill GUID / name unknown or not visible |
+| `AUDIT_NOT_FOUND` | No completed audit record matches the request |
+| `INTERNAL_ERROR` | Unhandled server exception |
+
+Domain-specific error codes are documented in each domain page.
+
+## Standard headers
+
+### Request headers honoured globally
+
+| Header | Required | Purpose |
+|---|---|---|
+| `X-NyxID-Identity-Token` | On required-auth routes | Forwarded by the NyxID proxy. Decoded for identity. |
+| `X-Request-ID` | Optional | If set, copied into the response. Otherwise the server generates one. |
+| `Content-Type` | On bodies | Discriminator for ZIP uploads vs. JSON vs. multipart |
+| `Accept` | Optional | Reserved for future content negotiation |
+
+### Response headers always set
+
+| Header | Notes |
+|---|---|
+| `X-Request-ID` | Echoed for log correlation |
+| `Content-Type` | `application/json; charset=utf-8` for envelope responses; `text/event-stream` for SSE |
+
+CORS allowlist comes from `ALLOWED_ORIGINS`; preflight allows `GET, POST, PUT, PATCH, DELETE, OPTIONS`.
+
+## Pagination shape
+
+Endpoints that paginate use offset pagination with this shape inside `data`:
+
+```jsonc
+{
+  "items": [ ... ],
+  "total": <int>,
+  "page": <int>,
+  "pageSize": <int>,
+  "totalPages": <int>
+}
+```
+
+Defaults vary; explicit values are documented per endpoint.
+
+## Activity logging
+
+Most write operations append to the `activities` collection (visible to platform admins via `GET /admin/activities`). Each activity record carries `userId`, `email`, `displayName`, `action`, `details`, `createdAt`.

--- a/ornn-web/src/docs/site/en/api-platform-settings.md
+++ b/ornn-web/src/docs/site/en/api-platform-settings.md
@@ -1,0 +1,46 @@
+# API Reference — Platform Settings
+
+## `GET /api/v1/admin/settings`
+
+**Read platform-wide settings.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+```jsonc
+{
+  "data": {
+    "auditWaiverThreshold": 5.5
+  },
+  "error": null
+}
+```
+
+`auditWaiverThreshold` is a 0–10 floating-point value retained from the previous audit-gated share design. It currently has no functional effect (sharing is unconditional); the field is preserved so we can re-introduce a threshold-based UX later without a migration.
+
+No errors.
+
+---
+
+## `PATCH /api/v1/admin/settings`
+
+**Patch platform-wide settings.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Request body
+
+```jsonc
+{ "auditWaiverThreshold": 5.5 }
+```
+
+Partial patch — only the keys you supply are written. Numbers are clamped to `[0, 10]` and rounded to 0.1.
+
+### Response 200
+
+Updated settings object.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_SETTING` | Unknown field or value out of range |

--- a/ornn-web/src/docs/site/en/api-playground.md
+++ b/ornn-web/src/docs/site/en/api-playground.md
@@ -1,0 +1,48 @@
+# API Reference — Playground (SSE)
+
+## `POST /api/v1/playground/chat`
+
+**Multi-turn chat with optional skill injection and sandbox tool execution.**
+
+> **Auth required.** Permission: `ornn:playground:use`.
+
+### Request body (`application/json`)
+
+```jsonc
+{
+  "messages": [
+    {
+      "role": "user" | "assistant" | "tool" | "system",
+      "content": "...",
+      "toolCalls": [ { "id": "...", "name": "execute_script", "args": { ... } } ],
+      "toolCallId": "..."
+    }
+  ],
+  "skillId": "<guid or name>",       // optional
+  "envVars": { "API_KEY": "..." }    // optional, injected into sandbox runs
+}
+```
+
+`messages` is 1–100 entries; each requires `role` + `content`. Server-side tool-use loop runs up to 5 rounds.
+
+### Response
+
+SSE stream — text deltas + tool-call events. Event names use kebab-case:
+
+| Event | Payload | Meaning |
+|---|---|---|
+| `text-delta` | `{ "delta": "<text>" }` | Incremental assistant text |
+| `tool-call` | `{ "id": "...", "name": "execute_script", "args": { ... } }` | Server is invoking a tool |
+| `tool-result` | `{ "id": "...", "result": { ... } }` | Tool returned |
+| `file-output` | `{ "path": "...", "content": "<text or base64>", "encoding": "utf8" \| "base64" }` | Tool produced a file artifact |
+| `finish` | `{ "reason": "stop" \| "max_rounds" \| "error", "message"?: "<text>" }` | Stream closes after this |
+
+Side effect: when bound to a real skill, fires a `pull` analytics event with `source = "playground"`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Message-array schema failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:playground:use` |

--- a/ornn-web/src/docs/site/en/api-search.md
+++ b/ornn-web/src/docs/site/en/api-search.md
@@ -1,0 +1,65 @@
+# API Reference — Skill Search
+
+## `GET /api/v1/skill-search`
+
+**Unified keyword / semantic search.**
+
+> **Auth optional.** Anonymous callers are forced to `scope=public` regardless of the query string.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `query` | string ≤ 2000 | `""` | Search term |
+| `mode` | `keyword` \| `semantic` | `keyword` | Semantic uses LLM re-ranking |
+| `scope` | `public` \| `private` \| `mixed` \| `shared-with-me` \| `mine` | `private` (auth) / `public` (anon) | — |
+| `page` | int ≥ 1 | `1` | — |
+| `pageSize` | int 1–100 | `9` | — |
+| `model` | string | platform default | LLM model override (semantic mode) |
+| `systemFilter` | `any` \| `only` \| `exclude` | `any` | "System skill" tri-state filter |
+| `sharedWithOrgs` | CSV of org IDs | — | Narrow by grant source |
+| `sharedWithUsers` | CSV of user IDs | — | Narrow by grant source |
+| `createdByAny` | CSV of user IDs | — | Narrow by author |
+
+System-skill filtering uses the caller's NyxID user-services slug list; unreachable NyxID fail-softs to "no system skills" instead of 500.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [ /* SkillSummary[] */ ],
+    "total": 42,
+    "page": 1,
+    "pageSize": 9,
+    "totalPages": 5
+  },
+  "error": null
+}
+```
+
+In semantic mode, each item also carries `relevanceScore: <0..1>`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `QUERY_REQUIRED` | `mode=semantic` with empty `query` |
+| 400 | `INVALID_QUERY` | Schema validation failed |
+| 401 | `AUTH_REQUIRED` | `mode=semantic` from anonymous caller |
+
+---
+
+## `GET /api/v1/skill-counts`
+
+**Counts for the registry tab badges (`Public`, `Mine`, `Shared with me`).**
+
+> **Auth optional.** Anonymous callers see `mine = 0`, `sharedWithMe = 0`.
+
+### Response 200
+
+```json
+{ "data": { "public": 42, "mine": 7, "sharedWithMe": 3 }, "error": null }
+```
+
+No errors.

--- a/ornn-web/src/docs/site/en/api-skills.md
+++ b/ornn-web/src/docs/site/en/api-skills.md
@@ -1,0 +1,469 @@
+# API Reference — Skills CRUD
+
+Mounted under `/api/v1/skills`. The skill package is a ZIP whose root folder contains a `SKILL.md` and any number of supporting files. The platform models each upload as a *new version* of a stable skill identity (`guid`).
+
+> Auth model + permission catalogue + visibility rules: see **API Reference — Overview & Conventions**.
+
+## `POST /api/v1/skills`
+
+**Upload a new skill (binary ZIP).**
+
+> **Auth required.** Permission: `ornn:skill:create`. New skills are created **private** by default.
+
+### Request
+
+| In | Header / Param | Type | Notes |
+|---|---|---|---|
+| Header | `Content-Type` | string | One of `application/zip`, `application/octet-stream`, or `multipart/form-data` |
+| Query | `skip_validation` | `"true"` (optional) | Skip skill-format validation when set; default false |
+| Body | binary | `application/zip` payload | The skill package ZIP |
+
+For multipart uploads, the file field is `package`.
+
+### Response 201
+
+```jsonc
+{
+  "data": {
+    "guid": "01J7...",
+    "name": "ornn-api",
+    "description": "...",
+    "version": "0.1",
+    "isPrivate": true,
+    "isDeprecated": false,
+    "deprecationNote": null,
+    "createdBy": "<userId>",
+    "createdOn": "2026-04-14T18:59:00.000Z",
+    "updatedOn": "2026-04-14T18:59:00.000Z",
+    "sharedWithUsers": [],
+    "sharedWithOrgs": [],
+    "storageKey": "skills/<guid>/<version>.zip",
+    "skillHash": "sha256:..."
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_CONTENT_TYPE` | Content-Type missing or unsupported |
+| 400 | `EMPTY_BODY` | Body bytes were empty |
+| 400 | `VALIDATION_ERROR` | ZIP failed format validation (`error.message` lists violations) |
+| 401 | `AUTH_MISSING` | Caller has no NyxID identity |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:create` |
+| 413 | `PAYLOAD_TOO_LARGE` | ZIP exceeds size cap |
+
+Activity logged: `skill:create`.
+
+---
+
+## `POST /api/v1/skills/pull`
+
+**Create a skill from a public GitHub repo.**
+
+> **Auth required.** Permission: `ornn:skill:create`. Pulled skills retain the GitHub source pointer for later refresh.
+
+### Request body (`application/json`)
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `repo` | string | yes | `owner/name` |
+| `ref` | string | no | Branch / tag / commit; default `HEAD` |
+| `path` | string | no | Subdirectory inside the repo to package |
+| `skip_validation` | boolean | no | Mirror of the query flag on direct upload |
+
+### Response 201
+
+Same shape as `POST /skills`. The skill record additionally carries a `source` object:
+
+```jsonc
+{ "type": "github", "repo": "<owner/name>", "ref": "<ref>", "path": "<path>", "commit": "<sha>" }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `MISSING_REPO` | `repo` empty or absent |
+| 400 | `INVALID_BODY` | Body not JSON |
+| 400 | `VALIDATION_ERROR` | Pulled package failed format validation |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:create` |
+| 502 | `PULL_FAILED` | GitHub fetch / clone / build failed |
+
+Activity logged: `skill:create` with `details.source = "github-pull"`.
+
+---
+
+## `POST /api/v1/skills/:id/refresh`
+
+**Re-pull a GitHub-sourced skill at the latest commit (publishes a new version).**
+
+> **Auth required.** Permission: `ornn:skill:update` plus **owner-or-admin** ownership check.
+
+### Path
+
+| Param | Type | Notes |
+|---|---|---|
+| `id` | string | Skill GUID. Name is **not** accepted on this endpoint. |
+
+### Response 200
+
+Updated skill document (latest version after re-pull).
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Caller is not the author and not a platform admin |
+| 404 | `SKILL_NOT_FOUND` | Skill GUID unknown |
+| 409 | `NOT_GITHUB_SOURCED` | Skill was not created via `/skills/pull` |
+| 502 | `PULL_FAILED` | Re-pull failed |
+
+Activity logged: `skill:refresh` with `details.commit`.
+
+---
+
+## `GET /api/v1/skills/:idOrName`
+
+**Fetch one skill, optionally pinned to a version.**
+
+> **Auth optional.** Visibility rules apply (see Overview).
+
+### Path & Query
+
+| Param | In | Type | Notes |
+|---|---|---|---|
+| `idOrName` | path | string | Skill GUID or kebab-case name |
+| `version` | query | string | `<major>.<minor>`; defaults to latest |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "guid": "01J7...",
+    "name": "ornn-api",
+    "description": "...",
+    "version": "0.1",
+    "isPrivate": true,
+    "isDeprecated": false,
+    "deprecationNote": null,
+    "createdBy": "<userId>",
+    "createdByEmail": "<email>",
+    "createdByDisplayName": "<display name>",
+    "createdOn": "...",
+    "updatedOn": "...",
+    "sharedWithUsers": [],
+    "sharedWithOrgs": [],
+    "tags": ["api", "ornn"],
+    "metadata": { "category": "plain" },
+    "storageKey": "skills/<guid>/<version>.zip",
+    "skillHash": "sha256:...",
+    "presignedPackageUrl": "https://..."
+  },
+  "error": null
+}
+```
+
+### Response headers (deprecation)
+
+| Header | When |
+|---|---|
+| `X-Skill-Deprecated: true` | The version returned is deprecated |
+| `X-Skill-Deprecation-Note: <urlencoded note>` | A deprecation note exists |
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | Unknown name/guid OR caller cannot see this skill |
+
+Side effect: emits a `pull` analytics event with `source = "web"` (fire-and-forget).
+
+---
+
+## `GET /api/v1/skills/:idOrName/json`
+
+**Fetch the full skill package as JSON (decoded UTF-8 file map).**
+
+> **Auth required.** Permission: `ornn:skill:read`. Visibility rules apply.
+
+This is the agent-friendly path: instead of a presigned ZIP URL, you get the whole package back as `{ files: [{ path, content }] }` so an agent can inject files into context directly.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "name": "ornn-api",
+    "version": "0.1",
+    "files": [
+      { "path": "SKILL.md", "content": "---\nname: ornn-api\n..." },
+      { "path": "scripts/run.py", "content": "..." }
+    ]
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:read` |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+Side effect: `pull` analytics event with `source = "api"`.
+
+---
+
+## `GET /api/v1/skills/:idOrName/versions`
+
+**List all published versions, newest first.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      {
+        "version": "0.2",
+        "isDeprecated": false,
+        "deprecationNote": null,
+        "createdBy": "<userId>",
+        "createdByEmail": "...",
+        "createdByDisplayName": "...",
+        "createdOn": "...",
+        "skillHash": "sha256:...",
+        "storageKey": "skills/<guid>/0.2.zip"
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `GET /api/v1/skills/:idOrName/versions/:fromVersion/diff/:toVersion`
+
+**Structured file-level diff between two versions.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "fromVersion": "0.1",
+    "toVersion": "0.2",
+    "files": [
+      { "path": "SKILL.md", "status": "modified", "fromContent": "...", "toContent": "..." },
+      { "path": "scripts/new.py", "status": "added",    "fromContent": null, "toContent": "..." },
+      { "path": "scripts/old.py", "status": "removed",  "fromContent": "...", "toContent": null }
+    ]
+  },
+  "error": null
+}
+```
+
+`status` is one of `added`, `removed`, `modified`. Both `fromContent` and `toContent` are full file text — clients render line-level diffs themselves.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | Skill or one of the versions unknown |
+
+---
+
+## `PATCH /api/v1/skills/:idOrName/versions/:version`
+
+**Toggle deprecation flag on a single version.**
+
+> **Auth required.** Permission: `ornn:skill:update` + owner-or-admin.
+
+### Request body
+
+```jsonc
+{
+  "isDeprecated": true,
+  "deprecationNote": "Use 0.2+; this version mishandles JSON arrays."
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `isDeprecated` | boolean | yes | — |
+| `deprecationNote` | string | no | ≤ 1024 chars |
+
+### Response 200
+
+The updated version row.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_DEPRECATION_PATCH` | Schema validation failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | Skill or version unknown |
+
+Activity logged: `skill:update` with `details.deprecationChange = true`.
+
+---
+
+## `PUT /api/v1/skills/:id`
+
+**Publish a new version of an existing skill, or flip its visibility, or both.**
+
+> **Auth required.** Permission: `ornn:skill:update` + owner-or-admin. Path takes the **GUID only**.
+
+This endpoint multiplexes by `Content-Type`:
+
+| Content-Type | Body | Effect |
+|---|---|---|
+| `application/zip` / `application/octet-stream` | binary ZIP | New version |
+| `multipart/form-data` | `package: <File>`, `isPrivate?: "true" \| "false"` | New version + optional visibility |
+| `application/json` | `{ "isPrivate": boolean }` | Visibility-only |
+
+Query `skip_validation=true` is honoured for ZIP uploads.
+
+### Response 200
+
+Updated skill document (same shape as `GET /skills/:idOrName`).
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_CONTENT_TYPE` | Unsupported MIME |
+| 400 | `NO_UPDATE` | Neither ZIP nor `isPrivate` provided |
+| 400 | `VALIDATION_ERROR` | ZIP failed format validation |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | Skill GUID unknown |
+| 413 | `PAYLOAD_TOO_LARGE` | — |
+
+Activity logged: `skill:update` (ZIP upload) or `skill:visibility_change` (visibility-only).
+
+---
+
+## `PUT /api/v1/skills/:id/permissions`
+
+**Replace the sharing allow-list (and / or `isPrivate`).**
+
+> **Auth required.** Permission: `ornn:skill:update` + owner-or-admin.
+>
+> **Sharing is unconditional.** The new state is applied immediately. There is no audit gate, no waiver, no reviewer.
+
+### Request body
+
+```jsonc
+{
+  "isPrivate": true,
+  "sharedWithUsers": ["user_abc", "user_def"],
+  "sharedWithOrgs": ["org_xyz"]
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `isPrivate` | boolean | Required |
+| `sharedWithUsers` | string[] | ≤ 500 entries, each 1–128 chars |
+| `sharedWithOrgs` | string[] | ≤ 100 entries, each 1–128 chars |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "skill": { /* full SkillDetail, same shape as GET /skills/:idOrName */ }
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_PERMISSIONS` | Body schema validation failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+Activity logged: `skill:permissions_change`.
+
+If the resulting state is yellow / red on a fresh audit, the audit pipeline (separately) will fire `audit.risky_for_consumer` notifications. This endpoint itself never blocks.
+
+---
+
+## `DELETE /api/v1/skills/:id`
+
+**Hard-delete a skill and every version.**
+
+> **Auth required.** Permission: `ornn:skill:delete` + owner-or-admin.
+
+### Response 200
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+Activity logged: `skill:delete`.
+
+---
+
+## `DELETE /api/v1/skills/:idOrName/versions/:version`
+
+**Delete one non-latest, non-only version.**
+
+> **Auth required.** Permission: `ornn:skill:delete` + owner-or-admin.
+
+Refuses to delete:
+
+- the **only** remaining version (`ONLY_VERSION_DELETE_REFUSED`) — use `DELETE /skills/:id` instead;
+- the **current latest** version (`LATEST_VERSION_DELETE_REFUSED`) — publish a newer version first.
+
+### Response 200
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `LATEST_VERSION_DELETE_REFUSED` | Caller targeted the latest |
+| 400 | `ONLY_VERSION_DELETE_REFUSED` | Caller targeted the sole remaining version |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | Skill or version unknown |
+
+Activity logged: `skill:version_delete`.

--- a/ornn-web/src/docs/site/en/api-users.md
+++ b/ornn-web/src/docs/site/en/api-users.md
@@ -1,0 +1,62 @@
+# API Reference — Users Directory
+
+These routes are scoped to users who have interacted with Ornn (have at least one row in the `activities` collection). They never query NyxID's full user directory.
+
+## `GET /api/v1/users/search`
+
+**Email-prefix typeahead. Powers the permissions modal user picker.**
+
+> **Auth required.**
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `q` | string ≤ 256 | `""` | Search prefix |
+| `limit` | int 1–50 | `10` | — |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "userId": "<userId>", "email": "alice@example.com", "displayName": "Alice" }
+    ]
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `GET /api/v1/users/resolve`
+
+**Batch-resolve user IDs to email + displayName.**
+
+> **Auth required.**
+
+### Query
+
+| Param | Type | Notes |
+|---|---|---|
+| `ids` | CSV of user IDs | ≤ 100 entries |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "userId": "<userId>", "email": "alice@example.com", "displayName": "Alice" }
+    ]
+  },
+  "error": null
+}
+```
+
+Unknown IDs are silently dropped (consumers fall back to rendering the raw id).
+
+No errors.

--- a/ornn-web/src/docs/site/en/menuStructure.json
+++ b/ornn-web/src/docs/site/en/menuStructure.json
@@ -6,15 +6,19 @@
       "label": "About",
       "order": 1,
       "children": [
-        { "id": "what-is-ornn", "label": "What is Ornn", "file": "what-is-ornn.md", "order": 1 }
+        { "id": "what-is-ornn", "label": "What is Ornn", "file": "what-is-ornn.md", "order": 1 },
+        { "id": "why-ornn", "label": "Why Ornn?", "file": "why-ornn.md", "order": 2 },
+        { "id": "vs-vercel-skills-sh", "label": "Ornn vs. Vercel skills.sh", "file": "vs-vercel-skills-sh.md", "order": 3 },
+        { "id": "vs-skillmp", "label": "Ornn vs. SkillMP", "file": "vs-skillmp.md", "order": 4 },
+        { "id": "vs-github", "label": "Ornn vs. GitHub", "file": "vs-github.md", "order": 5 }
       ]
     },
     {
-      "id": "get-started",
-      "label": "Get Started",
+      "id": "quick-start",
+      "label": "Quick Start",
       "order": 2,
       "children": [
-        { "id": "qs-web-user", "label": "Quick Start as a Web User", "file": "qs-web-user.md", "order": 1 },
+        { "id": "qs-web-user", "label": "Guide for Web Users", "file": "qs-web-user.md", "order": 1 },
         { "id": "agent-manual", "label": "Agent Manual", "file": "agent-manual.md", "order": 2 }
       ]
     },
@@ -23,8 +27,22 @@
       "label": "Technical References",
       "order": 3,
       "children": [
-        { "id": "system-architecture", "label": "System Architecture", "file": "system-architecture.md", "order": 1 },
-        { "id": "external-integrations", "label": "External Integrations", "file": "external-integrations.md", "order": 2 }
+        { "id": "api-overview", "label": "API Reference — Overview", "file": "api-overview.md", "order": 1 },
+        { "id": "api-out-of-band", "label": "API Reference — Out-of-band", "file": "api-out-of-band.md", "order": 2 },
+        { "id": "api-skills", "label": "API Reference — Skills CRUD", "file": "api-skills.md", "order": 3 },
+        { "id": "api-audit", "label": "API Reference — Skill Audit", "file": "api-audit.md", "order": 4 },
+        { "id": "api-search", "label": "API Reference — Skill Search", "file": "api-search.md", "order": 5 },
+        { "id": "api-format", "label": "API Reference — Skill Format", "file": "api-format.md", "order": 6 },
+        { "id": "api-generation", "label": "API Reference — Skill Generation (SSE)", "file": "api-generation.md", "order": 7 },
+        { "id": "api-playground", "label": "API Reference — Playground (SSE)", "file": "api-playground.md", "order": 8 },
+        { "id": "api-notifications", "label": "API Reference — Notifications", "file": "api-notifications.md", "order": 9 },
+        { "id": "api-analytics", "label": "API Reference — Analytics", "file": "api-analytics.md", "order": 10 },
+        { "id": "api-me", "label": "API Reference — Me / Caller scope", "file": "api-me.md", "order": 11 },
+        { "id": "api-users", "label": "API Reference — Users Directory", "file": "api-users.md", "order": 12 },
+        { "id": "api-admin", "label": "API Reference — Admin", "file": "api-admin.md", "order": 13 },
+        { "id": "api-platform-settings", "label": "API Reference — Platform Settings", "file": "api-platform-settings.md", "order": 14 },
+        { "id": "system-architecture", "label": "System Architecture", "file": "system-architecture.md", "order": 20 },
+        { "id": "external-integrations", "label": "External Integrations", "file": "external-integrations.md", "order": 21 }
       ]
     }
   ]

--- a/ornn-web/src/docs/site/en/vs-github.md
+++ b/ornn-web/src/docs/site/en/vs-github.md
@@ -1,0 +1,45 @@
+# Ornn vs. raw GitHub
+
+Plenty of teams already host their AI agent skills as `SKILL.md` files in a GitHub repo. That works. It's free, you already know how to use it, and your agent can curl the raw URL. This page is about the line where "just use GitHub" stops scaling and Ornn starts paying for itself.
+
+## TL;DR
+
+| | GitHub repo | Ornn |
+|---|---|---|
+| **What it is** | A code host. Stores files. | A skill-lifecycle API. Stores files plus everything around them. |
+| **Discovery** | `gh search`, your bookmarks, README | Keyword + semantic search across the registry, with caller-visibility scoping |
+| **Versioning** | Git tags / branches — yours to design | First-class skill versions; `GET /skills/:idOrName/versions`, `diff/:from/:to` |
+| **ACLs** | Public, or paid private repo (per-repo) | Per-skill ACL: private / shared-with-users / shared-with-orgs / public — without paying per-repo |
+| **Identity** | GitHub identity, fine for code review, not the right shape for "this user inside this org" | NyxID OAuth — real user + org membership at the API edge |
+| **Trust signal** | None — you trust the author | Audit verdict per version, with consumer notifications on yellow / red |
+| **Sandbox** | None — agent runs the code itself | First-party (chrono-sandbox), playground UI for try-before-install |
+| **Programmatic agent API** | Hand-rolled (parse README, raw URL, custom auth) | One HTTP / MCP API — search, pull, execute, build, upload, share |
+| **Best for** | Public, code-first skills with no privacy or org needs | Multi-user, multi-tenant, audit-aware skill operations |
+
+## When raw GitHub is fine
+
+- You're publishing a single open-source skill and the README + raw URL is enough.
+- You don't need to share the skill with specific people — public is fine.
+- Your agent's "install" step is `curl raw.githubusercontent.com/...` and you're happy with that.
+- You don't need search beyond `gh search code`.
+- You don't need an audit verdict; "trust the author" is good enough.
+
+If all five are true, GitHub is the cheapest path. Use it.
+
+## When Ornn pays for itself
+
+- **Multi-tenant.** You have skills that should be visible to one organisation but not another. GitHub solves this by paying per private repo or running an organisation; Ornn solves it with per-skill ACLs.
+- **Mixed trust.** Some skills public, some private to the team, some shared with one external partner. GitHub forces you to model this as separate repos / orgs; Ornn lets you flip a switch on each skill.
+- **Audit + notifications.** You care about whether a skill is risky and you want consumers to be told automatically. GitHub doesn't do this; Ornn does it as a first-class flow.
+- **Programmatic agent loop.** Your agent is supposed to discover and pull skills *at runtime*. With GitHub, that's `gh api` calls + raw-URL parsing + your own caching. With Ornn, it's one call per verb and a stable schema.
+- **Sandbox before install.** You want to let users try a skill in a controlled runtime before they take it. GitHub doesn't do this; Ornn's playground does.
+- **Telemetry.** You want pull counts, execution success rates, source breakdown (api / web / playground). GitHub gives you stars and clones; Ornn gives you the metrics that matter for skills specifically.
+
+## They aren't mutually exclusive
+
+`POST /skills/pull` imports a public GitHub repo as an Ornn skill. The skill remains linked to its GitHub source so `POST /skills/:id/refresh` can re-pull on demand. This is the recommended pattern for teams who want to:
+
+- Author + version-control skill source in git (the dev experience they already know).
+- Distribute + audit + ACL through Ornn (the operational story GitHub doesn't have).
+
+Use git for source-of-truth, Ornn for runtime distribution and trust.

--- a/ornn-web/src/docs/site/en/vs-skillmp.md
+++ b/ornn-web/src/docs/site/en/vs-skillmp.md
@@ -1,0 +1,43 @@
+# Ornn vs. SkillMP
+
+SkillMP and Ornn both name themselves around AI agent skills. They are not the same kind of product. Knowing which one fits your problem is mostly about knowing whether you're shopping or building.
+
+## TL;DR
+
+| | SkillMP | Ornn |
+|---|---|---|
+| **Shape of product** | Marketplace — human-facing directory of skills with creator pages, ratings, browse-style discovery | API layer — agents call Ornn directly to manage their own skill lifecycle |
+| **Primary consumer** | A human picking a skill to install | An AI agent at runtime |
+| **Authentication** | Marketplace account | NyxID OAuth — real org / user identity at the API edge |
+| **Per-skill ACLs** | Public / "premium" listings; the skill itself is the unit, not the recipient | Private, shared-with-users, shared-with-orgs, public — recipient is a real identity |
+| **Trust signal** | Ratings and creator reputation — social | Audit verdict (`green` / `yellow` / `red`) per version + consumer notifications when a skill flips risky |
+| **Build / publish flow** | Upload a skill, fill in a listing, wait for marketplace approval | Programmatic: `POST /skills`, `POST /skills/pull`, or `POST /skills/generate` (SSE) |
+| **Programmatic API** | Limited or absent | First-class — every operation is an HTTP / MCP call |
+| **Best for** | Browsing, paying for, or selling discrete skills | Building agentic systems whose skill management happens in code, not in a UI |
+
+## What SkillMP is good at
+
+Marketplaces are good at three things: **discovery**, **monetisation**, **social proof**. If you want to find a skill the way you find a Chrome extension, SkillMP-style products are the right shape. If you want to sell access to your skill or earn from usage, you need something with a billing / rev-share story baked in. If you trust a 4.8-star rating with 12k installs more than a verdict your own audit pipeline produced, marketplaces dominate.
+
+## What Ornn is good at
+
+Everything that happens *during* an agent's runtime, plus identity-aware operations:
+
+- **Search → pull → execute** is one HTTP call each. The agent never leaves its loop.
+- **Per-skill ACLs are real ACLs**, not honor-system "private listings". Sharing a private skill with `org_xyz` means everyone in `org_xyz` (resolved through NyxID) can see it; nobody else can.
+- **Audit verdict is structured data**, not a star rating. Consumers of a skill that flips to `yellow` / `red` get a `audit.risky_for_consumer` notification automatically. Owners get `audit.completed` on every run.
+- **AI-native publishing**. Generate a skill from a prompt or from existing source code. Stream the output. Validate it against the skill format. Upload it. All in code.
+
+## When to use which
+
+| You are… | Use |
+|---|---|
+| A solo builder wanting your skill to be discovered by humans | SkillMP-style marketplace |
+| A skill author wanting to monetise installs / usage | SkillMP-style marketplace |
+| Building an agent that needs to call out to dozens of skills at runtime | **Ornn** |
+| Operating skills inside an enterprise where org boundaries matter | **Ornn** |
+| Treating skills as part of your CI/CD pipeline (audit-on-publish, deprecate-on-replacement) | **Ornn** |
+
+## Federation isn't impossible
+
+If a SkillMP-style marketplace exposes a programmatic listing API, Ornn can mirror that listing locally and serve the agent-API contract over it. The public skill content is the federation primitive — once Ornn knows where to fetch the bytes, the agent calling Ornn doesn't care whether the original lived on Ornn or on a marketplace. That is a separate workstream and not a substitute for the comparison above.

--- a/ornn-web/src/docs/site/en/vs-vercel-skills-sh.md
+++ b/ornn-web/src/docs/site/en/vs-vercel-skills-sh.md
@@ -1,0 +1,48 @@
+# Ornn vs. Vercel `skills.sh`
+
+Both projects host AI agent skills. They solve different problems. This page is about when each one fits.
+
+## TL;DR
+
+| | `skills.sh` (Vercel) | Ornn |
+|---|---|---|
+| **Primary consumer** | Human developer browsing the directory | Agent calling the API |
+| **Surface** | Static-style directory + GitHub-backed pages | HTTP / MCP API + secondary web UI |
+| **Skill format** | Hosted GitHub repos rendered as listings | Portable ZIP package (SKILL.md + scripts + metadata) |
+| **Authentication** | None — public listings | NyxID OAuth (real user / org identity) |
+| **Authorization** | None | Per-skill ACL (private / shared with users / shared with orgs / public) |
+| **Trust signal** | None | Audit verdict (green / yellow / red) attached to every version, with consumer notifications |
+| **Sandbox** | Vercel Functions / external | First-party (chrono-sandbox), playground UI |
+| **Best for** | Discoverability, marketing, quick eyeball-the-skill | Programmatic agent lifecycle, enterprise use |
+
+## What `skills.sh` is good at
+
+A polished directory experience. Easy to browse, easy to bookmark, easy to send a link to a teammate. Vercel's strength is human-facing developer-tooling polish. If a human is the consumer — they want to scan listings, copy a snippet, run something quickly — `skills.sh` is a great fit.
+
+It's also free. The skill itself usually lives in a public GitHub repo, which is fine for open-source skills.
+
+## What Ornn is good at
+
+Everything an agent does *after* it has decided to use a skill, plus identity-aware operations:
+
+- **Programmatic listing**: keyword + semantic search via one HTTP call.
+- **Programmatic install**: fetch the package as JSON in one call (`GET /skills/:idOrName/json` returns `{ files: [{ path, content }] }` so an agent can inject files into context immediately).
+- **Programmatic publish**: SSE-streamed AI generation. An agent can generate a brand-new skill, validate it, and publish it without leaving its loop.
+- **Identity-aware sharing**: share a private skill with one user, with an organisation, with a list of organisations. Real ACLs, not just public/private.
+- **Audit verdict + notifications**: every skill has a verdict. Consumers of a yellow / red skill are notified by NyxID — they don't have to poll the directory.
+- **Execution telemetry**: per-skill pull counts (broken down by source: API / web / playground) and execution latency / success rate.
+
+## When to use which
+
+| You are… | Use |
+|---|---|
+| A human looking for a skill to copy and adapt | `skills.sh` |
+| Publishing a public skill that needs nothing more than a Markdown listing | `skills.sh` |
+| Building an AI agent that needs to programmatically discover, pull, and execute skills | **Ornn** |
+| An organisation that needs to keep skills private to specific people / orgs | **Ornn** |
+| An organisation that needs an audit-and-notification trail when a skill flips risky | **Ornn** |
+| A team with mixed trust requirements — some skills public, some private, some org-scoped | **Ornn** |
+
+## Federation isn't impossible
+
+Ornn's `POST /skills/pull` already imports a public GitHub repo as an Ornn skill. Importing a `skills.sh` listing reduces to importing the GitHub repo it points at. If `skills.sh` exposes a programmatic listing endpoint we'd build a thin sync that mirrors public listings into Ornn so they can flow through the agent-API contract — but that's a separate workstream, not a substitute for the comparison above.

--- a/ornn-web/src/docs/site/en/why-ornn.md
+++ b/ornn-web/src/docs/site/en/why-ornn.md
@@ -1,0 +1,44 @@
+# Why Ornn?
+
+Ornn is the API layer your AI agent calls to manage its own skill lifecycle. Search → pull → install → execute → build → upload → share — every action an agent might take with a skill is one HTTP / MCP call away. The closest analog is **npm registry + npm CLI fused together, model-agnostic**.
+
+This page exists to be honest about what Ornn is for and who it's for. If you came here looking for a human-facing skill marketplace, you'll be disappointed. If you came here looking for the substrate your agent calls, this is it.
+
+## The customer is the agent developer
+
+The product is consumed by **AI agents** — not by humans browsing a catalogue. The web UI exists, but it's a secondary surface for skill owners and platform admins to manage their own work. The primary contract is the API.
+
+That distinction shapes every design decision:
+
+- **API ergonomics over discovery UX.** A stable, well-typed schema beats a glossy hero image when the consumer is a Claude / GPT / Gemini call.
+- **Model-agnostic.** Skills are portable artifacts (a `SKILL.md` + optional scripts + metadata). Any agent runtime that can pull files and inject context can consume an Ornn skill.
+- **Lifecycle, not directory.** Listing skills is the boring part. Letting an agent build a new skill, audit it, share it with another user / org, and watch its execution analytics over time — that's the lifecycle.
+
+## What you actually get
+
+| Layer | What it does |
+|---|---|
+| **Registry + CRUD** | Skills are versioned, validated, and stored. Pull by GUID or by kebab-case name. Diff two versions. Deprecate a version without deleting it. |
+| **Search** | Keyword + semantic search across the public + caller-visible slice. System-skill filter via NyxID services. |
+| **AI generation** | Generate a new skill from a prompt, from inline source code, or from an OpenAPI spec. Streamed via SSE. |
+| **Sandbox playground** | Execute a skill end-to-end before installing it: chrono-sandbox runs the code, your LLM sees the result. |
+| **Audit as risk label** | Every skill has a verdict (`green` / `yellow` / `red`). Audits run on demand, never block sharing. Consumers of a skill that flips to `yellow` / `red` get notified. |
+| **NyxID identity** | Real org / user identity at the API edge. Per-skill ACLs are real ACLs, not honor-system. |
+| **Analytics** | Pull counts (api / web / playground sources) and execution telemetry per skill version. |
+
+## Model-agnostic by design
+
+Ornn does not bind you to a specific LLM provider. Skills are pulled and executed by whatever agent you point at the API. Internally Ornn uses NyxID's LLM gateway for skill generation + audit, but consumers of skills are free to use Claude, GPT, Gemini, or a custom runtime. The skill payload is portable text + scripts.
+
+## What Ornn is **not**
+
+- Not a human-facing skill marketplace. There is no leaderboard, no social ranking, no "trending this week" feed.
+- Not bound to one agent runtime. Skills are not Claude-specific or GPT-specific.
+- Not a substitute for git. We don't try to be a code host. If you want to track your skill's source in version control, do that in git and use `POST /skills/pull` to import.
+- Not a runtime guardrail. Audit is a label, not a runtime block. If you need runtime safety, layer Lakera / LLM Guard / NeMo on top of your agent.
+
+## Where to go next
+
+- **Quick Start → Web Users** for a guided tour of the GUI.
+- **Quick Start → Agent Manual** if you're an agent developer and want the operational manual to drop into your agent's system context.
+- **Technical References → API Reference** for the full endpoint catalogue.

--- a/ornn-web/src/docs/site/zh/agent-manual.md
+++ b/ornn-web/src/docs/site/zh/agent-manual.md
@@ -1,8 +1,20 @@
+---
+name: ornn-agent-manual
+description: 面向 AI agent 的 Ornn 技能生命周期 API 操作手册。以 skill 形式装载 —— 一旦安装，宿主 agent 即可通过 NyxID CLI 完成 skill 的搜索 / 拉取 / 执行 / 构建 / 上传 / 分享，无需额外配置。Ornn 与 agent 的权威契约。
+metadata:
+  category: plain
+  tags:
+    - ornn
+    - agent
+    - 手册
+    - skill-lifecycle
+---
+
 # Agent 操作手册
 
-> **本文档面向 AI agent 设计：作为上下文加载后，agent 即可通过 `nyxid` CLI 完整操作 Ornn 的所有能力** —— 发现 skill、拉 skill、执行 skill、创建 skill、管理自己的 skill 库、参与分享流程。不需要 SDK，不需要 MCP，只需要 CLI。
+> **请将本文档完整粘贴到 AI agent 的 system context 中。** 它本身就是一份 Ornn skill（`category: plain`）—— 上方 `SKILL.md` frontmatter + 下方正文构成整份 skill。一旦加载，agent 即可通过 `nyxid` CLI 完整操作 Ornn 的所有能力 —— 发现 skill、拉 skill、执行 skill、创建 skill、管理自己的 skill 库、参与分享流程。不需要 SDK，不需要 MCP，只需要 CLI。
 >
-> Ornn 的核心产品是 **面向 AI agent 的 Skill-as-a-Service**。Skill 是打包好的 AI 能力（一份 `SKILL.md` prompt + 可选脚本 + YAML 元数据），任何 agent 都能拉下来执行。本手册即 Ornn 与 agent 之间的契约。
+> Ornn 的产品是 **面向 AI agent 的 Skill-as-a-Service**。Skill 是打包好的 AI 能力（一份 `SKILL.md` prompt + 可选脚本 + YAML 元数据），任何 agent 都能拉下来执行。本手册即 Ornn 与 agent 之间的契约。
 
 ## §1. 前置条件
 

--- a/ornn-web/src/docs/site/zh/api-admin.md
+++ b/ornn-web/src/docs/site/zh/api-admin.md
@@ -1,0 +1,314 @@
+# API Reference — Admin
+
+Mounted under `/api/v1/admin`. Most endpoints require `ornn:admin:skill`. Category endpoints require `ornn:admin:category`.
+
+## `GET /api/v1/admin/stats`
+
+**Platform-wide totals for the dashboard.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+```jsonc
+{
+  "data": {
+    "totalSkills": 42,
+    "totalUsers": 15,
+    "totalActivities": 1234,
+    "skillsByCategory": { "plain": 10, "tool-based": 15, "runtime-based": 12, "mixed": 5 }
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `GET /api/v1/admin/activities`
+
+**Paginated activity log.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `page` | int ≥ 1 | `1` | — |
+| `pageSize` | int 1–100 | `20` | — |
+| `action` | activity action | — | Filter (see Appendix B in original API doc) |
+| `userId` | string | — | Filter by actor |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      {
+        "id": "...",
+        "userId": "...",
+        "userEmail": "...",
+        "userDisplayName": "...",
+        "action": "skill:create",
+        "details": { "skillId": "...", "skillName": "ornn-api" },
+        "createdAt": "..."
+      }
+    ],
+    "total": 1234,
+    "page": 1,
+    "pageSize": 20,
+    "totalPages": 62
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `GET /api/v1/admin/users`
+
+**Paginated user directory (aggregated from activities).**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Query
+
+| Param | Type | Default |
+|---|---|---|
+| `page` | int ≥ 1 | `1` |
+| `pageSize` | int 1–100 | `20` |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "userId": "...", "email": "...", "displayName": "...", "skillCount": 5, "lastActivityAt": "..." }
+    ],
+    "total": 15,
+    "page": 1,
+    "pageSize": 20,
+    "totalPages": 1
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `GET /api/v1/admin/skills`
+
+**Registry-wide skill browser. Admins see every skill, public or private, regardless of authorship.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `page` | int ≥ 1 | `1` | — |
+| `pageSize` | int 1–100 | `20` | — |
+| `q` | string | — | Search by name / description |
+| `userId` | string | — | Filter by author |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [ /* SkillSummary[] with createdByEmail / createdByDisplayName populated */ ],
+    "total": 42, "page": 1, "pageSize": 20, "totalPages": 3
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `DELETE /api/v1/admin/skills/:id`
+
+**Force-delete any skill (no ownership check).**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Response 200
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+
+Activity logged: `skill:delete` with `details.adminAction = true`.
+
+---
+
+## `GET /api/v1/admin/categories`
+
+**List all skill categories.**
+
+> **Auth required.** Permission: `ornn:admin:category`.
+
+```jsonc
+{
+  "data": [
+    { "id": "...", "name": "plain", "slug": "plain", "description": "Pure prompts", "order": 0 }
+  ],
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/admin/categories`
+
+**Create a category.**
+
+> **Auth required.** Permission: `ornn:admin:category`.
+
+### Request body
+
+```jsonc
+{ "name": "plain", "slug": "plain", "description": "...", "order": 0 }
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | One of `plain`, `tool-based`, `runtime-based`, `mixed` |
+| `slug` | yes | Kebab-case |
+| `description` | yes | — |
+| `order` | no | Default 0 |
+
+### Response 201
+
+The created category document.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Body validation failed |
+
+---
+
+## `PUT /api/v1/admin/categories/:id`
+
+**Patch category metadata. `name` and `slug` are immutable.**
+
+> **Auth required.** Permission: `ornn:admin:category`.
+
+### Request body
+
+```jsonc
+{ "description": "Updated", "order": 1 }
+```
+
+Both fields optional.
+
+### Response 200
+
+Updated category.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `CATEGORY_NOT_FOUND` | — |
+| 400 | `VALIDATION_ERROR` | — |
+
+---
+
+## `DELETE /api/v1/admin/categories/:id`
+
+**Delete a category.**
+
+> **Auth required.** Permission: `ornn:admin:category`.
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `CATEGORY_NOT_FOUND` | — |
+
+---
+
+## `GET /api/v1/admin/tags`
+
+**List skill tags.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Query
+
+| Param | Type | Notes |
+|---|---|---|
+| `type` | `predefined` \| `custom` | Optional filter |
+
+```jsonc
+{ "data": [ { "id": "...", "name": "api", "type": "predefined" } ], "error": null }
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/admin/tags`
+
+**Create a custom tag.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Request body
+
+```jsonc
+{ "name": "agent" }
+```
+
+`name` is ≤ 30 chars, lowercase alphanumerics with `-` / `_`.
+
+### Response 201
+
+Created tag document.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | — |
+| 409 | `TAG_EXISTS` | Tag with that name already exists |
+
+---
+
+## `DELETE /api/v1/admin/tags/:id`
+
+**Delete a tag.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `TAG_NOT_FOUND` | — |

--- a/ornn-web/src/docs/site/zh/api-analytics.md
+++ b/ornn-web/src/docs/site/zh/api-analytics.md
@@ -1,0 +1,82 @@
+# API Reference — Analytics
+
+Both endpoints follow skill visibility — anonymous callers can analyze public skills only.
+
+## `GET /api/v1/skills/:idOrName/analytics`
+
+**Execution summary for a skill.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `window` | `7d` \| `30d` \| `all` | `30d` | — |
+| `version` | `<major>.<minor>` | all | Aggregate one version |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "skillGuid": "...",
+    "skillName": "ornn-api",
+    "window": "30d",
+    "totalPulls": 14,
+    "uniqueUsers": 8,
+    "lastPull": "2026-04-28T...",
+    "pullsBySource": { "api": 0, "web": 13, "playground": 1 },
+    "executions": { "count": 42, "successRate": 0.95, "p50LatencyMs": 220, "p95LatencyMs": 1200, "p99LatencyMs": 3300, "topErrors": [] }
+  },
+  "error": null
+}
+```
+
+`executions` is omitted when no execution data exists in the window.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_WINDOW` | `window` not in 7d/30d/all |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `GET /api/v1/skills/:idOrName/analytics/pulls`
+
+**Pull time-series, bucketed.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `bucket` | `hour` \| `day` \| `month` | `day` | — |
+| `from` | ISO timestamp | now − 7d | — |
+| `to` | ISO timestamp | now | — |
+| `version` | `<major>.<minor>` | all | — |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "bucket": "2026-04-22T00:00:00Z", "total": 14, "bySource": { "api": 0, "web": 13, "playground": 1 } },
+      { "bucket": "2026-04-23T00:00:00Z", "total": 0, "bySource": { "api": 0, "web": 0, "playground": 0 } }
+    ]
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_BUCKET` | `bucket` not in hour/day/month |
+| 400 | `INVALID_RANGE` | `from`/`to` invalid ISO or `from >= to` |
+| 404 | `SKILL_NOT_FOUND` | — |

--- a/ornn-web/src/docs/site/zh/api-audit.md
+++ b/ornn-web/src/docs/site/zh/api-audit.md
@@ -1,0 +1,167 @@
+# API Reference — Skill Audit
+
+Audit verdicts are computed asynchronously and stored per-version. Verdicts are advisory: they appear on the skill detail UI, drive consumer notifications when risky, but never block sharing or use.
+
+## `GET /api/v1/skills/:idOrName/audit`
+
+**Most recent completed audit for the version (cache hit; never triggers).**
+
+> **Auth optional.** Visibility rules apply.
+
+### Query
+
+| Param | Type | Notes |
+|---|---|---|
+| `version` | string | `<major>.<minor>`; defaults to latest |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "_id": "01J...",
+    "skillGuid": "...",
+    "version": "0.1",
+    "status": "completed",
+    "verdict": "green",
+    "overallScore": 7.8,
+    "scores": [ { "dimension": "security", "score": 8, "rationale": "..." } ],
+    "findings": [ { "severity": "info", "dimension": "documentation", "message": "...", "file": "SKILL.md", "line": 12 } ],
+    "completedAt": "...",
+    "triggeredBy": "<userId>"
+  },
+  "error": null
+}
+```
+
+`verdict` is one of `green`, `yellow`, `red`. `status` is one of `running`, `completed`, `failed` — only `completed` rows are surfaced here. `findings[*].severity` is `info` / `warning` / `critical`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+| 404 | `AUDIT_NOT_FOUND` | No completed audit for that (skill, version) |
+
+---
+
+## `GET /api/v1/skills/:idOrName/audit/summary-by-version`
+
+**Latest completed audit per version (powers per-version badges).**
+
+> **Auth optional.** Visibility rules apply.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "byVersion": {
+      "0.1": { "verdict": "green", "overallScore": 7.8, "completedAt": "...", "status": "completed" },
+      "0.2": { "verdict": "yellow", "overallScore": 6.2, "completedAt": "...", "status": "completed" }
+    }
+  },
+  "error": null
+}
+```
+
+Versions without a completed audit are absent from the map.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `GET /api/v1/skills/:idOrName/audit/history`
+
+**All audit records, newest first. Optionally narrow to a single version.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Query
+
+| Param | Type | Notes |
+|---|---|---|
+| `version` | string | Narrow to one version |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "_id": "...", "version": "0.2", "status": "completed", "verdict": "yellow", "overallScore": 6.2 },
+      { "_id": "...", "version": "0.1", "status": "completed", "verdict": "green" }
+    ]
+  },
+  "error": null
+}
+```
+
+`running` rows are included so the UI can render in-flight badges.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `POST /api/v1/skills/:idOrName/audit`
+
+**Owner-triggered audit (Start Auditing).**
+
+> **Auth required.** Owner-or-admin only. Ownership is the gate; no permission string required.
+
+Returns immediately with the `running` row; clients poll `audit/history` (or wait for the `audit.completed` notification).
+
+### Request body
+
+```jsonc
+{ "force": false }
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `force` | boolean | Bypass the 30-day same-bytes cache |
+
+### Response 200
+
+Initial running record:
+
+```jsonc
+{
+  "data": {
+    "_id": "...",
+    "skillGuid": "...",
+    "version": "0.1",
+    "status": "running",
+    "triggeredBy": "<userId>"
+  },
+  "error": null
+}
+```
+
+If the cache is hit (`force=false` and a completed audit exists with the same skill hash within TTL) the existing record is returned with `status: "completed"`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `POST /api/v1/admin/skills/:idOrName/audit`
+
+**Force-rerun audit as platform admin (bypasses ownership).**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+Same body / response shape as the owner endpoint. `force: true` is honoured.

--- a/ornn-web/src/docs/site/zh/api-format.md
+++ b/ornn-web/src/docs/site/zh/api-format.md
@@ -1,0 +1,61 @@
+# API Reference — Skill Format
+
+## `GET /api/v1/skill-format/rules`
+
+**Canonical SKILL.md / package format spec, in Markdown.**
+
+> **Auth: anonymous.**
+
+### Response 200
+
+```json
+{ "data": { "rules": "# Skill format\n\n..." }, "error": null }
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/skill-format/validate`
+
+**Validate a ZIP without uploading it.**
+
+> **Auth required.** Permission: `ornn:skill:read`.
+
+### Request
+
+| In | Header / Body | Notes |
+|---|---|---|
+| Header | `Content-Type: application/zip` (or `application/octet-stream`) | Required |
+| Body | binary ZIP | Required |
+
+### Response 200 (valid)
+
+```json
+{ "data": { "valid": true }, "error": null }
+```
+
+### Response 200 (invalid — not an HTTP error)
+
+```jsonc
+{
+  "data": {
+    "valid": false,
+    "violations": [
+      { "rule": "FRONTMATTER_VALIDATION_FAILED", "message": "name must not contain 'claude'" }
+    ]
+  },
+  "error": null
+}
+```
+
+This intentionally returns 200; validation failures are content, not faults.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_CONTENT_TYPE` | — |
+| 400 | `EMPTY_BODY` | — |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:read` |

--- a/ornn-web/src/docs/site/zh/api-generation.md
+++ b/ornn-web/src/docs/site/zh/api-generation.md
@@ -1,0 +1,132 @@
+# API Reference — Skill Generation (SSE)
+
+These three endpoints stream Server-Sent Events. All set:
+
+```
+Cache-Control: no-cache
+Connection: keep-alive
+X-Accel-Buffering: no
+```
+
+Each SSE event is a `data: <json>` line; consumers JSON-parse the body.
+
+| Event payload | Meaning |
+|---|---|
+| `{ "type": "start" }` | Generation started |
+| `{ "type": "chunk", "delta": "<text>" }` | Incremental text |
+| `{ "type": "complete", "content": "<full>", "skillPackage": {...} }` | Generation finished. `skillPackage` present when the generator produced files |
+| `{ "type": "error", "message": "<text>" }` | Generation aborted; stream closes after this |
+| `{ "type": "keepalive" }` | Heartbeat |
+
+---
+
+## `POST /api/v1/skills/generate`
+
+**Generate a brand-new skill from a prompt.**
+
+> **Auth required.** Permission: `ornn:skill:build`.
+
+### Request
+
+Two body shapes are accepted; the discriminator is `Content-Type`.
+
+**Multipart (single-shot)** `Content-Type: multipart/form-data`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `prompt` | string | yes | Natural-language description |
+| `package` | File | no | Existing ZIP for context (iterative refinement) |
+
+**JSON (multi-turn)** `Content-Type: application/json`
+
+```jsonc
+{
+  "prompt": "Build a skill that ...",
+  "messages": [
+    { "role": "user", "content": "..." },
+    { "role": "assistant", "content": "..." }
+  ]
+}
+```
+
+`prompt` is required when `messages` is omitted; with `messages`, the array is the source of truth.
+
+### Response
+
+`200 OK` with `Content-Type: text/event-stream`. Events as above.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `MISSING_PROMPT` | Multipart body without `prompt` field |
+| 400 | `INVALID_CONTENT_TYPE` | Body type isn't multipart or JSON |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:build` |
+
+---
+
+## `POST /api/v1/skills/generate/from-source`
+
+**Generate a skill from an inline code snippet or a public GitHub URL.**
+
+> **Auth required.** Permission: `ornn:skill:build`.
+
+### Request body (`application/json`)
+
+```jsonc
+{
+  "code": "<inline source>",          // exactly one of code / repoUrl
+  "repoUrl": "https://github.com/owner/repo",
+  "path": "src/routes",                // optional; subpath inside repo
+  "framework": "hono",                 // optional; framework hint
+  "description": "Wraps the v1 routes" // optional; free-form context
+}
+```
+
+### Response
+
+SSE stream as in `/skills/generate`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `MISSING_SOURCE` | Neither `code` nor `repoUrl` |
+| 400 | `AMBIGUOUS_SOURCE` | Both `code` and `repoUrl` |
+| 400 | `EMPTY_SOURCE` | `code` empty after strip |
+| 400 | `INVALID_BODY` | JSON parse failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:build` |
+| 502 | `REPO_FETCH_FAILED` | Repo fetch failed |
+
+---
+
+## `POST /api/v1/skills/generate/from-openapi`
+
+**Generate a skill from an OpenAPI 3 specification.**
+
+> **Auth required.** Permission: `ornn:skill:build`.
+
+### Request body (`application/json`)
+
+```jsonc
+{
+  "spec": "<openapi yaml or json as a single string>",
+  "endpoints": ["GET /users", "POST /users"], // optional allow-list
+  "description": "..."                        // optional
+}
+```
+
+### Response
+
+SSE stream as in `/skills/generate`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `MISSING_SPEC` | `spec` missing or not a string |
+| 400 | `INVALID_BODY` | JSON parse failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:build` |

--- a/ornn-web/src/docs/site/zh/api-me.md
+++ b/ornn-web/src/docs/site/zh/api-me.md
@@ -1,0 +1,143 @@
+# API Reference — Me / Caller scope
+
+Every route below requires authentication. There is no permission gate beyond identity.
+
+## `GET /api/v1/me`
+
+**Snapshot of the authenticated caller.**
+
+```jsonc
+{
+  "data": {
+    "userId": "<sub>",
+    "email": "<email>",
+    "displayName": "<name>",
+    "roles": ["ornn-user"],
+    "permissions": ["ornn:skill:read", "ornn:skill:create", "ornn:playground:use"]
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/activity/login`
+
+**Record a session-opened event.**
+
+> **Auth required.** Fire-and-forget from the frontend after the OAuth callback completes.
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+Activity logged: `login`.
+
+---
+
+## `POST /api/v1/activity/logout`
+
+**Record a session-closed event.**
+
+> **Auth required.** Called by the frontend before clearing local auth state.
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+Activity logged: `logout`.
+
+---
+
+## `GET /api/v1/me/orgs`
+
+**Caller's NyxID org memberships (admin + member roles only).**
+
+> **Auth required.**
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "userId": "<orgId>", "role": "admin", "displayName": "Acme Corp" }
+    ]
+  },
+  "error": null
+}
+```
+
+Fail-soft: NyxID outage returns `items: []` rather than 5xx. Diagnosis: response duration ≈ 0 ms is the giveaway.
+
+No errors.
+
+---
+
+## `GET /api/v1/me/orgs/:orgId`
+
+**Resolve a single org (useful even after the caller leaves it).**
+
+> **Auth required.**
+
+```jsonc
+{
+  "data": { "userId": "<orgId>", "displayName": "Acme Corp", "avatarUrl": "https://..." },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `ORG_NOT_FOUND` | NyxID does not return that org or the caller cannot resolve it |
+
+---
+
+## `GET /api/v1/me/nyxid-services`
+
+**Caller's NyxID user-services (personal + org-inherited).**
+
+> **Auth required.**
+
+Used to power the system-skill filter on the registry.
+
+```jsonc
+{
+  "data": { "items": [ { "id": "...", "slug": "ornn-api", "label": "ornn-api" } ] },
+  "error": null
+}
+```
+
+Fail-soft: returns `items: []` when NyxID is unreachable or no proxy token is set.
+
+---
+
+## `GET /api/v1/me/skills/grants-summary`
+
+**Caller's outbound shares — orgs and users they've granted access to.**
+
+> **Auth required.**
+
+```jsonc
+{
+  "data": {
+    "orgs":  [ { "id": "<orgId>", "displayName": "Acme",     "skillCount": 5 } ],
+    "users": [ { "userId": "<userId>", "email": "...", "displayName": "...", "skillCount": 2 } ]
+  },
+  "error": null
+}
+```
+
+Display names are best-effort: orgs resolved via NyxID, users via Ornn activity directory; missing values fall back to the raw id.
+
+---
+
+## `GET /api/v1/me/shared-skills/sources-summary`
+
+**Caller's inbound shares — orgs and users that have granted them access.**
+
+> **Auth required.**
+
+Same shape as `grants-summary`. `orgs` are bridge memberships (orgs caller is in where someone has shared a skill); `users` are authors who shared directly.

--- a/ornn-web/src/docs/site/zh/api-notifications.md
+++ b/ornn-web/src/docs/site/zh/api-notifications.md
@@ -1,0 +1,96 @@
+# API Reference — Notifications
+
+All four endpoints are scoped to the caller's own notifications. There is no admin override.
+
+## `GET /api/v1/notifications`
+
+**List notifications, newest first.**
+
+> **Auth required.** No specific permission; identity is the gate.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `unread` | `"true"` | — | Filter to unread only |
+| `limit` | int 1–200 | `50` | — |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      {
+        "_id": "...",
+        "userId": "<self>",
+        "category": "audit.completed",
+        "title": "Skill audit passed — ornn-api v0.1 · score 7.8/10",
+        "body": "...",
+        "link": "/skills/<guid>/audits?version=0.1",
+        "data": { "skillGuid": "...", "version": "0.1", "verdict": "green", "overallScore": 7.8 },
+        "readAt": null,
+        "createdAt": "..."
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+Two categories are emitted today:
+
+| Category | Recipient | Trigger |
+|---|---|---|
+| `audit.completed` | Skill owner | Every audit completion |
+| `audit.risky_for_consumer` | Every consumer of a `yellow` / `red` skill | Same audit completion; `green` skipped |
+
+No errors.
+
+---
+
+## `GET /api/v1/notifications/unread-count`
+
+**Badge count for the bell.**
+
+> **Auth required.**
+
+```json
+{ "data": { "count": 5 }, "error": null }
+```
+
+No errors.
+
+---
+
+## `POST /api/v1/notifications/:id/read`
+
+**Mark a single notification read.**
+
+> **Auth required.** Caller must own the notification.
+
+### Response 200
+
+Updated notification document.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `NOTIFICATION_NOT_FOUND` | Unknown id or not the caller's |
+
+---
+
+## `POST /api/v1/notifications/mark-all-read`
+
+**Mark every unread notification read.**
+
+> **Auth required.**
+
+### Response 200
+
+```json
+{ "data": { "updated": 5 }, "error": null }
+```
+
+No errors.

--- a/ornn-web/src/docs/site/zh/api-out-of-band.md
+++ b/ornn-web/src/docs/site/zh/api-out-of-band.md
@@ -1,0 +1,73 @@
+# API Reference — Out-of-band Endpoints
+
+These four routes live outside `/api/v1` and are intended for infrastructure (k8s probes, OpenAPI tooling).
+
+## `GET /health`
+
+**Liveness probe (alias of `/livez`).**
+
+> **Auth: anonymous.**
+
+Used by k8s liveness checks and uptime monitors.
+
+**Response 200**
+
+```json
+{
+  "status": "ok",
+  "service": "ornn-api",
+  "version": "0.4.0",
+  "timestamp": "2026-04-28T07:00:00.000Z"
+}
+```
+
+No errors.
+
+---
+
+## `GET /livez`
+
+**k8s liveness probe.**
+
+> **Auth: anonymous.**
+
+Identical body to `/health`.
+
+---
+
+## `GET /readyz`
+
+**k8s readiness probe.**
+
+> **Auth: anonymous.**
+
+Pings MongoDB with a 2-second timeout.
+
+**Response 200 (ready)**
+
+```json
+{
+  "status": "ready",
+  "service": "ornn-api",
+  "mongoLatencyMs": 8
+}
+```
+
+**Response 503 (not ready)**
+
+```json
+{
+  "status": "not_ready",
+  "reason": "mongo_unreachable"
+}
+```
+
+---
+
+## `GET /api/v1/openapi.json`
+
+**Auto-generated OpenAPI 3 spec.**
+
+> **Auth: anonymous.**
+
+Generated from the Zod schemas attached to each route (Hono `@hono/zod-openapi` integration). Useful for SDK generators and IDE tooling. The document is regenerated per process start.

--- a/ornn-web/src/docs/site/zh/api-overview.md
+++ b/ornn-web/src/docs/site/zh/api-overview.md
@@ -1,0 +1,158 @@
+# API Reference — Overview & Conventions
+
+Ornn exposes one HTTP surface — `https://<host>/api/v1/*` — that AI agents and the web UI both consume. Every endpoint lives under `/api/v1` unless explicitly marked **out-of-band**. This page captures the conventions every domain shares; per-domain pages cover the actual endpoints.
+
+## Base URL and versioning
+
+| Environment | Base URL |
+|---|---|
+| Local k8s | `https://ornn.ornn-cluster.local/api/v1` |
+| Production | `https://ornn.<domain>/api/v1` (from `ORNN_API_URL` env) |
+
+`/api/v1` is the only mounted version.
+
+## Authentication model
+
+Ornn does not verify NyxID tokens itself. Every request goes through the NyxID proxy, which:
+
+1. Validates the user's NyxID OAuth session.
+2. Decodes the user's identity into a JWT.
+3. Forwards the request with `X-NyxID-Identity-Token: <jwt>` (and a few legacy `X-NyxID-*` headers for backwards compat).
+
+`ornn-api`'s middleware decodes that JWT *without re-verifying signatures* (the proxy already verified) and populates `c.var.auth` for the rest of the handler chain.
+
+| Field | Source | Notes |
+|---|---|---|
+| `userId` | JWT `sub` | Required. Used for ownership / authorship checks. |
+| `email` | JWT `email` | Optional; defaults to empty string. |
+| `displayName` | JWT `name` | Optional; falls back to `email`, then `userId`. |
+| `roles` | JWT `roles` | Array of role strings. |
+| `permissions` | JWT `permissions` | Array of permission strings (see catalogue below). |
+
+Endpoints fall into three auth tiers:
+
+| Tier | Behaviour |
+|---|---|
+| **Anonymous** | No identity token required. Used for public health / spec / public skill reads. |
+| **Optional** | Token decoded if present; handler observes `c.var.auth` may be `null`. Used for visibility-gated reads where unauthenticated callers see only public data. |
+| **Required** | Token must be present and well-formed; otherwise the request fails with `401 AUTH_MISSING`. |
+
+## Permission catalogue
+
+Required permissions are encoded as colon-separated namespaced strings on the JWT's `permissions` array. Missing the permission yields `403 FORBIDDEN`.
+
+| Permission | Typical role | What it grants |
+|---|---|---|
+| `ornn:skill:read` | `ornn-user` | Fetch skill packages as JSON, validate skill packages |
+| `ornn:skill:create` | `ornn-user` | Upload new skills, pull from GitHub |
+| `ornn:skill:update` | `ornn-user` | Change skills you own |
+| `ornn:skill:delete` | `ornn-user` | Delete skills / versions you own |
+| `ornn:skill:build` | `ornn-user` | Use the AI generation endpoints |
+| `ornn:playground:use` | `ornn-user` | Run the playground chat |
+| `ornn:admin:skill` | `ornn-admin` | Read and act on every skill regardless of ownership; admin stats / activities / users; force-audit / force-delete; tag CRUD |
+| `ornn:admin:category` | `ornn-admin` | Skill-category CRUD |
+
+Several endpoints add an **ownership** check on top of the permission gate (e.g. only the skill author can `PUT /skills/:id`, unless the caller also holds `ornn:admin:skill`). Each endpoint section calls those out explicitly.
+
+## Visibility rules for skills
+
+Most read paths use the same visibility rule, applied server-side:
+
+| Caller | Sees |
+|---|---|
+| Anonymous | Public skills only |
+| Authenticated, non-owner | Public + skills directly shared with their `userId` + skills shared with any org they belong to (admin or member role; viewer doesn't count) |
+| Authenticated, owner | All of the above + their own skills, including private |
+| Platform admin (`ornn:admin:skill`) | All skills |
+
+If a caller asks for a skill they cannot see, the response is `404 SKILL_NOT_FOUND` — never `403`. This avoids leaking the existence of private skills.
+
+> **Sharing is unconditional.** Editing the allow-list (`PUT /skills/:id/permissions`) applies the new state immediately. There is no audit gate, no waiver, no reviewer queue. Audit results travel separately as a passive label and notification.
+
+## Response envelope
+
+Every JSON response (success and error) uses the same envelope:
+
+```jsonc
+{
+  "data": <T> | null,
+  "error": { "code": "<MACHINE_CODE>", "message": "<human-readable>" } | null
+}
+```
+
+Streaming endpoints (SSE) do **not** wrap each event in this envelope.
+
+## HTTP status codes
+
+| Code | Meaning |
+|---|---|
+| `200 OK` | Successful GET / PUT / PATCH / DELETE |
+| `201 Created` | `POST /skills`, `POST /skills/pull`, `POST /admin/categories`, `POST /admin/tags` |
+| `400 Bad Request` | Validation failure, malformed body, missing required field, invalid query enum |
+| `401 Unauthorized` | Auth required but no usable identity token |
+| `403 Forbidden` | Authenticated but missing the permission, or failed an ownership check |
+| `404 Not Found` | Resource does not exist or is not visible to the caller |
+| `409 Conflict` | State conflict (rare) |
+| `413 Payload Too Large` | ZIP exceeds `MAX_PACKAGE_SIZE_BYTES` (default ~50 MiB) |
+| `500 Internal Server Error` | Unhandled exception; correlate via `X-Request-ID` |
+| `503 Service Unavailable` | Hard dependency (Mongo, NyxID) unreachable. `/readyz` only. |
+| `504 Gateway Timeout` | Upstream timed out |
+
+## Common error codes
+
+Codes are stable identifiers — branch on `error.code`, not on the HTTP status alone.
+
+| Code | Meaning |
+|---|---|
+| `AUTH_MISSING` | No usable NyxID identity token |
+| `FORBIDDEN` | Authenticated, but lacks permission or ownership |
+| `VALIDATION_ERROR` | Generic Zod validation failure |
+| `INVALID_BODY` | Body could not be parsed as JSON or was empty when required |
+| `EMPTY_BODY` | ZIP-upload route received empty bytes |
+| `INVALID_CONTENT_TYPE` | Content-Type was not `application/zip` / `application/octet-stream` / `multipart/form-data` |
+| `PAYLOAD_TOO_LARGE` | ZIP exceeds size cap |
+| `SKILL_NOT_FOUND` | Skill GUID / name unknown or not visible |
+| `AUDIT_NOT_FOUND` | No completed audit record matches the request |
+| `INTERNAL_ERROR` | Unhandled server exception |
+
+Domain-specific error codes are documented in each domain page.
+
+## Standard headers
+
+### Request headers honoured globally
+
+| Header | Required | Purpose |
+|---|---|---|
+| `X-NyxID-Identity-Token` | On required-auth routes | Forwarded by the NyxID proxy. Decoded for identity. |
+| `X-Request-ID` | Optional | If set, copied into the response. Otherwise the server generates one. |
+| `Content-Type` | On bodies | Discriminator for ZIP uploads vs. JSON vs. multipart |
+| `Accept` | Optional | Reserved for future content negotiation |
+
+### Response headers always set
+
+| Header | Notes |
+|---|---|
+| `X-Request-ID` | Echoed for log correlation |
+| `Content-Type` | `application/json; charset=utf-8` for envelope responses; `text/event-stream` for SSE |
+
+CORS allowlist comes from `ALLOWED_ORIGINS`; preflight allows `GET, POST, PUT, PATCH, DELETE, OPTIONS`.
+
+## Pagination shape
+
+Endpoints that paginate use offset pagination with this shape inside `data`:
+
+```jsonc
+{
+  "items": [ ... ],
+  "total": <int>,
+  "page": <int>,
+  "pageSize": <int>,
+  "totalPages": <int>
+}
+```
+
+Defaults vary; explicit values are documented per endpoint.
+
+## Activity logging
+
+Most write operations append to the `activities` collection (visible to platform admins via `GET /admin/activities`). Each activity record carries `userId`, `email`, `displayName`, `action`, `details`, `createdAt`.

--- a/ornn-web/src/docs/site/zh/api-platform-settings.md
+++ b/ornn-web/src/docs/site/zh/api-platform-settings.md
@@ -1,0 +1,46 @@
+# API Reference — Platform Settings
+
+## `GET /api/v1/admin/settings`
+
+**Read platform-wide settings.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+```jsonc
+{
+  "data": {
+    "auditWaiverThreshold": 5.5
+  },
+  "error": null
+}
+```
+
+`auditWaiverThreshold` is a 0–10 floating-point value retained from the previous audit-gated share design. It currently has no functional effect (sharing is unconditional); the field is preserved so we can re-introduce a threshold-based UX later without a migration.
+
+No errors.
+
+---
+
+## `PATCH /api/v1/admin/settings`
+
+**Patch platform-wide settings.**
+
+> **Auth required.** Permission: `ornn:admin:skill`.
+
+### Request body
+
+```jsonc
+{ "auditWaiverThreshold": 5.5 }
+```
+
+Partial patch — only the keys you supply are written. Numbers are clamped to `[0, 10]` and rounded to 0.1.
+
+### Response 200
+
+Updated settings object.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_SETTING` | Unknown field or value out of range |

--- a/ornn-web/src/docs/site/zh/api-playground.md
+++ b/ornn-web/src/docs/site/zh/api-playground.md
@@ -1,0 +1,48 @@
+# API Reference — Playground (SSE)
+
+## `POST /api/v1/playground/chat`
+
+**Multi-turn chat with optional skill injection and sandbox tool execution.**
+
+> **Auth required.** Permission: `ornn:playground:use`.
+
+### Request body (`application/json`)
+
+```jsonc
+{
+  "messages": [
+    {
+      "role": "user" | "assistant" | "tool" | "system",
+      "content": "...",
+      "toolCalls": [ { "id": "...", "name": "execute_script", "args": { ... } } ],
+      "toolCallId": "..."
+    }
+  ],
+  "skillId": "<guid or name>",       // optional
+  "envVars": { "API_KEY": "..." }    // optional, injected into sandbox runs
+}
+```
+
+`messages` is 1–100 entries; each requires `role` + `content`. Server-side tool-use loop runs up to 5 rounds.
+
+### Response
+
+SSE stream — text deltas + tool-call events. Event names use kebab-case:
+
+| Event | Payload | Meaning |
+|---|---|---|
+| `text-delta` | `{ "delta": "<text>" }` | Incremental assistant text |
+| `tool-call` | `{ "id": "...", "name": "execute_script", "args": { ... } }` | Server is invoking a tool |
+| `tool-result` | `{ "id": "...", "result": { ... } }` | Tool returned |
+| `file-output` | `{ "path": "...", "content": "<text or base64>", "encoding": "utf8" \| "base64" }` | Tool produced a file artifact |
+| `finish` | `{ "reason": "stop" \| "max_rounds" \| "error", "message"?: "<text>" }` | Stream closes after this |
+
+Side effect: when bound to a real skill, fires a `pull` analytics event with `source = "playground"`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Message-array schema failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:playground:use` |

--- a/ornn-web/src/docs/site/zh/api-search.md
+++ b/ornn-web/src/docs/site/zh/api-search.md
@@ -1,0 +1,65 @@
+# API Reference — Skill Search
+
+## `GET /api/v1/skill-search`
+
+**Unified keyword / semantic search.**
+
+> **Auth optional.** Anonymous callers are forced to `scope=public` regardless of the query string.
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `query` | string ≤ 2000 | `""` | Search term |
+| `mode` | `keyword` \| `semantic` | `keyword` | Semantic uses LLM re-ranking |
+| `scope` | `public` \| `private` \| `mixed` \| `shared-with-me` \| `mine` | `private` (auth) / `public` (anon) | — |
+| `page` | int ≥ 1 | `1` | — |
+| `pageSize` | int 1–100 | `9` | — |
+| `model` | string | platform default | LLM model override (semantic mode) |
+| `systemFilter` | `any` \| `only` \| `exclude` | `any` | "System skill" tri-state filter |
+| `sharedWithOrgs` | CSV of org IDs | — | Narrow by grant source |
+| `sharedWithUsers` | CSV of user IDs | — | Narrow by grant source |
+| `createdByAny` | CSV of user IDs | — | Narrow by author |
+
+System-skill filtering uses the caller's NyxID user-services slug list; unreachable NyxID fail-softs to "no system skills" instead of 500.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [ /* SkillSummary[] */ ],
+    "total": 42,
+    "page": 1,
+    "pageSize": 9,
+    "totalPages": 5
+  },
+  "error": null
+}
+```
+
+In semantic mode, each item also carries `relevanceScore: <0..1>`.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `QUERY_REQUIRED` | `mode=semantic` with empty `query` |
+| 400 | `INVALID_QUERY` | Schema validation failed |
+| 401 | `AUTH_REQUIRED` | `mode=semantic` from anonymous caller |
+
+---
+
+## `GET /api/v1/skill-counts`
+
+**Counts for the registry tab badges (`Public`, `Mine`, `Shared with me`).**
+
+> **Auth optional.** Anonymous callers see `mine = 0`, `sharedWithMe = 0`.
+
+### Response 200
+
+```json
+{ "data": { "public": 42, "mine": 7, "sharedWithMe": 3 }, "error": null }
+```
+
+No errors.

--- a/ornn-web/src/docs/site/zh/api-skills.md
+++ b/ornn-web/src/docs/site/zh/api-skills.md
@@ -1,0 +1,469 @@
+# API Reference — Skills CRUD
+
+Mounted under `/api/v1/skills`. The skill package is a ZIP whose root folder contains a `SKILL.md` and any number of supporting files. The platform models each upload as a *new version* of a stable skill identity (`guid`).
+
+> Auth model + permission catalogue + visibility rules: see **API Reference — Overview & Conventions**.
+
+## `POST /api/v1/skills`
+
+**Upload a new skill (binary ZIP).**
+
+> **Auth required.** Permission: `ornn:skill:create`. New skills are created **private** by default.
+
+### Request
+
+| In | Header / Param | Type | Notes |
+|---|---|---|---|
+| Header | `Content-Type` | string | One of `application/zip`, `application/octet-stream`, or `multipart/form-data` |
+| Query | `skip_validation` | `"true"` (optional) | Skip skill-format validation when set; default false |
+| Body | binary | `application/zip` payload | The skill package ZIP |
+
+For multipart uploads, the file field is `package`.
+
+### Response 201
+
+```jsonc
+{
+  "data": {
+    "guid": "01J7...",
+    "name": "ornn-api",
+    "description": "...",
+    "version": "0.1",
+    "isPrivate": true,
+    "isDeprecated": false,
+    "deprecationNote": null,
+    "createdBy": "<userId>",
+    "createdOn": "2026-04-14T18:59:00.000Z",
+    "updatedOn": "2026-04-14T18:59:00.000Z",
+    "sharedWithUsers": [],
+    "sharedWithOrgs": [],
+    "storageKey": "skills/<guid>/<version>.zip",
+    "skillHash": "sha256:..."
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_CONTENT_TYPE` | Content-Type missing or unsupported |
+| 400 | `EMPTY_BODY` | Body bytes were empty |
+| 400 | `VALIDATION_ERROR` | ZIP failed format validation (`error.message` lists violations) |
+| 401 | `AUTH_MISSING` | Caller has no NyxID identity |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:create` |
+| 413 | `PAYLOAD_TOO_LARGE` | ZIP exceeds size cap |
+
+Activity logged: `skill:create`.
+
+---
+
+## `POST /api/v1/skills/pull`
+
+**Create a skill from a public GitHub repo.**
+
+> **Auth required.** Permission: `ornn:skill:create`. Pulled skills retain the GitHub source pointer for later refresh.
+
+### Request body (`application/json`)
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `repo` | string | yes | `owner/name` |
+| `ref` | string | no | Branch / tag / commit; default `HEAD` |
+| `path` | string | no | Subdirectory inside the repo to package |
+| `skip_validation` | boolean | no | Mirror of the query flag on direct upload |
+
+### Response 201
+
+Same shape as `POST /skills`. The skill record additionally carries a `source` object:
+
+```jsonc
+{ "type": "github", "repo": "<owner/name>", "ref": "<ref>", "path": "<path>", "commit": "<sha>" }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `MISSING_REPO` | `repo` empty or absent |
+| 400 | `INVALID_BODY` | Body not JSON |
+| 400 | `VALIDATION_ERROR` | Pulled package failed format validation |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:create` |
+| 502 | `PULL_FAILED` | GitHub fetch / clone / build failed |
+
+Activity logged: `skill:create` with `details.source = "github-pull"`.
+
+---
+
+## `POST /api/v1/skills/:id/refresh`
+
+**Re-pull a GitHub-sourced skill at the latest commit (publishes a new version).**
+
+> **Auth required.** Permission: `ornn:skill:update` plus **owner-or-admin** ownership check.
+
+### Path
+
+| Param | Type | Notes |
+|---|---|---|
+| `id` | string | Skill GUID. Name is **not** accepted on this endpoint. |
+
+### Response 200
+
+Updated skill document (latest version after re-pull).
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Caller is not the author and not a platform admin |
+| 404 | `SKILL_NOT_FOUND` | Skill GUID unknown |
+| 409 | `NOT_GITHUB_SOURCED` | Skill was not created via `/skills/pull` |
+| 502 | `PULL_FAILED` | Re-pull failed |
+
+Activity logged: `skill:refresh` with `details.commit`.
+
+---
+
+## `GET /api/v1/skills/:idOrName`
+
+**Fetch one skill, optionally pinned to a version.**
+
+> **Auth optional.** Visibility rules apply (see Overview).
+
+### Path & Query
+
+| Param | In | Type | Notes |
+|---|---|---|---|
+| `idOrName` | path | string | Skill GUID or kebab-case name |
+| `version` | query | string | `<major>.<minor>`; defaults to latest |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "guid": "01J7...",
+    "name": "ornn-api",
+    "description": "...",
+    "version": "0.1",
+    "isPrivate": true,
+    "isDeprecated": false,
+    "deprecationNote": null,
+    "createdBy": "<userId>",
+    "createdByEmail": "<email>",
+    "createdByDisplayName": "<display name>",
+    "createdOn": "...",
+    "updatedOn": "...",
+    "sharedWithUsers": [],
+    "sharedWithOrgs": [],
+    "tags": ["api", "ornn"],
+    "metadata": { "category": "plain" },
+    "storageKey": "skills/<guid>/<version>.zip",
+    "skillHash": "sha256:...",
+    "presignedPackageUrl": "https://..."
+  },
+  "error": null
+}
+```
+
+### Response headers (deprecation)
+
+| Header | When |
+|---|---|
+| `X-Skill-Deprecated: true` | The version returned is deprecated |
+| `X-Skill-Deprecation-Note: <urlencoded note>` | A deprecation note exists |
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | Unknown name/guid OR caller cannot see this skill |
+
+Side effect: emits a `pull` analytics event with `source = "web"` (fire-and-forget).
+
+---
+
+## `GET /api/v1/skills/:idOrName/json`
+
+**Fetch the full skill package as JSON (decoded UTF-8 file map).**
+
+> **Auth required.** Permission: `ornn:skill:read`. Visibility rules apply.
+
+This is the agent-friendly path: instead of a presigned ZIP URL, you get the whole package back as `{ files: [{ path, content }] }` so an agent can inject files into context directly.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "name": "ornn-api",
+    "version": "0.1",
+    "files": [
+      { "path": "SKILL.md", "content": "---\nname: ornn-api\n..." },
+      { "path": "scripts/run.py", "content": "..." }
+    ]
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Missing `ornn:skill:read` |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+Side effect: `pull` analytics event with `source = "api"`.
+
+---
+
+## `GET /api/v1/skills/:idOrName/versions`
+
+**List all published versions, newest first.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      {
+        "version": "0.2",
+        "isDeprecated": false,
+        "deprecationNote": null,
+        "createdBy": "<userId>",
+        "createdByEmail": "...",
+        "createdByDisplayName": "...",
+        "createdOn": "...",
+        "skillHash": "sha256:...",
+        "storageKey": "skills/<guid>/0.2.zip"
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | — |
+
+---
+
+## `GET /api/v1/skills/:idOrName/versions/:fromVersion/diff/:toVersion`
+
+**Structured file-level diff between two versions.**
+
+> **Auth optional.** Visibility rules apply.
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "fromVersion": "0.1",
+    "toVersion": "0.2",
+    "files": [
+      { "path": "SKILL.md", "status": "modified", "fromContent": "...", "toContent": "..." },
+      { "path": "scripts/new.py", "status": "added",    "fromContent": null, "toContent": "..." },
+      { "path": "scripts/old.py", "status": "removed",  "fromContent": "...", "toContent": null }
+    ]
+  },
+  "error": null
+}
+```
+
+`status` is one of `added`, `removed`, `modified`. Both `fromContent` and `toContent` are full file text — clients render line-level diffs themselves.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 404 | `SKILL_NOT_FOUND` | Skill or one of the versions unknown |
+
+---
+
+## `PATCH /api/v1/skills/:idOrName/versions/:version`
+
+**Toggle deprecation flag on a single version.**
+
+> **Auth required.** Permission: `ornn:skill:update` + owner-or-admin.
+
+### Request body
+
+```jsonc
+{
+  "isDeprecated": true,
+  "deprecationNote": "Use 0.2+; this version mishandles JSON arrays."
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `isDeprecated` | boolean | yes | — |
+| `deprecationNote` | string | no | ≤ 1024 chars |
+
+### Response 200
+
+The updated version row.
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_DEPRECATION_PATCH` | Schema validation failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | Skill or version unknown |
+
+Activity logged: `skill:update` with `details.deprecationChange = true`.
+
+---
+
+## `PUT /api/v1/skills/:id`
+
+**Publish a new version of an existing skill, or flip its visibility, or both.**
+
+> **Auth required.** Permission: `ornn:skill:update` + owner-or-admin. Path takes the **GUID only**.
+
+This endpoint multiplexes by `Content-Type`:
+
+| Content-Type | Body | Effect |
+|---|---|---|
+| `application/zip` / `application/octet-stream` | binary ZIP | New version |
+| `multipart/form-data` | `package: <File>`, `isPrivate?: "true" \| "false"` | New version + optional visibility |
+| `application/json` | `{ "isPrivate": boolean }` | Visibility-only |
+
+Query `skip_validation=true` is honoured for ZIP uploads.
+
+### Response 200
+
+Updated skill document (same shape as `GET /skills/:idOrName`).
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_CONTENT_TYPE` | Unsupported MIME |
+| 400 | `NO_UPDATE` | Neither ZIP nor `isPrivate` provided |
+| 400 | `VALIDATION_ERROR` | ZIP failed format validation |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | Skill GUID unknown |
+| 413 | `PAYLOAD_TOO_LARGE` | — |
+
+Activity logged: `skill:update` (ZIP upload) or `skill:visibility_change` (visibility-only).
+
+---
+
+## `PUT /api/v1/skills/:id/permissions`
+
+**Replace the sharing allow-list (and / or `isPrivate`).**
+
+> **Auth required.** Permission: `ornn:skill:update` + owner-or-admin.
+>
+> **Sharing is unconditional.** The new state is applied immediately. There is no audit gate, no waiver, no reviewer.
+
+### Request body
+
+```jsonc
+{
+  "isPrivate": true,
+  "sharedWithUsers": ["user_abc", "user_def"],
+  "sharedWithOrgs": ["org_xyz"]
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `isPrivate` | boolean | Required |
+| `sharedWithUsers` | string[] | ≤ 500 entries, each 1–128 chars |
+| `sharedWithOrgs` | string[] | ≤ 100 entries, each 1–128 chars |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "skill": { /* full SkillDetail, same shape as GET /skills/:idOrName */ }
+  },
+  "error": null
+}
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `INVALID_PERMISSIONS` | Body schema validation failed |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+Activity logged: `skill:permissions_change`.
+
+If the resulting state is yellow / red on a fresh audit, the audit pipeline (separately) will fire `audit.risky_for_consumer` notifications. This endpoint itself never blocks.
+
+---
+
+## `DELETE /api/v1/skills/:id`
+
+**Hard-delete a skill and every version.**
+
+> **Auth required.** Permission: `ornn:skill:delete` + owner-or-admin.
+
+### Response 200
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | — |
+
+Activity logged: `skill:delete`.
+
+---
+
+## `DELETE /api/v1/skills/:idOrName/versions/:version`
+
+**Delete one non-latest, non-only version.**
+
+> **Auth required.** Permission: `ornn:skill:delete` + owner-or-admin.
+
+Refuses to delete:
+
+- the **only** remaining version (`ONLY_VERSION_DELETE_REFUSED`) — use `DELETE /skills/:id` instead;
+- the **current latest** version (`LATEST_VERSION_DELETE_REFUSED`) — publish a newer version first.
+
+### Response 200
+
+```json
+{ "data": { "success": true }, "error": null }
+```
+
+### Errors
+
+| HTTP | Code | Meaning |
+|---|---|---|
+| 400 | `LATEST_VERSION_DELETE_REFUSED` | Caller targeted the latest |
+| 400 | `ONLY_VERSION_DELETE_REFUSED` | Caller targeted the sole remaining version |
+| 401 | `AUTH_MISSING` | — |
+| 403 | `FORBIDDEN` | Not author and not admin |
+| 404 | `SKILL_NOT_FOUND` | Skill or version unknown |
+
+Activity logged: `skill:version_delete`.

--- a/ornn-web/src/docs/site/zh/api-users.md
+++ b/ornn-web/src/docs/site/zh/api-users.md
@@ -1,0 +1,62 @@
+# API Reference — Users Directory
+
+These routes are scoped to users who have interacted with Ornn (have at least one row in the `activities` collection). They never query NyxID's full user directory.
+
+## `GET /api/v1/users/search`
+
+**Email-prefix typeahead. Powers the permissions modal user picker.**
+
+> **Auth required.**
+
+### Query
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `q` | string ≤ 256 | `""` | Search prefix |
+| `limit` | int 1–50 | `10` | — |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "userId": "<userId>", "email": "alice@example.com", "displayName": "Alice" }
+    ]
+  },
+  "error": null
+}
+```
+
+No errors.
+
+---
+
+## `GET /api/v1/users/resolve`
+
+**Batch-resolve user IDs to email + displayName.**
+
+> **Auth required.**
+
+### Query
+
+| Param | Type | Notes |
+|---|---|---|
+| `ids` | CSV of user IDs | ≤ 100 entries |
+
+### Response 200
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "userId": "<userId>", "email": "alice@example.com", "displayName": "Alice" }
+    ]
+  },
+  "error": null
+}
+```
+
+Unknown IDs are silently dropped (consumers fall back to rendering the raw id).
+
+No errors.

--- a/ornn-web/src/docs/site/zh/menuStructure.json
+++ b/ornn-web/src/docs/site/zh/menuStructure.json
@@ -6,16 +6,41 @@
       "label": "关于",
       "order": 1,
       "children": [
-        { "id": "what-is-ornn", "label": "什么是 Ornn", "file": "what-is-ornn.md", "order": 1 }
+        { "id": "what-is-ornn", "label": "什么是 Ornn", "file": "what-is-ornn.md", "order": 1 },
+        { "id": "why-ornn", "label": "为什么是 Ornn", "file": "why-ornn.md", "order": 2 },
+        { "id": "vs-vercel-skills-sh", "label": "Ornn vs. Vercel skills.sh", "file": "vs-vercel-skills-sh.md", "order": 3 },
+        { "id": "vs-skillmp", "label": "Ornn vs. SkillMP", "file": "vs-skillmp.md", "order": 4 },
+        { "id": "vs-github", "label": "Ornn vs. GitHub", "file": "vs-github.md", "order": 5 }
       ]
     },
     {
-      "id": "get-started",
+      "id": "quick-start",
       "label": "快速开始",
       "order": 2,
       "children": [
         { "id": "qs-web-user", "label": "Web 用户快速入门", "file": "qs-web-user.md", "order": 1 },
         { "id": "agent-manual", "label": "Agent 操作手册", "file": "agent-manual.md", "order": 2 }
+      ]
+    },
+    {
+      "id": "reference",
+      "label": "技术参考",
+      "order": 3,
+      "children": [
+        { "id": "api-overview", "label": "API Reference — Overview", "file": "api-overview.md", "order": 1 },
+        { "id": "api-out-of-band", "label": "API Reference — Out-of-band", "file": "api-out-of-band.md", "order": 2 },
+        { "id": "api-skills", "label": "API Reference — Skills CRUD", "file": "api-skills.md", "order": 3 },
+        { "id": "api-audit", "label": "API Reference — Skill Audit", "file": "api-audit.md", "order": 4 },
+        { "id": "api-search", "label": "API Reference — Skill Search", "file": "api-search.md", "order": 5 },
+        { "id": "api-format", "label": "API Reference — Skill Format", "file": "api-format.md", "order": 6 },
+        { "id": "api-generation", "label": "API Reference — Skill Generation (SSE)", "file": "api-generation.md", "order": 7 },
+        { "id": "api-playground", "label": "API Reference — Playground (SSE)", "file": "api-playground.md", "order": 8 },
+        { "id": "api-notifications", "label": "API Reference — Notifications", "file": "api-notifications.md", "order": 9 },
+        { "id": "api-analytics", "label": "API Reference — Analytics", "file": "api-analytics.md", "order": 10 },
+        { "id": "api-me", "label": "API Reference — Me / Caller scope", "file": "api-me.md", "order": 11 },
+        { "id": "api-users", "label": "API Reference — Users Directory", "file": "api-users.md", "order": 12 },
+        { "id": "api-admin", "label": "API Reference — Admin", "file": "api-admin.md", "order": 13 },
+        { "id": "api-platform-settings", "label": "API Reference — Platform Settings", "file": "api-platform-settings.md", "order": 14 }
       ]
     }
   ]

--- a/ornn-web/src/docs/site/zh/vs-github.md
+++ b/ornn-web/src/docs/site/zh/vs-github.md
@@ -1,0 +1,45 @@
+# Ornn 与裸 GitHub 的对比
+
+很多团队已经把 AI agent skill 以 `SKILL.md` 文件的形式放在 GitHub repo 里。能用、免费、你已经会用、agent 可以 curl raw URL 拿到。这一页讲清楚什么时候"裸 GitHub 就够"，什么时候 Ornn 真正开始物有所值。
+
+## TL;DR
+
+| | GitHub repo | Ornn |
+|---|---|---|
+| **是什么** | 代码托管。存文件。 | Skill 生命周期 API。除了存文件，把围绕文件的所有事情都做了。 |
+| **发现** | `gh search`、你自己的书签、README | 跨 registry 的 keyword + semantic 搜索，按调用方可见性 scope |
+| **版本** | Git tag / branch —— 你自己设计规则 | 一等公民的 skill 版本；`GET /skills/:idOrName/versions`、`diff/:from/:to` |
+| **ACL** | 公开，或付费私有 repo（per-repo） | Per-skill ACL：private / 给指定用户 / 给指定组织 / 公开 —— 不需要 per-repo 付费 |
+| **身份** | GitHub 身份，code review 用着不错，但不是"这个 org 里的这个用户"该有的形状 | NyxID OAuth —— API 边缘有真实用户 + 组织成员关系 |
+| **信任信号** | 没有 —— 你信任作者 | 每个版本有审计 verdict，变 risky 时给使用者发通知 |
+| **沙箱** | 没有 —— agent 自己跑代码 | 一等公民（chrono-sandbox）；试验场 UI 支持 try-before-install |
+| **程序化 agent API** | 自己拼（解析 README、raw URL、自定义 auth） | 一个 HTTP / MCP API 解决一切 —— 搜索、拉取、执行、构建、上传、分享 |
+| **最适合** | 公开、代码优先、不需要隐私或组织边界的 skill | 多用户、多租户、需要审计能力的 skill 操作 |
+
+## 什么时候裸 GitHub 就够
+
+- 你在发布单个开源 skill，README + raw URL 已经够了。
+- 你不需要把 skill 限定给特定的人 —— 公开就行。
+- agent 的"安装"步骤就是 `curl raw.githubusercontent.com/...`，你也接受这种方式。
+- 搜索不需要超过 `gh search code` 的能力。
+- 不需要审计 verdict，"信任作者"够了。
+
+如果上述五条全成立，GitHub 是最便宜的路径，用它。
+
+## 什么时候 Ornn 物有所值
+
+- **多租户。** 有些 skill 应该让一个组织看到，但不让另一个组织看到。GitHub 解决方案是付费私有 repo / 跑组织；Ornn 用 per-skill ACL 解决。
+- **混合信任。** 一些 skill 公开，一些限定团队，一些只分享给一个外部合作方。GitHub 强迫你用不同的 repo / 组织建模；Ornn 让你在每个 skill 上拨开关就行。
+- **审计 + 通知。** 你在意一个 skill 是否 risky，并且想让使用者自动得知。GitHub 没有；Ornn 当作一等公民来做。
+- **程序化 agent 循环。** agent 应该在 *runtime* 自动发现并拉取 skill。GitHub 的方式是 `gh api` 调用 + raw URL 解析 + 你自己的缓存；Ornn 的方式是每个动词一次调用 + 稳定 schema。
+- **安装前沙箱。** 想让用户在受控 runtime 里试一下 skill 再装。GitHub 没有；Ornn 试验场就是。
+- **使用数据。** 你想要拉取数、执行成功率、来源拆分（API / web / playground）。GitHub 给你 stars 和 clone 数；Ornn 给你与 skill 真正相关的指标。
+
+## 二者并非互斥
+
+`POST /skills/pull` 把公开 GitHub repo 导入成 Ornn skill。Skill 保持与 GitHub 源的链接，所以 `POST /skills/:id/refresh` 可以按需重拉。推荐给那种希望：
+
+- skill 源码 + 版本控制留在 git（已有的开发体验）
+- 通过 Ornn 做分发 + 审计 + ACL（GitHub 没有的运维故事）
+
+…的团队。Git 做 source-of-truth，Ornn 做 runtime 分发与信任。

--- a/ornn-web/src/docs/site/zh/vs-skillmp.md
+++ b/ornn-web/src/docs/site/zh/vs-skillmp.md
@@ -1,0 +1,43 @@
+# Ornn 与 SkillMP 的对比
+
+SkillMP 和 Ornn 都把自己定位在 AI agent skill 上，但它们不是同一种产品。判断哪个适合你，主要看你是在"逛"还是在"造"。
+
+## TL;DR
+
+| | SkillMP | Ornn |
+|---|---|---|
+| **产品形状** | Marketplace —— 给人逛的目录站，有 creator 页、评分、浏览式发现 | API 层 —— agent 直接调用 API 来管理它自己的 skill 生命周期 |
+| **主要消费者** | 挑 skill 安装的人 | runtime 中的 AI agent |
+| **认证** | 站内账号 | NyxID OAuth —— API 边缘有真实组织 / 用户身份 |
+| **Per-skill ACL** | 公开 / "premium" 列表；单位是 skill，不是接收者 | 私有 / 给指定用户 / 给指定组织 / 公开 —— 接收者是真实身份 |
+| **信任信号** | 评分 + 作者声誉 —— 社交化 | 每个版本的审计 verdict（绿/黄/红）+ 变成 risky 时给使用者发通知 |
+| **构建 / 发布** | 上传 skill、填列表、等 marketplace 审核 | 程序化：`POST /skills`、`POST /skills/pull` 或 `POST /skills/generate`（SSE） |
+| **程序化 API** | 有限或没有 | 一等公民 —— 每个操作都是 HTTP / MCP 调用 |
+| **最适合** | 浏览、为某个 skill 付费、发布出售 skill | 构建 agentic 系统，技能管理在代码里发生而不是在 UI 里 |
+
+## SkillMP 擅长什么
+
+Marketplace 擅长三件事：**发现**、**变现**、**社交背书**。如果你想用类似 Chrome extension 的方式找一个 skill，marketplace 形状是对的；如果你想为自己 skill 的访问权 / 使用次数收钱，你需要一个本身有 billing / rev-share 故事的产品；如果你更信任 4.8 星 12k 安装这种数字而不是你自己审计 pipeline 的 verdict —— marketplace 占优。
+
+## Ornn 擅长什么
+
+agent 在 runtime 中发生的所有事，加上身份感知的操作：
+
+- **搜索 → 拉取 → 执行** 各是一次 HTTP 调用，agent 不离开它的循环。
+- **Per-skill ACL 是真 ACL**，不是 honor-system 的"私有列表"。把私有 skill 分享给 `org_xyz`，意思是 NyxID 里 `org_xyz` 的所有人能看到，其它人看不到。
+- **审计 verdict 是结构化数据**，不是星级。skill 变成 yellow/red 时使用者自动收到 `audit.risky_for_consumer` 通知；作者每次审计完成时收到 `audit.completed`。
+- **AI 原生发布。** 从 prompt 或源码生成 skill。流式输出。校验。上传。全部在代码里完成。
+
+## 怎么选
+
+| 你是… | 选 |
+|---|---|
+| 单干的开发者，希望自己 skill 被人发现 | SkillMP-style marketplace |
+| 想靠 skill 安装 / 调用收钱 | SkillMP-style marketplace |
+| 在做一个 runtime 中要调用一堆 skill 的 agent | **Ornn** |
+| 在企业内部运行 skill，组织边界很重要 | **Ornn** |
+| 想把 skill 做进 CI/CD（发布即审计、替换即 deprecate） | **Ornn** |
+
+## 二者并非互斥
+
+如果一个 marketplace 暴露了程序化的列表 API，Ornn 可以把它本地镜像，然后用 agent-API 契约对外服务。公开 skill 内容就是联邦的原语 —— 一旦 Ornn 知道去哪取字节，调用 Ornn 的 agent 不在意原始来源是 Ornn 还是 marketplace。这是另一个工作流，不是上面对比表的替代。

--- a/ornn-web/src/docs/site/zh/vs-vercel-skills-sh.md
+++ b/ornn-web/src/docs/site/zh/vs-vercel-skills-sh.md
@@ -1,0 +1,48 @@
+# Ornn 与 Vercel `skills.sh` 的对比
+
+两个项目都在托管 AI agent skill。它们解决的问题不一样。这一页讲清什么时候用谁。
+
+## TL;DR
+
+| | `skills.sh`（Vercel） | Ornn |
+|---|---|---|
+| **主要消费者** | 浏览目录的人类开发者 | 调用 API 的 agent |
+| **Surface** | 静态目录站 + GitHub 后端的列表页 | HTTP / MCP API + 次要 Web UI |
+| **Skill 格式** | 托管在 GitHub 上的 repo，渲染成列表 | 可移植的 ZIP 包（SKILL.md + 脚本 + 元数据） |
+| **认证** | 无 —— 公开列表 | NyxID OAuth（真实 user / org 身份） |
+| **授权** | 无 | Per-skill ACL（私有 / 给指定用户 / 给指定组织 / 公开） |
+| **信任信号** | 无 | 每个版本都有审计 verdict（绿 / 黄 / 红），并对使用者发通知 |
+| **沙箱** | Vercel Functions / 外部 | 一等公民（chrono-sandbox），有 playground UI |
+| **最适合** | 发现、营销、人类快速看一眼 | agent 在 runtime 自动管理 skill，企业场景 |
+
+## `skills.sh` 擅长什么
+
+打磨过的目录体验。容易浏览、容易收藏、容易把链接发给同事。Vercel 强在面向人类的 dev-tooling 打磨。如果消费者是人类 —— 想扫一眼列表、复制一段代码、跑起来 —— `skills.sh` 是合适的形状。
+
+它也是免费的。Skill 本身通常住在公开 GitHub repo 里，对开源 skill 来说够用。
+
+## Ornn 擅长什么
+
+agent 决定要用某个 skill 之后所有要做的事，加上身份感知的操作：
+
+- **程序化列表**：keyword + semantic 搜索一次 HTTP 调用搞定。
+- **程序化 install**：一次调用拿到 JSON 化的整包（`GET /skills/:idOrName/json` 返回 `{ files: [{ path, content }] }`，agent 直接注入到上下文）。
+- **程序化发布**：SSE 流式 AI 生成。agent 可以生成新 skill、校验、发布，都不离开它的循环。
+- **身份感知的分享**：把私有 skill 分享给一个用户、一个组织、一组组织。真 ACL，不只是 public/private。
+- **审计 verdict + 通知**：每个 skill 都有 verdict。变成 yellow/red 时使用者会被 NyxID 通知，不需要轮询目录。
+- **执行数据**：每个 skill 的拉取数（按 API / web / playground 来源拆分）+ 延迟和成功率。
+
+## 怎么选
+
+| 你是… | 选 |
+|---|---|
+| 想找个 skill 抄回来改改的人 | `skills.sh` |
+| 发布一个公开 skill，一份 markdown 列表就够了 | `skills.sh` |
+| 在做一个 agent，要自动发现/拉取/执行 skill | **Ornn** |
+| 一个组织，需要把 skill 限定给特定的人/组织看 | **Ornn** |
+| 一个组织，需要 skill 变成 risky 时有审计 + 通知链路 | **Ornn** |
+| 团队信任要求混合 —— 有的公开、有的私有、有的限定组织 | **Ornn** |
+
+## 二者并非互斥
+
+Ornn 的 `POST /skills/pull` 已经支持把公开 GitHub repo 导入成 Ornn skill。如果将来 `skills.sh` 也提供程序化列表接口，我们会做一个 thin sync 把它的公开列表镜像到 Ornn，让这些 skill 也能流过 agent-API 契约 —— 但这是另外一个工作流，不是上面对比表的替代。

--- a/ornn-web/src/docs/site/zh/why-ornn.md
+++ b/ornn-web/src/docs/site/zh/why-ornn.md
@@ -1,0 +1,44 @@
+# 为什么是 Ornn
+
+Ornn 是 AI agent 调用的 API 层，用来管理它自己的技能生命周期：搜索 → 拉取 → 安装 → 执行 → 构建 → 上传 → 分享 —— 每一个 agent 想对一个 skill 做的事情，都是一次 HTTP / MCP 调用。最接近的类比是 **npm registry + npm CLI 融为一体，model-agnostic**。
+
+这一页只想说清楚一件事：Ornn 是给谁用的、解决谁的问题。如果你来这里是想找一个给人浏览的 skill marketplace，你会失望；如果你来这里是想找一个 agent 真正在调用的底座，那就是它。
+
+## 客户是 agent 开发者
+
+产品是被 **AI agent** 消费的 —— 不是被人浏览目录消费的。Web UI 当然也存在，但它是次要 surface，给 skill owner 和平台管理员管理自己工作的地方。主产品是 API 契约。
+
+这个区别会贯穿到所有设计决策里：
+
+- **API 工效优先于发现 UX。** 一个稳定、强类型的 schema，比一张漂亮的 hero banner 更重要 —— 因为消费者是 Claude / GPT / Gemini 的一次调用。
+- **Model-agnostic。** Skill 是可移植的产物（一份 `SKILL.md` + 可选脚本 + 元数据）。任何能拉文件并注入上下文的 agent runtime 都能消费 Ornn skill。
+- **生命周期，不是目录。** 列 skill 是无聊的部分。让 agent 构建一个新 skill、审计它、和另一个用户/组织共享、一段时间后看执行分析数据 —— 这才是生命周期。
+
+## 你真正得到什么
+
+| 层 | 能力 |
+|---|---|
+| **Registry + CRUD** | Skill 是版本化的、可校验的、有存储。按 GUID 或 kebab-case 名字拉。两个版本 diff。可以 deprecate 一个版本而不删除它。 |
+| **Search** | Keyword + semantic search，跨公开 + 调用方可见的切片。通过 NyxID services 实现 system-skill filter。 |
+| **AI 生成** | 从 prompt、源码、OpenAPI spec 生成新 skill。SSE 流式返回。 |
+| **沙箱试验场** | 安装前完整试用一个 skill：chrono-sandbox 跑代码，你的 LLM 看到结果。 |
+| **审计作为风险标签** | 每个 skill 都有 verdict（`green` / `yellow` / `red`）。审计按需运行，永远不会阻塞分享；变成 `yellow` / `red` 时使用者会收到通知。 |
+| **NyxID 身份** | API 边缘有真实的 org / 用户身份。Per-skill ACL 是真 ACL，不是 honor system。 |
+| **分析数据** | 每个 skill 版本的拉取数（按 api / web / playground 来源拆分）和执行 telemetry。 |
+
+## Model-agnostic by design
+
+Ornn 不绑定特定 LLM 厂商。Skill 由你指向 API 的那个 agent 拉取并执行。Ornn 内部使用 NyxID LLM gateway 处理 skill 生成 + 审计，但消费 skill 的 agent 自由选择 Claude / GPT / Gemini / 自研 runtime。Skill 内容是可移植的文本 + 脚本。
+
+## Ornn **不是**
+
+- 不是给人逛的 skill marketplace。没有排行榜，没有社交评分，没有"本周热门"feed。
+- 不绑定任何 agent runtime。Skill 不是 Claude-only / GPT-only。
+- 不是 git 替代品。我们不打算做 code host。如果你想用版本控制管理 skill 源码，就在 git 里管，然后用 `POST /skills/pull` 导入即可。
+- 不是 runtime 防护栏。审计是标签，不是 runtime block。要 runtime 安全请在你的 agent 上叠 Lakera / LLM Guard / NeMo。
+
+## 接下来去哪儿
+
+- **快速开始 → Web 用户快速入门**：GUI 操作向导。
+- **快速开始 → Agent 操作手册**：如果你是 agent 开发者，把它整份扔进你 agent 的 system context 即可。
+- **技术参考 → API Reference**：完整的端点目录。

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -439,7 +439,10 @@
   "docs": {
     "onThisPage": "On this page",
     "notFound": "Not Found",
-    "loadFailed": "Failed to fetch documentation."
+    "loadFailed": "Failed to fetch documentation.",
+    "copyMarkdown": "Copy as markdown",
+    "copyMarkdownHint": "Copy this whole document as markdown — paste it into your AI agent to install as a skill",
+    "copied": "Copied"
   },
   "skillToggle": {
     "makePrivateTitle": "Make Skill Private?",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -439,7 +439,10 @@
   "docs": {
     "onThisPage": "本页目录",
     "notFound": "未找到",
-    "loadFailed": "获取文档失败。"
+    "loadFailed": "获取文档失败。",
+    "copyMarkdown": "复制 Markdown",
+    "copyMarkdownHint": "把整篇文档复制为 markdown —— 粘贴到你的 AI agent 中即可作为 skill 安装",
+    "copied": "已复制"
   },
   "skillToggle": {
     "makePrivateTitle": "设为私有?",

--- a/ornn-web/src/pages/DocsPage.tsx
+++ b/ornn-web/src/pages/DocsPage.tsx
@@ -623,6 +623,7 @@ export function DocsPage() {
   const lang = (i18n.language === "zh" ? "zh" : "en") as Lang;
 
   const [activeHeadingId, setActiveHeadingId] = useState("");
+  const [docCopied, setDocCopied] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
   const menu = useMemo(() => getDocsTree(lang), [lang]);
@@ -633,6 +634,20 @@ export function DocsPage() {
     const content = getDocContent(lang, activeId);
     return content ?? `# ${t("docs.notFound")}\n\nCould not load \`${activeId}\`.`;
   }, [lang, activeId, t]);
+
+  // The Agent Manual is intentionally a paste-installable skill (see its
+  // SKILL.md frontmatter). Every doc is copyable for parity, but the
+  // button matters most on agent-manual where the recipient is the agent
+  // itself.
+  const handleCopyDoc = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setDocCopied(true);
+      setTimeout(() => setDocCopied(false), 1800);
+    } catch {
+      /* ignore clipboard errors — older browsers, sandboxed iframes, etc. */
+    }
+  }, [markdown]);
 
   const toc = useMemo(() => extractToc(markdown), [markdown]);
 
@@ -757,6 +772,36 @@ export function DocsPage() {
               </article>
             ) : (
               <article className="markdown-body max-w-4xl mx-auto">
+                <div className="not-prose mb-6 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={handleCopyDoc}
+                    className={`inline-flex items-center gap-2 rounded-sm border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors duration-150 cursor-pointer ${
+                      docCopied
+                        ? "border-success/60 bg-success-soft text-success"
+                        : "border-strong-edge text-meta hover:border-strong hover:text-strong"
+                    }`}
+                    aria-label={t("docs.copyMarkdown", "Copy as markdown")}
+                    title={t("docs.copyMarkdownHint", "Copy this whole document as markdown — paste into your AI agent to install it as a skill") as string}
+                  >
+                    {docCopied ? (
+                      <>
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden>
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                        {t("docs.copied", "Copied")}
+                      </>
+                    ) : (
+                      <>
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                          <rect x="9" y="9" width="13" height="13" rx="1" />
+                          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                        </svg>
+                        {t("docs.copyMarkdown", "Copy as markdown")}
+                      </>
+                    )}
+                  </button>
+                </div>
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeHighlight]}


### PR DESCRIPTION
Three changes. Closes #215. Menu: About / Quick Start / Technical References. New About pages: Why Ornn? + 3 comparisons. API Reference split into 14 per-domain pages. Copy-as-markdown button on every doc; Agent Manual starts with SKILL.md frontmatter so paste-into-agent installs it as a real Ornn skill.