### PR TITLE
[Feature] Version diff/delete UI + GitHub link redesign + agent manual v1.1

### DIFF
--- a/.changeset/github-link-redesign.md
+++ b/.changeset/github-link-redesign.md
@@ -1,0 +1,23 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+feat: redesign the GitHub-link feature around a single folder URL + manual sync.
+
+**Backend.**
+
+- New `parseGithubUrl(url)` helper accepts the canonical folder URL a user copies from the browser address bar (e.g. `https://github.com/owner/repo/tree/<ref>/<path>`) and returns `{ repo, ref, path }`. Bare-repo URLs and the `tree/<ref>` form (no path) work too. `blob/` URLs and non-github hosts are rejected. 11 unit tests.
+- New endpoint `PUT /api/v1/skills/:id/source` attaches (or clears, with `{ githubUrl: null }`) a GitHub source pointer on an existing skill *without* pulling. Auth: skill author or platform admin + `ornn:skill:update`. Lets a user link an originally hand-uploaded skill to its GitHub source first and trigger the sync separately. The stored `source` is missing `lastSyncedAt`/`lastSyncedCommit` until the first sync.
+- `POST /api/v1/skills/:id/refresh` now accepts `{ dryRun?: boolean, skipValidation?: boolean }`. When `dryRun: true`: pulls from the linked source, computes a structured diff against the current latest version, and returns `{ skill, source, pendingVersion, hasChanges, diff }` without bumping. Powers the preview-then-confirm flow on the detail-page Advanced Options panel. When `dryRun: false`: existing behavior; `skipValidation` opts out of the format validator on the pulled package.
+- `POST /api/v1/skills/pull` now accepts `githubUrl` (preferred) alongside the existing `repo`/`ref`/`path` form, so the build flow can post the same single-URL form the panel uses.
+- `SkillSource.lastSyncedAt` / `lastSyncedCommit` are now optional on both the API and SDK shape, reflecting the new "linked but never synced" state.
+- New activity-log entries `skill:source_link` / `skill:source_unlink`.
+
+**Frontend.**
+
+- New "Link to GitHub" panel inside the `AdvancedOptionsModal` on the skill detail page. Single URL input, skip-validation checkbox, plus Save / Sync / Unlink buttons. Sync runs the dry-run preview → if no changes detected, toasts "already in sync"; otherwise switches the panel into a Sync-preview view that renders the diff via the new `VersionDiffView` component and asks the user to confirm with an "Apply sync" button.
+- `VersionDiffView` is a new pure renderer extracted from `VersionDiffModal` (which now consumes it) so the diff layout is shared between the version-compare modal and the GitHub sync preview.
+- `/skills/new/from-github` page redesigned to take a single GitHub folder URL + skip-validation toggle. Submitting calls `POST /skills/pull` with the URL and routes the user to the new skill's detail page.
+- New API client functions `setSkillSource`, `previewSkillRefresh`, plus hooks `useSetSkillSource`, `usePreviewSkillRefresh`. `useRefreshSkillFromSource` now takes `{ guid, skipValidation? }` so the Apply-sync step can opt out of validation.
+- en + zh translations.

--- a/.changeset/version-diff-ui.md
+++ b/.changeset/version-diff-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+feat(web): surface skill version diff in the UI (#225). The all-versions modal on the skill detail page now has a "Compare versions" button that opens a new `VersionDiffModal`. Two version pickers (defaulted to current ↔ latest) call `GET /api/v1/skills/:idOrName/versions/:from/diff/:to` and the result renders three sections — Modified / Added / Removed — with file paths, byte sizes, and a unified line-level diff for every modified text file via the `diff` npm package. Binary files report their size + hash change without inline content. Same-version compares short-circuit locally so the backend doesn't see them. en + zh translations added.

--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@tanstack/react-query": "^5.62.0",
+        "diff": "^9.0.0",
         "framer-motion": "^11.15.0",
         "highlight.js": "^11.10.0",
         "i18next": "^25.8.17",
@@ -75,6 +76,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/diff": "^8.0.0",
         "@types/jszip": "^3.4.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -523,6 +525,8 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
+    "@types/diff": ["@types/diff@8.0.0", "", { "dependencies": { "diff": "*" } }, "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw=="],
+
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -836,6 +840,8 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 

--- a/ornn-api/src/domains/admin/activityRepository.ts
+++ b/ornn-api/src/domains/admin/activityRepository.ts
@@ -19,7 +19,9 @@ export type ActivityAction =
   | "skill:visibility_change"
   | "skill:permissions_change"
   | "skill:refresh"
-  | "skill:nyxid_service_tie";
+  | "skill:nyxid_service_tie"
+  | "skill:source_link"
+  | "skill:source_unlink";
 
 export interface ActivityDocument {
   _id: string;

--- a/ornn-api/src/domains/skills/crud/repository.ts
+++ b/ornn-api/src/domains/skills/crud/repository.ts
@@ -180,6 +180,23 @@ export class SkillRepository {
   }
 
   /**
+   * Remove the `source` field entirely from a skill doc (i.e. unlink the
+   * upstream pointer). Use $unset rather than `$set: { source: null }` so
+   * the field is absent from the doc — matches the "originally hand-
+   * uploaded skill" shape.
+   */
+  async clearSource(guid: string, updatedBy: string): Promise<SkillDocument | null> {
+    await this.collection.updateOne(
+      { _id: guid as any },
+      {
+        $set: { updatedBy, updatedOn: new Date() },
+        $unset: { source: "" },
+      },
+    );
+    return this.findByGuid(guid);
+  }
+
+  /**
    * Set or clear a NyxID-service tie. When `data.nyxidServiceId` is `null`
    * we wipe all four cached fields. Caller must have already validated
    * eligibility + decided whether to flip `isPrivate` (admin tie forces

--- a/ornn-api/src/domains/skills/crud/repository.ts
+++ b/ornn-api/src/domains/skills/crud/repository.ts
@@ -728,8 +728,18 @@ function mapDoc(doc: Document | null): SkillDocument | null {
           repo: String(doc.source.repo ?? ""),
           ref: String(doc.source.ref ?? ""),
           path: String(doc.source.path ?? ""),
-          lastSyncedAt: doc.source.lastSyncedAt instanceof Date ? doc.source.lastSyncedAt : new Date(doc.source.lastSyncedAt),
-          lastSyncedCommit: String(doc.source.lastSyncedCommit ?? ""),
+          // Both fields are optional — when the user attached a GitHub
+          // link via PUT /skills/:id/source without an immediate sync,
+          // they're absent from the doc. Don't fabricate an Invalid
+          // Date by feeding `undefined` to the Date constructor.
+          ...(doc.source.lastSyncedAt instanceof Date
+            ? { lastSyncedAt: doc.source.lastSyncedAt }
+            : doc.source.lastSyncedAt != null
+              ? { lastSyncedAt: new Date(doc.source.lastSyncedAt) }
+              : {}),
+          ...(typeof doc.source.lastSyncedCommit === "string" && doc.source.lastSyncedCommit
+            ? { lastSyncedCommit: doc.source.lastSyncedCommit }
+            : {}),
         }
       : undefined,
     nyxidServiceId: typeof doc.nyxidServiceId === "string" ? doc.nyxidServiceId : null,

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -26,6 +26,7 @@ import {
 import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import { AppError } from "../../../shared/types/index";
 import { canReadSkill, canManageSkill } from "./authorize";
+import { parseGithubUrl } from "./utils/githubPull";
 import pino from "pino";
 
 const deprecationPatchSchema = z.object({
@@ -149,32 +150,57 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     async (c) => {
       const authCtx = getAuth(c);
       const body = (await c.req.json().catch(() => ({}))) as {
+        // Preferred: a single GitHub folder URL the user copied from the
+        // browser address bar. Server parses out repo / ref / path.
+        githubUrl?: unknown;
+        // Legacy / explicit form: caller already split the source apart.
         repo?: unknown;
         ref?: unknown;
         path?: unknown;
         skip_validation?: unknown;
       };
 
-      if (typeof body.repo !== "string" || !body.repo) {
-        throw AppError.badRequest("MISSING_REPO", "A 'repo' field (format 'owner/name') is required");
+      let repo: string;
+      let ref: string | undefined;
+      let path: string | undefined;
+
+      if (typeof body.githubUrl === "string" && body.githubUrl) {
+        try {
+          const parsed = parseGithubUrl(body.githubUrl);
+          repo = parsed.repo;
+          ref = parsed.ref;
+          path = parsed.path;
+        } catch (err) {
+          throw AppError.badRequest(
+            "INVALID_GITHUB_URL",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      } else if (typeof body.repo === "string" && body.repo) {
+        repo = body.repo;
+        ref = typeof body.ref === "string" && body.ref ? body.ref : undefined;
+        path = typeof body.path === "string" ? body.path : undefined;
+      } else {
+        throw AppError.badRequest(
+          "MISSING_SOURCE",
+          "Provide either 'githubUrl' (preferred) or 'repo' (with optional 'ref'/'path').",
+        );
       }
 
-      const ref = typeof body.ref === "string" && body.ref ? body.ref : undefined;
-      const path = typeof body.path === "string" ? body.path : undefined;
       const skipValidation = body.skip_validation === true;
       const userEmail = authCtx.email || undefined;
       const userDisplayName = authCtx.displayName || undefined;
 
       try {
         const { guid } = await skillService.createSkillFromGitHub(
-          { repo: body.repo, ref, path },
+          { repo, ref, path },
           authCtx.userId,
           { userEmail, userDisplayName, skipValidation },
         );
         const skill = await skillService.getSkill(guid);
 
         logger.info(
-          { guid, userId: authCtx.userId, repo: body.repo, ref, path },
+          { guid, userId: authCtx.userId, repo, ref, path },
           "Skill created via GitHub pull",
         );
 
@@ -208,6 +234,13 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     async (c) => {
       const authCtx = getAuth(c);
       const guid = c.req.param("id");
+      const body = (await c.req.json().catch(() => ({}))) as {
+        dryRun?: unknown;
+        skipValidation?: unknown;
+        skip_validation?: unknown;
+      };
+      const dryRun = body.dryRun === true;
+      const skipValidation = body.skipValidation === true || body.skip_validation === true;
 
       const existing = await skillService.getSkill(guid);
       const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
@@ -218,10 +251,25 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         );
       }
 
+      // Dry-run path — pull from GitHub, compute diff vs the current
+      // latest version, return the diff WITHOUT bumping. Powers the
+      // "preview-then-confirm" flow on the detail-page advanced settings.
+      if (dryRun) {
+        try {
+          const preview = await skillService.previewRefreshFromSource(guid);
+          return c.json({ data: preview, error: null });
+        } catch (err) {
+          if (err instanceof AppError) throw err;
+          const message = err instanceof Error ? err.message : String(err);
+          throw AppError.badRequest("REFRESH_PREVIEW_FAILED", message);
+        }
+      }
+
       try {
         const refreshed = await skillService.refreshSkillFromSource(guid, authCtx.userId, {
           userEmail: authCtx.email || undefined,
           userDisplayName: authCtx.displayName || undefined,
+          skipValidation,
         });
 
         logger.info(
@@ -249,6 +297,75 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         const message = err instanceof Error ? err.message : String(err);
         throw AppError.badRequest("REFRESH_FAILED", message);
       }
+    },
+  );
+
+  /**
+   * PUT /skills/:id/source — Attach (or clear) a GitHub source pointer
+   * on a skill without pulling.
+   *
+   * Body: `{ githubUrl: string | null }`. A non-null value is parsed
+   * (e.g. `https://github.com/owner/repo/tree/<ref>/<path>`) and stored
+   * on the skill; `lastSyncedAt` / `lastSyncedCommit` are intentionally
+   * absent until the user triggers `POST /skills/:id/refresh`. Pass
+   * `null` to unlink.
+   *
+   * Requires: `ornn:skill:update` AND skill author or platform admin.
+   */
+  app.put(
+    "/skills/:id/source",
+    auth,
+    requirePermission("ornn:skill:update"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const guid = c.req.param("id");
+      const body = (await c.req.json().catch(() => ({}))) as { githubUrl?: unknown };
+
+      const existing = await skillService.getSkill(guid);
+      const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
+      if (existing.createdBy !== authCtx.userId && !isPlatformAdmin) {
+        throw AppError.forbidden(
+          "NOT_SKILL_OWNER",
+          "Only the skill's author or a platform admin may set its source",
+        );
+      }
+
+      let githubUrl: string | null;
+      if (body.githubUrl === null) {
+        githubUrl = null;
+      } else if (typeof body.githubUrl === "string") {
+        githubUrl = body.githubUrl;
+      } else {
+        throw AppError.badRequest(
+          "INVALID_BODY",
+          "Body must include 'githubUrl' as a string (to link) or null (to unlink).",
+        );
+      }
+
+      const updated = await skillService.setSkillSource(guid, githubUrl, authCtx.userId);
+
+      logger.info(
+        { guid, userId: authCtx.userId, action: githubUrl === null ? "unlink" : "link" },
+        "Skill source pointer updated",
+      );
+
+      activityRepo
+        ?.log(
+          authCtx.userId,
+          authCtx.email ?? "",
+          authCtx.displayName ?? "",
+          githubUrl === null ? "skill:source_unlink" : "skill:source_link",
+          {
+            skillId: guid,
+            skillName: updated.name,
+            repo: updated.source?.repo,
+            ref: updated.source?.ref,
+            path: updated.source?.path,
+          },
+        )
+        .catch((err) => logger.warn({ err }, "Failed to log skill:source activity"));
+
+      return c.json({ data: updated, error: null });
     },
   );
 

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -11,7 +11,7 @@ import type { SkillVersionRepository } from "./skillVersionRepository";
 import type { IStorageClient } from "../../../clients/storageClient";
 import type { SkillDocument, SkillMetadata, SkillDetailResponse, SkillVersionDocument, SkillSource } from "../../../shared/types/index";
 import { AppError } from "../../../shared/types/index";
-import { fetchSkillFromGitHub, type GitHubPullInput } from "./utils/githubPull";
+import { fetchSkillFromGitHub, parseGithubUrl, type GitHubPullInput } from "./utils/githubPull";
 import { computeVersionDiff, type VersionDiffResult } from "./utils/versionDiff";
 import { isReservedVerb } from "../../../shared/reservedVerbs";
 import { validateSkillFrontmatter } from "../../../shared/schemas/skillFrontmatter";
@@ -496,6 +496,124 @@ export class SkillService {
       userDisplayName: options?.userDisplayName,
       source: newSource,
     });
+  }
+
+  /**
+   * Attach (or clear) a GitHub source pointer on an existing skill without
+   * pulling. Lets a user link an originally-uploaded skill to its GitHub
+   * source first and trigger the actual sync separately. Pass `null` to
+   * unlink. The pointer is parsed from a GitHub URL (e.g.
+   * `https://github.com/owner/repo/tree/<ref>/<path>`); `lastSyncedAt` /
+   * `lastSyncedCommit` are intentionally absent until the first refresh.
+   */
+  async setSkillSource(
+    guid: string,
+    githubUrl: string | null,
+    userId: string,
+  ): Promise<SkillDetailResponse> {
+    const existing = await this.skillRepo.findByGuid(guid);
+    if (!existing) {
+      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+    }
+
+    if (githubUrl === null) {
+      await this.skillRepo.clearSource(guid, userId);
+      return this.getSkill(guid);
+    }
+
+    let parsed: { repo: string; ref?: string; path?: string };
+    try {
+      parsed = parseGithubUrl(githubUrl);
+    } catch (err) {
+      throw AppError.badRequest(
+        "INVALID_GITHUB_URL",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    const newSource: SkillSource = {
+      type: "github",
+      repo: parsed.repo,
+      ref: parsed.ref ?? "HEAD",
+      path: parsed.path ?? "",
+    };
+
+    await this.skillRepo.update(guid, { source: newSource, updatedBy: userId });
+    return this.getSkill(guid);
+  }
+
+  /**
+   * Dry-run a refresh: pull the latest content from the skill's stored
+   * GitHub source, compute a structured diff against the current latest
+   * version, and return the diff without persisting anything. Drives the
+   * "preview-then-confirm" UI flow on the detail-page advanced settings.
+   *
+   * Throws NO_SOURCE if the skill has no `source`. Throws PULL_FAILED with
+   * a useful message if the upstream folder no longer exists / responds.
+   */
+  async previewRefreshFromSource(guid: string): Promise<{
+    skill: { guid: string; name: string };
+    source: SkillSource;
+    pendingVersion: string;
+    hasChanges: boolean;
+    diff: VersionDiffResult;
+  }> {
+    const existing = await this.skillRepo.findByGuid(guid);
+    if (!existing) {
+      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+    }
+    if (!existing.source || existing.source.type !== "github") {
+      throw AppError.badRequest(
+        "NO_SOURCE",
+        "Skill has no linked GitHub source. Link one via PUT /api/v1/skills/:id/source first.",
+      );
+    }
+
+    const pulled = await fetchSkillFromGitHub({
+      repo: existing.source.repo,
+      ref: existing.source.ref,
+      path: existing.source.path,
+    });
+
+    const latestVersionDoc = await this.skillVersionRepo.findBySkillAndVersion(
+      existing.guid,
+      existing.latestVersion,
+    );
+    if (!latestVersionDoc) {
+      throw AppError.internalError(
+        "MISSING_VERSION",
+        `Latest version '${existing.latestVersion}' has no version row`,
+      );
+    }
+    const latestZip = await this.downloadPackage(latestVersionDoc.storageKey);
+    const diff = await computeVersionDiff(latestZip, pulled.zipBuffer);
+
+    const hasChanges =
+      diff.files.added.length > 0 ||
+      diff.files.removed.length > 0 ||
+      diff.files.modified.length > 0;
+
+    // Predict what the next version label will be. The actual bump
+    // happens inside `updateSkill` from the SKILL.md frontmatter, which
+    // is what the user already edited in the GitHub repo. We extract it
+    // out of the pulled ZIP so the UI can show "you'll create v1.2".
+    let pendingVersion = existing.latestVersion;
+    try {
+      const info = await this.extractSkillInfo(pulled.zipBuffer);
+      pendingVersion = info.version;
+    } catch {
+      // If the package can't be parsed (e.g. malformed frontmatter),
+      // fall back to the existing latest. The actual sync will surface
+      // the validation error properly.
+    }
+
+    return {
+      skill: { guid: existing.guid, name: existing.name },
+      source: { ...existing.source, lastSyncedCommit: pulled.resolvedCommitSha },
+      pendingVersion,
+      hasChanges,
+      diff,
+    };
   }
 
   /**

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -1132,11 +1132,15 @@ export class SkillService {
             repo: skill.source.repo,
             ref: skill.source.ref,
             path: skill.source.path,
-            lastSyncedAt:
-              skill.source.lastSyncedAt instanceof Date
-                ? skill.source.lastSyncedAt.toISOString()
-                : String(skill.source.lastSyncedAt),
-            lastSyncedCommit: skill.source.lastSyncedCommit,
+            // Both fields are optional and absent for the "linked but
+            // never synced" state. Only include them when present so
+            // we never serialize an Invalid Date.
+            ...(skill.source.lastSyncedAt instanceof Date
+              ? { lastSyncedAt: skill.source.lastSyncedAt.toISOString() }
+              : {}),
+            ...(typeof skill.source.lastSyncedCommit === "string" && skill.source.lastSyncedCommit
+              ? { lastSyncedCommit: skill.source.lastSyncedCommit }
+              : {}),
           }
         : undefined,
       nyxidServiceId: skill.nyxidServiceId ?? null,

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
@@ -4,7 +4,79 @@ import {
   fetchSkillFromGitHub,
   normalizePath,
   normalizeRepoIdentifier,
+  parseGithubUrl,
 } from "./githubPull";
+
+describe("parseGithubUrl", () => {
+  test("extracts repo + ref + path from a /tree/ URL", () => {
+    expect(
+      parseGithubUrl(
+        "https://github.com/ChronoAIProject/Ornn/tree/develop/skills/ornn-agent-manual-cli",
+      ),
+    ).toEqual({
+      repo: "ChronoAIProject/Ornn",
+      ref: "develop",
+      path: "skills/ornn-agent-manual-cli",
+    });
+  });
+
+  test("/tree/<ref> with no path → path undefined", () => {
+    expect(parseGithubUrl("https://github.com/owner/repo/tree/main")).toEqual({
+      repo: "owner/repo",
+      ref: "main",
+    });
+  });
+
+  test("bare repo URL → { repo } only", () => {
+    expect(parseGithubUrl("https://github.com/owner/repo")).toEqual({
+      repo: "owner/repo",
+    });
+  });
+
+  test("trailing slash is stripped", () => {
+    expect(parseGithubUrl("https://github.com/owner/repo/")).toEqual({
+      repo: "owner/repo",
+    });
+  });
+
+  test("rejects blob URLs (point at file, not folder)", () => {
+    expect(() =>
+      parseGithubUrl("https://github.com/owner/repo/blob/main/SKILL.md"),
+    ).toThrow(/blob URL/);
+  });
+
+  test("rejects non-github hosts", () => {
+    expect(() => parseGithubUrl("https://gitlab.com/owner/repo/tree/main")).toThrow(
+      /github\.com/,
+    );
+  });
+
+  test("rejects empty URL", () => {
+    expect(() => parseGithubUrl("")).toThrow(/empty/);
+  });
+
+  test("rejects URLs missing the repo name", () => {
+    expect(() => parseGithubUrl("https://github.com/owner")).toThrow(/<owner> and <repo>/);
+  });
+
+  test("rejects /tree/ without a ref segment", () => {
+    expect(() => parseGithubUrl("https://github.com/owner/repo/tree")).toThrow(
+      /missing the <ref>/,
+    );
+  });
+
+  test("multi-segment path is preserved", () => {
+    expect(
+      parseGithubUrl("https://github.com/owner/repo/tree/main/a/b/c"),
+    ).toEqual({ repo: "owner/repo", ref: "main", path: "a/b/c" });
+  });
+
+  test("accepts www.github.com host alias", () => {
+    expect(
+      parseGithubUrl("https://www.github.com/owner/repo/tree/main/x"),
+    ).toEqual({ repo: "owner/repo", ref: "main", path: "x" });
+  });
+});
 
 describe("normalizeRepoIdentifier", () => {
   test("accepts owner/name", () => {

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.ts
@@ -80,6 +80,73 @@ export function normalizePath(path: string | undefined): string {
 }
 
 /**
+ * Parse a GitHub URL into `{ repo, ref, path }`. Accepts the canonical
+ * tree-link form a user copies from a folder page:
+ *
+ *   https://github.com/<owner>/<repo>/tree/<ref>/<sub/dir/path>
+ *   https://github.com/<owner>/<repo>/tree/<ref>
+ *   https://github.com/<owner>/<repo>             (no tree, no ref → repo root)
+ *
+ * Rejects `blob/` URLs (they point at a single file, not a directory) and
+ * any URL that isn't on `github.com`. Branch names with slashes (e.g.
+ * `feature/foo-bar`) are NOT supported because the URL alone is ambiguous
+ * — `tree/feature/foo-bar/skills/x` could mean ref=feature/foo-bar
+ * path=skills/x OR ref=feature path=foo-bar/skills/x. The user can fall
+ * back to the explicit `{ repo, ref, path }` form for those.
+ */
+export function parseGithubUrl(rawUrl: string): { repo: string; ref?: string; path?: string } {
+  const url = rawUrl.trim();
+  if (!url) throw new Error("GitHub URL is empty");
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid GitHub URL '${rawUrl}'`);
+  }
+  if (parsed.host !== "github.com" && parsed.host !== "www.github.com") {
+    throw new Error(`Expected a github.com URL, got '${parsed.host}'`);
+  }
+
+  // Drop leading slash, split, drop trailing empty segment ("/foo/bar/" → ["foo","bar"]).
+  const segments = parsed.pathname.replace(/^\/+|\/+$/g, "").split("/").filter(Boolean);
+  if (segments.length < 2) {
+    throw new Error("GitHub URL must include both <owner> and <repo>");
+  }
+
+  const [owner, repoName, tree, ...rest] = segments;
+  const repo = `${owner}/${repoName}`;
+  normalizeRepoIdentifier(repo); // throws on invalid characters
+
+  // Bare repo URL: https://github.com/owner/repo (no tree segment).
+  if (tree === undefined) {
+    return { repo };
+  }
+
+  if (tree === "blob") {
+    throw new Error(
+      "GitHub blob URL points at a single file. Use the folder URL ('/tree/<ref>/<path>') of the skill root instead.",
+    );
+  }
+  if (tree !== "tree") {
+    throw new Error(
+      `Unsupported GitHub URL shape: '/${tree}/...'. Use the folder URL ('/tree/<ref>/<path>').`,
+    );
+  }
+
+  if (rest.length === 0) {
+    throw new Error("GitHub tree URL is missing the <ref> segment");
+  }
+
+  // First segment after `/tree/` is the ref. We accept simple refs only
+  // (no slashes) — see the doc comment above. Anything else and we make
+  // the user provide repo/ref/path explicitly.
+  const ref = rest[0];
+  const path = rest.slice(1).join("/");
+  return { repo, ref, path: path || undefined };
+}
+
+/**
  * Fetch and package a skill from a public GitHub repo.
  */
 export async function fetchSkillFromGitHub(

--- a/ornn-api/src/domains/skills/search/service.ts
+++ b/ornn-api/src/domains/skills/search/service.ts
@@ -410,5 +410,10 @@ function enrichItem(
     nyxidServiceSlug: s.nyxidServiceSlug ?? null,
     nyxidServiceLabel: s.nyxidServiceLabel ?? null,
     isSystemSkill: s.isSystemSkill === true,
+    // Boolean — true when the skill is linked to a GitHub source. The
+    // card uses this to render a small non-clickable GitHub mark in the
+    // badge row. We don't leak the actual repo URL to search results;
+    // the user can drill into the detail page for that.
+    hasGithubSource: !!(s.source && s.source.type === "github"),
   };
 }

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -355,6 +355,13 @@ export interface SkillSearchItem {
   nyxidServiceLabel?: string | null;
   /** Cached: true iff tied to an admin/platform-wide NyxID service. */
   isSystemSkill?: boolean;
+  /**
+   * True when the skill has a `source` pointer of type "github". The
+   * card UI uses this to render a small non-clickable GitHub mark; the
+   * actual repo URL is not exposed in search results — callers drill
+   * into the detail page if they want to follow the link.
+   */
+  hasGithubSource?: boolean;
 }
 
 export interface SkillSearchResponse {

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -167,10 +167,18 @@ export type SkillSource =
       ref: string;
       /** Subdirectory inside the repo that contains SKILL.md. Empty string = repo root. */
       path: string;
-      /** ISO timestamp of the most recent successful pull / refresh. */
-      lastSyncedAt: Date;
-      /** Commit SHA that was fetched at `lastSyncedAt`. Allows drift detection. */
-      lastSyncedCommit: string;
+      /**
+       * ISO timestamp of the most recent successful pull / refresh.
+       * Absent when the source pointer was attached without an immediate
+       * sync (the user can save a GitHub link first and trigger the sync
+       * later from the detail-page advanced options).
+       */
+      lastSyncedAt?: Date;
+      /**
+       * Commit SHA that was fetched at `lastSyncedAt`. Allows drift
+       * detection. Absent in the same "linked but not yet synced" state.
+       */
+      lastSyncedCommit?: string;
     };
 
 /**
@@ -273,8 +281,14 @@ export interface SkillDetailResponse {
     repo: string;
     ref: string;
     path: string;
-    lastSyncedAt: string;
-    lastSyncedCommit: string;
+    /**
+     * Absent when the skill was linked but not yet synced (the user can
+     * attach a GitHub URL via PUT /skills/:id/source first and trigger
+     * the sync separately via POST /skills/:id/refresh).
+     */
+    lastSyncedAt?: string;
+    /** Absent in the same "linked but never synced" state. */
+    lastSyncedCommit?: string;
   };
   /** NyxID service tie (null when untied). See `SkillDocument.nyxidServiceId`. */
   nyxidServiceId?: string | null;

--- a/ornn-web/package.json
+++ b/ornn-web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
     "@tanstack/react-query": "^5.62.0",
+    "diff": "^9.0.0",
     "framer-motion": "^11.15.0",
     "highlight.js": "^11.10.0",
     "i18next": "^25.8.17",
@@ -39,6 +40,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/diff": "^8.0.0",
     "@types/jszip": "^3.4.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/ornn-web/src/components/skill/AdvancedOptionsModal.tsx
+++ b/ornn-web/src/components/skill/AdvancedOptionsModal.tsx
@@ -15,12 +15,19 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
+import { VersionDiffView } from "@/components/skill/VersionDiffView";
 import { useMyNyxidServices } from "@/hooks/useMe";
-import { useTieSkillToNyxidService } from "@/hooks/useSkills";
+import {
+  usePreviewSkillRefresh,
+  useRefreshSkillFromSource,
+  useSetSkillSource,
+  useTieSkillToNyxidService,
+} from "@/hooks/useSkills";
 import { useToastStore } from "@/stores/toastStore";
+import type { RefreshPreviewResponse } from "@/services/skillApi";
 import type { SkillDetail } from "@/types/domain";
 
-type AdvancedSettingId = "nyxid-service-binding";
+type AdvancedSettingId = "nyxid-service-binding" | "github-link";
 
 interface AdvancedOptionsModalProps {
   isOpen: boolean;
@@ -38,6 +45,11 @@ const SETTINGS: ReadonlyArray<{
     id: "nyxid-service-binding",
     labelKey: "advancedOptions.nyxidServiceBinding",
     fallback: "Bind to NyxID Service",
+  },
+  {
+    id: "github-link",
+    labelKey: "advancedOptions.githubLink",
+    fallback: "Link to GitHub",
   },
 ];
 
@@ -88,6 +100,9 @@ export function AdvancedOptionsModal({ isOpen, onClose, skill }: AdvancedOptions
         <div className="min-w-0">
           {selected === "nyxid-service-binding" && (
             <NyxidServiceBindingPanel skill={skill} onClose={onClose} />
+          )}
+          {selected === "github-link" && (
+            <GithubLinkPanel skill={skill} onClose={onClose} />
           )}
         </div>
       </div>
@@ -269,6 +284,307 @@ interface ServiceOptionProps {
   tier: "admin" | "personal" | "none";
   selected: boolean;
   onSelect: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// GithubLinkPanel — attach / sync a GitHub source pointer
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconstruct a folder URL from a stored `source` pointer so the input
+ * defaults to whatever was last saved. Mirrors the URL the user would
+ * have typed in originally. Skills that have never been linked default
+ * to the empty string.
+ */
+function urlFromSource(skill: SkillDetail): string {
+  const src = skill.source;
+  if (!src || src.type !== "github") return "";
+  const ref = src.lastSyncedCommit || src.ref || "HEAD";
+  const pathSuffix = src.path ? `/${src.path.replace(/^\/+/, "")}` : "";
+  return `https://github.com/${src.repo}/tree/${ref}${pathSuffix}`;
+}
+
+function GithubLinkPanel({ skill, onClose }: { skill: SkillDetail; onClose: () => void }) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const setSourceMutation = useSetSkillSource(skill.guid);
+  const previewMutation = usePreviewSkillRefresh();
+  const refreshMutation = useRefreshSkillFromSource(skill.guid);
+
+  const initialUrl = useMemo(() => urlFromSource(skill), [skill]);
+  const [url, setUrl] = useState(initialUrl);
+  const [skipValidation, setSkipValidation] = useState(false);
+  const [preview, setPreview] = useState<RefreshPreviewResponse | null>(null);
+
+  // When the modal reopens (or the skill changes), reset to whatever the
+  // server says is currently linked.
+  useEffect(() => {
+    setUrl(initialUrl);
+    setPreview(null);
+  }, [initialUrl]);
+
+  const isLinked = !!(skill.source && skill.source.type === "github");
+  const dirty = url.trim() !== initialUrl;
+
+  const handleSave = async () => {
+    try {
+      const trimmed = url.trim();
+      await setSourceMutation.mutateAsync({
+        guid: skill.guid,
+        githubUrl: trimmed === "" ? null : trimmed,
+      });
+      addToast({
+        type: "success",
+        message:
+          trimmed === ""
+            ? (t("githubLink.unlinkSuccess", "GitHub link removed") as string)
+            : (t("githubLink.linkSuccess", "GitHub link saved") as string),
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const handleUnlink = async () => {
+    try {
+      await setSourceMutation.mutateAsync({ guid: skill.guid, githubUrl: null });
+      setUrl("");
+      setPreview(null);
+      addToast({
+        type: "success",
+        message: t("githubLink.unlinkSuccess", "GitHub link removed") as string,
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const handlePreviewSync = async () => {
+    try {
+      const result = await previewMutation.mutateAsync(skill.guid);
+      if (!result.hasChanges) {
+        addToast({
+          type: "success",
+          message: t(
+            "githubLink.alreadyInSync",
+            "Already in sync — no changes to pull from GitHub.",
+          ) as string,
+        });
+        return;
+      }
+      setPreview(result);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const handleApplySync = async () => {
+    try {
+      await refreshMutation.mutateAsync({ guid: skill.guid, skipValidation });
+      setPreview(null);
+      addToast({
+        type: "success",
+        message: t(
+          "githubLink.syncSuccess",
+          "Synced from GitHub — new version published.",
+        ) as string,
+      });
+      onClose();
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const lastSyncedAt = skill.source?.lastSyncedAt;
+
+  // ── Preview mode ─────────────────────────────────────────────────────
+  if (preview) {
+    return (
+      <div className="flex h-full flex-col gap-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="font-display text-lg font-semibold text-strong">
+              {t("githubLink.previewTitle", "Sync preview") as string}
+            </h3>
+            <p className="font-body text-xs text-text-muted">
+              {t("githubLink.previewSubtitle", {
+                defaultValue:
+                  "Apply this sync to publish v{{version}} of {{name}} from the linked GitHub source.",
+                version: preview.pendingVersion,
+                name: preview.skill.name,
+              })}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto pr-1">
+          <VersionDiffView diff={preview.diff} showSummary />
+        </div>
+
+        <div className="flex items-center justify-between gap-3 border-t border-subtle pt-3">
+          <label className="inline-flex items-center gap-2 font-body text-xs text-text-muted">
+            <input
+              type="checkbox"
+              checked={skipValidation}
+              onChange={(e) => setSkipValidation(e.target.checked)}
+            />
+            {t("githubLink.skipValidationLabel", "Skip Ornn package validation")}
+          </label>
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => setPreview(null)}
+              disabled={refreshMutation.isPending}
+            >
+              {t("common.cancel", "Cancel")}
+            </Button>
+            <Button onClick={handleApplySync} loading={refreshMutation.isPending}>
+              {t("githubLink.applySync", "Apply sync")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Edit mode ────────────────────────────────────────────────────────
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <p className="font-body text-sm text-text-muted">
+        {t(
+          "githubLink.intro",
+          "Point this skill at a folder in a public GitHub repo. Saving the link does not pull anything; click Sync afterwards to preview changes and publish a new version.",
+        )}
+      </p>
+
+      <div className="flex-1 space-y-4 overflow-y-auto pr-1">
+        <div className="space-y-2">
+          <label
+            htmlFor="github-url"
+            className="block font-heading text-[10px] uppercase tracking-wider text-text-muted"
+          >
+            {t("githubLink.urlLabel", "GitHub folder URL")}
+          </label>
+          <input
+            id="github-url"
+            type="url"
+            inputMode="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://github.com/owner/repo/tree/main/path/to/skill"
+            className="
+              w-full rounded border border-strong-edge bg-card px-3 py-2
+              font-mono text-sm text-text-primary
+              focus:outline-none focus:border-strong
+            "
+          />
+          <p className="font-body text-[11px] text-text-muted">
+            {t(
+              "githubLink.urlHelp",
+              "Use the folder URL (the /tree/<ref>/<path> form). The skill's SKILL.md must be at the root of that folder. Default branch and repo-root URLs work too.",
+            )}
+          </p>
+        </div>
+
+        <label className="inline-flex items-start gap-2 font-body text-sm text-text-muted">
+          <input
+            type="checkbox"
+            checked={skipValidation}
+            onChange={(e) => setSkipValidation(e.target.checked)}
+            className="mt-1"
+          />
+          <span>
+            <span className="block font-heading text-xs text-text-primary">
+              {t("githubLink.skipValidationLabel", "Skip Ornn package validation")}
+            </span>
+            <span className="block text-[11px]">
+              {t(
+                "githubLink.skipValidationHelp",
+                "GitHub-hosted skills don't always follow Ornn's package rules; tick this if you trust the upstream and want syncs to succeed even when the validator would reject the layout.",
+              )}
+            </span>
+          </span>
+        </label>
+
+        {isLinked && (
+          <div className="rounded border border-subtle bg-elevated p-3">
+            <p className="font-heading text-[10px] uppercase tracking-wider text-text-muted">
+              {t("githubLink.currentlyLinked", "Currently linked")}
+            </p>
+            <p className="mt-1 font-mono text-xs text-text-primary break-all">{initialUrl}</p>
+            <p className="mt-1 font-body text-[11px] text-text-muted">
+              {lastSyncedAt
+                ? t("githubLink.lastSyncedAt", {
+                    defaultValue: "Last synced {{when}}",
+                    when: new Date(lastSyncedAt).toLocaleString(),
+                  })
+                : t("githubLink.neverSynced", "Linked but never synced.")}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-subtle pt-3">
+        <div className="flex gap-2">
+          {isLinked && (
+            <span
+              title={
+                dirty
+                  ? (t(
+                      "githubLink.saveBeforeSync",
+                      "Save the URL change first, then sync.",
+                    ) as string)
+                  : undefined
+              }
+            >
+              <Button
+                variant="secondary"
+                onClick={handlePreviewSync}
+                loading={previewMutation.isPending}
+                disabled={dirty}
+              >
+                {t("githubLink.syncButton", "Sync from GitHub")}
+              </Button>
+            </span>
+          )}
+          {isLinked && (
+            <Button
+              variant="danger"
+              onClick={handleUnlink}
+              loading={setSourceMutation.isPending}
+            >
+              {t("githubLink.unlinkButton", "Unlink")}
+            </Button>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={setSourceMutation.isPending}>
+            {t("common.close", "Close")}
+          </Button>
+          <Button
+            onClick={handleSave}
+            loading={setSourceMutation.isPending}
+            disabled={!dirty}
+          >
+            {t("common.save", "Save")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function ServiceOption({ label, description, tier, selected, onSelect }: ServiceOptionProps) {

--- a/ornn-web/src/components/skill/AdvancedOptionsModal.tsx
+++ b/ornn-web/src/components/skill/AdvancedOptionsModal.tsx
@@ -69,13 +69,20 @@ export function AdvancedOptionsModal({ isOpen, onClose, skill }: AdvancedOptions
       isOpen={isOpen}
       onClose={onClose}
       title={t("advancedOptions.title", "Advanced options") as string}
-      className="!max-w-4xl"
+      className="!max-w-4xl !h-[80vh] !max-h-[80vh] !overflow-hidden flex flex-col"
     >
-      <div className="grid min-h-[420px] grid-cols-[200px_1fr] gap-5">
+      {/*
+        Fixed-height modal. The grid below grabs the remaining vertical
+        space (flex-1 min-h-0) and gives both cells their own scroll
+        container, so a long settings list on the left and a long
+        settings panel on the right scroll independently — neither one
+        forces the modal to grow.
+      */}
+      <div className="grid flex-1 min-h-0 grid-cols-[200px_1fr] gap-5">
         {/* Left rail — settings list */}
         <nav
           aria-label={t("advancedOptions.navLabel", "Advanced settings") as string}
-          className="flex flex-col gap-1 border-r border-subtle pr-4"
+          className="flex flex-col gap-1 overflow-y-auto border-r border-subtle pr-4"
         >
           {SETTINGS.map((s) => {
             const active = s.id === selected;
@@ -84,7 +91,7 @@ export function AdvancedOptionsModal({ isOpen, onClose, skill }: AdvancedOptions
                 key={s.id}
                 type="button"
                 onClick={() => setSelected(s.id)}
-                className={`rounded-sm px-3 py-2 text-left font-mono text-[11px] uppercase tracking-wider transition-colors ${
+                className={`shrink-0 rounded-sm px-3 py-2 text-left font-mono text-[11px] uppercase tracking-wider transition-colors ${
                   active
                     ? "bg-accent-soft text-accent"
                     : "text-meta hover:bg-elevated hover:text-strong"
@@ -96,8 +103,13 @@ export function AdvancedOptionsModal({ isOpen, onClose, skill }: AdvancedOptions
           })}
         </nav>
 
-        {/* Right pane — the selected setting's content */}
-        <div className="min-w-0">
+        {/*
+          Right pane — the selected setting's content. The panel itself
+          owns its scroll via its own flex column (header / scrollable
+          body / footer), so we just give it a min-h-0 flex column to
+          fill and let the panel handle the inside.
+        */}
+        <div className="flex min-h-0 min-w-0 flex-col">
           {selected === "nyxid-service-binding" && (
             <NyxidServiceBindingPanel skill={skill} onClose={onClose} />
           )}

--- a/ornn-web/src/components/skill/SkillCard.tsx
+++ b/ornn-web/src/components/skill/SkillCard.tsx
@@ -111,6 +111,17 @@ export function SkillCard({
           {skill.name}
         </h3>
         <div className="flex shrink-0 items-center gap-1.5 flex-wrap justify-end">
+          {skill.hasGithubSource && (
+            <span
+              className="inline-flex h-5 w-5 items-center justify-center text-text-muted"
+              aria-label="Linked to GitHub"
+              title="Linked to GitHub"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                <path d="M12 .5a11.5 11.5 0 00-3.64 22.42c.58.11.79-.25.79-.56v-2.16c-3.21.7-3.89-1.37-3.89-1.37-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.97.1-.76.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.72 0-1.26.45-2.3 1.19-3.11-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.92-.39 2.9-.39.99 0 1.98.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.11 3.06.74.81 1.19 1.85 1.19 3.11 0 4.45-2.7 5.42-5.28 5.71.41.35.78 1.05.78 2.12v3.14c0 .31.21.67.8.56A11.5 11.5 0 0012 .5z" />
+              </svg>
+            </span>
+          )}
           <PermissionBadges skill={skill} />
           {skill.isSystemForMe && skill.systemForService && (
             <Badge color="yellow">⚙ {skill.systemForService.label}</Badge>

--- a/ornn-web/src/components/skill/SkillHeroStrip.tsx
+++ b/ornn-web/src/components/skill/SkillHeroStrip.tsx
@@ -229,8 +229,24 @@ export function SkillHeroStrip({
         </div>
 
         {/* Actions */}
-        {isAuthenticated && (
+        {(isAuthenticated || (skill.source && skill.source.type === "github")) && (
           <div className="flex shrink-0 items-center gap-2">
+            {skill.source && skill.source.type === "github" && (
+              <a
+                href={buildGithubFolderUrl(skill.source)}
+                target="_blank"
+                rel="noreferrer noopener"
+                aria-label={t("skillDetail.heroOpenOnGithub", "Open on GitHub") as string}
+                title={t("skillDetail.heroOpenOnGithub", "Open on GitHub") as string}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-sm border border-strong-edge text-body transition-colors hover:bg-elevated hover:text-strong hover:border-strong"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                  <path d="M12 .5a11.5 11.5 0 00-3.64 22.42c.58.11.79-.25.79-.56v-2.16c-3.21.7-3.89-1.37-3.89-1.37-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.97.1-.76.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.72 0-1.26.45-2.3 1.19-3.11-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.92-.39 2.9-.39.99 0 1.98.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.11 3.06.74.81 1.19 1.85 1.19 3.11 0 4.45-2.7 5.42-5.28 5.71.41.35.78 1.05.78 2.12v3.14c0 .31.21.67.8.56A11.5 11.5 0 0012 .5z" />
+                </svg>
+              </a>
+            )}
+            {isAuthenticated && (
+              <>
             <button
               type="button"
               onClick={onTryPlayground}
@@ -283,11 +299,25 @@ export function SkillHeroStrip({
                 </div>
               )}
             </div>
+              </>
+            )}
           </div>
         )}
       </div>
     </section>
   );
+}
+
+/**
+ * Build a deep link to the skill's source folder on GitHub. Prefers the
+ * exact synced commit when available so the link is stable; falls back
+ * to the originally-requested ref (or "HEAD") when the skill was linked
+ * but never synced. Mirrors `GitHubOriginChip`'s logic.
+ */
+function buildGithubFolderUrl(source: NonNullable<SkillDetail["source"]>): string {
+  const treeRef = source.lastSyncedCommit || source.ref || "HEAD";
+  const pathSuffix = source.path ? `/${source.path.replace(/^\/+/, "")}` : "";
+  return `https://github.com/${source.repo}/tree/${treeRef}${pathSuffix}`;
 }
 
 function DropdownItem({ children, onClick }: { children: ReactNode; onClick: () => void }) {

--- a/ornn-web/src/components/skill/SkillVersionList.tsx
+++ b/ornn-web/src/components/skill/SkillVersionList.tsx
@@ -219,26 +219,47 @@ export function SkillVersionList({
                       : t("skillDetail.markDeprecated")}
                   </button>
                 )}
-                {canManage &&
-                  onDeleteVersion &&
-                  !isLatest &&
-                  versions.length > 1 && (
+                {canManage && onDeleteVersion && (() => {
+                  const isOnly = versions.length <= 1;
+                  // Backend rejects deleting the only-remaining version
+                  // (use the danger-zone "Delete skill" instead) and the
+                  // current latest (publish a newer version first). We
+                  // mirror that here as a disabled button with a tooltip
+                  // so the affordance stays discoverable.
+                  const blockedReason = isOnly
+                    ? (t(
+                        "skillDetail.deleteVersionBlockedOnly",
+                        "Can't delete the only remaining version. Use 'Delete skill' in the danger zone instead.",
+                      ) as string)
+                    : isLatest
+                      ? (t(
+                          "skillDetail.deleteVersionBlockedLatest",
+                          "Can't delete the current latest version. Publish a newer version first, then delete this one.",
+                        ) as string)
+                      : null;
+                  const isBlocked = blockedReason !== null;
+                  return (
                     <button
                       type="button"
-                      onClick={() => setDeleteTarget(v)}
-                      disabled={isDeleting}
-                      title={t("skillDetail.deleteVersion", "Delete this version")}
+                      onClick={() => !isBlocked && setDeleteTarget(v)}
+                      disabled={isDeleting || isBlocked}
+                      title={
+                        blockedReason ??
+                        (t("skillDetail.deleteVersion", "Delete this version") as string)
+                      }
                       className="
                         shrink-0 rounded border border-transparent px-2 py-1
                         font-body text-xs text-text-muted
                         hover:text-neon-red hover:border-neon-red/40
                         disabled:opacity-50 disabled:cursor-not-allowed
+                        disabled:hover:text-text-muted disabled:hover:border-transparent
                         transition-colors cursor-pointer
                       "
                     >
                       {t("common.delete")}
                     </button>
-                  )}
+                  );
+                })()}
               </div>
             </li>
           );

--- a/ornn-web/src/components/skill/VersionDiffModal.tsx
+++ b/ornn-web/src/components/skill/VersionDiffModal.tsx
@@ -5,9 +5,9 @@
  * Hits `GET /api/v1/skills/:idOrName/versions/:from/diff/:to`. Server
  * inlines text content for both sides of every modified file (capped at
  * ~64 KiB per side; flag `truncated: true` when capped) so we can do
- * line-level diff client-side via the `diff` package without a second
- * round-trip. Binary files come back without inline content; we just
- * report the size + hash change.
+ * line-level diff client-side without a second round-trip. Binary files
+ * come back without inline content; we just report the size + hash
+ * change.
  *
  * The default (`from`, `to`) lands as (currently-viewed version, latest)
  * so the common case — "what changed since the version I'm looking at" —
@@ -15,20 +15,19 @@
  * compares are short-circuited locally (the backend would 400 with
  * `SAME_VERSION` and the round-trip is wasted).
  *
+ * Diff rendering is delegated to `VersionDiffView` so the same renderer
+ * powers the GitHub-link sync-preview flow on the advanced options
+ * panel.
+ *
  * @module components/skill/VersionDiffModal
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { diffLines } from "diff";
 import { Modal } from "@/components/ui/Modal";
+import { VersionDiffView } from "@/components/skill/VersionDiffView";
 import { useSkillVersionDiff } from "@/hooks/useSkills";
-import type {
-  DiffFileAdded,
-  DiffFileModified,
-  DiffFileRemoved,
-  SkillVersionEntry,
-} from "@/types/domain";
+import type { SkillVersionEntry } from "@/types/domain";
 
 export interface VersionDiffModalProps {
   isOpen: boolean;
@@ -39,163 +38,6 @@ export interface VersionDiffModalProps {
   versions: SkillVersionEntry[];
   /** Version the page is currently rendering — defaults the `from` picker. */
   currentVersion: string;
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
-  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
-}
-
-/**
- * Render a unified line-level diff for one modified text file. Uses the
- * `diff` package's `diffLines` to produce a sequence of chunks:
- * additions, deletions, and unchanged context. Each chunk's `value`
- * already includes trailing newlines, so we split on `\n` to render one
- * `<div>` per line and color the chunk accordingly.
- */
-function ModifiedFileDiff({ file }: { file: DiffFileModified }) {
-  const { t } = useTranslation();
-  if (!file.isText || file.fromContent === undefined || file.toContent === undefined) {
-    return (
-      <p className="font-mono text-[11px] text-text-muted">
-        {t("versionDiff.binaryHint", {
-          defaultValue:
-            "Binary file. {{from}} → {{to}} (hash {{fromHash}} → {{toHash}})",
-          from: formatBytes(file.fromBytes),
-          to: formatBytes(file.toBytes),
-          fromHash: file.fromHash.slice(0, 8),
-          toHash: file.toHash.slice(0, 8),
-        })}
-      </p>
-    );
-  }
-
-  const chunks = diffLines(file.fromContent, file.toContent);
-  return (
-    <div className="overflow-x-auto rounded border border-subtle bg-page font-mono text-[11px] leading-snug">
-      {chunks.map((chunk, idx) => {
-        const lines = chunk.value.split("\n");
-        // diffLines preserves a trailing empty token after the final newline;
-        // drop it so we don't emit a blank line per chunk.
-        if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
-        const sigil = chunk.added ? "+" : chunk.removed ? "-" : " ";
-        const lineCls = chunk.added
-          ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-          : chunk.removed
-            ? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
-            : "text-text-muted";
-        return (
-          <div key={idx} className={lineCls}>
-            {lines.map((line, lineIdx) => (
-              <div key={lineIdx} className="px-3 py-px whitespace-pre-wrap break-all">
-                <span className="select-none mr-2 text-text-muted/60">{sigil}</span>
-                {line || " "}
-              </div>
-            ))}
-          </div>
-        );
-      })}
-      {file.truncated && (
-        <p className="border-t border-subtle px-3 py-1.5 text-[11px] text-text-muted italic">
-          {t("versionDiff.truncated", "File content truncated at 64 KiB per side.")}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function FileHeader({
-  path,
-  meta,
-  badge,
-  badgeCls,
-}: {
-  path: string;
-  meta?: string;
-  badge: string;
-  badgeCls: string;
-}) {
-  return (
-    <div className="flex items-baseline justify-between gap-3 border-b border-subtle pb-1.5">
-      <div className="flex items-baseline gap-2 min-w-0">
-        <span
-          className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${badgeCls}`}
-        >
-          {badge}
-        </span>
-        <span className="truncate font-mono text-xs text-text-primary">{path}</span>
-      </div>
-      {meta && <span className="shrink-0 font-mono text-[10px] text-text-muted">{meta}</span>}
-    </div>
-  );
-}
-
-function AddedFile({ file }: { file: DiffFileAdded }) {
-  const { t } = useTranslation();
-  return (
-    <div className="space-y-1.5">
-      <FileHeader
-        path={file.path}
-        meta={formatBytes(file.bytes)}
-        badge={t("versionDiff.added", "added")}
-        badgeCls="bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
-      />
-      {file.isText && file.content !== undefined ? (
-        <pre className="overflow-x-auto rounded border border-subtle bg-page p-3 font-mono text-[11px] leading-snug text-text-primary whitespace-pre-wrap break-all">
-          {file.content}
-        </pre>
-      ) : (
-        <p className="font-mono text-[11px] text-text-muted">
-          {t("versionDiff.binaryAdded", {
-            defaultValue: "Binary file ({{size}}).",
-            size: formatBytes(file.bytes),
-          })}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function RemovedFile({ file }: { file: DiffFileRemoved }) {
-  const { t } = useTranslation();
-  return (
-    <div className="space-y-1.5">
-      <FileHeader
-        path={file.path}
-        meta={formatBytes(file.bytes)}
-        badge={t("versionDiff.removed", "removed")}
-        badgeCls="bg-rose-500/15 text-rose-700 dark:text-rose-300"
-      />
-      {file.isText && file.content !== undefined ? (
-        <pre className="overflow-x-auto rounded border border-subtle bg-page p-3 font-mono text-[11px] leading-snug text-text-primary whitespace-pre-wrap break-all">
-          {file.content}
-        </pre>
-      ) : (
-        <p className="font-mono text-[11px] text-text-muted">
-          {t("versionDiff.binaryRemoved", {
-            defaultValue: "Binary file ({{size}}).",
-            size: formatBytes(file.bytes),
-          })}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function ModifiedFile({ file }: { file: DiffFileModified }) {
-  const { t } = useTranslation();
-  return (
-    <div className="space-y-1.5">
-      <FileHeader
-        path={file.path}
-        meta={`${formatBytes(file.fromBytes)} → ${formatBytes(file.toBytes)}`}
-        badge={t("versionDiff.modified", "modified")}
-        badgeCls="bg-amber-500/15 text-amber-700 dark:text-amber-300"
-      />
-      <ModifiedFileDiff file={file} />
-    </div>
-  );
 }
 
 export function VersionDiffModal({
@@ -241,17 +83,6 @@ export function VersionDiffModal({
     fromVersion,
     toVersion,
   );
-
-  const summary = useMemo(() => {
-    if (!data) return null;
-    const f = data.diff.files;
-    return {
-      added: f.added.length,
-      removed: f.removed.length,
-      modified: f.modified.length,
-      unchanged: f.unchangedCount,
-    };
-  }, [data]);
 
   return (
     <Modal
@@ -317,19 +148,6 @@ export function VersionDiffModal({
                 ))}
               </select>
             </label>
-
-            {summary && !sameVersion && (
-              <p className="ml-auto pb-2 font-mono text-[11px] text-text-muted">
-                {t("versionDiff.summary", {
-                  defaultValue:
-                    "{{added}} added · {{removed}} removed · {{modified}} modified · {{unchanged}} unchanged",
-                  added: summary.added,
-                  removed: summary.removed,
-                  modified: summary.modified,
-                  unchanged: summary.unchanged,
-                })}
-              </p>
-            )}
           </div>
 
           {sameVersion && (
@@ -355,66 +173,7 @@ export function VersionDiffModal({
             </p>
           )}
 
-          {!sameVersion && data && summary && (
-            <div className="space-y-6">
-              {summary.added === 0 && summary.removed === 0 && summary.modified === 0 ? (
-                <p className="font-body text-sm text-text-muted">
-                  {t(
-                    "versionDiff.noChanges",
-                    "These two versions have identical files.",
-                  )}
-                </p>
-              ) : (
-                <>
-                  {data.diff.files.modified.length > 0 && (
-                    <section className="space-y-3">
-                      <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
-                        {t("versionDiff.modifiedHeading", {
-                          defaultValue: "Modified ({{count}})",
-                          count: data.diff.files.modified.length,
-                        })}
-                      </h3>
-                      <div className="space-y-4">
-                        {data.diff.files.modified.map((f) => (
-                          <ModifiedFile key={f.path} file={f} />
-                        ))}
-                      </div>
-                    </section>
-                  )}
-                  {data.diff.files.added.length > 0 && (
-                    <section className="space-y-3">
-                      <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
-                        {t("versionDiff.addedHeading", {
-                          defaultValue: "Added ({{count}})",
-                          count: data.diff.files.added.length,
-                        })}
-                      </h3>
-                      <div className="space-y-4">
-                        {data.diff.files.added.map((f) => (
-                          <AddedFile key={f.path} file={f} />
-                        ))}
-                      </div>
-                    </section>
-                  )}
-                  {data.diff.files.removed.length > 0 && (
-                    <section className="space-y-3">
-                      <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
-                        {t("versionDiff.removedHeading", {
-                          defaultValue: "Removed ({{count}})",
-                          count: data.diff.files.removed.length,
-                        })}
-                      </h3>
-                      <div className="space-y-4">
-                        {data.diff.files.removed.map((f) => (
-                          <RemovedFile key={f.path} file={f} />
-                        ))}
-                      </div>
-                    </section>
-                  )}
-                </>
-              )}
-            </div>
-          )}
+          {!sameVersion && data && <VersionDiffView diff={data.diff} showSummary />}
         </div>
       )}
     </Modal>

--- a/ornn-web/src/components/skill/VersionDiffModal.tsx
+++ b/ornn-web/src/components/skill/VersionDiffModal.tsx
@@ -1,0 +1,422 @@
+/**
+ * VersionDiffModal — pick two published versions of a skill and render a
+ * file-level diff between them.
+ *
+ * Hits `GET /api/v1/skills/:idOrName/versions/:from/diff/:to`. Server
+ * inlines text content for both sides of every modified file (capped at
+ * ~64 KiB per side; flag `truncated: true` when capped) so we can do
+ * line-level diff client-side via the `diff` package without a second
+ * round-trip. Binary files come back without inline content; we just
+ * report the size + hash change.
+ *
+ * The default (`from`, `to`) lands as (currently-viewed version, latest)
+ * so the common case — "what changed since the version I'm looking at" —
+ * is one click away. The user can re-pick either side; same-version
+ * compares are short-circuited locally (the backend would 400 with
+ * `SAME_VERSION` and the round-trip is wasted).
+ *
+ * @module components/skill/VersionDiffModal
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { diffLines } from "diff";
+import { Modal } from "@/components/ui/Modal";
+import { useSkillVersionDiff } from "@/hooks/useSkills";
+import type {
+  DiffFileAdded,
+  DiffFileModified,
+  DiffFileRemoved,
+  SkillVersionEntry,
+} from "@/types/domain";
+
+export interface VersionDiffModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Skill id or name — passed straight to the diff endpoint. */
+  idOrName: string;
+  /** Full version list (already-fetched). Newest first. */
+  versions: SkillVersionEntry[];
+  /** Version the page is currently rendering — defaults the `from` picker. */
+  currentVersion: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+}
+
+/**
+ * Render a unified line-level diff for one modified text file. Uses the
+ * `diff` package's `diffLines` to produce a sequence of chunks:
+ * additions, deletions, and unchanged context. Each chunk's `value`
+ * already includes trailing newlines, so we split on `\n` to render one
+ * `<div>` per line and color the chunk accordingly.
+ */
+function ModifiedFileDiff({ file }: { file: DiffFileModified }) {
+  const { t } = useTranslation();
+  if (!file.isText || file.fromContent === undefined || file.toContent === undefined) {
+    return (
+      <p className="font-mono text-[11px] text-text-muted">
+        {t("versionDiff.binaryHint", {
+          defaultValue:
+            "Binary file. {{from}} → {{to}} (hash {{fromHash}} → {{toHash}})",
+          from: formatBytes(file.fromBytes),
+          to: formatBytes(file.toBytes),
+          fromHash: file.fromHash.slice(0, 8),
+          toHash: file.toHash.slice(0, 8),
+        })}
+      </p>
+    );
+  }
+
+  const chunks = diffLines(file.fromContent, file.toContent);
+  return (
+    <div className="overflow-x-auto rounded border border-subtle bg-page font-mono text-[11px] leading-snug">
+      {chunks.map((chunk, idx) => {
+        const lines = chunk.value.split("\n");
+        // diffLines preserves a trailing empty token after the final newline;
+        // drop it so we don't emit a blank line per chunk.
+        if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+        const sigil = chunk.added ? "+" : chunk.removed ? "-" : " ";
+        const lineCls = chunk.added
+          ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+          : chunk.removed
+            ? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
+            : "text-text-muted";
+        return (
+          <div key={idx} className={lineCls}>
+            {lines.map((line, lineIdx) => (
+              <div key={lineIdx} className="px-3 py-px whitespace-pre-wrap break-all">
+                <span className="select-none mr-2 text-text-muted/60">{sigil}</span>
+                {line || " "}
+              </div>
+            ))}
+          </div>
+        );
+      })}
+      {file.truncated && (
+        <p className="border-t border-subtle px-3 py-1.5 text-[11px] text-text-muted italic">
+          {t("versionDiff.truncated", "File content truncated at 64 KiB per side.")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function FileHeader({
+  path,
+  meta,
+  badge,
+  badgeCls,
+}: {
+  path: string;
+  meta?: string;
+  badge: string;
+  badgeCls: string;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-subtle pb-1.5">
+      <div className="flex items-baseline gap-2 min-w-0">
+        <span
+          className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${badgeCls}`}
+        >
+          {badge}
+        </span>
+        <span className="truncate font-mono text-xs text-text-primary">{path}</span>
+      </div>
+      {meta && <span className="shrink-0 font-mono text-[10px] text-text-muted">{meta}</span>}
+    </div>
+  );
+}
+
+function AddedFile({ file }: { file: DiffFileAdded }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-1.5">
+      <FileHeader
+        path={file.path}
+        meta={formatBytes(file.bytes)}
+        badge={t("versionDiff.added", "added")}
+        badgeCls="bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+      />
+      {file.isText && file.content !== undefined ? (
+        <pre className="overflow-x-auto rounded border border-subtle bg-page p-3 font-mono text-[11px] leading-snug text-text-primary whitespace-pre-wrap break-all">
+          {file.content}
+        </pre>
+      ) : (
+        <p className="font-mono text-[11px] text-text-muted">
+          {t("versionDiff.binaryAdded", {
+            defaultValue: "Binary file ({{size}}).",
+            size: formatBytes(file.bytes),
+          })}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function RemovedFile({ file }: { file: DiffFileRemoved }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-1.5">
+      <FileHeader
+        path={file.path}
+        meta={formatBytes(file.bytes)}
+        badge={t("versionDiff.removed", "removed")}
+        badgeCls="bg-rose-500/15 text-rose-700 dark:text-rose-300"
+      />
+      {file.isText && file.content !== undefined ? (
+        <pre className="overflow-x-auto rounded border border-subtle bg-page p-3 font-mono text-[11px] leading-snug text-text-primary whitespace-pre-wrap break-all">
+          {file.content}
+        </pre>
+      ) : (
+        <p className="font-mono text-[11px] text-text-muted">
+          {t("versionDiff.binaryRemoved", {
+            defaultValue: "Binary file ({{size}}).",
+            size: formatBytes(file.bytes),
+          })}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ModifiedFile({ file }: { file: DiffFileModified }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-1.5">
+      <FileHeader
+        path={file.path}
+        meta={`${formatBytes(file.fromBytes)} → ${formatBytes(file.toBytes)}`}
+        badge={t("versionDiff.modified", "modified")}
+        badgeCls="bg-amber-500/15 text-amber-700 dark:text-amber-300"
+      />
+      <ModifiedFileDiff file={file} />
+    </div>
+  );
+}
+
+export function VersionDiffModal({
+  isOpen,
+  onClose,
+  idOrName,
+  versions,
+  currentVersion,
+}: VersionDiffModalProps) {
+  const { t } = useTranslation();
+
+  // Latest is the first row (versions are newest-first).
+  const latestVersion = versions[0]?.version ?? "";
+
+  // Default `from` = current; `to` = latest. If the user is already on
+  // latest, default `from` to the second-newest so the picker isn't
+  // pointing at the same row on both sides.
+  const [fromVersion, setFromVersion] = useState<string>(() => {
+    if (currentVersion && currentVersion !== latestVersion) return currentVersion;
+    return versions[1]?.version ?? currentVersion ?? "";
+  });
+  const [toVersion, setToVersion] = useState<string>(latestVersion);
+
+  // If the user reopens the modal after viewing a different version, snap
+  // the defaults to the new `currentVersion`. Skipped while open so manual
+  // picks aren't trampled mid-session.
+  useEffect(() => {
+    if (!isOpen) {
+      const nextFrom =
+        currentVersion && currentVersion !== latestVersion
+          ? currentVersion
+          : versions[1]?.version ?? currentVersion ?? "";
+      setFromVersion(nextFrom);
+      setToVersion(latestVersion);
+    }
+  }, [isOpen, currentVersion, latestVersion, versions]);
+
+  const sameVersion = fromVersion && toVersion && fromVersion === toVersion;
+  const enoughVersions = versions.length >= 2;
+
+  const { data, isLoading, isFetching, error } = useSkillVersionDiff(
+    idOrName,
+    fromVersion,
+    toVersion,
+  );
+
+  const summary = useMemo(() => {
+    if (!data) return null;
+    const f = data.diff.files;
+    return {
+      added: f.added.length,
+      removed: f.removed.length,
+      modified: f.modified.length,
+      unchanged: f.unchangedCount,
+    };
+  }, [data]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t("versionDiff.title", "Compare versions") as string}
+      className="!max-w-4xl"
+    >
+      {!enoughVersions ? (
+        <p className="font-body text-sm text-text-muted">
+          {t(
+            "versionDiff.needTwoVersions",
+            "This skill only has one version — there's nothing to compare yet.",
+          )}
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <label className="space-y-1">
+              <span className="block font-heading text-[10px] uppercase tracking-wider text-text-muted">
+                {t("versionDiff.fromLabel", "From")}
+              </span>
+              <select
+                value={fromVersion}
+                onChange={(e) => setFromVersion(e.target.value)}
+                className="
+                  rounded border border-strong-edge bg-card px-2.5 py-1.5
+                  font-mono text-sm text-text-primary
+                  focus:outline-none focus:border-strong
+                "
+              >
+                {versions.map((v) => (
+                  <option key={v.version} value={v.version}>
+                    {v.version}
+                    {v.version === latestVersion ? ` (${t("skillDetail.latest")})` : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <span className="pb-2 font-mono text-text-muted" aria-hidden>
+              →
+            </span>
+
+            <label className="space-y-1">
+              <span className="block font-heading text-[10px] uppercase tracking-wider text-text-muted">
+                {t("versionDiff.toLabel", "To")}
+              </span>
+              <select
+                value={toVersion}
+                onChange={(e) => setToVersion(e.target.value)}
+                className="
+                  rounded border border-strong-edge bg-card px-2.5 py-1.5
+                  font-mono text-sm text-text-primary
+                  focus:outline-none focus:border-strong
+                "
+              >
+                {versions.map((v) => (
+                  <option key={v.version} value={v.version}>
+                    {v.version}
+                    {v.version === latestVersion ? ` (${t("skillDetail.latest")})` : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {summary && !sameVersion && (
+              <p className="ml-auto pb-2 font-mono text-[11px] text-text-muted">
+                {t("versionDiff.summary", {
+                  defaultValue:
+                    "{{added}} added · {{removed}} removed · {{modified}} modified · {{unchanged}} unchanged",
+                  added: summary.added,
+                  removed: summary.removed,
+                  modified: summary.modified,
+                  unchanged: summary.unchanged,
+                })}
+              </p>
+            )}
+          </div>
+
+          {sameVersion && (
+            <p className="font-body text-sm text-text-muted">
+              {t(
+                "versionDiff.sameVersion",
+                "Pick two different versions to see a diff.",
+              )}
+            </p>
+          )}
+
+          {!sameVersion && (isLoading || isFetching) && !data && (
+            <p className="font-body text-sm text-text-muted">
+              {t("versionDiff.loading", "Computing diff…")}
+            </p>
+          )}
+
+          {!sameVersion && error && (
+            <p className="font-body text-sm text-danger">
+              {error instanceof Error
+                ? error.message
+                : t("versionDiff.error", "Failed to compute diff.")}
+            </p>
+          )}
+
+          {!sameVersion && data && summary && (
+            <div className="space-y-6">
+              {summary.added === 0 && summary.removed === 0 && summary.modified === 0 ? (
+                <p className="font-body text-sm text-text-muted">
+                  {t(
+                    "versionDiff.noChanges",
+                    "These two versions have identical files.",
+                  )}
+                </p>
+              ) : (
+                <>
+                  {data.diff.files.modified.length > 0 && (
+                    <section className="space-y-3">
+                      <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+                        {t("versionDiff.modifiedHeading", {
+                          defaultValue: "Modified ({{count}})",
+                          count: data.diff.files.modified.length,
+                        })}
+                      </h3>
+                      <div className="space-y-4">
+                        {data.diff.files.modified.map((f) => (
+                          <ModifiedFile key={f.path} file={f} />
+                        ))}
+                      </div>
+                    </section>
+                  )}
+                  {data.diff.files.added.length > 0 && (
+                    <section className="space-y-3">
+                      <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+                        {t("versionDiff.addedHeading", {
+                          defaultValue: "Added ({{count}})",
+                          count: data.diff.files.added.length,
+                        })}
+                      </h3>
+                      <div className="space-y-4">
+                        {data.diff.files.added.map((f) => (
+                          <AddedFile key={f.path} file={f} />
+                        ))}
+                      </div>
+                    </section>
+                  )}
+                  {data.diff.files.removed.length > 0 && (
+                    <section className="space-y-3">
+                      <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+                        {t("versionDiff.removedHeading", {
+                          defaultValue: "Removed ({{count}})",
+                          count: data.diff.files.removed.length,
+                        })}
+                      </h3>
+                      <div className="space-y-4">
+                        {data.diff.files.removed.map((f) => (
+                          <RemovedFile key={f.path} file={f} />
+                        ))}
+                      </div>
+                    </section>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/ornn-web/src/components/skill/VersionDiffView.tsx
+++ b/ornn-web/src/components/skill/VersionDiffView.tsx
@@ -1,0 +1,254 @@
+/**
+ * VersionDiffView — pure renderer for a `VersionDiffResponse["diff"]`
+ * payload. Knows how to draw the Modified / Added / Removed sections,
+ * with a unified line-level diff for every modified text file via the
+ * `diff` package.
+ *
+ * Used by `VersionDiffModal` (compare two existing versions) and by the
+ * GitHub-link panel inside `AdvancedOptionsModal` (preview a pending
+ * sync against the upstream repo). Pure: no fetching, no state — caller
+ * passes the already-fetched `diff` object in.
+ *
+ * @module components/skill/VersionDiffView
+ */
+
+import { useTranslation } from "react-i18next";
+import { diffLines } from "diff";
+import type {
+  DiffFileAdded,
+  DiffFileModified,
+  DiffFileRemoved,
+  VersionDiffResponse,
+} from "@/types/domain";
+
+export interface VersionDiffViewProps {
+  diff: VersionDiffResponse["diff"];
+  /** Optional — render an "X added · Y removed · Z modified · W unchanged" summary line at the top. */
+  showSummary?: boolean;
+  /** Optional — placeholder when no changes are detected. Default reads `versionDiff.noChanges`. */
+  emptyLabel?: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+}
+
+function ModifiedFileDiff({ file }: { file: DiffFileModified }) {
+  const { t } = useTranslation();
+  if (!file.isText || file.fromContent === undefined || file.toContent === undefined) {
+    return (
+      <p className="font-mono text-[11px] text-text-muted">
+        {t("versionDiff.binaryHint", {
+          defaultValue:
+            "Binary file. {{from}} → {{to}} (hash {{fromHash}} → {{toHash}})",
+          from: formatBytes(file.fromBytes),
+          to: formatBytes(file.toBytes),
+          fromHash: file.fromHash.slice(0, 8),
+          toHash: file.toHash.slice(0, 8),
+        })}
+      </p>
+    );
+  }
+  const chunks = diffLines(file.fromContent, file.toContent);
+  return (
+    <div className="overflow-x-auto rounded border border-subtle bg-page font-mono text-[11px] leading-snug">
+      {chunks.map((chunk, idx) => {
+        const lines = chunk.value.split("\n");
+        if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+        const sigil = chunk.added ? "+" : chunk.removed ? "-" : " ";
+        const lineCls = chunk.added
+          ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+          : chunk.removed
+            ? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
+            : "text-text-muted";
+        return (
+          <div key={idx} className={lineCls}>
+            {lines.map((line, lineIdx) => (
+              <div key={lineIdx} className="px-3 py-px whitespace-pre-wrap break-all">
+                <span className="select-none mr-2 text-text-muted/60">{sigil}</span>
+                {line || " "}
+              </div>
+            ))}
+          </div>
+        );
+      })}
+      {file.truncated && (
+        <p className="border-t border-subtle px-3 py-1.5 text-[11px] text-text-muted italic">
+          {t("versionDiff.truncated", "File content truncated at 64 KiB per side.")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function FileHeader({
+  path,
+  meta,
+  badge,
+  badgeCls,
+}: {
+  path: string;
+  meta?: string;
+  badge: string;
+  badgeCls: string;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-subtle pb-1.5">
+      <div className="flex items-baseline gap-2 min-w-0">
+        <span
+          className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${badgeCls}`}
+        >
+          {badge}
+        </span>
+        <span className="truncate font-mono text-xs text-text-primary">{path}</span>
+      </div>
+      {meta && <span className="shrink-0 font-mono text-[10px] text-text-muted">{meta}</span>}
+    </div>
+  );
+}
+
+function AddedFile({ file }: { file: DiffFileAdded }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-1.5">
+      <FileHeader
+        path={file.path}
+        meta={formatBytes(file.bytes)}
+        badge={t("versionDiff.added", "added")}
+        badgeCls="bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+      />
+      {file.isText && file.content !== undefined ? (
+        <pre className="overflow-x-auto rounded border border-subtle bg-page p-3 font-mono text-[11px] leading-snug text-text-primary whitespace-pre-wrap break-all">
+          {file.content}
+        </pre>
+      ) : (
+        <p className="font-mono text-[11px] text-text-muted">
+          {t("versionDiff.binaryAdded", {
+            defaultValue: "Binary file ({{size}}).",
+            size: formatBytes(file.bytes),
+          })}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function RemovedFile({ file }: { file: DiffFileRemoved }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-1.5">
+      <FileHeader
+        path={file.path}
+        meta={formatBytes(file.bytes)}
+        badge={t("versionDiff.removed", "removed")}
+        badgeCls="bg-rose-500/15 text-rose-700 dark:text-rose-300"
+      />
+      {file.isText && file.content !== undefined ? (
+        <pre className="overflow-x-auto rounded border border-subtle bg-page p-3 font-mono text-[11px] leading-snug text-text-primary whitespace-pre-wrap break-all">
+          {file.content}
+        </pre>
+      ) : (
+        <p className="font-mono text-[11px] text-text-muted">
+          {t("versionDiff.binaryRemoved", {
+            defaultValue: "Binary file ({{size}}).",
+            size: formatBytes(file.bytes),
+          })}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ModifiedFile({ file }: { file: DiffFileModified }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-1.5">
+      <FileHeader
+        path={file.path}
+        meta={`${formatBytes(file.fromBytes)} → ${formatBytes(file.toBytes)}`}
+        badge={t("versionDiff.modified", "modified")}
+        badgeCls="bg-amber-500/15 text-amber-700 dark:text-amber-300"
+      />
+      <ModifiedFileDiff file={file} />
+    </div>
+  );
+}
+
+export function VersionDiffView({ diff, showSummary = false, emptyLabel }: VersionDiffViewProps) {
+  const { t } = useTranslation();
+  const f = diff.files;
+  const isEmpty = f.added.length === 0 && f.removed.length === 0 && f.modified.length === 0;
+
+  if (isEmpty) {
+    return (
+      <p className="font-body text-sm text-text-muted">
+        {emptyLabel ??
+          (t("versionDiff.noChanges", "These two versions have identical files.") as string)}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {showSummary && (
+        <p className="font-mono text-[11px] text-text-muted">
+          {t("versionDiff.summary", {
+            defaultValue:
+              "{{added}} added · {{removed}} removed · {{modified}} modified · {{unchanged}} unchanged",
+            added: f.added.length,
+            removed: f.removed.length,
+            modified: f.modified.length,
+            unchanged: f.unchangedCount,
+          })}
+        </p>
+      )}
+      {f.modified.length > 0 && (
+        <section className="space-y-3">
+          <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+            {t("versionDiff.modifiedHeading", {
+              defaultValue: "Modified ({{count}})",
+              count: f.modified.length,
+            })}
+          </h3>
+          <div className="space-y-4">
+            {f.modified.map((file) => (
+              <ModifiedFile key={file.path} file={file} />
+            ))}
+          </div>
+        </section>
+      )}
+      {f.added.length > 0 && (
+        <section className="space-y-3">
+          <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+            {t("versionDiff.addedHeading", {
+              defaultValue: "Added ({{count}})",
+              count: f.added.length,
+            })}
+          </h3>
+          <div className="space-y-4">
+            {f.added.map((file) => (
+              <AddedFile key={file.path} file={file} />
+            ))}
+          </div>
+        </section>
+      )}
+      {f.removed.length > 0 && (
+        <section className="space-y-3">
+          <h3 className="font-heading text-[11px] uppercase tracking-wider text-text-muted">
+            {t("versionDiff.removedHeading", {
+              defaultValue: "Removed ({{count}})",
+              count: f.removed.length,
+            })}
+          </h3>
+          <div className="space-y-4">
+            {f.removed.map((file) => (
+              <RemovedFile key={file.path} file={file} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -12,6 +12,8 @@ import {
   setSkillVersionDeprecation,
   pullSkillFromGitHub,
   refreshSkillFromSource,
+  previewSkillRefresh,
+  setSkillSource,
   tieSkillToNyxidService,
   type PullFromGitHubInput,
 } from "@/services/skillApi";
@@ -254,7 +256,13 @@ export function usePullSkillFromGitHub() {
 export function useRefreshSkillFromSource(idOrName: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (guid: string) => refreshSkillFromSource(guid),
+    mutationFn: ({
+      guid,
+      skipValidation,
+    }: {
+      guid: string;
+      skipValidation?: boolean;
+    }) => refreshSkillFromSource(guid, { skipValidation }),
     onSuccess: (updated) => {
       // Prime the detail cache with the refreshed payload so the chip
       // updates in place.
@@ -262,6 +270,26 @@ export function useRefreshSkillFromSource(idOrName: string) {
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [SKILL_VERSIONS_KEY, idOrName] });
       queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
+    },
+  });
+}
+
+/** Dry-run a refresh — pull from GitHub, compute diff, return without bumping. */
+export function usePreviewSkillRefresh() {
+  return useMutation({
+    mutationFn: (guid: string) => previewSkillRefresh(guid),
+  });
+}
+
+/** Attach (or clear) a GitHub source pointer on an existing skill. */
+export function useSetSkillSource(idOrName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ guid, githubUrl }: { guid: string; githubUrl: string | null }) =>
+      setSkillSource(guid, githubUrl),
+    onSuccess: (updated) => {
+      queryClient.setQueryData([SKILLS_KEY, idOrName, undefined], updated);
+      queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
     },
   });
 }

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -3,6 +3,7 @@ import { searchSkills, fetchSkillCounts } from "@/services/searchApi";
 import {
   fetchSkill,
   fetchSkillVersions,
+  fetchSkillVersionDiff,
   createSkill,
   updateSkill,
   updateSkillPackage,
@@ -23,6 +24,7 @@ const MY_SKILLS_KEY = "my-skills";
 const SHARED_WITH_ME_KEY = "shared-with-me-skills";
 const SKILL_COUNTS_KEY = "skill-counts";
 const SKILL_VERSIONS_KEY = "skill-versions";
+const SKILL_VERSION_DIFF_KEY = "skill-version-diff";
 
 /**
  * Search platform-wide system skills. System skills are always public,
@@ -182,6 +184,24 @@ export function useSkillVersions(idOrName: string) {
     queryKey: [SKILL_VERSIONS_KEY, idOrName],
     queryFn: () => fetchSkillVersions(idOrName),
     enabled: !!idOrName,
+  });
+}
+
+/**
+ * Diff two specific versions of a skill. Disabled until both `from` and
+ * `to` are non-empty AND distinct — the backend rejects a same-version
+ * compare with `400 SAME_VERSION` and we don't want that round-trip.
+ */
+export function useSkillVersionDiff(
+  idOrName: string,
+  fromVersion: string,
+  toVersion: string,
+) {
+  return useQuery({
+    queryKey: [SKILL_VERSION_DIFF_KEY, idOrName, fromVersion, toVersion],
+    queryFn: () => fetchSkillVersionDiff(idOrName, fromVersion, toVersion),
+    enabled:
+      !!idOrName && !!fromVersion && !!toVersion && fromVersion !== toVersion,
   });
 }
 

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -331,19 +331,19 @@
     "guidedTitle": "Guided Mode",
     "guidedDesc": "Step-by-step wizard that guides you through creating a skill. Perfect for beginners or structured authoring.",
     "guidedBullets": ["Step-by-step form", "Markdown editor with preview", "Folder-based file uploads", "Full package preview"],
-    "startGuided": "Start Guided Mode",
+    "startGuided": "Start",
     "freeTitle": "Free Mode",
     "freeDesc": "Upload a pre-built skill package as a ZIP file. Best for experienced authors with existing skills.",
     "freeBullets": ["ZIP file upload", "Structure validation", "Auto-metadata extraction", "Preview before upload"],
-    "startFree": "Start Free Mode",
+    "startFree": "Start",
     "genTitle": "Generative Mode",
     "genDesc": "Describe what you need and let AI generate a complete skill for you. Refine with chat.",
     "genBullets": ["AI-powered generation", "Real-time streaming", "Chat refinement", "Auto-structured output"],
-    "startGen": "Start Generative Mode",
+    "startGen": "Start",
     "githubTitle": "Import from GitHub",
     "githubDesc": "Pull a skill from a public GitHub repo. Later updates can be re-synced with one click.",
     "githubBullets": ["Public repos only", "Branch / tag / commit pinning", "One-click resync", "No ZIP packaging needed"],
-    "startGithub": "Import from GitHub"
+    "startGithub": "Import"
   },
   "guided": {
     "backToModes": "Back to mode selection",

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -139,6 +139,8 @@
     "auditBannerYellow": "Audit verdict for v{{v}} is YELLOW ({{score}}/10). Some findings flagged.",
     "auditBannerRed": "Audit verdict for v{{v}} is RED ({{score}}/10). Use with caution.",
     "deleteVersion": "Delete this version",
+    "deleteVersionBlockedOnly": "Can't delete the only remaining version. Use 'Delete skill' in the danger zone instead.",
+    "deleteVersionBlockedLatest": "Can't delete the current latest version. Publish a newer version first, then delete this one.",
     "deleteVersionTitle": "Delete v{{version}}?",
     "deleteVersionConfirm": "Are you sure you want to delete v{{version}}? The version's package zip and audit history are removed and this cannot be undone.",
     "versionDeleted": "Version v{{version}} deleted",

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -537,5 +537,44 @@
     "feature2Desc": "Cryptographic signatures ensure skill integrity.",
     "feature3Title": "Seamless SDK Integration",
     "feature3Desc": "One line to discover. One line to execute."
+  },
+  "advancedOptions": {
+    "title": "Advanced options",
+    "navLabel": "Advanced settings",
+    "nyxidServiceBinding": "Bind to NyxID Service",
+    "githubLink": "Link to GitHub"
+  },
+  "githubLink": {
+    "intro": "Point this skill at a folder in a public GitHub repo. Saving the link does not pull anything; click Sync afterwards to preview changes and publish a new version.",
+    "urlLabel": "GitHub folder URL",
+    "urlHelp": "Use the folder URL (the /tree/<ref>/<path> form). The skill's SKILL.md must be at the root of that folder. Default-branch and repo-root URLs work too.",
+    "skipValidationLabel": "Skip Ornn package validation",
+    "skipValidationHelp": "GitHub-hosted skills don't always follow Ornn's package rules; tick this if you trust the upstream and want syncs to succeed even when the validator would reject the layout.",
+    "currentlyLinked": "Currently linked",
+    "lastSyncedAt": "Last synced {{when}}",
+    "neverSynced": "Linked but never synced.",
+    "syncButton": "Sync from GitHub",
+    "unlinkButton": "Unlink",
+    "saveBeforeSync": "Save the URL change first, then sync.",
+    "linkSuccess": "GitHub link saved",
+    "unlinkSuccess": "GitHub link removed",
+    "alreadyInSync": "Already in sync — no changes to pull from GitHub.",
+    "syncSuccess": "Synced from GitHub — new version published.",
+    "previewTitle": "Sync preview",
+    "previewSubtitle": "Apply this sync to publish v{{version}} of {{name}} from the linked GitHub source.",
+    "applySync": "Apply sync"
+  },
+  "githubImport": {
+    "title": "Import from GitHub",
+    "subtitle": "Publish a skill from a folder in a public GitHub repo. Subsequent updates can be re-synced from the same link in one click.",
+    "urlLabel": "GitHub folder URL",
+    "urlHint": "Use the folder URL (the /tree/<ref>/<path> form). The skill's SKILL.md must sit at the root of that folder. Default-branch and repo-root URLs work too.",
+    "urlInvalid": "Enter a github.com URL (e.g. https://github.com/owner/repo/tree/main/path).",
+    "skipValidationLabel": "Skip Ornn package validation",
+    "skipValidationHelp": "GitHub-hosted skills don't always follow Ornn's package rules; tick this if you trust the upstream and want the import to succeed even when the validator would reject the layout.",
+    "syncButton": "Sync from GitHub",
+    "backToModes": "Back to creation modes",
+    "success": "Skill pulled from GitHub.",
+    "genericError": "Failed to pull from GitHub."
   }
 }

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -246,6 +246,28 @@
     "totalPulls": "Total",
     "noUsage": "No usage in this range."
   },
+  "versionDiff": {
+    "openButton": "Compare versions",
+    "title": "Compare versions",
+    "fromLabel": "From",
+    "toLabel": "To",
+    "summary": "{{added}} added · {{removed}} removed · {{modified}} modified · {{unchanged}} unchanged",
+    "needTwoVersions": "This skill only has one version — there's nothing to compare yet.",
+    "sameVersion": "Pick two different versions to see a diff.",
+    "loading": "Computing diff…",
+    "error": "Failed to compute diff.",
+    "noChanges": "These two versions have identical files.",
+    "addedHeading": "Added ({{count}})",
+    "removedHeading": "Removed ({{count}})",
+    "modifiedHeading": "Modified ({{count}})",
+    "added": "added",
+    "removed": "removed",
+    "modified": "modified",
+    "binaryHint": "Binary file. {{from}} → {{to}} (hash {{fromHash}} → {{toHash}})",
+    "binaryAdded": "Binary file ({{size}}).",
+    "binaryRemoved": "Binary file ({{size}}).",
+    "truncated": "File content truncated at 64 KiB per side."
+  },
   "notifications": {
     "bellAria": "Notifications",
     "title": "Notifications",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -246,6 +246,28 @@
     "totalPulls": "总计",
     "noUsage": "此区间内没有使用记录。"
   },
+  "versionDiff": {
+    "openButton": "对比版本",
+    "title": "对比版本",
+    "fromLabel": "从",
+    "toLabel": "到",
+    "summary": "新增 {{added}} · 删除 {{removed}} · 修改 {{modified}} · 不变 {{unchanged}}",
+    "needTwoVersions": "此技能只有一个版本,暂无可对比的内容。",
+    "sameVersion": "请选择两个不同的版本进行对比。",
+    "loading": "正在计算差异…",
+    "error": "差异计算失败。",
+    "noChanges": "这两个版本的文件内容完全一致。",
+    "addedHeading": "新增 ({{count}})",
+    "removedHeading": "删除 ({{count}})",
+    "modifiedHeading": "修改 ({{count}})",
+    "added": "新增",
+    "removed": "删除",
+    "modified": "修改",
+    "binaryHint": "二进制文件。{{from}} → {{to}}(哈希 {{fromHash}} → {{toHash}})",
+    "binaryAdded": "二进制文件({{size}})。",
+    "binaryRemoved": "二进制文件({{size}})。",
+    "truncated": "每侧文件内容已截断至 64 KiB。"
+  },
   "notifications": {
     "bellAria": "通知",
     "title": "通知",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -537,5 +537,44 @@
     "feature2Desc": "加密签名保证技能完整性。",
     "feature3Title": "无缝 SDK 集成",
     "feature3Desc": "一行代码发现，一行代码执行。"
+  },
+  "advancedOptions": {
+    "title": "高级选项",
+    "navLabel": "高级设置",
+    "nyxidServiceBinding": "绑定 NyxID 服务",
+    "githubLink": "关联 GitHub"
+  },
+  "githubLink": {
+    "intro": "将此技能指向一个公开 GitHub 仓库中的文件夹。仅保存链接不会拉取内容,需要点击 Sync 才会预览改动并发布新版本。",
+    "urlLabel": "GitHub 文件夹 URL",
+    "urlHelp": "请使用文件夹 URL(/tree/<ref>/<path> 形式)。该文件夹根目录下必须有 SKILL.md。默认分支或仓库根目录的 URL 同样可以。",
+    "skipValidationLabel": "跳过 Ornn 包格式校验",
+    "skipValidationHelp": "GitHub 上托管的技能不一定遵循 Ornn 的包规范;如果你信任上游且希望即便校验失败也能完成同步,请勾选此项。",
+    "currentlyLinked": "当前已关联",
+    "lastSyncedAt": "上次同步:{{when}}",
+    "neverSynced": "已关联但尚未同步。",
+    "syncButton": "从 GitHub 同步",
+    "unlinkButton": "取消关联",
+    "saveBeforeSync": "请先保存 URL 修改再同步。",
+    "linkSuccess": "GitHub 链接已保存",
+    "unlinkSuccess": "GitHub 链接已移除",
+    "alreadyInSync": "已是最新 — GitHub 上没有新的改动可同步。",
+    "syncSuccess": "已从 GitHub 同步,并发布了新版本。",
+    "previewTitle": "同步预览",
+    "previewSubtitle": "确认后将从已关联的 GitHub 源发布 {{name}} 的 v{{version}} 版本。",
+    "applySync": "应用同步"
+  },
+  "githubImport": {
+    "title": "从 GitHub 导入",
+    "subtitle": "从公开 GitHub 仓库的某个文件夹发布一个技能。后续更新可通过同一链接一键重新同步。",
+    "urlLabel": "GitHub 文件夹 URL",
+    "urlHint": "请使用文件夹 URL(/tree/<ref>/<path> 形式)。该文件夹根目录下必须有 SKILL.md。默认分支或仓库根目录的 URL 同样可以。",
+    "urlInvalid": "请输入 github.com URL(例如 https://github.com/owner/repo/tree/main/path)。",
+    "skipValidationLabel": "跳过 Ornn 包格式校验",
+    "skipValidationHelp": "GitHub 上托管的技能不一定遵循 Ornn 的包规范;如果你信任上游且希望即便校验失败也能完成导入,请勾选此项。",
+    "syncButton": "从 GitHub 同步",
+    "backToModes": "返回创建模式",
+    "success": "已从 GitHub 拉取技能。",
+    "genericError": "从 GitHub 拉取失败。"
   }
 }

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -139,6 +139,8 @@
     "auditBannerYellow": "v{{v}} 的审计裁决为黄色（{{score}}/10），存在一些发现，谨慎使用。",
     "auditBannerRed": "v{{v}} 的审计裁决为红色（{{score}}/10），请谨慎使用。",
     "deleteVersion": "删除此版本",
+    "deleteVersionBlockedOnly": "无法删除唯一剩余的版本。请改用危险区的“删除技能”操作。",
+    "deleteVersionBlockedLatest": "无法删除当前的最新版本。请先发布一个更新的版本,然后再删除这一版。",
     "deleteVersionTitle": "删除 v{{version}}？",
     "deleteVersionConfirm": "确定要删除 v{{version}} 吗？该版本的安装包和审计历史会一并移除，此操作不可撤销。",
     "versionDeleted": "版本 v{{version}} 已删除",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -331,19 +331,19 @@
     "guidedTitle": "引导模式",
     "guidedDesc": "分步向导引导你逐步创建技能。适合新手或希望结构化创作的作者。",
     "guidedBullets": ["分步表单", "支持预览的 Markdown 编辑器", "基于文件夹的文件上传", "完整的技能包预览"],
-    "startGuided": "使用引导模式",
+    "startGuided": "开始",
     "freeTitle": "自由模式",
     "freeDesc": "直接上传现成的技能包 ZIP 文件。适合已有技能的经验作者。",
     "freeBullets": ["上传 ZIP 文件", "结构校验", "自动提取元数据", "上传前预览"],
-    "startFree": "使用自由模式",
+    "startFree": "开始",
     "genTitle": "AI 生成模式",
     "genDesc": "描述你的需求，让 AI 为你生成完整的技能，可通过对话继续调整。",
     "genBullets": ["AI 生成", "实时流式输出", "对话迭代", "自动组织结构"],
-    "startGen": "使用 AI 生成模式",
+    "startGen": "开始",
     "githubTitle": "从 GitHub 导入",
     "githubDesc": "从公开的 GitHub 仓库拉取技能，之后可一键同步更新。",
     "githubBullets": ["仅支持公开仓库", "可按分支 / tag / commit 锁定", "一键重新同步", "无需打包成 ZIP"],
-    "startGithub": "从 GitHub 导入"
+    "startGithub": "导入"
   },
   "guided": {
     "backToModes": "返回模式选择",

--- a/ornn-web/src/pages/skill/CreateSkillFromGitHubPage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillFromGitHubPage.tsx
@@ -1,9 +1,16 @@
 /**
- * /skills/new/from-github — create a skill by pulling a public GitHub repo.
+ * /skills/new/from-github — create a skill by syncing a folder in a
+ * public GitHub repo.
  *
- * Thin wrapper around `POST /api/v1/skills/pull`: the backend does the
- * cloning, zipping, and publication. This page just collects the repo
- * coords and surfaces errors.
+ * Single-step form: enter the folder URL (e.g.
+ * `https://github.com/owner/repo/tree/<ref>/<path>`), optionally tick
+ * "skip validation" if your upstream doesn't strictly follow Ornn's
+ * package layout, then click "Sync from GitHub" to actually pull. The
+ * folder URL is parsed server-side into repo / ref / path. Without the
+ * Sync click, nothing is fetched — the form is the contract.
+ *
+ * Mirrors the GitHub-link panel inside `AdvancedOptionsModal` so the
+ * "first sync" and "subsequent sync" UX are visually consistent.
  *
  * @module pages/CreateSkillFromGitHubPage
  */
@@ -19,8 +26,6 @@ import { ArrowLeftIcon } from "@/components/icons";
 import { usePullSkillFromGitHub } from "@/hooks/useSkills";
 import { useToastStore } from "@/stores/toastStore";
 
-const REPO_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?\/[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$/;
-
 function GitHubMarkIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -34,35 +39,31 @@ function GitHubMarkIcon({ className }: { className?: string }) {
   );
 }
 
+const VALID_URL_PREFIX = /^https?:\/\/(www\.)?github\.com\//i;
+
 export function CreateSkillFromGitHubPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const addToast = useToastStore((s) => s.addToast);
   const pull = usePullSkillFromGitHub();
 
-  const [repo, setRepo] = useState("");
-  const [ref, setRef] = useState("");
-  const [path, setPath] = useState("");
+  const [githubUrl, setGithubUrl] = useState("");
   const [skipValidation, setSkipValidation] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
-  const repoValid = REPO_PATTERN.test(repo.trim());
-  const canSubmit = repoValid && !pull.isPending;
+  const trimmed = githubUrl.trim();
+  const urlValid = VALID_URL_PREFIX.test(trimmed);
+  const canSubmit = urlValid && !pull.isPending;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitted(true);
-    if (!repoValid) return;
+    if (!urlValid) return;
     try {
-      const skill = await pull.mutateAsync({
-        repo: repo.trim(),
-        ref: ref.trim() || undefined,
-        path: path.trim() || undefined,
-        skipValidation,
-      });
+      const skill = await pull.mutateAsync({ githubUrl: trimmed, skipValidation });
       addToast({
         type: "success",
-        message: t("githubImport.success", "Skill pulled from GitHub."),
+        message: t("githubImport.success", "Skill pulled from GitHub.") as string,
       });
       navigate(`/skills/${skill.guid}`);
     } catch (err) {
@@ -71,7 +72,7 @@ export function CreateSkillFromGitHubPage() {
         message:
           err instanceof Error
             ? err.message
-            : t("githubImport.genericError", "Failed to pull from GitHub."),
+            : (t("githubImport.genericError", "Failed to pull from GitHub.") as string),
       });
     }
   };
@@ -105,7 +106,7 @@ export function CreateSkillFromGitHubPage() {
                   <p className="mt-1 font-body text-sm text-text-muted">
                     {t(
                       "githubImport.subtitle",
-                      "Publish a skill from a public GitHub repo. Later updates can be pulled in one click.",
+                      "Publish a skill from a folder in a public GitHub repo. Subsequent updates can be re-synced from the same link in one click.",
                     )}
                   </p>
                 </div>
@@ -114,20 +115,21 @@ export function CreateSkillFromGitHubPage() {
               <form onSubmit={handleSubmit} className="space-y-5">
                 <div>
                   <label
-                    htmlFor="repo"
+                    htmlFor="github-url"
                     className="mb-1 block font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted"
                   >
-                    {t("githubImport.repoLabel", "Repository")}{" "}
+                    {t("githubImport.urlLabel", "GitHub folder URL")}{" "}
                     <span className="text-neon-red">*</span>
                   </label>
                   <input
-                    id="repo"
-                    type="text"
-                    placeholder="owner/name"
-                    value={repo}
-                    onChange={(e) => setRepo(e.target.value)}
+                    id="github-url"
+                    type="url"
+                    inputMode="url"
+                    placeholder="https://github.com/owner/repo/tree/main/path/to/skill"
+                    value={githubUrl}
+                    onChange={(e) => setGithubUrl(e.target.value)}
                     className={`w-full rounded-lg border bg-bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 ${
-                      submitted && !repoValid
+                      submitted && !urlValid
                         ? "border-neon-red/40 focus:ring-neon-red/40"
                         : "border-neon-cyan/20 focus:border-neon-cyan/60 focus:ring-neon-cyan/30"
                     }`}
@@ -136,77 +138,38 @@ export function CreateSkillFromGitHubPage() {
                   />
                   <p className="mt-1 font-body text-xs text-text-muted">
                     {t(
-                      "githubImport.repoHint",
-                      "The repo must be public. Private repos are not yet supported.",
+                      "githubImport.urlHint",
+                      "Use the folder URL (the /tree/<ref>/<path> form). The skill's SKILL.md must sit at the root of that folder. Default-branch and repo-root URLs work too.",
                     )}
                   </p>
-                  {submitted && !repoValid && (
+                  {submitted && !urlValid && (
                     <p className="mt-1 font-body text-xs text-neon-red">
                       {t(
-                        "githubImport.repoInvalid",
-                        "Expected format: owner/name (e.g. anthropics/claude-code).",
+                        "githubImport.urlInvalid",
+                        "Enter a github.com URL (e.g. https://github.com/owner/repo/tree/main/path).",
                       )}
                     </p>
                   )}
                 </div>
 
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div>
-                    <label
-                      htmlFor="ref"
-                      className="mb-1 block font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted"
-                    >
-                      {t("githubImport.refLabel", "Branch / tag / commit")}
-                    </label>
-                    <input
-                      id="ref"
-                      type="text"
-                      placeholder="main"
-                      value={ref}
-                      onChange={(e) => setRef(e.target.value)}
-                      className="w-full rounded-lg border border-neon-cyan/20 bg-bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-neon-cyan/60 focus:ring-2 focus:ring-neon-cyan/30"
-                      autoComplete="off"
-                      spellCheck={false}
-                    />
-                    <p className="mt-1 font-body text-xs text-text-muted">
-                      {t("githubImport.refHint", "Leave blank to use the default branch.")}
-                    </p>
-                  </div>
-
-                  <div>
-                    <label
-                      htmlFor="path"
-                      className="mb-1 block font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted"
-                    >
-                      {t("githubImport.pathLabel", "Path in repo")}
-                    </label>
-                    <input
-                      id="path"
-                      type="text"
-                      placeholder="skills/my-skill"
-                      value={path}
-                      onChange={(e) => setPath(e.target.value)}
-                      className="w-full rounded-lg border border-neon-cyan/20 bg-bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-neon-cyan/60 focus:ring-2 focus:ring-neon-cyan/30"
-                      autoComplete="off"
-                      spellCheck={false}
-                    />
-                    <p className="mt-1 font-body text-xs text-text-muted">
-                      {t(
-                        "githubImport.pathHint",
-                        "Sub-directory that contains SKILL.md. Leave blank for repo root.",
-                      )}
-                    </p>
-                  </div>
-                </div>
-
-                <label className="flex cursor-pointer items-center gap-2 font-body text-sm text-text-muted">
+                <label className="flex cursor-pointer items-start gap-2 font-body text-sm text-text-muted">
                   <input
                     type="checkbox"
                     checked={skipValidation}
                     onChange={(e) => setSkipValidation(e.target.checked)}
-                    className="h-4 w-4 accent-neon-cyan"
+                    className="h-4 w-4 mt-1 accent-neon-cyan"
                   />
-                  {t("githubImport.skipValidation", "Skip format validation (advanced)")}
+                  <span>
+                    <span className="block font-heading text-xs text-text-primary">
+                      {t("githubImport.skipValidationLabel", "Skip Ornn package validation")}
+                    </span>
+                    <span className="block text-[11px]">
+                      {t(
+                        "githubImport.skipValidationHelp",
+                        "GitHub-hosted skills don't always follow Ornn's package rules; tick this if you trust the upstream and want the import to succeed even when the validator would reject the layout.",
+                      )}
+                    </span>
+                  </span>
                 </label>
 
                 <div className="flex items-center justify-end gap-3 pt-2">
@@ -218,7 +181,7 @@ export function CreateSkillFromGitHubPage() {
                     {t("common.cancel", "Cancel")}
                   </Button>
                   <Button type="submit" disabled={!canSubmit} loading={pull.isPending}>
-                    {t("githubImport.submit", "Import")}
+                    {t("githubImport.syncButton", "Sync from GitHub")}
                   </Button>
                 </div>
               </form>

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -33,6 +33,7 @@ import { useSkillPulls } from "@/hooks/useAnalytics";
 import { SkillVersionList } from "@/components/skill/SkillVersionList";
 import { PermissionsModal } from "@/components/skill/PermissionsModal";
 import { AdvancedOptionsModal } from "@/components/skill/AdvancedOptionsModal";
+import { VersionDiffModal } from "@/components/skill/VersionDiffModal";
 import {
   useSkill,
   useDeleteSkill,
@@ -164,10 +165,14 @@ export function SkillDetailPage() {
   const [deletedPaths, setDeletedPaths] = useState<Set<string>>(new Set());
   const [skipValidation, setSkipValidation] = useState(false);
   const [showVersions, setShowVersions] = useState(false);
+  const [showVersionDiff, setShowVersionDiff] = useState(false);
   const hasChanges = editedContents.size > 0 || addedPaths.length > 0 || deletedPaths.size > 0;
 
   // Reset version expansion when skill changes.
-  useEffect(() => { setShowVersions(false); }, [skill?.guid]);
+  useEffect(() => {
+    setShowVersions(false);
+    setShowVersionDiff(false);
+  }, [skill?.guid]);
 
   const handleContentChange = useCallback((fileId: string, content: string) => {
     setEditedContents((prev) => {
@@ -938,6 +943,17 @@ export function SkillDetailPage() {
         title={t("skillDetail.versionsTitle", "All versions") as string}
         className="!max-w-3xl"
       >
+        {versionList.length >= 2 && (
+          <div className="mb-4 flex justify-end">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowVersionDiff(true)}
+            >
+              {t("versionDiff.openButton", "Compare versions")}
+            </Button>
+          </div>
+        )}
         <SkillVersionList
           versions={versionList}
           currentVersion={skill.version}
@@ -970,6 +986,15 @@ export function SkillDetailPage() {
           }}
         />
       </Modal>
+
+      {/* ── Version diff modal ── */}
+      <VersionDiffModal
+        isOpen={showVersionDiff}
+        onClose={() => setShowVersionDiff(false)}
+        idOrName={skill.guid}
+        versions={versionList}
+        currentVersion={skill.version}
+      />
 
       {/* ── Delete confirmation modal ── */}
       <Modal

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -419,7 +419,7 @@ export function SkillDetailPage() {
             source={skill.source}
             canRefresh={isOwner || isAdminUser}
             isRefreshing={refreshMutation.isPending}
-            onRefresh={() => refreshMutation.mutate(skill.guid)}
+            onRefresh={() => refreshMutation.mutate({ guid: skill.guid })}
           />
         )}
 

--- a/ornn-web/src/pages/skill/UploadSkillPage.tsx
+++ b/ornn-web/src/pages/skill/UploadSkillPage.tsx
@@ -104,7 +104,7 @@ const MODE_CARDS: ModeCardConfig[] = [
     bulletsKey: "upload.freeBullets",
     ctaKey: "upload.startFree",
     route: "/skills/new/free",
-    variant: "secondary",
+    variant: "primary",
     delay: 0.2,
   },
   {
@@ -132,7 +132,7 @@ const MODE_CARDS: ModeCardConfig[] = [
     bulletsKey: "upload.githubBullets",
     ctaKey: "upload.startGithub",
     route: "/skills/new/from-github",
-    variant: "secondary",
+    variant: "primary",
     delay: 0.4,
   },
 ];
@@ -167,7 +167,14 @@ export function UploadSkillPage() {
                   onClick={() => navigate(card.route)}
                   className="h-full cursor-pointer group"
                 >
-                  <div className="flex flex-col items-center text-center p-4">
+                  {/*
+                    Inner column is the full card height (h-full) so the
+                    Button can use `mt-auto` to pin to the card's bottom.
+                    All four cards therefore have their CTAs sitting on
+                    exactly the same baseline regardless of whether the
+                    description / bullet list above is shorter or longer.
+                  */}
+                  <div className="flex flex-col items-center text-center p-4 h-full">
                     <div
                       className={`mb-6 p-4 rounded-2xl ${card.accentBg} border ${card.accentBorder} ${card.accentGlow} transition-all`}
                     >
@@ -198,7 +205,16 @@ export function UploadSkillPage() {
                       ))}
                     </ul>
 
-                    <Button variant={card.variant} className="w-full">
+                    {/*
+                      mt-auto pushes this CTA to the bottom; whitespace-nowrap
+                      keeps the text on one line so all four buttons share
+                      the same height (no two-line wrapping for the longer
+                      "Start Generative Mode" label).
+                    */}
+                    <Button
+                      variant={card.variant}
+                      className="w-full mt-auto whitespace-nowrap"
+                    >
                       {t(card.ctaKey)}
                     </Button>
                   </div>

--- a/ornn-web/src/pages/skill/UploadSkillPage.tsx
+++ b/ornn-web/src/pages/skill/UploadSkillPage.tsx
@@ -213,7 +213,7 @@ export function UploadSkillPage() {
                     */}
                     <Button
                       variant={card.variant}
-                      className="w-full mt-auto whitespace-nowrap"
+                      className="w-full mt-auto"
                     >
                       {t(card.ctaKey)}
                     </Button>

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -1,6 +1,6 @@
 import { apiGet, apiPost, apiPut, apiDelete } from "./apiClient";
 import type { UpdateSkillMetadata } from "@/types/api";
-import type { SkillDetail, SkillVersionEntry } from "@/types/domain";
+import type { SkillDetail, SkillVersionEntry, VersionDiffResponse } from "@/types/domain";
 import { useAuthStore } from "@/stores/authStore";
 import { config } from "@/config";
 
@@ -22,6 +22,24 @@ export async function fetchSkillVersions(idOrName: string): Promise<SkillVersion
     `/api/v1/skills/${encodeURIComponent(idOrName)}/versions`,
   );
   return res.data?.items ?? [];
+}
+
+/**
+ * Fetch a structured diff between two published versions of a skill.
+ * Server returns added/removed/modified file lists with text content
+ * inlined for diffable files; binary files come back as path + hash + size.
+ */
+export async function fetchSkillVersionDiff(
+  idOrName: string,
+  fromVersion: string,
+  toVersion: string,
+): Promise<VersionDiffResponse> {
+  const res = await apiGet<VersionDiffResponse>(
+    `/api/v1/skills/${encodeURIComponent(idOrName)}/versions/${encodeURIComponent(
+      fromVersion,
+    )}/diff/${encodeURIComponent(toVersion)}`,
+  );
+  return res.data!;
 }
 
 /** Toggle the deprecation flag on a specific published version. */

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -181,23 +181,25 @@ export async function deleteSkillVersion(
 }
 
 export interface PullFromGitHubInput {
-  /** `owner/name`. */
-  repo: string;
-  /** Branch / tag / commit SHA. Omit for the repo default. */
+  /** Preferred: a folder URL like `https://github.com/owner/repo/tree/<ref>/<path>`. */
+  githubUrl?: string;
+  /** Legacy / explicit form. Pass instead of (or alongside, ignored if) `githubUrl`. */
+  repo?: string;
   ref?: string;
-  /** Subdirectory that contains `SKILL.md`. Omit for repo root. */
   path?: string;
   /** Skip the format-validation pass on the generated ZIP. */
   skipValidation?: boolean;
 }
 
 /**
- * Create a skill by cloning a public GitHub repo. Backend zips the tree,
- * records the source pointer, and publishes as v1. Subsequent updates
- * come via `refreshSkillFromSource`.
+ * Create a skill by cloning a public GitHub repo. Backend parses the URL
+ * (or the explicit `repo`/`ref`/`path`), zips the tree, records the
+ * source pointer, and publishes as v1. Subsequent updates come via
+ * `refreshSkillFromSource`.
  */
 export async function pullSkillFromGitHub(input: PullFromGitHubInput): Promise<SkillDetail> {
   const res = await apiPost<SkillDetail>("/api/v1/skills/pull", {
+    githubUrl: input.githubUrl,
     repo: input.repo,
     ref: input.ref,
     path: input.path,
@@ -207,11 +209,54 @@ export async function pullSkillFromGitHub(input: PullFromGitHubInput): Promise<S
 }
 
 /**
- * Re-pull the skill's GitHub source at the current ref HEAD and publish as
- * a new version. Requires owner or platform admin.
+ * Re-pull the skill's GitHub source and publish a new version. Requires
+ * owner or platform admin. `skipValidation` opts out of the format
+ * validator on the pulled package — useful when the upstream repo
+ * doesn't strictly conform to Ornn's skill-package layout.
  */
-export async function refreshSkillFromSource(id: string): Promise<SkillDetail> {
-  const res = await apiPost<SkillDetail>(`/api/v1/skills/${id}/refresh`, {});
+export async function refreshSkillFromSource(
+  id: string,
+  options?: { skipValidation?: boolean },
+): Promise<SkillDetail> {
+  const res = await apiPost<SkillDetail>(`/api/v1/skills/${id}/refresh`, {
+    skipValidation: options?.skipValidation ?? false,
+  });
+  return res.data!;
+}
+
+/**
+ * Dry-run a refresh. Server pulls the latest content from the skill's
+ * stored GitHub source, computes a structured diff against the current
+ * latest version, and returns it WITHOUT bumping. Powers the
+ * preview-then-confirm flow on the detail-page Advanced Options panel.
+ */
+export interface RefreshPreviewResponse {
+  skill: { guid: string; name: string };
+  source: import("@/types/domain").SkillSource;
+  pendingVersion: string;
+  hasChanges: boolean;
+  diff: import("@/types/domain").VersionDiffResponse["diff"];
+}
+
+export async function previewSkillRefresh(id: string): Promise<RefreshPreviewResponse> {
+  const res = await apiPost<RefreshPreviewResponse>(`/api/v1/skills/${id}/refresh`, {
+    dryRun: true,
+  });
+  return res.data!;
+}
+
+/**
+ * Attach (or clear) a GitHub source pointer on an existing skill. Pass
+ * `null` for `githubUrl` to unlink. The pointer is parsed server-side
+ * from a folder URL like `https://github.com/<owner>/<repo>/tree/<ref>/<path>`.
+ * Does NOT pull — the user triggers `previewSkillRefresh` →
+ * `refreshSkillFromSource` separately.
+ */
+export async function setSkillSource(
+  id: string,
+  githubUrl: string | null,
+): Promise<SkillDetail> {
+  const res = await apiPut<SkillDetail>(`/api/v1/skills/${id}/source`, { githubUrl });
   return res.data!;
 }
 

--- a/ornn-web/src/types/domain.ts
+++ b/ornn-web/src/types/domain.ts
@@ -76,3 +76,75 @@ export interface SkillVersionEntry {
   isDeprecated: boolean;
   deprecationNote: string | null;
 }
+
+/**
+ * One file present only in `to` (a freshly added file). For text files the
+ * server inlines `content` (possibly capped at ~64 KiB → `truncated: true`);
+ * binary files come back without `content`.
+ */
+export interface DiffFileAdded {
+  path: string;
+  bytes: number;
+  hash: string;
+  isText: boolean;
+  content?: string;
+  truncated?: boolean;
+}
+
+/** One file present only in `from` (deleted in `to`). Same shape as added. */
+export interface DiffFileRemoved {
+  path: string;
+  bytes: number;
+  hash: string;
+  isText: boolean;
+  content?: string;
+  truncated?: boolean;
+}
+
+/**
+ * One file present in both versions but with different bytes. For text
+ * files the server inlines both sides so the client can render a unified
+ * line-level diff without a second fetch.
+ */
+export interface DiffFileModified {
+  path: string;
+  fromBytes: number;
+  toBytes: number;
+  fromHash: string;
+  toHash: string;
+  isText: boolean;
+  fromContent?: string;
+  toContent?: string;
+  truncated?: boolean;
+}
+
+/**
+ * Response shape for `GET /api/v1/skills/:idOrName/versions/:from/diff/:to`.
+ * `unchangedCount` is files that exist with identical bytes in both
+ * versions — only the count is reported to keep the response small.
+ */
+export interface VersionDiffResponse {
+  skill: { guid: string; name: string };
+  from: {
+    version: string;
+    hash: string;
+    createdOn: string;
+    isDeprecated: boolean;
+    releaseNotes: string | null;
+  };
+  to: {
+    version: string;
+    hash: string;
+    createdOn: string;
+    isDeprecated: boolean;
+    releaseNotes: string | null;
+  };
+  diff: {
+    files: {
+      added: DiffFileAdded[];
+      removed: DiffFileRemoved[];
+      modified: DiffFileModified[];
+      unchangedCount: number;
+    };
+  };
+}

--- a/ornn-web/src/types/domain.ts
+++ b/ornn-web/src/types/domain.ts
@@ -26,10 +26,18 @@ export type SkillSource =
       ref: string;
       /** Subdirectory inside the repo that contains SKILL.md. Empty = repo root. */
       path: string;
-      /** ISO timestamp of the most recent successful pull / refresh. */
-      lastSyncedAt: string;
-      /** Commit SHA fetched at `lastSyncedAt`. */
-      lastSyncedCommit: string;
+      /**
+       * ISO timestamp of the most recent successful pull / refresh.
+       * Absent when the user attached a GitHub link without triggering
+       * a sync — the source pointer is stored, but no version has been
+       * pulled from it yet.
+       */
+      lastSyncedAt?: string;
+      /**
+       * Commit SHA fetched at `lastSyncedAt`. Absent in the same
+       * "linked but never synced" state.
+       */
+      lastSyncedCommit?: string;
     };
 
 export interface SkillDetail extends SkillSummary {

--- a/ornn-web/src/types/search.ts
+++ b/ornn-web/src/types/search.ts
@@ -64,6 +64,14 @@ export interface SkillSearchResult {
   nyxidServiceLabel?: string | null;
   /** True iff tied to an admin/platform NyxID service. */
   isSystemSkill?: boolean;
+  /**
+   * True when the skill has a `source` pointer of type "github" — i.e.
+   * the owner has linked it to a folder in a public GitHub repo. The
+   * card uses this to render a small non-clickable GitHub mark in the
+   * badge row. The actual repo URL is not exposed in search results —
+   * users open the detail page to follow it.
+   */
+  hasGithubSource?: boolean;
 }
 
 export interface SkillSearchResponse {

--- a/skills/ornn-agent-manual-cli/SKILL.md
+++ b/skills/ornn-agent-manual-cli/SKILL.md
@@ -9,7 +9,7 @@ metadata:
     - manual
     - skill-lifecycle
     - cli
-version: "1.0"
+version: "1.1"
 lastUpdated: 2026-04-29
 ---
 
@@ -38,12 +38,13 @@ lastUpdated: 2026-04-29
 > - **Update a skill's visibility** (private / shared / public) — §2.2.
 > - **Publish a new version** of a skill you own — §2.3.
 > - **Trigger an audit** or **review the audit history** for a skill — §2.4 / §2.5.
-> - **Pull a non-latest version**, **diff two versions**, or **delete a version** — §2.6 / §2.7 / §2.10.
+> - **Pull a non-latest version**, **compare two versions**, or **delete / deprecate a version** — §2.6 / §2.7 / §2.10.
 > - **Check usage analytics** for a skill — §2.8.
 > - **Bind a skill to a NyxID service** (system / personal) — §2.9.
 > - **Delete a skill** entirely — §2.11.
 > - **Find skills** (by tag, author, system, shared, etc.) — §2.12.
 > - **Pull your Ornn notifications** (audit fan-out, etc.) — §2.13.
+> - **Link a skill to GitHub** or **trigger a sync** from the linked source — §2.14.
 >
 > Without this manual loaded, you do not know which endpoint to call, how to authenticate, or how to read the response shapes.
 >
@@ -397,9 +398,9 @@ nyxid proxy request ornn-api \
 
 **Step 3 — Install locally + update the registry.** **You are encouraged to ask the user for consent before overwriting an existing local copy.** If they say yes, write the new files over the old, bump `installedVersion` + `installedAt` in `~/.ornn/installed-skills.json`. If the user picked this version specifically as a pin, also set `isPinned: true` on the record so future sessions don't auto-prompt to update.
 
-### 2.7 Diff two versions of a skill — *spec: `api-reference.md` §3 Skills CRUD*
+### 2.7 Compare diff between two skill versions — *spec: `api-reference.md` §3.7 Skills CRUD*
 
-Useful before upgrading: see exactly what changed.
+**When:** the user (or you) want to know what changed between two published versions before pulling, upgrading, or generating a changelog.
 
 ```bash
 nyxid proxy request ornn-api \
@@ -407,7 +408,30 @@ nyxid proxy request ornn-api \
   --method GET --output json
 ```
 
-Response: `{ skill, from, to, diff: { added: [{ path, content }], removed: [{ path, content }], modified: [{ path, before, after }] } }`. File-level. Modified files include both sides' content so you can render a unified diff client-side.
+Response shape:
+
+```jsonc
+{
+  "data": {
+    "skill": { "guid": "…", "name": "…" },
+    "from":  { "version": "1.2", "hash": "…", "createdOn": "…", "isDeprecated": false, "releaseNotes": null },
+    "to":    { "version": "1.3", "hash": "…", "createdOn": "…", "isDeprecated": false, "releaseNotes": null },
+    "diff": {
+      "files": {
+        "added":   [{ "path": "scripts/new.js", "bytes": 1234, "isText": true, "content": "…" }],
+        "removed": [{ "path": "old.txt",        "bytes":  120, "isText": true, "content": "…" }],
+        "modified":[{ "path": "SKILL.md",       "fromBytes": 800, "toBytes": 920, "isText": true, "fromContent": "…", "toContent": "…" }],
+        "unchangedCount": 7
+      }
+    }
+  },
+  "error": null
+}
+```
+
+File-level diff. Text files come back with both sides' content (capped at ~64 KiB per side; flag `truncated: true` when capped) so you can render a unified line-level diff client-side without a second fetch — feed `fromContent` / `toContent` to your diff renderer (e.g., the `diff` npm package's `diffLines`). Binary files come back without `content` — just report the size + hash change.
+
+Same-version compares are rejected with `400 SAME_VERSION`. Short-circuit them locally — don't burn a round-trip on `from === to`.
 
 ### 2.8 Check a skill's usage analytics — *spec: `api-reference.md` §10 Analytics*
 
@@ -459,7 +483,26 @@ nyxid proxy request ornn-api "/api/v1/skills/<id>/nyxid-service" \
 
 Eligibility: regular users can bind a skill they own to (a) any admin service, or (b) one of *their own* personal services. Trying to bind to another user's personal service returns `403 NYXID_SERVICE_NOT_ELIGIBLE`. To make a system skill private again, unbind first — `PUT /skills/:id/permissions` with `isPrivate: true` is rejected with `SYSTEM_SKILL_MUST_BE_PUBLIC` while it's bound to an admin service.
 
-### 2.10 Delete a single non-latest version of a skill — *spec: `api-reference.md` §3 Skills CRUD*
+### 2.10 Delete or deprecate a single version — *spec: `api-reference.md` §3.8 + §3.14*
+
+**When:** an old version is broken, superseded, or otherwise something the user doesn't want consumers to keep using. Two options that leave the rest of the skill alone:
+
+- **Deprecate** — keeps the version readable and pullable, but stamps a warning on every read (`X-Skill-Deprecated: true` + `X-Skill-Deprecation-Note: <urlencoded>` headers, plus the deprecation note on the JSON response). Fully reversible. Use this when consumers may still need the version for compatibility.
+- **Delete** — removes the version row + its package zip from storage. Irreversible. Use this when the version is broken enough that you actively want it unreachable.
+
+**Mark deprecated** (the version stays — just flagged):
+
+```bash
+nyxid proxy request ornn-api \
+  "/api/v1/skills/<idOrName>/versions/<X.Y>" \
+  --method PATCH \
+  --data '{"isDeprecated": true, "deprecationNote": "Breaks with axios >= 1.7; use 1.3+."}' \
+  --output json
+```
+
+Un-deprecate: send the same request with `{"isDeprecated": false}`. Empty / omitted `deprecationNote` clears the message.
+
+**Hard-delete a non-latest version**:
 
 ```bash
 nyxid proxy request ornn-api \
@@ -467,7 +510,12 @@ nyxid proxy request ornn-api \
   --method DELETE --output json
 ```
 
-The backend refuses to delete the only-remaining version (use §2.11 to delete the whole skill instead) or the current latest version (publish a newer version first via §2.3, then delete the old one). After the call succeeds, **if the deleted version was your locally-installed one, also remove or refresh your local copy + update `~/.ornn/installed-skills.json` accordingly**.
+Backend refusals:
+
+- The version is the only-remaining version → `409 CANNOT_DELETE_ONLY_VERSION`. Use §2.11 to delete the whole skill instead.
+- The version is the current latest → `409 CANNOT_DELETE_LATEST`. Publish a newer version first via §2.3, then delete the older one.
+
+After the delete succeeds, **if the deleted version was your locally-installed one, also remove or refresh your local copy + update `~/.ornn/installed-skills.json` accordingly**.
 
 ### 2.11 Delete an entire skill — *spec: `api-reference.md` §3 Skills CRUD*
 
@@ -551,6 +599,69 @@ Two notification categories are emitted today:
 
 - `audit.completed` — sent to the skill owner on every audit completion.
 - `audit.risky_for_consumer` — fanned out to every consumer of the skill (everyone in `sharedWithUsers` + members of every org in `sharedWithOrgs`) when a verdict comes back `yellow` or `red`. **Treat this as a hard signal to stop using the skill** until you've reviewed the findings; surface it to the user and ask before continuing.
+
+### 2.14 Link a skill to GitHub or trigger a sync — *spec: `api-reference.md` §3.2 + §3.3 + §3.15*
+
+**When:** the user wants their Ornn skill to live in (or co-exist with) a public GitHub repo so updates flow from there into Ornn one-click. Three flows depending on starting state:
+
+#### A — Brand-new skill from GitHub *(no Ornn skill exists yet)*
+
+```bash
+nyxid proxy request ornn-api "/api/v1/skills/pull" \
+  --method POST \
+  --data '{
+    "githubUrl": "https://github.com/owner/repo/tree/main/path/to/skill",
+    "skip_validation": false
+  }' \
+  --output json
+```
+
+Server parses the URL, clones the folder, validates (unless `skip_validation`), and publishes as v1. The new skill carries a `source` block; `source.lastSyncedCommit` records the commit pulled at creation. Use `skip_validation: true` when the upstream repo wasn't authored against Ornn's package layout (most third-party repos).
+
+#### B — Attach a GitHub link to an EXISTING Ornn skill *(originally hand-uploaded)*
+
+```bash
+nyxid proxy request ornn-api "/api/v1/skills/<id>/source" \
+  --method PUT \
+  --data '{"githubUrl": "https://github.com/owner/repo/tree/main/path/to/skill"}' \
+  --output json
+```
+
+This **stores the source pointer without pulling**. `lastSyncedAt` / `lastSyncedCommit` stay absent until the first sync — the documented "linked but never synced" state. To unlink, call again with `{"githubUrl": null}`.
+
+#### C — Sync (pull updates from the linked GitHub source)
+
+Run as **two calls** so you can show the user a diff before bumping the version:
+
+```bash
+# 1. Dry-run — pull, compute diff vs current latest, return WITHOUT bumping.
+nyxid proxy request ornn-api "/api/v1/skills/<id>/refresh" \
+  --method POST \
+  --data '{"dryRun": true}' \
+  --output json
+```
+
+Dry-run response: `{ skill, source, pendingVersion, hasChanges, diff }`. The `diff` field has the same shape as §2.7's response (file-level added / removed / modified with inline content for text files), so you can hand it to the same diff renderer.
+
+- If `hasChanges: false` → the skill is already in sync. Tell the user, don't proceed.
+- If `hasChanges: true` → surface the diff and `pendingVersion` to the user. Ask for confirmation.
+
+```bash
+# 2. Apply — actually bump the version and replace the latest content.
+nyxid proxy request ornn-api "/api/v1/skills/<id>/refresh" \
+  --method POST \
+  --data '{"dryRun": false, "skipValidation": false}' \
+  --output json
+```
+
+Apply response: the refreshed `SkillDetail`. `source.lastSyncedAt` and `source.lastSyncedCommit` advance.
+
+#### Errors worth handling
+
+- `INVALID_GITHUB_URL` (400) on flows A or B — the URL is `blob/...`, non-`github.com`, or otherwise unparseable. Show the user the message; they need a folder URL like `tree/<ref>/<path>`.
+- `NO_SOURCE` (400) on flow C — no link is attached. Run flow B first, then re-try.
+- `REFRESH_FAILED` (400) on apply, `REFRESH_PREVIEW_FAILED` (400) on dry-run — the upstream folder no longer exists, or the pulled package failed validation. If the upstream is trusted and the failure is validation, retry apply with `skipValidation: true`.
+- `NOT_SKILL_OWNER` (403) — the caller isn't the author and lacks `ornn:admin:skill`.
 
 ---
 

--- a/skills/ornn-agent-manual-cli/references/api-reference.md
+++ b/skills/ornn-agent-manual-cli/references/api-reference.md
@@ -345,39 +345,76 @@ Request body (`application/json`):
 
 ```jsonc
 {
-  "repo": "owner/name",          // required
+  // Preferred — a single folder URL the user copied from the browser
+  // address bar; the server parses out repo / ref / path.
+  "githubUrl": "https://github.com/owner/repo/tree/main/path/to/skill",
+
+  // Legacy / explicit form. Either provide `githubUrl` OR (`repo` plus
+  // optional `ref`/`path`). `githubUrl` wins when both are sent.
+  "repo": "owner/name",
   "ref": "main",                 // optional — branch, tag, or commit SHA. Default: repo default branch.
   "path": "skills/my-skill",     // optional — sub-directory inside repo. Default: repo root.
-  "skip_validation": false       // optional
+
+  "skip_validation": false       // optional. Skips the format validator on the pulled ZIP — useful when upstream doesn't strictly conform to Ornn's package layout.
 }
 ```
+
+The accepted `githubUrl` shapes are: `https://github.com/<owner>/<repo>/tree/<ref>/<path...>`, `https://github.com/<owner>/<repo>/tree/<ref>`, and `https://github.com/<owner>/<repo>` (defaults to the repo root). `blob/` URLs (which point at a single file) and non-`github.com` hosts are rejected with `INVALID_GITHUB_URL`.
 
 Response 200: same shape as `POST /skills` — the freshly created `SkillDetail`. The skill's `source.lastSyncedCommit` records the commit SHA pulled at creation time.
 
 | Code | Status | Cause |
 |---|---|---|
-| `MISSING_REPO` | 400 | `repo` field missing or non-string. |
+| `MISSING_SOURCE` | 400 | Neither `githubUrl` nor `repo` was provided. |
+| `INVALID_GITHUB_URL` | 400 | `githubUrl` couldn't be parsed (blob URL, non-github host, missing repo, etc.). `message` carries the specific reason. |
 | `PULL_FAILED` | 400 | The repo couldn't be cloned, the path was empty, or the package failed to materialise. `message` carries the underlying cause. |
-| `VALIDATION_FAILED` | 400 | Pulled package failed format validation. |
-| `AUTH_MISSING` | 401 / `FORBIDDEN` | 403 — same as §3.1. |
+| `VALIDATION_FAILED` | 400 | Pulled package failed format validation (and `skip_validation` was not set). |
+| `AUTH_MISSING` / `FORBIDDEN` | 401 / 403 | Same as §3.1. |
 
 ### 3.3 Refresh from source — `POST /api/v1/skills/:id/refresh`
 
-Re-pull the skill's recorded GitHub source and publish a new version if the bytes changed.
+Re-pull the skill's recorded GitHub source. Two modes selected by the request body:
+
+- **Apply mode (default).** Pulls, validates (unless `skipValidation` is `true`), and publishes a new version when the bytes differ from the current latest.
+- **Dry-run mode (`dryRun: true`).** Pulls, computes a structured diff against the current latest version, and returns the diff without publishing. Drives the "preview-then-confirm" UI flow on the detail-page Advanced Options panel — surface the diff to the user, then call again with `dryRun: false` to commit.
 
 **Auth: required.** **Permission: `ornn:skill:update`.** **Owner OR platform admin** (`ornn:admin:skill`).
 
 Path param: `:id` — skill GUID (not name).
 
-Body: ignored.
+Request body (`application/json`):
 
-Response 200: the refreshed `SkillDetail`. `source.lastSyncedCommit` and `source.lastSyncedAt` advance.
+```jsonc
+{
+  "dryRun": false,         // optional. true → diff preview, no version bump. false / omitted → apply.
+  "skipValidation": false  // optional (apply mode only). Skips the format validator on the pulled package.
+}
+```
+
+Response 200 — apply mode: the refreshed `SkillDetail`. `source.lastSyncedCommit` and `source.lastSyncedAt` advance.
+
+Response 200 — dry-run mode:
+
+```jsonc
+{
+  "data": {
+    "skill":           { "guid": "…", "name": "…" },
+    "source":          { /* SkillSource, with lastSyncedCommit set to the commit that WOULD be pulled */ },
+    "pendingVersion":  "1.3",            // version the SKILL.md frontmatter inside the pulled bytes declares
+    "hasChanges":      true,             // false → upstream is byte-identical to current latest; nothing to bump
+    "diff":            { /* same shape as §3.7 — { files: { added, removed, modified, unchangedCount } } */ }
+  },
+  "error": null
+}
+```
 
 | Code | Status | Cause |
 |---|---|---|
 | `SKILL_NOT_FOUND` | 404 | No skill with that GUID. |
 | `NOT_SKILL_OWNER` | 403 | Caller is not the author and lacks `ornn:admin:skill`. |
-| `REFRESH_FAILED` | 400 | Source repo could not be re-fetched, or the resulting package failed validation. |
+| `NO_SOURCE` | 400 | Skill has no linked GitHub source. Attach one via §3.15 first. |
+| `REFRESH_FAILED` | 400 | Source repo could not be re-fetched, or the resulting package failed validation (apply mode). |
+| `REFRESH_PREVIEW_FAILED` | 400 | Dry-run pull failed (e.g. upstream folder removed). |
 | `AUTH_MISSING` / `FORBIDDEN` | 401 / 403 | Standard. |
 
 ### 3.4 Get skill — `GET /api/v1/skills/:idOrName`
@@ -798,6 +835,35 @@ Both refusals surface as a 400 with a descriptive code (`CANNOT_DELETE_LATEST`, 
 | `CANNOT_DELETE_ONLY_VERSION` | 400 | Skill has only one version. |
 | `FORBIDDEN` | 403 | Caller is not the author / not platform admin. |
 | `AUTH_MISSING` | 401 | Standard. |
+
+### 3.15 Set / clear GitHub source — `PUT /api/v1/skills/:id/source`
+
+Attach (or clear) a GitHub source pointer on an existing skill **without pulling**. Lets a user link an originally hand-uploaded skill to its GitHub source first and trigger the actual sync separately via §3.3 (typically dry-run → confirm → apply). Pass `null` to unlink.
+
+**Auth: required.** **Permission: `ornn:skill:update`.** **Owner OR platform admin** (`ornn:admin:skill`).
+
+Path param: `:id` — skill GUID (not name).
+
+Request body (`application/json`):
+
+```jsonc
+{
+  // Folder URL on github.com. Same shapes accepted by §3.2's `githubUrl`:
+  // /tree/<ref>/<path>, /tree/<ref>, or bare repo URL.
+  // Pass `null` to remove the existing source pointer.
+  "githubUrl": "https://github.com/owner/repo/tree/main/path/to/skill"
+}
+```
+
+Response 200: the updated `SkillDetail`. The stored `source` block omits `lastSyncedAt` / `lastSyncedCommit` until the first sync (apply-mode refresh) — that's the documented "linked but never synced" state.
+
+| Code | Status | Cause |
+|---|---|---|
+| `SKILL_NOT_FOUND` | 404 | No skill with that GUID. |
+| `NOT_SKILL_OWNER` | 403 | Caller is not the author and lacks `ornn:admin:skill`. |
+| `INVALID_BODY` | 400 | `githubUrl` is missing or not `string \| null`. |
+| `INVALID_GITHUB_URL` | 400 | URL couldn't be parsed (blob URL, non-github host, missing repo, etc.). |
+| `AUTH_MISSING` / `FORBIDDEN` | 401 / 403 | Standard. |
 
 ---
 

--- a/skills/ornn-agent-manual-http/SKILL.md
+++ b/skills/ornn-agent-manual-http/SKILL.md
@@ -9,7 +9,7 @@ metadata:
     - manual
     - skill-lifecycle
     - http
-version: "1.0"
+version: "1.1"
 lastUpdated: 2026-04-29
 ---
 
@@ -38,12 +38,13 @@ lastUpdated: 2026-04-29
 > - **Update a skill's visibility** (private / shared / public) — §2.2.
 > - **Publish a new version** of a skill you own — §2.3.
 > - **Trigger an audit** or **review the audit history** for a skill — §2.4 / §2.5.
-> - **Pull a non-latest version**, **diff two versions**, or **delete a version** — §2.6 / §2.7 / §2.10.
+> - **Pull a non-latest version**, **compare two versions**, or **delete / deprecate a version** — §2.6 / §2.7 / §2.10.
 > - **Check usage analytics** for a skill — §2.8.
 > - **Bind a skill to a NyxID service** (system / personal) — §2.9.
 > - **Delete a skill** entirely — §2.11.
 > - **Find skills** (by tag, author, system, shared, etc.) — §2.12.
 > - **Pull your Ornn notifications** (audit fan-out, etc.) — §2.13.
+> - **Link a skill to GitHub** or **trigger a sync** from the linked source — §2.14.
 >
 > Without this manual loaded, you do not know which endpoint to call, how to authenticate, or how to read the response shapes.
 >
@@ -423,16 +424,39 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 **Step 3 — Install locally + update the registry.** **You are encouraged to ask the user for consent before overwriting an existing local copy.** If they say yes, write the new files over the old, bump `installedVersion` + `installedAt` in `~/.ornn/installed-skills.json`. If the user picked this version specifically as a pin, also set `isPinned: true` on the record so future sessions don't auto-prompt to update.
 
-### 2.7 Diff two versions of a skill — *spec: `api-reference.md` §3 Skills CRUD*
+### 2.7 Compare diff between two skill versions — *spec: `api-reference.md` §3.7 Skills CRUD*
 
-Useful before upgrading: see exactly what changed.
+**When:** the user (or you) want to know what changed between two published versions before pulling, upgrading, or generating a changelog.
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
   "https://ornn.chrono-ai.fun/api/v1/skills/<idOrName>/versions/<from-X.Y>/diff/<to-X.Y>"
 ```
 
-Response: `{ skill, from, to, diff: { added: [{ path, content }], removed: [{ path, content }], modified: [{ path, before, after }] } }`. File-level. Modified files include both sides' content so you can render a unified diff client-side.
+Response shape:
+
+```jsonc
+{
+  "data": {
+    "skill": { "guid": "…", "name": "…" },
+    "from":  { "version": "1.2", "hash": "…", "createdOn": "…", "isDeprecated": false, "releaseNotes": null },
+    "to":    { "version": "1.3", "hash": "…", "createdOn": "…", "isDeprecated": false, "releaseNotes": null },
+    "diff": {
+      "files": {
+        "added":   [{ "path": "scripts/new.js", "bytes": 1234, "isText": true, "content": "…" }],
+        "removed": [{ "path": "old.txt",        "bytes":  120, "isText": true, "content": "…" }],
+        "modified":[{ "path": "SKILL.md",       "fromBytes": 800, "toBytes": 920, "isText": true, "fromContent": "…", "toContent": "…" }],
+        "unchangedCount": 7
+      }
+    }
+  },
+  "error": null
+}
+```
+
+File-level diff. Text files come back with both sides' content (capped at ~64 KiB per side; flag `truncated: true` when capped) so you can render a unified line-level diff client-side without a second fetch — feed `fromContent` / `toContent` to your diff renderer (e.g., the `diff` npm package's `diffLines`). Binary files come back without `content` — just report the size + hash change.
+
+Same-version compares are rejected with `400 SAME_VERSION`. Short-circuit them locally — don't burn a round-trip on `from === to`.
 
 ### 2.8 Check a skill's usage analytics — *spec: `api-reference.md` §10 Analytics*
 
@@ -484,7 +508,26 @@ curl -X PUT \
 
 Eligibility: regular users can bind a skill they own to (a) any admin service, or (b) one of *their own* personal services. Trying to bind to another user's personal service returns `403 NYXID_SERVICE_NOT_ELIGIBLE`. To make a system skill private again, unbind first — `PUT /skills/:id/permissions` with `isPrivate: true` is rejected with `SYSTEM_SKILL_MUST_BE_PUBLIC` while it's bound to an admin service.
 
-### 2.10 Delete a single non-latest version of a skill — *spec: `api-reference.md` §3 Skills CRUD*
+### 2.10 Delete or deprecate a single version — *spec: `api-reference.md` §3.8 + §3.14*
+
+**When:** an old version is broken, superseded, or otherwise something the user doesn't want consumers to keep using. Two options that leave the rest of the skill alone:
+
+- **Deprecate** — keeps the version readable and pullable, but stamps a warning on every read (`X-Skill-Deprecated: true` + `X-Skill-Deprecation-Note: <urlencoded>` headers, plus the deprecation note on the JSON response). Fully reversible. Use this when consumers may still need the version for compatibility.
+- **Delete** — removes the version row + its package zip from storage. Irreversible. Use this when the version is broken enough that you actively want it unreachable.
+
+**Mark deprecated** (the version stays — just flagged):
+
+```bash
+curl -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"isDeprecated": true, "deprecationNote": "Breaks with axios >= 1.7; use 1.3+."}' \
+  "https://ornn.chrono-ai.fun/api/v1/skills/<idOrName>/versions/<X.Y>"
+```
+
+Un-deprecate: send the same request with `{"isDeprecated": false}`. Empty / omitted `deprecationNote` clears the message.
+
+**Hard-delete a non-latest version**:
 
 ```bash
 curl -X DELETE \
@@ -492,7 +535,12 @@ curl -X DELETE \
   "https://ornn.chrono-ai.fun/api/v1/skills/<idOrName>/versions/<X.Y>"
 ```
 
-The backend refuses to delete the only-remaining version (use §2.11 to delete the whole skill instead) or the current latest version (publish a newer version first via §2.3, then delete the old one). After the call succeeds, **if the deleted version was your locally-installed one, also remove or refresh your local copy + update `~/.ornn/installed-skills.json` accordingly**.
+Backend refusals:
+
+- The version is the only-remaining version → `409 CANNOT_DELETE_ONLY_VERSION`. Use §2.11 to delete the whole skill instead.
+- The version is the current latest → `409 CANNOT_DELETE_LATEST`. Publish a newer version first via §2.3, then delete the older one.
+
+After the delete succeeds, **if the deleted version was your locally-installed one, also remove or refresh your local copy + update `~/.ornn/installed-skills.json` accordingly**.
 
 ### 2.11 Delete an entire skill — *spec: `api-reference.md` §3 Skills CRUD*
 
@@ -578,6 +626,73 @@ Two notification categories are emitted today:
 
 - `audit.completed` — sent to the skill owner on every audit completion.
 - `audit.risky_for_consumer` — fanned out to every consumer of the skill (everyone in `sharedWithUsers` + members of every org in `sharedWithOrgs`) when a verdict comes back `yellow` or `red`. **Treat this as a hard signal to stop using the skill** until you've reviewed the findings; surface it to the user and ask before continuing.
+
+### 2.14 Link a skill to GitHub or trigger a sync — *spec: `api-reference.md` §3.2 + §3.3 + §3.15*
+
+**When:** the user wants their Ornn skill to live in (or co-exist with) a public GitHub repo so updates flow from there into Ornn one-click. Three flows depending on starting state:
+
+#### A — Brand-new skill from GitHub *(no Ornn skill exists yet)*
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "githubUrl": "https://github.com/owner/repo/tree/main/path/to/skill",
+    "skip_validation": false
+  }' \
+  "https://ornn.chrono-ai.fun/api/v1/skills/pull"
+```
+
+Server parses the URL, clones the folder, validates (unless `skip_validation`), and publishes as v1. The new skill carries a `source` block; `source.lastSyncedCommit` records the commit pulled at creation. Use `skip_validation: true` when the upstream repo wasn't authored against Ornn's package layout (most third-party repos).
+
+#### B — Attach a GitHub link to an EXISTING Ornn skill *(originally hand-uploaded)*
+
+```bash
+curl -X PUT \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"githubUrl": "https://github.com/owner/repo/tree/main/path/to/skill"}' \
+  "https://ornn.chrono-ai.fun/api/v1/skills/<id>/source"
+```
+
+This **stores the source pointer without pulling**. `lastSyncedAt` / `lastSyncedCommit` stay absent until the first sync — the documented "linked but never synced" state. To unlink, call again with `{"githubUrl": null}`.
+
+#### C — Sync (pull updates from the linked GitHub source)
+
+Run as **two calls** so you can show the user a diff before bumping the version:
+
+```bash
+# 1. Dry-run — pull, compute diff vs current latest, return WITHOUT bumping.
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dryRun": true}' \
+  "https://ornn.chrono-ai.fun/api/v1/skills/<id>/refresh"
+```
+
+Dry-run response: `{ skill, source, pendingVersion, hasChanges, diff }`. The `diff` field has the same shape as §2.7's response (file-level added / removed / modified with inline content for text files), so you can hand it to the same diff renderer.
+
+- If `hasChanges: false` → the skill is already in sync. Tell the user, don't proceed.
+- If `hasChanges: true` → surface the diff and `pendingVersion` to the user. Ask for confirmation.
+
+```bash
+# 2. Apply — actually bump the version and replace the latest content.
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"dryRun": false, "skipValidation": false}' \
+  "https://ornn.chrono-ai.fun/api/v1/skills/<id>/refresh"
+```
+
+Apply response: the refreshed `SkillDetail`. `source.lastSyncedAt` and `source.lastSyncedCommit` advance.
+
+#### Errors worth handling
+
+- `INVALID_GITHUB_URL` (400) on flows A or B — the URL is `blob/...`, non-`github.com`, or otherwise unparseable. Show the user the message; they need a folder URL like `tree/<ref>/<path>`.
+- `NO_SOURCE` (400) on flow C — no link is attached. Run flow B first, then re-try.
+- `REFRESH_FAILED` (400) on apply, `REFRESH_PREVIEW_FAILED` (400) on dry-run — the upstream folder no longer exists, or the pulled package failed validation. If the upstream is trusted and the failure is validation, retry apply with `skipValidation: true`.
+- `NOT_SKILL_OWNER` (403) — the caller isn't the author and lacks `ornn:admin:skill`.
 
 ---
 

--- a/skills/ornn-agent-manual-http/references/api-reference.md
+++ b/skills/ornn-agent-manual-http/references/api-reference.md
@@ -345,39 +345,76 @@ Request body (`application/json`):
 
 ```jsonc
 {
-  "repo": "owner/name",          // required
+  // Preferred — a single folder URL the user copied from the browser
+  // address bar; the server parses out repo / ref / path.
+  "githubUrl": "https://github.com/owner/repo/tree/main/path/to/skill",
+
+  // Legacy / explicit form. Either provide `githubUrl` OR (`repo` plus
+  // optional `ref`/`path`). `githubUrl` wins when both are sent.
+  "repo": "owner/name",
   "ref": "main",                 // optional — branch, tag, or commit SHA. Default: repo default branch.
   "path": "skills/my-skill",     // optional — sub-directory inside repo. Default: repo root.
-  "skip_validation": false       // optional
+
+  "skip_validation": false       // optional. Skips the format validator on the pulled ZIP — useful when upstream doesn't strictly conform to Ornn's package layout.
 }
 ```
+
+The accepted `githubUrl` shapes are: `https://github.com/<owner>/<repo>/tree/<ref>/<path...>`, `https://github.com/<owner>/<repo>/tree/<ref>`, and `https://github.com/<owner>/<repo>` (defaults to the repo root). `blob/` URLs (which point at a single file) and non-`github.com` hosts are rejected with `INVALID_GITHUB_URL`.
 
 Response 200: same shape as `POST /skills` — the freshly created `SkillDetail`. The skill's `source.lastSyncedCommit` records the commit SHA pulled at creation time.
 
 | Code | Status | Cause |
 |---|---|---|
-| `MISSING_REPO` | 400 | `repo` field missing or non-string. |
+| `MISSING_SOURCE` | 400 | Neither `githubUrl` nor `repo` was provided. |
+| `INVALID_GITHUB_URL` | 400 | `githubUrl` couldn't be parsed (blob URL, non-github host, missing repo, etc.). `message` carries the specific reason. |
 | `PULL_FAILED` | 400 | The repo couldn't be cloned, the path was empty, or the package failed to materialise. `message` carries the underlying cause. |
-| `VALIDATION_FAILED` | 400 | Pulled package failed format validation. |
-| `AUTH_MISSING` | 401 / `FORBIDDEN` | 403 — same as §3.1. |
+| `VALIDATION_FAILED` | 400 | Pulled package failed format validation (and `skip_validation` was not set). |
+| `AUTH_MISSING` / `FORBIDDEN` | 401 / 403 | Same as §3.1. |
 
 ### 3.3 Refresh from source — `POST /api/v1/skills/:id/refresh`
 
-Re-pull the skill's recorded GitHub source and publish a new version if the bytes changed.
+Re-pull the skill's recorded GitHub source. Two modes selected by the request body:
+
+- **Apply mode (default).** Pulls, validates (unless `skipValidation` is `true`), and publishes a new version when the bytes differ from the current latest.
+- **Dry-run mode (`dryRun: true`).** Pulls, computes a structured diff against the current latest version, and returns the diff without publishing. Drives the "preview-then-confirm" UI flow on the detail-page Advanced Options panel — surface the diff to the user, then call again with `dryRun: false` to commit.
 
 **Auth: required.** **Permission: `ornn:skill:update`.** **Owner OR platform admin** (`ornn:admin:skill`).
 
 Path param: `:id` — skill GUID (not name).
 
-Body: ignored.
+Request body (`application/json`):
 
-Response 200: the refreshed `SkillDetail`. `source.lastSyncedCommit` and `source.lastSyncedAt` advance.
+```jsonc
+{
+  "dryRun": false,         // optional. true → diff preview, no version bump. false / omitted → apply.
+  "skipValidation": false  // optional (apply mode only). Skips the format validator on the pulled package.
+}
+```
+
+Response 200 — apply mode: the refreshed `SkillDetail`. `source.lastSyncedCommit` and `source.lastSyncedAt` advance.
+
+Response 200 — dry-run mode:
+
+```jsonc
+{
+  "data": {
+    "skill":           { "guid": "…", "name": "…" },
+    "source":          { /* SkillSource, with lastSyncedCommit set to the commit that WOULD be pulled */ },
+    "pendingVersion":  "1.3",            // version the SKILL.md frontmatter inside the pulled bytes declares
+    "hasChanges":      true,             // false → upstream is byte-identical to current latest; nothing to bump
+    "diff":            { /* same shape as §3.7 — { files: { added, removed, modified, unchangedCount } } */ }
+  },
+  "error": null
+}
+```
 
 | Code | Status | Cause |
 |---|---|---|
 | `SKILL_NOT_FOUND` | 404 | No skill with that GUID. |
 | `NOT_SKILL_OWNER` | 403 | Caller is not the author and lacks `ornn:admin:skill`. |
-| `REFRESH_FAILED` | 400 | Source repo could not be re-fetched, or the resulting package failed validation. |
+| `NO_SOURCE` | 400 | Skill has no linked GitHub source. Attach one via §3.15 first. |
+| `REFRESH_FAILED` | 400 | Source repo could not be re-fetched, or the resulting package failed validation (apply mode). |
+| `REFRESH_PREVIEW_FAILED` | 400 | Dry-run pull failed (e.g. upstream folder removed). |
 | `AUTH_MISSING` / `FORBIDDEN` | 401 / 403 | Standard. |
 
 ### 3.4 Get skill — `GET /api/v1/skills/:idOrName`
@@ -798,6 +835,35 @@ Both refusals surface as a 400 with a descriptive code (`CANNOT_DELETE_LATEST`, 
 | `CANNOT_DELETE_ONLY_VERSION` | 400 | Skill has only one version. |
 | `FORBIDDEN` | 403 | Caller is not the author / not platform admin. |
 | `AUTH_MISSING` | 401 | Standard. |
+
+### 3.15 Set / clear GitHub source — `PUT /api/v1/skills/:id/source`
+
+Attach (or clear) a GitHub source pointer on an existing skill **without pulling**. Lets a user link an originally hand-uploaded skill to its GitHub source first and trigger the actual sync separately via §3.3 (typically dry-run → confirm → apply). Pass `null` to unlink.
+
+**Auth: required.** **Permission: `ornn:skill:update`.** **Owner OR platform admin** (`ornn:admin:skill`).
+
+Path param: `:id` — skill GUID (not name).
+
+Request body (`application/json`):
+
+```jsonc
+{
+  // Folder URL on github.com. Same shapes accepted by §3.2's `githubUrl`:
+  // /tree/<ref>/<path>, /tree/<ref>, or bare repo URL.
+  // Pass `null` to remove the existing source pointer.
+  "githubUrl": "https://github.com/owner/repo/tree/main/path/to/skill"
+}
+```
+
+Response 200: the updated `SkillDetail`. The stored `source` block omits `lastSyncedAt` / `lastSyncedCommit` until the first sync (apply-mode refresh) — that's the documented "linked but never synced" state.
+
+| Code | Status | Cause |
+|---|---|---|
+| `SKILL_NOT_FOUND` | 404 | No skill with that GUID. |
+| `NOT_SKILL_OWNER` | 403 | Caller is not the author and lacks `ornn:admin:skill`. |
+| `INVALID_BODY` | 400 | `githubUrl` is missing or not `string \| null`. |
+| `INVALID_GITHUB_URL` | 400 | URL couldn't be parsed (blob URL, non-github host, missing repo, etc.). |
+| `AUTH_MISSING` / `FORBIDDEN` | 401 / 403 | Standard. |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #225 (version diff UI) and #226 (delete-non-latest-version polish). Bundles the GitHub-link redesign requested mid-session and the agent-manual v1.1 refresh.

### Frontend (`ornn-web`)

- **#225 — Version diff UI.** New `VersionDiffModal` accessible from the all-versions modal on the skill detail page. Two version pickers default to current → latest; the response (added / removed / modified) renders with a unified line-level diff for every modified text file via the `diff` npm package. Same-version compares short-circuit locally so the backend doesn't see them.
- **#226 — Delete-version button polish.** The per-row Delete button now stays visible for owners / admins on the only-remaining and current-latest cases, but renders disabled with a tooltip pointing the user at the right alternative (use the danger-zone delete-skill, or publish a newer version first). Previously it just disappeared so on a single-version skill there was no affordance at all.
- **GitHub-link redesign.** New "Link to GitHub" panel inside `AdvancedOptionsModal`: a single GitHub folder URL, skip-validation toggle, Save / Sync / Unlink. Sync runs a dry-run preview first; if no changes detected, toasts "already in sync"; otherwise switches the panel into a sync-preview view (rendered via the new shared `VersionDiffView`) and asks the user to confirm with an "Apply sync" button. The `/skills/new/from-github` build flow was rewritten to take the same single GitHub folder URL + skip-validation toggle.
- **Surface GitHub-linked skills.** A small icon button to the left of "Try in Playground" on the skill detail page (opens the deep-linked folder); a small non-clickable github mark in the badge cluster on each explore card.
- **Advanced Options modal — fixed 80vh shell.** Left rail and right pane scroll independently; long sync-preview content no longer stretches the modal.
- **Build-page mode cards** — uniform primary CTA across all four modes, pinned to the card bottom via `mt-auto`, short labels (Start / Start / Start / Import) so they fit in any card width.

### Backend (`ornn-api`)

- New `parseGithubUrl` helper accepts the canonical folder URL (`https://github.com/<owner>/<repo>/tree/<ref>/<path>`) and rejects `blob/` URLs / non-github hosts. 11 unit tests.
- New `PUT /api/v1/skills/:id/source` — attach (or clear with `{ githubUrl: null }`) a GitHub source pointer **without pulling**. Lets a hand-uploaded skill be linked to a GitHub source and synced separately. The stored `source` omits `lastSyncedAt` / `lastSyncedCommit` until the first sync (the new "linked but never synced" state — both fields made optional).
- `POST /api/v1/skills/:id/refresh` now accepts `{ dryRun?, skipValidation? }`. `dryRun: true` pulls, computes a diff vs latest, and returns `{ skill, source, pendingVersion, hasChanges, diff }` without bumping. `skipValidation: true` opts out of the format validator.
- `POST /api/v1/skills/pull` now accepts `githubUrl` (preferred) alongside the legacy `repo`/`ref`/`path` form.
- Search service projects `hasGithubSource: boolean` on every search row.
- `mapDoc` no longer fabricates an `Invalid Date` when source was linked but never synced.

### Docs / skills

- Both `ornn-agent-manual-cli` and `ornn-agent-manual-http` bumped to **v1.1** with three updated / new use cases:
  - **§2.7** rewritten as "Compare diff between two skill versions" with full response shape + same-version short-circuit guidance.
  - **§2.10** expanded to "Delete or deprecate a single version" — covers PATCH (deprecate / un-deprecate) and DELETE with refusal cases.
  - **§2.14** NEW: "Link a skill to GitHub or trigger a sync" — three flows (new from GitHub / attach link / dry-run-then-apply sync) with error handling.
- `references/api-reference.md` updated for §3.2 (`githubUrl` field), §3.3 (`dryRun` + `skipValidation`), and a new §3.15 (`PUT /skills/:id/source`).

## Test plan

- [ ] CI green (lint, typecheck, api / web / sdk tests, docker-build)
- [ ] On a multi-version skill: open the all-versions modal → "Compare versions" button → pick two versions → verify diff renders with the file-level + line-level breakdown
- [ ] On a single-version skill: open the all-versions modal → Delete button is visible but disabled with tooltip
- [ ] On a skill you own: Advanced Options → Link to GitHub → save a folder URL → toast "GitHub link saved" → click Sync → diff preview opens (or "already in sync" toast)
- [ ] Confirm Apply on the preview → toast "Synced from GitHub" → version bumps and the skill body refreshes
- [ ] `/skills/new/from-github` accepts a single folder URL and creates the skill in one click
- [ ] Build page (`/skills/new`): all four mode cards have the same color/size CTA pinned to the bottom; labels are visible at any card width
- [ ] GitHub-linked skill: GitHub icon visible on the hero strip (clickable, new tab) and on the explore card (non-clickable)