### PR TITLE
fix(infra): pin bun + copy real workspace package.jsons in both Dockerfiles

### DIFF
--- a/.changeset/dockerfile-pin-bun-and-copy-real-workspace-package-jsons.md
+++ b/.changeset/dockerfile-pin-bun-and-copy-real-workspace-package-jsons.md
@@ -1,0 +1,24 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+fix(infra): pin bun in both Dockerfiles + copy real sibling workspace package.jsons instead of stubbing.
+
+Caught while redeploying locally: a fresh `--no-cache` build of `ornn-web` failed at typecheck with `Cannot find module 'zustand'`. `bun install` ran successfully but skipped hoisting some transitive deps because the stubbed `ornn-api` / `ornn-sdk` `package.json` files (`{"name":"...","version":"...","private":true}` — no `dependencies` block) misled bun's hoister. The host's pinned bun (`1.3.8`) hoisted those deps fine; the floating `oven/bun:latest` had already moved to `1.3.13`, which behaves differently here.
+
+Two-line repro of the hoister mismatch:
+
+```
+COPY ornn-api/package.json ornn-api/   # real, with deps
+COPY ornn-sdk/package.json ornn-sdk/   # real, with deps
+```
+
+…replaces the previous `RUN mkdir … && echo '{}' > …/package.json` stubs that used to drift away from `bun.lock`.
+
+Both Dockerfiles now:
+
+- **Pin to `oven/bun:1.3.13`** (was `oven/bun:latest`). Stops surprise-upgrades from breaking the build.
+- **Copy the real workspace `package.json` files** for every sibling the lockfile references, instead of stubbing them. Keeps `bun.lock` + the on-disk workspace graph consistent.
+
+No runtime behaviour changes — pure build-pipeline reliability.

--- a/ornn-api/Dockerfile
+++ b/ornn-api/Dockerfile
@@ -1,23 +1,27 @@
-FROM oven/bun:latest AS install
+# Pin bun explicitly. `oven/bun:latest` floats and bun's workspace
+# hoister behaviour has shifted between releases (see the comment in
+# ornn-web/Dockerfile for the failure mode). Same pinning + same
+# copy-the-real-package.jsons treatment here so the install stage stays
+# reproducible.
+FROM oven/bun:1.3.13 AS install
 
 WORKDIR /app
 
 # Copy workspace root package files
 COPY package.json bun.lock ./
 
-# Copy this service
+# Copy every workspace package.json the lockfile references. Stubs used
+# to live here too (see git history) and they hit the same bun-hoister
+# issue documented in ornn-web/Dockerfile — the lockfile and stubbed
+# package.jsons drifted apart and `bun install` skipped hoistable deps.
 COPY ornn-api/package.json ornn-api/
-
-# Stub sibling workspaces (required by bun workspace resolution) —
-# only the ornn-api dep graph is actually needed at runtime, so minimal
-# placeholders satisfy the resolver without pulling their deps.
-RUN mkdir -p ornn-web && echo '{"name":"ornn-web","version":"1.0.0","private":true}' > ornn-web/package.json
-RUN mkdir -p ornn-sdk && echo '{"name":"@chronoai/ornn-sdk","version":"1.0.0","private":true}' > ornn-sdk/package.json
+COPY ornn-web/package.json ornn-web/
+COPY ornn-sdk/package.json ornn-sdk/
 
 RUN bun install
 
 # Runtime stage
-FROM oven/bun:latest
+FROM oven/bun:1.3.13
 
 WORKDIR /app
 

--- a/ornn-web/Dockerfile
+++ b/ornn-web/Dockerfile
@@ -1,16 +1,26 @@
-FROM oven/bun:latest AS build
+# Pin bun explicitly. `oven/bun:latest` floats and bun's workspace
+# hoister behaviour has shifted between releases — earlier we saw
+# `bun install` silently skip hoistable deps (e.g. `zustand`) when
+# sibling workspaces were stubbed with empty `dependencies` blocks,
+# then `bun run build` blew up at typecheck with "Cannot find module
+# 'zustand'". Pinning here + copying the real sibling package.jsons
+# below makes the install reproducible across CI / local / fresh dev
+# machines.
+FROM oven/bun:1.3.13 AS build
 WORKDIR /app
 
 # Copy workspace root package files
 COPY package.json bun.lock ./
 
-# Copy frontend package
+# Copy every workspace package.json the lockfile references. We used to
+# stub ornn-api / ornn-sdk to skip pulling their deps for the frontend
+# build, but that's exactly what tripped the hoister: bun.lock was
+# resolved against the real package.jsons, and the stubs (no deps) made
+# bun think hoistable transitive deps weren't needed. Copying the real
+# files keeps the lockfile + workspace graph consistent.
 COPY ornn-web/package.json ornn-web/
-
-# Stub sibling workspaces (required by bun workspace resolution) —
-# only ornn-web's dep graph is actually needed for the frontend build.
-RUN mkdir -p ornn-api && echo '{"name":"ornn-api","version":"2.0.0","private":true}' > ornn-api/package.json
-RUN mkdir -p ornn-sdk && echo '{"name":"@chronoai/ornn-sdk","version":"1.0.0","private":true}' > ornn-sdk/package.json
+COPY ornn-api/package.json ornn-api/
+COPY ornn-sdk/package.json ornn-sdk/
 
 RUN bun install
 


### PR DESCRIPTION
## Summary

A fresh `--no-cache` `docker build` of `ornn-web` against `develop` failed at typecheck with:

```
src/stores/toastStore.ts(1,24): error TS2307: Cannot find module 'zustand' or its corresponding type declarations.
```

`bun install` ran fine (1284 packages installed), but `node_modules/zustand` wasn't in the resulting filesystem. Caused by a combination:

1. **Floating bun version.** Both Dockerfiles use `FROM oven/bun:latest`. My host has bun pinned at `1.3.8` (where the stub-workspace install hoists everything correctly). The Docker base had already drifted to `1.3.13`, which apparently changed the hoister's behaviour around stubbed sibling workspaces.
2. **Stubbed sibling workspace package.jsons.** Both Dockerfiles wrote synthetic `{"name":"…","version":"…","private":true}` files (no `dependencies` block) to satisfy the resolver. That made `bun install` think hoistable transitive deps weren't needed — even though `bun.lock` was resolved against the real workspace graph and contained those deps.

CI hasn't tripped on this so far because `docker-build` runs against a clean BuildKit cache and the timing of bun version pins likely changed in the last few weeks.

## Fix

Both `ornn-web/Dockerfile` and `ornn-api/Dockerfile`:

- **Pin `oven/bun:1.3.13`** (was `oven/bun:latest`). Stops surprise-upgrades.
- **Copy the real workspace `package.json` files** for every sibling the lockfile references, instead of writing stubs. The lockfile + the on-disk workspace graph now agree, and `bun install` hoists exactly what's expected.

Verified locally — both `docker build --no-cache` runs succeed and the resulting `ornn-web:latest` bundle contains the latest landing-page redesign content (Space Grotesk + Forge Workshop v3 from Calvin's PR #222).

No runtime behaviour change. Pure build-pipeline reliability.

## Test plan

- [ ] CI green (lint, typecheck, api / web / sdk tests, docker-build)
- [ ] Reviewer can verify locally: `docker build --no-cache -f ornn-web/Dockerfile .` succeeds and emits `Space Grotesk` in the built CSS