### PR TITLE
[Feature] Landing + app-shell UI polish — tag pills, nav highlighter, detail layout

### DIFF
--- a/.changeset/landing-and-app-shell-ui-polish.md
+++ b/.changeset/landing-and-app-shell-ui-polish.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+UI polish across landing + app shell. (1) Featured-skill cards: replace the legacy `$ ornn install …` box with a wrapped row of monospace tag chips drawn from each skill's `tags` — CLI is no longer the agent path, so the card's visual gravity is preserved without implying install. (2) Active nav state: both `LandingNav` and the app-shell `Navbar` now wrap the active route's text in `<HighlighterMark>` for the same hand-drawn ember wash used on the landing headline; the singleton `<HighlighterMarkFilter />` is hoisted from `LandingPage` to `App` so every route shares the SVG turbulence filter. (3) `SkillDetailPage`: drop the `lg:h-[80vh] lg:max-h-[calc(100vh-140px)]` clamps on both columns and the right-rail's `lg:overflow-y-auto` so neither column has its own inner scroll; default flex `stretch` keeps both columns ending at the same y-pixel; responsive `min-h-[420px] lg:min-h-[680px]` keeps the file panel substantial when the package is small.

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -27,6 +27,7 @@ import { AdminLayout } from "@/components/layout/AdminLayout";
 import { AuthGuard } from "@/components/auth/AuthGuard";
 import { AdminGuard } from "@/components/auth/AdminGuard";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { HighlighterMarkFilter } from "@/pages/landing/HighlighterMark";
 
 // Route-level code split. Each lazy() call becomes its own async chunk.
 // Pages export named members, so the import() is unwrapped to a default.
@@ -191,6 +192,11 @@ export function App() {
   return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
+        {/* Singleton SVG turbulence filter referenced by every
+            <HighlighterMark>. Mounted at the app root so both the
+            landing surface and the app-shell nav can use the
+            highlighter wash without duplicating filter IDs in the DOM. */}
+        <HighlighterMarkFilter />
         <Suspense fallback={<RouteFallback />}>
           <RouterProvider router={router} />
         </Suspense>

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -24,6 +24,7 @@ import { useThemeStore } from "@/stores/themeStore";
 import { logActivity } from "@/services/activityApi";
 import { Logo } from "@/components/brand/Logo";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
+import { HighlighterMark } from "@/pages/landing/HighlighterMark";
 import { config } from "@/config";
 
 function getNyxIdUrl(): string {
@@ -173,9 +174,13 @@ export function Navbar({ className = "" }: NavbarProps) {
   const closeMenu = () => setMenuOpen(false);
   const toggleLang = () => i18n.changeLanguage(i18n.language === "zh" ? "en" : "zh");
 
+  // Active-tab styling: the link text is wrapped in <HighlighterMark>
+  // so the active route gets the same hand-drawn ember wash used on the
+  // landing-page headline. The text itself stays bold + strong-color so
+  // the multiply-blended wash reads cleanly on top.
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     `font-text text-[15px] transition-colors duration-150 ${
-      isActive ? "text-accent" : "text-body hover:text-accent"
+      isActive ? "font-semibold text-strong" : "text-body hover:text-accent"
     }`;
 
   return (
@@ -203,7 +208,13 @@ export function Navbar({ className = "" }: NavbarProps) {
               }}
               className={navLinkClass}
             >
-              {t(item.i18nKey)}
+              {({ isActive }) =>
+                isActive ? (
+                  <HighlighterMark>{t(item.i18nKey)}</HighlighterMark>
+                ) : (
+                  t(item.i18nKey)
+                )
+              }
             </NavLink>
           ))}
         </div>
@@ -371,11 +382,17 @@ export function Navbar({ className = "" }: NavbarProps) {
                 tabIndex={menuOpen ? 0 : -1}
                 className={({ isActive }) =>
                   `border-b border-subtle py-3 font-text text-[16px] transition-colors ${
-                    isActive ? "text-accent" : "text-body hover:text-accent"
+                    isActive ? "font-semibold text-strong" : "text-body hover:text-accent"
                   }`
                 }
               >
-                {t(item.i18nKey)}
+                {({ isActive }) =>
+                  isActive ? (
+                    <HighlighterMark>{t(item.i18nKey)}</HighlighterMark>
+                  ) : (
+                    t(item.i18nKey)
+                  )
+                }
               </NavLink>
             ))}
 

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -210,7 +210,7 @@ export function Navbar({ className = "" }: NavbarProps) {
             >
               {({ isActive }) =>
                 isActive ? (
-                  <HighlighterMark>{t(item.i18nKey)}</HighlighterMark>
+                  <HighlighterMark className="highlighter-mark--loose">{t(item.i18nKey)}</HighlighterMark>
                 ) : (
                   t(item.i18nKey)
                 )
@@ -388,7 +388,7 @@ export function Navbar({ className = "" }: NavbarProps) {
               >
                 {({ isActive }) =>
                   isActive ? (
-                    <HighlighterMark>{t(item.i18nKey)}</HighlighterMark>
+                    <HighlighterMark className="highlighter-mark--loose">{t(item.i18nKey)}</HighlighterMark>
                   ) : (
                     t(item.i18nKey)
                   )

--- a/ornn-web/src/pages/LandingPage.tsx
+++ b/ornn-web/src/pages/LandingPage.tsx
@@ -17,7 +17,6 @@ import { VSComparisonSection } from "@/pages/landing/VSComparisonSection";
 import { PublishSection } from "@/pages/landing/PublishSection";
 import { LandingFooter } from "@/pages/landing/LandingFooter";
 import { SectionRule } from "@/pages/landing/HammeredDivider";
-import { HighlighterMarkFilter } from "@/pages/landing/HighlighterMark";
 import { LandingChrome } from "@/pages/landing/LandingChrome";
 
 export function LandingPage() {
@@ -27,8 +26,8 @@ export function LandingPage() {
           overlay (light-mode page-edge dim rulers). Scoped to .landing-route
           so app-shell pages do NOT inherit. */}
       <LandingChrome />
-      {/* Singleton SVG turbulence filter referenced by every <HighlighterMark> */}
-      <HighlighterMarkFilter />
+      {/* SVG turbulence filter for <HighlighterMark> is mounted once at
+          the app root in App.tsx so app-shell pages share it. */}
       <LandingNav />
       <main>
         <HeroStage />

--- a/ornn-web/src/pages/landing/LandingNav.tsx
+++ b/ornn-web/src/pages/landing/LandingNav.tsx
@@ -160,7 +160,7 @@ export function LandingNav() {
             }`}
           >
             {isNavActive("/registry") ? (
-              <HighlighterMark>{t("nav.registry")}</HighlighterMark>
+              <HighlighterMark className="highlighter-mark--loose">{t("nav.registry")}</HighlighterMark>
             ) : (
               t("nav.registry")
             )}
@@ -175,7 +175,7 @@ export function LandingNav() {
             }`}
           >
             {isNavActive("/skills/new") ? (
-              <HighlighterMark>{t("nav.build")}</HighlighterMark>
+              <HighlighterMark className="highlighter-mark--loose">{t("nav.build")}</HighlighterMark>
             ) : (
               t("nav.build")
             )}
@@ -190,7 +190,7 @@ export function LandingNav() {
             }`}
           >
             {isNavActive("/docs") ? (
-              <HighlighterMark>{t("nav.docs")}</HighlighterMark>
+              <HighlighterMark className="highlighter-mark--loose">{t("nav.docs")}</HighlighterMark>
             ) : (
               t("nav.docs")
             )}
@@ -454,7 +454,7 @@ export function LandingNav() {
               }`}
             >
               {isNavActive("/registry") ? (
-                <HighlighterMark>{t("nav.registry")}</HighlighterMark>
+                <HighlighterMark className="highlighter-mark--loose">{t("nav.registry")}</HighlighterMark>
               ) : (
                 t("nav.registry")
               )}
@@ -471,7 +471,7 @@ export function LandingNav() {
               }`}
             >
               {isNavActive("/skills/new") ? (
-                <HighlighterMark>{t("nav.build")}</HighlighterMark>
+                <HighlighterMark className="highlighter-mark--loose">{t("nav.build")}</HighlighterMark>
               ) : (
                 t("nav.build")
               )}
@@ -488,7 +488,7 @@ export function LandingNav() {
               }`}
             >
               {isNavActive("/docs") ? (
-                <HighlighterMark>{t("nav.docs")}</HighlighterMark>
+                <HighlighterMark className="highlighter-mark--loose">{t("nav.docs")}</HighlighterMark>
               ) : (
                 t("nav.docs")
               )}

--- a/ornn-web/src/pages/landing/LandingNav.tsx
+++ b/ornn-web/src/pages/landing/LandingNav.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { useThemeStore } from "@/stores/themeStore";
@@ -9,6 +9,7 @@ import { config } from "@/config";
 import { Logo } from "@/components/brand/Logo";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { EmberLink } from "./EmberButton";
+import { HighlighterMark } from "./HighlighterMark";
 
 /** Derive NyxID home URL from the authorize URL env var. */
 function getNyxIdUrl(): string {
@@ -83,9 +84,21 @@ function DropdownInternal({
 export function LandingNav() {
   const { theme, toggle } = useThemeStore();
   const { t, i18n } = useTranslation();
+  const { pathname } = useLocation();
   const [menuOpen, setMenuOpen] = useState(false);
   const closeMenu = () => setMenuOpen(false);
   const toggleLang = () => i18n.changeLanguage(i18n.language === "zh" ? "en" : "zh");
+
+  // Active-tab matcher. `/skills/new` must NOT activate when the user is on a
+  // skill detail page like `/skills/some-skill` — so its match is scoped to
+  // exact / nested paths under `/skills/new` only. Other links use a loose
+  // prefix match so `/registry/foo` still highlights "Registry".
+  const isNavActive = (to: string): boolean => {
+    if (to === "/skills/new") {
+      return pathname === "/skills/new" || pathname.startsWith("/skills/new/");
+    }
+    return pathname === to || pathname.startsWith(to + "/");
+  };
 
   const isAuthenticated = useIsAuthenticated();
   const user = useCurrentUser();
@@ -133,23 +146,54 @@ export function LandingNav() {
         </Link>
 
         <div className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 gap-7 font-text text-[15px] font-normal text-bone md:flex">
+          {/* Active links use the same hand-drawn ember wash as the
+              landing-page headline (<HighlighterMark>). Text stays
+              parchment-strong on active so the multiply-blend wash
+              reads cleanly on top. */}
           <Link
             to="/registry"
-            className="focus-ring-ember transition-colors duration-150 hover:text-ember"
+            aria-current={isNavActive("/registry") ? "page" : undefined}
+            className={`focus-ring-ember transition-colors duration-150 ${
+              isNavActive("/registry")
+                ? "font-semibold text-parchment"
+                : "hover:text-ember"
+            }`}
           >
-            {t("nav.registry")}
+            {isNavActive("/registry") ? (
+              <HighlighterMark>{t("nav.registry")}</HighlighterMark>
+            ) : (
+              t("nav.registry")
+            )}
           </Link>
           <Link
             to="/skills/new"
-            className="focus-ring-ember transition-colors duration-150 hover:text-ember"
+            aria-current={isNavActive("/skills/new") ? "page" : undefined}
+            className={`focus-ring-ember transition-colors duration-150 ${
+              isNavActive("/skills/new")
+                ? "font-semibold text-parchment"
+                : "hover:text-ember"
+            }`}
           >
-            {t("nav.build")}
+            {isNavActive("/skills/new") ? (
+              <HighlighterMark>{t("nav.build")}</HighlighterMark>
+            ) : (
+              t("nav.build")
+            )}
           </Link>
           <Link
             to="/docs"
-            className="focus-ring-ember transition-colors duration-150 hover:text-ember"
+            aria-current={isNavActive("/docs") ? "page" : undefined}
+            className={`focus-ring-ember transition-colors duration-150 ${
+              isNavActive("/docs")
+                ? "font-semibold text-parchment"
+                : "hover:text-ember"
+            }`}
           >
-            {t("nav.docs")}
+            {isNavActive("/docs") ? (
+              <HighlighterMark>{t("nav.docs")}</HighlighterMark>
+            ) : (
+              t("nav.docs")
+            )}
           </Link>
         </div>
 
@@ -402,25 +446,52 @@ export function LandingNav() {
               to="/registry"
               onClick={closeMenu}
               tabIndex={menuOpen ? 0 : -1}
-              className="focus-ring-ember border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] text-bone transition-colors hover:text-ember"
+              aria-current={isNavActive("/registry") ? "page" : undefined}
+              className={`focus-ring-ember border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] transition-colors ${
+                isNavActive("/registry")
+                  ? "font-semibold text-parchment"
+                  : "text-bone hover:text-ember"
+              }`}
             >
-              {t("nav.registry")}
+              {isNavActive("/registry") ? (
+                <HighlighterMark>{t("nav.registry")}</HighlighterMark>
+              ) : (
+                t("nav.registry")
+              )}
             </Link>
             <Link
               to="/skills/new"
               onClick={closeMenu}
               tabIndex={menuOpen ? 0 : -1}
-              className="focus-ring-ember border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] text-bone transition-colors hover:text-ember"
+              aria-current={isNavActive("/skills/new") ? "page" : undefined}
+              className={`focus-ring-ember border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] transition-colors ${
+                isNavActive("/skills/new")
+                  ? "font-semibold text-parchment"
+                  : "text-bone hover:text-ember"
+              }`}
             >
-              {t("nav.build")}
+              {isNavActive("/skills/new") ? (
+                <HighlighterMark>{t("nav.build")}</HighlighterMark>
+              ) : (
+                t("nav.build")
+              )}
             </Link>
             <Link
               to="/docs"
               onClick={closeMenu}
               tabIndex={menuOpen ? 0 : -1}
-              className="focus-ring-ember border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] text-bone transition-colors hover:text-ember"
+              aria-current={isNavActive("/docs") ? "page" : undefined}
+              className={`focus-ring-ember border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] transition-colors ${
+                isNavActive("/docs")
+                  ? "font-semibold text-parchment"
+                  : "text-bone hover:text-ember"
+              }`}
             >
-              {t("nav.docs")}
+              {isNavActive("/docs") ? (
+                <HighlighterMark>{t("nav.docs")}</HighlighterMark>
+              ) : (
+                t("nav.docs")
+              )}
             </Link>
             <a
               href="https://github.com/ChronoAIProject/Ornn"

--- a/ornn-web/src/pages/landing/SkillCard.tsx
+++ b/ornn-web/src/pages/landing/SkillCard.tsx
@@ -16,9 +16,18 @@ export function SkillCard({ skill }: { skill: FeaturedSkill }) {
       <div className="flex-grow text-[13px] leading-[1.55] text-bone">
         {skill.desc}
       </div>
-      <div className="mt-3 rounded-[2px] border border-[color:var(--color-border-subtle)] bg-obsidian px-2.5 py-2 font-mono text-[11px] text-parchment before:text-ember before:content-['$_']">
-        {skill.install}
-      </div>
+      {skill.tags.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          {skill.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-[2px] border border-[color:var(--color-border-subtle)] bg-obsidian px-2 py-1 font-mono text-[10px] tracking-[0.04em] text-bone"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
       <div className="mt-4 flex justify-between border-t border-dashed border-[color:var(--color-border-strong)] pt-3.5 font-mono text-[11px] text-meta">
         <span>
           {skill.author} · {skill.version}

--- a/ornn-web/src/pages/landing/skillsData.ts
+++ b/ornn-web/src/pages/landing/skillsData.ts
@@ -11,7 +11,7 @@ export type FeaturedSkill = {
   tag: string;
   name: string;
   desc: string;
-  install: string;
+  tags: string[];
   author: string;
   version: string;
   date: string;
@@ -44,7 +44,7 @@ export const FEATURED_DEFAULT: FeaturedSkill[] = [
     tag: "FEATURED · search",
     name: "ornn-search-and-run",
     desc: "Find any skill on the registry from inside your agent — semantic ranking via NyxID MCP, loaded into context on demand, no separate install step.",
-    install: 'ornn-search-and-run "<query>"',
+    tags: ["search", "discovery", "mcp"],
     author: "@ornn",
     version: "v 0.9.1",
     date: "24 Apr",
@@ -54,7 +54,7 @@ export const FEATURED_DEFAULT: FeaturedSkill[] = [
     tag: "FEATURED · publish",
     name: "ornn-upload",
     desc: "Package a local skill folder and push it to the registry — versioned, audited, ready for any agent that consumes the format.",
-    install: "ornn-upload <skill-folder>",
+    tags: ["publish", "registry", "versioning"],
     author: "@ornn",
     version: "v 0.9.0",
     date: "20 Apr",
@@ -64,7 +64,7 @@ export const FEATURED_DEFAULT: FeaturedSkill[] = [
     tag: "FEATURED · build",
     name: "ornn-build",
     desc: "Meta-skill: describe the task in plain English, ornn-build drafts a working SKILL.md you can iterate on, sandbox, and publish.",
-    install: 'ornn-build "<prompt>"',
+    tags: ["meta-skill", "scaffolding", "skill.md"],
     author: "@ornn",
     version: "v 0.9.0",
     date: "22 Apr",

--- a/ornn-web/src/pages/landing/useFeaturedSkills.ts
+++ b/ornn-web/src/pages/landing/useFeaturedSkills.ts
@@ -69,7 +69,7 @@ function toFeatured(item: SkillSearchResult): FeaturedSkill {
     tag: `FEATURED · ${tag}`,
     name: item.name,
     desc: item.description || "—",
-    install: `ornn install ${item.name}`,
+    tags: item.tags ?? [],
     author: owner.startsWith("@") ? owner : `@${owner}`,
     version: "v 1.0.0",
     date: formatShortDate(item.updatedOn),

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -499,15 +499,18 @@ export function SkillDetailPage() {
         />
 
         {/* ── Main grid ── */}
-        {/* Two-column layout (lg+). Both columns get the *exact same*
-            explicit height ladder so they end at the same y-pixel —
-            stretch via flex was inconsistent because something in
-            the page/PageTransition chain was letting the right rail
-            grow past the row. Belt + braces: explicit h on both. */}
-        <main className="flex flex-col gap-4 lg:flex-row">
+        {/* Two-column layout (lg+). Columns flow with content; flex's
+            default `align-items: stretch` keeps both ending at the same
+            y-pixel (whichever column is taller wins; the shorter one
+            grows to match). Page-level scroll is the only scroll —
+            neither column has its own. A responsive `min-h` on the left
+            section keeps the file panel substantial when the package is
+            small; the right rail's intrinsic card stack handles the
+            rest. */}
+        <main className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
 
           {/* Left: tabs + content. */}
-          <section className="card-impression flex min-h-0 flex-col overflow-hidden rounded border border-subtle bg-card lg:h-[80vh] lg:min-h-[640px] lg:max-h-[calc(100vh-140px)] lg:flex-1 lg:min-w-0">
+          <section className="card-impression flex min-h-[420px] flex-col overflow-hidden rounded border border-subtle bg-card lg:min-h-[680px] lg:flex-1 lg:min-w-0">
             {/* Toolbar — VersionPicker carries its own "Version" label, so
                 no outer label here (we used to render two). Audit history
                 lives in the right-rail card now. */}
@@ -560,11 +563,11 @@ export function SkillDetailPage() {
             </div>
           </section>
 
-          {/* Right rail — same explicit height ladder as the left so
-              both columns end at the same y-pixel. Cards inside scroll
-              via `overflow-y-auto` when their stacked height exceeds
-              the bounded box. */}
-          <aside className="flex flex-col gap-4 min-h-0 lg:h-[80vh] lg:min-h-[640px] lg:max-h-[calc(100vh-140px)] lg:w-[320px] lg:shrink-0 lg:overflow-y-auto lg:pr-1">
+          {/* Right rail — flows with content, no inner scroll. Flex
+              stretch keeps it aligned to the left section's y-extent
+              (or pushes the left section to grow when the rail is
+              taller). */}
+          <aside className="flex flex-col gap-4 lg:w-[320px] lg:shrink-0">
 
             {/* ── Audit card ── */}
             <section className="rounded-md border border-subtle bg-card p-5 card-impression">
@@ -870,12 +873,6 @@ export function SkillDetailPage() {
                 </div>
               </dl>
             </section>
-
-            {/* Spacer — eats any remaining vertical space when the cards
-                still don't fill the 80vh column, so Danger zone hugs
-                the bottom and both columns end at the same y-pixel.
-                Collapses to 0 when overflow-y-auto kicks in. */}
-            <div className="hidden lg:block lg:flex-1 lg:min-h-0" aria-hidden />
 
             {/* ── Danger zone (owner only) ── */}
             {isOwner && (

--- a/ornn-web/src/styles/neon.css
+++ b/ornn-web/src/styles/neon.css
@@ -763,6 +763,17 @@ html {
 .highlighter-mark--gold::before { background: var(--color-molten); }
 .highlighter-mark--arc::before  { background: var(--color-arc); }
 
+/* Loose sizing — wash extends further past the text. The default em-based
+   inset (-0.16em horizontal, 0.04em top, 0 bottom) is tuned for the giant
+   landing headline; on small text (e.g. 15px nav links) it reads tight,
+   so loose variants used in nav-scale contexts pad the wash out. */
+.highlighter-mark--loose::before {
+  left: -0.4em;
+  right: -0.4em;
+  top: -0.12em;
+  bottom: -0.08em;
+}
+
 /* Card letterpress — paired with --card-shadow-rest / --card-shadow-hover.
    Apply via .card-letterpress on any interactive card / panel / terminal
    that currently uses inline `shadow-[...]` Tailwind arbitrary syntax.


### PR DESCRIPTION
## Summary

Three landing/app-shell UX improvements bundled in one pass — see #240 for the full proposal:

- **Featured skill cards** drop the `$ ornn install …` CLI box (CLI is no longer the agent path) and replace it with a wrapped row of monospace tag chips drawn from each skill's `tags`. Cards with zero tags hide the row gracefully.
- **Nav active state** in both `LandingNav` (marketing) and `Navbar` (app shell) now wraps the active link's text in `<HighlighterMark>` for the same hand-drawn ember wash used on the landing headline ("NOTHING." / "EVERYTHING."). The singleton `<HighlighterMarkFilter />` is hoisted from `LandingPage` to the app root in `App.tsx`, so every route shares the SVG turbulence filter without duplicating the `id="ornn-highlighter-rough"` in the DOM. Active links also get `aria-current="page"`.
- **`SkillDetailPage` layout** drops the `lg:h-[80vh] lg:max-h-[calc(100vh-140px)]` clamps on both columns and the right rail's `lg:overflow-y-auto`. Flex `stretch` keeps both columns ending at the same y-pixel; whichever side is taller wins. Responsive min-height (`min-h-[420px]` mobile / `lg:min-h-[680px]` desktop) keeps the file panel substantial when the package is small. The pre-existing right-rail spacer div is removed (stretch handles alignment now).

## Test plan

- [x] Visit `/` — featured skill cards show monospace tag pills (no `$ ornn install …` box). Cards with no tags hide the row entirely.
- [x] Visit `/registry` — "Registry" link in the top nav has the hand-drawn ember highlighter wash, bold weight, strong text color.
- [x] Visit `/docs` — same wash on "Docs". Active state moves with the route.
- [ ] Visit `/skills/new` — "Build" gets the wash. Drilling into `/skills/:idOrName` does NOT activate "Build" (scoped match).
- [ ] Visit a real skill detail page — no inner scroll on either the file viewer column or the right card stack. Both columns end at the same y-pixel; the page scroll is the only scroll. Resize to mobile width — left section min-height ~420px; on desktop ~680px.
- [ ] Inspect DOM — exactly one `<svg>` element with `defs > filter#ornn-highlighter-rough` (the singleton mount in `App.tsx`).

## Out of scope (separate followup)

`InstallEverywhereSection` + `AnimatedTerminal` on the landing still showcase `ornn install pdf-extract` as the headline interaction. That whole section needs a rethink in the post-CLI direction — to be tracked as its own issue.

Closes #240