### PR TITLE
[Feature] #250 + #251 — Quota chip, model picker, admin pages (frontend)

### DIFF
--- a/.changeset/quota-models-frontend.md
+++ b/.changeset/quota-models-frontend.md
@@ -1,0 +1,12 @@
+---
+"ornn-web": minor
+---
+
+feat(web): per-user quota UI + admin model selection (frontend for #250 + #251).
+
+- **Quota chip** (#250): persistent counter pill in the top nav for authenticated users (admin-bypassed). Click → drawer with monthly base, daily ceiling, beta-credit balance, and reset times for both surfaces. Tone goes amber at 80% and red at zero.
+- **In-context displays** on the playground and skill-gen pages — compact stamp by default, soft-warning banner at 80% of monthly base, and a brand-consistent `OverLimitPage` (CTA-forward, screenshot-friendly) when the surface is exhausted.
+- **Admin grant UI** at `/admin/quota`: per-user inline `GrantCreditsForm` and bulk-select `BulkGrantCreditsModal`, plus a recent-grants audit-trail card.
+- **Model picker** (#251) on playground + skill-gen: dropdown sourced from the admin-curated catalog, ordered default-first. Selection persists per-surface via `localStorage` (`ornn.preferredModel.playground`, `ornn.preferredModel.skillGen`); stored values that the admin later disables silently fall back to the surface default without clearing storage.
+- **Admin Models** page at `/admin/models`: catalog list with per-surface enable toggles, default radios, archived flag, refresh-from-upstream button, and search.
+- Wires `modelId` through the playground and skill-gen SSE clients so the picker's choice reaches the backend resolver added in #258.

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -132,6 +132,12 @@ const AdminPlatformSettingsPage = lazy(() =>
 const AdminMirrorPage = lazy(() =>
   import("@/pages/admin").then((m) => ({ default: m.MirrorPage })),
 );
+const AdminModelsPage = lazy(() =>
+  import("@/pages/admin").then((m) => ({ default: m.AdminModelsPage })),
+);
+const AdminQuotaPage = lazy(() =>
+  import("@/pages/admin").then((m) => ({ default: m.AdminQuotaPage })),
+);
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -201,6 +207,8 @@ const router = createBrowserRouter(
             <Route path="/admin/tags" element={<AdminTagsPage />} />
             <Route path="/admin/settings" element={<AdminPlatformSettingsPage />} />
             <Route path="/admin/mirror" element={<AdminMirrorPage />} />
+            <Route path="/admin/models" element={<AdminModelsPage />} />
+            <Route path="/admin/quota" element={<AdminQuotaPage />} />
           </Route>
         </Route>
       </Route>

--- a/ornn-web/src/components/admin/BulkGrantCreditsModal.tsx
+++ b/ornn-web/src/components/admin/BulkGrantCreditsModal.tsx
@@ -1,0 +1,156 @@
+/**
+ * BulkGrantCreditsModal — dispatches `+N credits` to every selected
+ * user on a chosen surface in one POST.
+ *
+ * Backend caps payloads at 500 user ids — the modal disables submission
+ * past that ceiling and surfaces a single error message instead of
+ * silently truncating.
+ *
+ * @module components/admin/BulkGrantCreditsModal
+ */
+
+import { useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { useToastStore } from "@/stores/toastStore";
+import { useBulkGrantQuota } from "@/hooks/useQuota";
+import type { Surface } from "@/services/quotaApi";
+
+const MAX_USERS = 500;
+
+interface BulkGrantCreditsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  userIds: string[];
+  /** Optional human label — "12 selected users". Falls back to count. */
+  selectionLabel?: string;
+}
+
+export function BulkGrantCreditsModal({
+  isOpen,
+  onClose,
+  userIds,
+  selectionLabel,
+}: BulkGrantCreditsModalProps) {
+  const [surface, setSurface] = useState<Surface>("playground");
+  const [amount, setAmount] = useState("10");
+  const [note, setNote] = useState("");
+  const grant = useBulkGrantQuota();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const tooMany = userIds.length > MAX_USERS;
+  const empty = userIds.length === 0;
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const n = Number(amount);
+    if (!n || n <= 0) {
+      addToast({ type: "warning", message: "Enter a positive credit amount." });
+      return;
+    }
+    if (tooMany) {
+      addToast({
+        type: "error",
+        message: `Cannot grant in one batch — ${userIds.length} selected, ${MAX_USERS} max.`,
+      });
+      return;
+    }
+    if (empty) return;
+    try {
+      const out = await grant.mutateAsync({
+        userIds,
+        surface,
+        amount: n,
+        note: note || undefined,
+      });
+      addToast({
+        type: "success",
+        message: `Granted +${n} ${surface === "playground" ? "playground" : "skill-gen"} credits to ${out.applied}/${out.requested} users.`,
+      });
+      onClose();
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : "Bulk grant failed",
+      });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Grant credits to selected">
+      <form onSubmit={submit} className="space-y-4">
+        <p className="font-text text-sm text-body">
+          Issue beta credits to{" "}
+          <strong className="text-strong">
+            {selectionLabel ?? `${userIds.length} selected user${userIds.length === 1 ? "" : "s"}`}
+          </strong>
+          . Beta credits are non-expiring and recorded in the audit trail.
+        </p>
+
+        {tooMany && (
+          <div className="rounded border border-danger/40 bg-danger-soft px-3 py-2 font-mono text-[11px] text-danger">
+            Selection exceeds {MAX_USERS}-user batch limit. Trim before granting.
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <label className="flex flex-col gap-1.5">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Surface
+            </span>
+            <select
+              value={surface}
+              onChange={(e) => setSurface(e.target.value as Surface)}
+              className="rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+            >
+              <option value="playground">Playground</option>
+              <option value="skillGen">Skill Generation</option>
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Credits per user
+            </span>
+            <input
+              type="number"
+              min={1}
+              max={100000}
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              className="rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+            />
+          </label>
+        </div>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+            Note (optional)
+          </span>
+          <input
+            type="text"
+            maxLength={500}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Reason for grant — surfaced in audit trail"
+            className="rounded-sm border border-subtle bg-card px-3 py-2 font-text text-sm text-strong focus:border-accent focus:outline-none"
+          />
+        </label>
+
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" size="sm" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            type="submit"
+            loading={grant.isPending}
+            disabled={tooMany || empty}
+          >
+            Grant
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/ornn-web/src/components/admin/GrantCreditsForm.tsx
+++ b/ornn-web/src/components/admin/GrantCreditsForm.tsx
@@ -1,0 +1,146 @@
+/**
+ * GrantCreditsForm — per-user grant for the admin quota detail row.
+ *
+ * Two integer inputs (playground / skill-gen) + an optional note. Submit
+ * fires the appropriate POST(s) — only non-zero amounts result in a
+ * grant call, so the form can be used to issue credit on one surface
+ * without touching the other.
+ *
+ * @module components/admin/GrantCreditsForm
+ */
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { useToastStore } from "@/stores/toastStore";
+import { useGrantQuota } from "@/hooks/useQuota";
+
+interface GrantCreditsFormProps {
+  userId: string;
+  email: string;
+  displayName: string;
+  /** Called after every successful grant so parents can refresh lists. */
+  onGranted?: () => void;
+  className?: string;
+}
+
+export function GrantCreditsForm({
+  userId,
+  email,
+  displayName,
+  onGranted,
+  className = "",
+}: GrantCreditsFormProps) {
+  const [playground, setPlayground] = useState("");
+  const [skillGen, setSkillGen] = useState("");
+  const [note, setNote] = useState("");
+  const grant = useGrantQuota();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const pg = Number(playground);
+    const sg = Number(skillGen);
+    if ((!pg || pg <= 0) && (!sg || sg <= 0)) {
+      addToast({
+        type: "warning",
+        message: "Enter a positive amount on at least one surface.",
+      });
+      return;
+    }
+    try {
+      if (pg > 0) {
+        await grant.mutateAsync({ userId, surface: "playground", amount: pg, note: note || undefined });
+      }
+      if (sg > 0) {
+        await grant.mutateAsync({ userId, surface: "skillGen", amount: sg, note: note || undefined });
+      }
+      const summary = [
+        pg > 0 ? `+${pg} playground` : null,
+        sg > 0 ? `+${sg} skill-gen` : null,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      addToast({
+        type: "success",
+        message: `Granted ${summary} to ${displayName || email}.`,
+      });
+      setPlayground("");
+      setSkillGen("");
+      setNote("");
+      onGranted?.();
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : "Grant failed",
+      });
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className={`rounded border border-subtle bg-elevated/40 p-4 ${className}`}
+    >
+      <header className="mb-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+          [§ GRANT — BETA CREDITS]
+        </p>
+        <p className="mt-1 font-text text-sm text-strong">
+          {displayName || email}
+        </p>
+        <p className="font-mono text-[11px] text-meta">{email}</p>
+      </header>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+            Playground credits
+          </span>
+          <input
+            type="number"
+            min={0}
+            max={100000}
+            value={playground}
+            onChange={(e) => setPlayground(e.target.value)}
+            placeholder="0"
+            className="w-full rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+          />
+        </label>
+        <label className="flex flex-col gap-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+            Skill-gen credits
+          </span>
+          <input
+            type="number"
+            min={0}
+            max={100000}
+            value={skillGen}
+            onChange={(e) => setSkillGen(e.target.value)}
+            placeholder="0"
+            className="w-full rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+          />
+        </label>
+      </div>
+
+      <label className="mt-3 flex flex-col gap-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+          Note (optional)
+        </span>
+        <input
+          type="text"
+          maxLength={500}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Reason for grant — surfaced in audit trail"
+          className="w-full rounded-sm border border-subtle bg-card px-3 py-2 font-text text-sm text-strong focus:border-accent focus:outline-none"
+        />
+      </label>
+
+      <div className="mt-4 flex justify-end">
+        <Button type="submit" loading={grant.isPending} size="sm">
+          Grant credits
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/ornn-web/src/components/layout/AdminLayout.tsx
+++ b/ornn-web/src/components/layout/AdminLayout.tsx
@@ -8,6 +8,7 @@ import { Outlet, NavLink, useLocation } from "react-router-dom";
 import { motion } from "framer-motion";
 import { ToastContainer } from "@/components/ui/Toast";
 import { Logo } from "@/components/brand/Logo";
+import { QuotaChip } from "@/components/quota/QuotaChip";
 
 interface NavItem {
   path: string;
@@ -49,6 +50,24 @@ const NAV_ITEMS: NavItem[] = [
     icon: (
       <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+      </svg>
+    ),
+  },
+  {
+    path: "/admin/models",
+    label: "Models",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.75 17 9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2Z" />
+      </svg>
+    ),
+  },
+  {
+    path: "/admin/quota",
+    label: "Quota",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 3v18h18M7 14l4-4 4 4 5-5" />
       </svg>
     ),
   },
@@ -104,6 +123,10 @@ function getBreadcrumbs(pathname: string): Array<{ label: string; path?: string 
     breadcrumbs.push({ label: "Users" });
   } else if (pathname.startsWith("/admin/skills")) {
     breadcrumbs.push({ label: "Skills" });
+  } else if (pathname.startsWith("/admin/models")) {
+    breadcrumbs.push({ label: "Models" });
+  } else if (pathname.startsWith("/admin/quota")) {
+    breadcrumbs.push({ label: "Quota" });
   } else if (pathname.startsWith("/admin/categories")) {
     breadcrumbs.push({ label: "Categories" });
   } else if (pathname.startsWith("/admin/tags")) {
@@ -151,11 +174,13 @@ export function AdminLayout() {
             ))}
           </nav>
 
-          {/* Back to Main */}
-          <NavLink
-            to="/"
-            className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.14em] text-meta transition-colors hover:text-accent"
-          >
+          {/* Right cluster: quota chip + back to main */}
+          <div className="flex items-center gap-3">
+            <QuotaChip className="hidden md:inline-flex" />
+            <NavLink
+              to="/"
+              className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.14em] text-meta transition-colors hover:text-accent"
+            >
             <svg
               className="h-4 w-4"
               fill="none"
@@ -170,7 +195,8 @@ export function AdminLayout() {
               />
             </svg>
             Exit Admin
-          </NavLink>
+            </NavLink>
+          </div>
         </div>
       </header>
 

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -24,6 +24,7 @@ import { useThemeStore } from "@/stores/themeStore";
 import { logActivity } from "@/services/activityApi";
 import { Logo } from "@/components/brand/Logo";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
+import { QuotaChip } from "@/components/quota/QuotaChip";
 import { HighlighterMark } from "@/pages/landing/HighlighterMark";
 import { config } from "@/config";
 
@@ -248,6 +249,7 @@ export function Navbar({ className = "" }: NavbarProps) {
             {theme === "light" ? <MoonIcon className="h-4 w-4" /> : <SunIcon className="h-4 w-4" />}
           </button>
 
+          {isAuthenticated && <QuotaChip />}
           {isAuthenticated && <NotificationBell />}
 
           {isAuthenticated && user ? (

--- a/ornn-web/src/components/models/ModelPicker.tsx
+++ b/ornn-web/src/components/models/ModelPicker.tsx
@@ -1,0 +1,100 @@
+/**
+ * ModelPicker — surface-scoped model dropdown.
+ *
+ * Reads the admin-curated picker list for the surface, renders a native
+ * `<select>` styled per the Forge Workshop input vocabulary, and writes
+ * the choice through `usePreferredModel` so the next visit lands on the
+ * same model. When the admin has nothing enabled for the surface, the
+ * picker degrades into an inline empty-state stamp instead.
+ *
+ * @module components/models/ModelPicker
+ */
+
+import { useEffect } from "react";
+import { usePreferredModel } from "@/hooks/useModels";
+import type { Surface } from "@/services/quotaApi";
+
+interface ModelPickerProps {
+  surface: Surface;
+  /** Fired whenever the effective modelId changes (initial load + user pick). */
+  onChange?: (modelId: string | null) => void;
+  className?: string;
+  label?: string;
+}
+
+const SURFACE_LABEL: Record<Surface, string> = {
+  playground: "Playground",
+  skillGen: "Skill Generation",
+};
+
+export function ModelPicker({
+  surface,
+  onChange,
+  className = "",
+  label = "Model",
+}: ModelPickerProps) {
+  const {
+    options,
+    effectiveModelId,
+    setPreferred,
+    isLoading,
+    isEmpty,
+  } = usePreferredModel(surface);
+
+  // Keep parent in sync with the resolved model — initial load and any
+  // upstream change (e.g. admin disables the user's pick) flow back here.
+  useEffect(() => {
+    onChange?.(effectiveModelId);
+  }, [effectiveModelId, onChange]);
+
+  if (isLoading) {
+    return (
+      <div
+        className={`inline-flex items-center gap-2 rounded-sm border border-subtle bg-elevated/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-meta ${className}`}
+      >
+        <span className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+        Loading models…
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <div
+        role="status"
+        className={`inline-flex items-center gap-2 rounded-sm border border-warning/40 bg-warning-soft px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-warning ${className}`}
+      >
+        {SURFACE_LABEL[surface]} — temporarily unavailable. Contact admin.
+      </div>
+    );
+  }
+
+  return (
+    <label className={`inline-flex items-center gap-2 ${className}`}>
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+        {label}
+      </span>
+      <select
+        value={effectiveModelId ?? ""}
+        onChange={(e) => {
+          const next = e.target.value;
+          if (next) setPreferred(next);
+        }}
+        className="appearance-none rounded-sm border border-subtle bg-elevated/40 px-2.5 py-1.5 pr-7 font-mono text-[11px] text-strong transition-colors duration-150 focus:border-accent focus:outline-none focus:bg-card cursor-pointer"
+        style={{
+          backgroundImage:
+            "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23C94A0E' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")",
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "right 8px center",
+        }}
+      >
+        {options.map((m) => (
+          <option key={m.modelId} value={m.modelId} className="bg-card text-strong">
+            {m.displayName}
+            {m.isDefault ? " — default" : ""}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/ornn-web/src/components/quota/OverLimitPage.tsx
+++ b/ornn-web/src/components/quota/OverLimitPage.tsx
@@ -1,0 +1,127 @@
+/**
+ * OverLimitPage — surface-level "you've hit your limit" page.
+ *
+ * Rendered when the playground or skill-gen page sees a 429 from the
+ * backend's `QUOTA_EXCEEDED` shape, or pre-emptively when the cached
+ * quota snapshot already shows zero remaining for the surface.
+ *
+ * Brand-consistent (Forge Workshop tokens — letterpress card, Space
+ * Grotesk display, mono micro-labels) and screenshot-friendly per #250.
+ *
+ * @module components/quota/OverLimitPage
+ */
+
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import type { Surface, SurfaceSnapshot } from "@/services/quotaApi";
+
+const SURFACE_LABEL: Record<Surface, string> = {
+  playground: "Playground",
+  skillGen: "Skill Generation",
+};
+
+interface OverLimitPageProps {
+  surface: Surface;
+  snapshot: SurfaceSnapshot;
+  /** Override message (used when the 429 carried server-side context). */
+  message?: string;
+}
+
+function formatReset(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZoneName: "short",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function OverLimitPage({ surface, snapshot, message }: OverLimitPageProps) {
+  const label = SURFACE_LABEL[surface];
+  const monthlyExhausted = snapshot.monthly.remaining <= 0;
+  const heading = monthlyExhausted
+    ? `You've hit your monthly ${label.toLowerCase()} limit.`
+    : `You've hit today's ${label.toLowerCase()} ceiling.`;
+  const reset = monthlyExhausted ? snapshot.monthlyResetAt : snapshot.dailyResetAt;
+  const resetCopy = monthlyExhausted ? "Quota refreshes" : "Daily ceiling resets";
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+      className="mx-auto flex min-h-full max-w-2xl flex-col items-center justify-center py-12"
+    >
+      <div className="card-impression w-full rounded border border-subtle bg-card p-8 sm:p-10">
+        <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-accent">
+          [§ QUOTA — LIMIT REACHED]
+        </p>
+
+        <h1 className="mt-4 font-display text-3xl font-bold uppercase tracking-tight text-strong sm:text-4xl">
+          {heading}
+        </h1>
+
+        <p className="mt-4 max-w-prose font-text text-base leading-relaxed text-body">
+          {message ??
+            `You've used ${snapshot.monthly.used} of ${snapshot.monthly.limit} monthly ${label.toLowerCase()} calls. ${resetCopy} ${formatReset(reset)}.`}
+        </p>
+
+        <dl className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="rounded border border-subtle bg-elevated/40 p-4">
+            <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Monthly used
+            </dt>
+            <dd className="mt-1 font-display text-2xl font-bold text-strong">
+              {snapshot.monthly.used}
+              <span className="text-base font-medium text-meta">
+                {" "}
+                / {snapshot.monthly.limit}
+              </span>
+            </dd>
+          </div>
+          <div className="rounded border border-subtle bg-elevated/40 p-4">
+            <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Beta credits
+            </dt>
+            <dd className="mt-1 font-display text-2xl font-bold text-accent">
+              +{snapshot.credits.balance}
+            </dd>
+          </div>
+          <div className="rounded border border-subtle bg-elevated/40 p-4">
+            <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Resets
+            </dt>
+            <dd className="mt-1 font-mono text-sm text-strong">
+              {formatReset(reset)}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+          <a
+            href="mailto:hello@chrono-ai.fun?subject=Ornn%20beta%20credits"
+            className="cta-letterpress inline-flex items-center gap-2 rounded-sm border border-accent-muted bg-accent px-5 py-2.5 font-mono text-xs font-semibold uppercase tracking-[0.12em] text-page hover:bg-accent-muted"
+          >
+            Contact admin for credits
+          </a>
+          <Link
+            to="/registry"
+            className="cta-letterpress cta-letterpress--ghost inline-flex items-center gap-2 rounded-sm border border-strong-edge bg-card px-5 py-2.5 font-mono text-xs font-semibold uppercase tracking-[0.12em] text-strong hover:border-accent"
+          >
+            Back to registry
+          </Link>
+        </div>
+
+        <p className="mt-6 font-text text-xs text-meta">
+          Paid plans are coming soon. Beta credits are non-expiring and granted
+          by an Ornn admin.
+        </p>
+      </div>
+    </motion.div>
+  );
+}

--- a/ornn-web/src/components/quota/QuotaChip.tsx
+++ b/ornn-web/src/components/quota/QuotaChip.tsx
@@ -1,0 +1,80 @@
+/**
+ * QuotaChip — ambient quota counter pill in the top nav.
+ *
+ * Shows the playground surface's remaining count by default (the
+ * higher-volume surface). Click to open the QuotaSummary drawer with
+ * the full breakdown across both surfaces. Hidden for admins (they
+ * bypass the counter entirely) and for anonymous callers.
+ *
+ * The chip turns warning-toned when the playground surface crosses the
+ * 80% threshold and danger-toned at zero. This visual state is kept in
+ * lockstep with the soft-warning banner / over-limit page so the user
+ * sees one consistent signal across the app.
+ *
+ * @module components/quota/QuotaChip
+ */
+
+import { useState } from "react";
+import { useMyQuota } from "@/hooks/useQuota";
+import { QuotaSummary } from "./QuotaSummary";
+
+function nfmt(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+export function QuotaChip({ className = "" }: { className?: string }) {
+  const { data: quota } = useMyQuota();
+  const [open, setOpen] = useState(false);
+
+  if (!quota) return null;
+  if (quota.isAdmin) return null;
+
+  const playground = quota.playground;
+  const remaining = playground.monthly.remaining + playground.credits.balance;
+  const tone =
+    remaining <= 0 ? "danger" : playground.warning ? "warning" : "ok";
+
+  const toneClass =
+    tone === "danger"
+      ? "border-danger/50 text-danger hover:border-danger"
+      : tone === "warning"
+      ? "border-warning/50 text-warning hover:border-warning"
+      : "border-strong-edge text-strong hover:border-accent";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Quota usage details"
+        className={`
+          group inline-flex h-9 items-center gap-2 rounded-sm border bg-transparent
+          px-2.5 font-mono text-[10px] font-semibold uppercase tracking-[0.14em]
+          transition-colors duration-200
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+          ${toneClass}
+          ${className}
+        `}
+      >
+        <svg
+          className="h-3.5 w-3.5 shrink-0 opacity-80"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 2v4M5 8l2.5 2.5M2 16h4M19 8l-2.5 2.5M22 16h-4" />
+          <circle cx="12" cy="16" r="6" />
+          <path d="M12 13v3l2 1" />
+        </svg>
+        <span>{nfmt(Math.max(0, remaining))}</span>
+        <span className="text-meta">/{nfmt(playground.monthly.limit)}</span>
+      </button>
+
+      <QuotaSummary isOpen={open} onClose={() => setOpen(false)} quota={quota} />
+    </>
+  );
+}

--- a/ornn-web/src/components/quota/QuotaInline.test.tsx
+++ b/ornn-web/src/components/quota/QuotaInline.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for `QuotaInline` rendering branches: admin-bypass, normal,
+ * 80% warning, and exhausted-suppress.
+ *
+ * The component reads the cached caller quota — we mock the hook
+ * directly so the test stays focused on render behavior.
+ *
+ * @module components/quota/QuotaInline.test
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { QuotaSnapshot } from "@/services/quotaApi";
+
+const useMyQuota = vi.fn();
+
+vi.mock("@/hooks/useQuota", () => ({
+  useMyQuota: () => useMyQuota(),
+}));
+
+import { QuotaInline } from "./QuotaInline";
+
+function snapshot(overrides: Partial<QuotaSnapshot["playground"]> = {}): QuotaSnapshot {
+  const playground: QuotaSnapshot["playground"] = {
+    monthly: { limit: 200, used: 10, remaining: 190 },
+    daily: { limit: 50, used: 2, remaining: 48 },
+    credits: { balance: 0 },
+    warningThreshold: 0.8,
+    warning: false,
+    monthlyResetAt: "2026-06-01T00:00:00.000Z",
+    dailyResetAt: "2026-05-05T00:00:00.000Z",
+    ...overrides,
+  };
+  return {
+    playground,
+    skillGen: { ...playground, monthly: { ...playground.monthly, limit: 20 } },
+    isAdmin: false,
+  };
+}
+
+describe("QuotaInline", () => {
+  it("renders nothing for admins", () => {
+    useMyQuota.mockReturnValue({ data: { ...snapshot(), isAdmin: true } });
+    const { container } = render(<QuotaInline surface="playground" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows compact stamp under threshold", () => {
+    useMyQuota.mockReturnValue({ data: snapshot() });
+    render(<QuotaInline surface="playground" />);
+    expect(screen.getByText(/playground left/i)).toBeInTheDocument();
+  });
+
+  it("renders the warning banner at 80%+", () => {
+    useMyQuota.mockReturnValue({
+      data: snapshot({
+        warning: true,
+        monthly: { limit: 200, used: 160, remaining: 40 },
+      }),
+    });
+    render(<QuotaInline surface="playground" />);
+    expect(screen.getByText(/80% used/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing when surface is exhausted (over-limit page takes over)", () => {
+    useMyQuota.mockReturnValue({
+      data: snapshot({
+        monthly: { limit: 200, used: 200, remaining: 0 },
+      }),
+    });
+    const { container } = render(<QuotaInline surface="playground" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/ornn-web/src/components/quota/QuotaInline.tsx
+++ b/ornn-web/src/components/quota/QuotaInline.tsx
@@ -1,0 +1,96 @@
+/**
+ * QuotaInline — in-context surface display + soft 80% warning banner.
+ *
+ * Sits at the top of the playground / skill-gen pages and renders one of
+ * three states based on the cached caller quota:
+ *
+ *  - admin-bypass:  rendered nothing (admins bypass the counter).
+ *  - normal:        compact "X / Y left" stamp with reset hint.
+ *  - warning:       full-width banner at 80% of monthly base, copy
+ *                   directing the user to the QuotaChip drawer for
+ *                   detail.
+ *
+ * @module components/quota/QuotaInline
+ */
+
+import type { Surface, SurfaceSnapshot } from "@/services/quotaApi";
+import { useMyQuota } from "@/hooks/useQuota";
+
+const SURFACE_LABEL: Record<Surface, string> = {
+  playground: "playground",
+  skillGen: "skill-gen",
+};
+
+interface QuotaInlineProps {
+  surface: Surface;
+  className?: string;
+}
+
+function nfmt(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+function totalRemaining(s: SurfaceSnapshot): number {
+  return s.monthly.remaining + s.credits.balance;
+}
+
+export function QuotaInline({ surface, className = "" }: QuotaInlineProps) {
+  const { data: quota } = useMyQuota();
+  if (!quota || quota.isAdmin) return null;
+  const snap = surface === "playground" ? quota.playground : quota.skillGen;
+
+  const remaining = totalRemaining(snap);
+  const exhausted = remaining <= 0;
+  const warning = snap.warning && !exhausted;
+
+  if (warning) {
+    return (
+      <div
+        role="status"
+        className={`flex items-start gap-3 rounded border border-warning/40 bg-warning-soft px-4 py-3 ${className}`}
+      >
+        <svg
+          className="mt-0.5 h-4 w-4 shrink-0 text-warning"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <div className="flex-1">
+          <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-warning">
+            {SURFACE_LABEL[surface]} — {Math.round(((snap.monthly.limit - snap.monthly.remaining) / snap.monthly.limit) * 100)}% used
+          </p>
+          <p className="mt-1 font-text text-xs leading-relaxed text-body">
+            {nfmt(remaining)} {SURFACE_LABEL[surface]} calls left this month
+            {snap.credits.balance > 0
+              ? ` (includes ${nfmt(snap.credits.balance)} beta credits)`
+              : ""}
+            . Click the quota chip in the nav for full breakdown.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (exhausted) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`inline-flex items-center gap-2 rounded-sm border border-subtle bg-elevated/40 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-meta ${className}`}
+    >
+      <span className="text-accent">{nfmt(remaining)}</span>
+      <span className="opacity-70">/{nfmt(snap.monthly.limit)} {SURFACE_LABEL[surface]} left</span>
+      <span className="hidden sm:inline opacity-50">·</span>
+      <span className="hidden sm:inline opacity-70">
+        daily {nfmt(snap.daily.remaining)}/{nfmt(snap.daily.limit)}
+      </span>
+    </div>
+  );
+}

--- a/ornn-web/src/components/quota/QuotaSummary.tsx
+++ b/ornn-web/src/components/quota/QuotaSummary.tsx
@@ -1,0 +1,209 @@
+/**
+ * QuotaSummary — drawer showing the full quota breakdown across both
+ * surfaces. Opened from the QuotaChip in the top nav.
+ *
+ * Layout per surface: monthly bar with used / limit, daily ceiling
+ * sub-bar, credit balance line, next reset times. A single CTA at the
+ * bottom directs the user to the admin contact / paid-plan upsell.
+ *
+ * @module components/quota/QuotaSummary
+ */
+
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useEffect } from "react";
+import type { QuotaSnapshot, SurfaceSnapshot } from "@/services/quotaApi";
+
+const SURFACE_LABEL: Record<"playground" | "skillGen", string> = {
+  playground: "Playground",
+  skillGen: "Skill Generation",
+};
+
+function nfmt(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+function formatReset(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZoneName: "short",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function pct(used: number, limit: number): number {
+  if (limit <= 0) return 0;
+  return Math.max(0, Math.min(100, Math.round((used / limit) * 100)));
+}
+
+interface SurfaceRowProps {
+  label: string;
+  snapshot: SurfaceSnapshot;
+}
+
+function SurfaceRow({ label, snapshot }: SurfaceRowProps) {
+  const monthlyPct = pct(snapshot.monthly.used, snapshot.monthly.limit);
+  const dailyPct = pct(snapshot.daily.used, snapshot.daily.limit);
+  const monthlyTone =
+    snapshot.monthly.remaining <= 0
+      ? "bg-danger"
+      : snapshot.warning
+      ? "bg-warning"
+      : "bg-accent";
+  const totalRemaining = snapshot.monthly.remaining + snapshot.credits.balance;
+
+  return (
+    <section className="rounded border border-subtle bg-elevated/40 p-4">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h3 className="font-display text-sm font-semibold uppercase tracking-[0.12em] text-strong">
+          {label}
+        </h3>
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+          {nfmt(totalRemaining)} remaining
+        </span>
+      </header>
+
+      <dl className="space-y-3">
+        <div>
+          <div className="mb-1 flex items-baseline justify-between font-mono text-[10px] uppercase tracking-[0.14em]">
+            <dt className="text-meta">Monthly base</dt>
+            <dd className="text-strong">
+              <span className="text-meta">{nfmt(snapshot.monthly.used)} /</span>{" "}
+              {nfmt(snapshot.monthly.limit)}
+            </dd>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-sm bg-card">
+            <div
+              className={`h-full transition-all duration-300 ${monthlyTone}`}
+              style={{ width: `${monthlyPct}%` }}
+            />
+          </div>
+          <p className="mt-1 font-mono text-[10px] text-meta">
+            Resets {formatReset(snapshot.monthlyResetAt)}
+          </p>
+        </div>
+
+        <div>
+          <div className="mb-1 flex items-baseline justify-between font-mono text-[10px] uppercase tracking-[0.14em]">
+            <dt className="text-meta">Daily ceiling</dt>
+            <dd className="text-strong">
+              <span className="text-meta">{nfmt(snapshot.daily.used)} /</span>{" "}
+              {nfmt(snapshot.daily.limit)}
+            </dd>
+          </div>
+          <div className="h-1 w-full overflow-hidden rounded-sm bg-card">
+            <div
+              className="h-full bg-accent-support transition-all duration-300"
+              style={{ width: `${dailyPct}%` }}
+            />
+          </div>
+          <p className="mt-1 font-mono text-[10px] text-meta">
+            Resets {formatReset(snapshot.dailyResetAt)}
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between border-t border-subtle pt-3 font-mono text-[11px]">
+          <dt className="uppercase tracking-[0.14em] text-meta">
+            Beta credits
+          </dt>
+          <dd className="text-accent">+{nfmt(snapshot.credits.balance)}</dd>
+        </div>
+      </dl>
+    </section>
+  );
+}
+
+export interface QuotaSummaryProps {
+  isOpen: boolean;
+  onClose: () => void;
+  quota: QuotaSnapshot;
+}
+
+export function QuotaSummary({ isOpen, onClose, quota }: QuotaSummaryProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-50">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="absolute inset-0 bg-black/55 backdrop-blur-[2px]"
+            onClick={onClose}
+          />
+          <motion.aside
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ type: "spring", stiffness: 240, damping: 28, mass: 0.9 }}
+            role="dialog"
+            aria-label="Quota usage details"
+            className="card-impression absolute right-0 top-0 flex h-full w-full max-w-md flex-col gap-5 border-l border-subtle bg-page p-6 sm:p-8"
+          >
+            <header className="flex items-baseline justify-between">
+              <div>
+                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                  [§ QUOTA — USAGE]
+                </p>
+                <h2 className="mt-1 font-display text-xl font-semibold tracking-tight text-strong">
+                  Your usage this period
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className="-mr-2 -mt-2 inline-flex h-8 w-8 items-center justify-center rounded-sm text-meta transition-colors hover:bg-elevated hover:text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden="true">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </header>
+
+            <div className="flex-1 space-y-4 overflow-y-auto">
+              <SurfaceRow label={SURFACE_LABEL.playground} snapshot={quota.playground} />
+              <SurfaceRow label={SURFACE_LABEL.skillGen} snapshot={quota.skillGen} />
+            </div>
+
+            <footer className="rounded border border-accent/30 bg-accent/5 p-4">
+              <p className="font-text text-sm text-strong">
+                Need more headroom?
+              </p>
+              <p className="mt-1 font-text text-xs leading-relaxed text-body">
+                Beta credits are non-expiring and granted by an Ornn admin.
+                Paid plans are coming soon.
+              </p>
+              <a
+                href="mailto:hello@chrono-ai.fun?subject=Ornn%20beta%20credits"
+                className="mt-3 inline-flex items-center gap-2 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-accent hover:text-accent-muted"
+              >
+                Contact admin
+                <span aria-hidden>→</span>
+              </a>
+            </footer>
+          </motion.aside>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/ornn-web/src/hooks/useModels.test.tsx
+++ b/ornn-web/src/hooks/useModels.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Tests for `usePreferredModel`.
+ *
+ * Three load-bearing behaviors:
+ *  1. Stored model that's still enabled wins.
+ *  2. Stored model that's been disabled silently falls back to the
+ *     admin default — without clearing storage.
+ *  3. With no stored value, the admin default is used.
+ *
+ * @module hooks/useModels.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { PickerResult } from "@/services/modelsApi";
+
+// Mock the auth store so `usePickerModels` is enabled.
+vi.mock("@/stores/authStore", () => ({
+  useIsAuthenticated: () => true,
+}));
+
+const fetchPickerModels = vi.fn();
+
+vi.mock("@/services/modelsApi", () => ({
+  fetchPickerModels: (...args: unknown[]) => fetchPickerModels(...args),
+  fetchAdminModels: vi.fn(),
+  refreshModelCatalog: vi.fn(),
+  patchModelFlags: vi.fn(),
+}));
+
+import { usePreferredModel } from "./useModels";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const KEY = "ornn.preferredModel.playground";
+
+/**
+ * bun's test runner injects a stripped-down localStorage object that
+ * jsdom doesn't override. Replace it with an in-memory shim every test
+ * so getItem / setItem / removeItem are guaranteed to exist.
+ */
+function installStorageShim(): void {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(k) {
+      return store.has(k) ? (store.get(k) as string) : null;
+    },
+    key(i) {
+      return Array.from(store.keys())[i] ?? null;
+    },
+    removeItem(k) {
+      store.delete(k);
+    },
+    setItem(k, v) {
+      store.set(k, String(v));
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: shim,
+  });
+}
+
+describe("usePreferredModel", () => {
+  beforeEach(() => {
+    fetchPickerModels.mockReset();
+    installStorageShim();
+  });
+
+  afterEach(() => {
+    installStorageShim();
+  });
+
+  it("uses the admin default when no value is stored", async () => {
+    const result: PickerResult = {
+      items: [
+        { modelId: "gpt-5", displayName: "GPT 5", isDefault: true },
+        { modelId: "gpt-5-mini", displayName: "GPT 5 mini", isDefault: false },
+      ],
+      defaultModelId: "gpt-5",
+    };
+    fetchPickerModels.mockResolvedValue(result);
+
+    const { result: hookResult } = renderHook(
+      () => usePreferredModel("playground"),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() =>
+      expect(hookResult.current.effectiveModelId).toBe("gpt-5"),
+    );
+    expect(hookResult.current.storedModelId).toBeNull();
+  });
+
+  it("uses the stored value when it's still enabled", async () => {
+    window.localStorage.setItem(KEY, "gpt-5-mini");
+    const result: PickerResult = {
+      items: [
+        { modelId: "gpt-5", displayName: "GPT 5", isDefault: true },
+        { modelId: "gpt-5-mini", displayName: "GPT 5 mini", isDefault: false },
+      ],
+      defaultModelId: "gpt-5",
+    };
+    fetchPickerModels.mockResolvedValue(result);
+
+    const { result: hookResult } = renderHook(
+      () => usePreferredModel("playground"),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() =>
+      expect(hookResult.current.effectiveModelId).toBe("gpt-5-mini"),
+    );
+    expect(hookResult.current.storedModelId).toBe("gpt-5-mini");
+  });
+
+  it("falls back to default when the stored model is no longer enabled, without clearing storage", async () => {
+    window.localStorage.setItem(KEY, "gpt-4-old");
+    const result: PickerResult = {
+      items: [
+        { modelId: "gpt-5", displayName: "GPT 5", isDefault: true },
+      ],
+      defaultModelId: "gpt-5",
+    };
+    fetchPickerModels.mockResolvedValue(result);
+
+    const { result: hookResult } = renderHook(
+      () => usePreferredModel("playground"),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() =>
+      expect(hookResult.current.effectiveModelId).toBe("gpt-5"),
+    );
+    // Storage is preserved so a later re-enable restores the user pick.
+    expect(window.localStorage.getItem(KEY)).toBe("gpt-4-old");
+    expect(hookResult.current.storedModelId).toBe("gpt-4-old");
+  });
+
+  it("setPreferred persists to localStorage and updates effective", async () => {
+    const result: PickerResult = {
+      items: [
+        { modelId: "gpt-5", displayName: "GPT 5", isDefault: true },
+        { modelId: "gpt-5-mini", displayName: "GPT 5 mini", isDefault: false },
+      ],
+      defaultModelId: "gpt-5",
+    };
+    fetchPickerModels.mockResolvedValue(result);
+
+    const { result: hookResult } = renderHook(
+      () => usePreferredModel("playground"),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() =>
+      expect(hookResult.current.effectiveModelId).toBe("gpt-5"),
+    );
+
+    act(() => hookResult.current.setPreferred("gpt-5-mini"));
+
+    expect(window.localStorage.getItem(KEY)).toBe("gpt-5-mini");
+    await waitFor(() =>
+      expect(hookResult.current.effectiveModelId).toBe("gpt-5-mini"),
+    );
+  });
+
+  it("flags isEmpty when admin has nothing enabled for the surface", async () => {
+    const result: PickerResult = { items: [], defaultModelId: null };
+    fetchPickerModels.mockResolvedValue(result);
+
+    const { result: hookResult } = renderHook(
+      () => usePreferredModel("playground"),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(hookResult.current.isLoading).toBe(false));
+    expect(hookResult.current.isEmpty).toBe(true);
+    expect(hookResult.current.effectiveModelId).toBeNull();
+  });
+});

--- a/ornn-web/src/hooks/useModels.ts
+++ b/ornn-web/src/hooks/useModels.ts
@@ -1,0 +1,163 @@
+/**
+ * Models hooks — picker (caller-side) and admin catalog mutations.
+ *
+ * `usePreferredModel` returns a `[modelId, setModelId]` pair backed by
+ * `localStorage` so the user's last choice survives reloads, with a
+ * stale-value fallback to the admin default when the stored choice is no
+ * longer enabled. The picker on playground / skill-gen consumes this
+ * directly.
+ *
+ * @module hooks/useModels
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import {
+  fetchAdminModels,
+  fetchPickerModels,
+  patchModelFlags,
+  refreshModelCatalog,
+  type AdminModelsList,
+  type PatchFlagsInput,
+  type PickerResult,
+  type RefreshOutcome,
+} from "@/services/modelsApi";
+import type { Surface } from "@/services/quotaApi";
+import { useIsAuthenticated } from "@/stores/authStore";
+
+const STORAGE_KEY: Record<Surface, string> = {
+  playground: "ornn.preferredModel.playground",
+  skillGen: "ornn.preferredModel.skillGen",
+};
+
+export const PICKER_MODELS_KEY = (surface: Surface) =>
+  ["me", "models", surface] as const;
+
+export function usePickerModels(
+  surface: Surface,
+  enabled = true,
+): UseQueryResult<PickerResult> {
+  const isAuthed = useIsAuthenticated();
+  return useQuery({
+    queryKey: PICKER_MODELS_KEY(surface),
+    queryFn: () => fetchPickerModels(surface),
+    enabled: enabled && isAuthed,
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Read+write the user's preferred model for a given surface. The stored
+ * value is the modelId. When the stored model is no longer enabled (e.g.
+ * admin disabled it after the user last picked), `effectiveModelId`
+ * silently falls back to the admin default while leaving the stored
+ * value alone — so if the model gets re-enabled, the user's preference
+ * is restored.
+ */
+export function usePreferredModel(surface: Surface): {
+  effectiveModelId: string | null;
+  storedModelId: string | null;
+  setPreferred: (modelId: string) => void;
+  options: PickerResult["items"];
+  defaultModelId: string | null;
+  isLoading: boolean;
+  isEmpty: boolean;
+} {
+  const { data, isLoading } = usePickerModels(surface);
+
+  const [storedModelId, setStoredModelId] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    try {
+      return window.localStorage.getItem(STORAGE_KEY[surface]);
+    } catch {
+      return null;
+    }
+  });
+
+  // Sync state if the user clears storage in another tab.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY[surface]) {
+        setStoredModelId(e.newValue);
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [surface]);
+
+  const setPreferred = useCallback(
+    (modelId: string) => {
+      setStoredModelId(modelId);
+      try {
+        window.localStorage.setItem(STORAGE_KEY[surface], modelId);
+      } catch {
+        /* storage may be unavailable in private mode — ignore */
+      }
+    },
+    [surface],
+  );
+
+  const options = data?.items ?? [];
+  const defaultModelId = data?.defaultModelId ?? null;
+
+  const effectiveModelId = useMemo(() => {
+    if (!data) return storedModelId ?? null;
+    if (
+      storedModelId &&
+      data.items.some((m) => m.modelId === storedModelId)
+    ) {
+      return storedModelId;
+    }
+    return defaultModelId;
+  }, [data, defaultModelId, storedModelId]);
+
+  return {
+    effectiveModelId,
+    storedModelId,
+    setPreferred,
+    options,
+    defaultModelId,
+    isLoading,
+    isEmpty: !isLoading && (data?.items.length ?? 0) === 0,
+  };
+}
+
+export function useAdminModels(includeArchived: boolean): UseQueryResult<AdminModelsList> {
+  return useQuery({
+    queryKey: ["admin", "models", { includeArchived }] as const,
+    queryFn: () => fetchAdminModels(includeArchived),
+    staleTime: 15_000,
+  });
+}
+
+export function useRefreshModels() {
+  const qc = useQueryClient();
+  return useMutation<RefreshOutcome, Error, void>({
+    mutationFn: refreshModelCatalog,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "models"] });
+      qc.invalidateQueries({ queryKey: ["me", "models"] });
+    },
+  });
+}
+
+export function usePatchModelFlags() {
+  const qc = useQueryClient();
+  return useMutation<
+    Awaited<ReturnType<typeof patchModelFlags>>,
+    Error,
+    { modelId: string; patch: PatchFlagsInput }
+  >({
+    mutationFn: ({ modelId, patch }) => patchModelFlags(modelId, patch),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "models"] });
+      qc.invalidateQueries({ queryKey: ["me", "models"] });
+    },
+  });
+}

--- a/ornn-web/src/hooks/usePlaygroundChat.ts
+++ b/ornn-web/src/hooks/usePlaygroundChat.ts
@@ -122,7 +122,12 @@ export function usePlaygroundChat() {
   );
 
   const sendMessage = useCallback(
-    (content: string, skillId?: string, envVars?: Record<string, string>) => {
+    (
+      content: string,
+      skillId?: string,
+      envVars?: Record<string, string>,
+      modelId?: string,
+    ) => {
       streamRef.current?.abort();
       tokenBufferRef.current = "";
       cancelFlush();
@@ -140,11 +145,12 @@ export function usePlaygroundChat() {
         skillId: skillId ?? null,
         promptLength: content.length,
         hasEnvVars: Boolean(envVars && Object.keys(envVars).length),
+        modelId: modelId ?? null,
       });
 
       const msgs = usePlaygroundStore.getState().messages;
       const mapped = msgs.map((m) => ({ role: m.role, content: m.content }));
-      const handle = streamChat({ messages: mapped, skillId, envVars }, handleEvent);
+      const handle = streamChat({ messages: mapped, skillId, envVars, modelId }, handleEvent);
       streamRef.current = handle;
     },
     [handleEvent, cancelFlush],

--- a/ornn-web/src/hooks/useQuota.ts
+++ b/ornn-web/src/hooks/useQuota.ts
@@ -1,0 +1,117 @@
+/**
+ * Quota hooks — caller snapshot + admin grant mutations.
+ *
+ * `useMyQuota` is the chip / drawer / banner / playground in-context source.
+ * Grant hooks invalidate the relevant cache keys so the admin Users + caller
+ * counters refresh in lockstep when admins issue credits.
+ *
+ * @module hooks/useQuota
+ */
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { useIsAuthenticated } from "@/stores/authStore";
+import {
+  bulkGrantQuota,
+  fetchAdminQuotaGrants,
+  fetchAdminQuotaUsers,
+  fetchMyQuota,
+  grantQuota,
+  type BulkGrantInput,
+  type BulkGrantOutcome,
+  type GrantInput,
+  type QuotaSnapshot,
+  type Surface,
+} from "@/services/quotaApi";
+
+export const MY_QUOTA_KEY = ["me", "quota"] as const;
+
+/**
+ * Caller-scoped quota snapshot. Polls every 60s while the tab is visible
+ * so the chip / drawer stay accurate after charges land. Disabled for
+ * anonymous callers.
+ */
+export function useMyQuota(): UseQueryResult<QuotaSnapshot> {
+  const isAuthed = useIsAuthenticated();
+  return useQuery({
+    queryKey: MY_QUOTA_KEY,
+    queryFn: fetchMyQuota,
+    enabled: isAuthed,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: false,
+  });
+}
+
+/**
+ * Resolve a single surface's snapshot from the cached caller quota.
+ * Returns undefined while the query is in flight or for admins (admins
+ * still get a snapshot but the consumer typically wants to skip the chip
+ * — checking `quota?.isAdmin` is the right gate).
+ */
+export function useSurfaceQuota(
+  surface: Surface,
+): { snapshot: QuotaSnapshot["playground"] | undefined; quota: QuotaSnapshot | undefined; isLoading: boolean } {
+  const q = useMyQuota();
+  const surfaceData = q.data
+    ? surface === "playground"
+      ? q.data.playground
+      : q.data.skillGen
+    : undefined;
+  return {
+    snapshot: surfaceData,
+    quota: q.data,
+    isLoading: q.isLoading,
+  };
+}
+
+export function useAdminQuotaUsers(params: {
+  page?: number;
+  pageSize?: number;
+  q?: string;
+}) {
+  return useQuery({
+    queryKey: ["admin", "quota", "users", params] as const,
+    queryFn: () => fetchAdminQuotaUsers(params),
+    staleTime: 15_000,
+  });
+}
+
+export function useGrantQuota() {
+  const qc = useQueryClient();
+  return useMutation<{ auditId: string }, Error, GrantInput>({
+    mutationFn: grantQuota,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "quota"] });
+      qc.invalidateQueries({ queryKey: MY_QUOTA_KEY });
+    },
+  });
+}
+
+export function useBulkGrantQuota() {
+  const qc = useQueryClient();
+  return useMutation<BulkGrantOutcome, Error, BulkGrantInput>({
+    mutationFn: bulkGrantQuota,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "quota"] });
+      qc.invalidateQueries({ queryKey: MY_QUOTA_KEY });
+    },
+  });
+}
+
+export function useAdminQuotaGrants(params: {
+  page?: number;
+  pageSize?: number;
+  userId?: string;
+  adminUserId?: string;
+}) {
+  return useQuery({
+    queryKey: ["admin", "quota", "grants", params] as const,
+    queryFn: () => fetchAdminQuotaGrants(params),
+    staleTime: 30_000,
+  });
+}

--- a/ornn-web/src/hooks/useSkillGeneration.ts
+++ b/ornn-web/src/hooks/useSkillGeneration.ts
@@ -37,8 +37,10 @@ interface GenerationState {
 }
 
 export interface UseSkillGenerationReturn extends GenerationState {
-  /** Send a message (user prompt) to the generation stream */
-  sendMessage: (content: string) => void;
+  /** Send a message (user prompt) to the generation stream. Optional
+   * `modelId` overrides the surface default — picker passes the
+   * caller's preferred model in. */
+  sendMessage: (content: string, modelId?: string) => void;
   /** Abort current stream */
   abort: () => void;
   /** Reset to input phase */
@@ -260,7 +262,7 @@ export function useSkillGeneration(): UseSkillGenerationReturn {
   }, [cancelFlush]);
 
   const sendMessage = useCallback(
-    (content: string) => {
+    (content: string, modelId?: string) => {
       abort();
       tokenBufferRef.current = "";
 
@@ -270,6 +272,7 @@ export function useSkillGeneration(): UseSkillGenerationReturn {
       track("skill_gen.started", {
         promptLength: content.length,
         turn: conversationHistoryRef.current.length / 2 + 1,
+        modelId: modelId ?? null,
       });
 
       const userMsgId = crypto.randomUUID();
@@ -306,7 +309,7 @@ export function useSkillGeneration(): UseSkillGenerationReturn {
       }));
 
       const handle = generateSkillStream(
-        { messages: messagesForApi },
+        { messages: messagesForApi, modelId },
         handleEvent,
       );
       abortRef.current = handle.abort;

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -12,9 +12,13 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { Badge } from "@/components/ui/Badge";
 import { ChatInput } from "@/components/playground/ChatInput";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
+import { ModelPicker } from "@/components/models/ModelPicker";
+import { OverLimitPage } from "@/components/quota/OverLimitPage";
+import { QuotaInline } from "@/components/quota/QuotaInline";
 import { useSkill } from "@/hooks/useSkills";
 import { useSkillPackage } from "@/hooks/useSkillPackage";
 import { usePlaygroundChat } from "@/hooks/usePlaygroundChat";
+import { useMyQuota } from "@/hooks/useQuota";
 import { useTranslation } from "react-i18next";
 
 /** Extract env var keys from skill metadata */
@@ -84,6 +88,20 @@ export function PlaygroundPage() {
     setEnvVars((prev) => ({ ...prev, [key]: value }));
   }, []);
 
+  // Picked model (forwarded with each send). Picker maintains the
+  // localStorage source of truth — we just hold the latest value here so
+  // the chat hook can pass it to the SSE endpoint.
+  const [pickedModelId, setPickedModelId] = useState<string | null>(null);
+
+  // Caller quota — drives the soft warning + over-limit gate. Admins
+  // bypass via `quota.isAdmin` inside the components.
+  const { data: quotaSnapshot } = useMyQuota();
+  const playgroundSnap = quotaSnapshot?.playground;
+  const isOverLimit =
+    Boolean(playgroundSnap) &&
+    !quotaSnapshot?.isAdmin &&
+    playgroundSnap!.monthly.remaining + playgroundSnap!.credits.balance <= 0;
+
   // Chat
   const {
     messages,
@@ -103,9 +121,14 @@ export function PlaygroundPage() {
   }, [messages, currentAssistantContent]);
 
   const handleSend = useCallback((content: string) => {
-    // Pass skillId and envVars with the message
-    sendMessage(content, skillName ?? undefined, needsEnvVars ? envVars : undefined);
-  }, [sendMessage, skillName, envVars, needsEnvVars]);
+    // Pass skillId, envVars, and the user's picked model with each message.
+    sendMessage(
+      content,
+      skillName ?? undefined,
+      needsEnvVars ? envVars : undefined,
+      pickedModelId ?? undefined,
+    );
+  }, [sendMessage, skillName, envVars, needsEnvVars, pickedModelId]);
 
   // No skill specified
   if (!skillName) {
@@ -139,9 +162,29 @@ export function PlaygroundPage() {
     );
   }
 
+  if (isOverLimit && playgroundSnap) {
+    return (
+      <PageTransition>
+        <OverLimitPage surface="playground" snapshot={playgroundSnap} />
+      </PageTransition>
+    );
+  }
+
   return (
     <PageTransition>
       <div className="flex flex-col h-full py-1">
+        {/* Surface header — quota inline + model picker. The 80% warning
+            banner replaces the inline stamp at threshold; admins see
+            nothing because both components self-skip. */}
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-3 shrink-0">
+          <QuotaInline surface="playground" />
+          <ModelPicker
+            surface="playground"
+            onChange={setPickedModelId}
+            className="ml-auto"
+          />
+        </div>
+
         {/* Two-column layout */}
         <div className="flex flex-1 min-h-0 gap-4">
           {/* Left: Chat (40%) */}

--- a/ornn-web/src/pages/admin/AdminModelsPage.tsx
+++ b/ornn-web/src/pages/admin/AdminModelsPage.tsx
@@ -1,0 +1,334 @@
+/**
+ * Admin Models page (#251).
+ *
+ * Shows the on-disk model catalog. Admin can:
+ *   - refresh from upstream (Chrono LLM via NyxID proxy),
+ *   - filter / search,
+ *   - toggle per-surface enable flags,
+ *   - set the per-surface default (radio — server enforces at-most-one).
+ *   - see archived (no longer in upstream) rows segregated below active.
+ *
+ * @module pages/admin/AdminModelsPage
+ */
+
+import { useMemo, useState } from "react";
+import { motion } from "framer-motion";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { Badge } from "@/components/ui/Badge";
+import { useToastStore } from "@/stores/toastStore";
+import {
+  useAdminModels,
+  usePatchModelFlags,
+  useRefreshModels,
+} from "@/hooks/useModels";
+import type { AdminModelRow } from "@/services/modelsApi";
+
+function formatDateSGT(iso: string | undefined): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString("en-SG", {
+      timeZone: "Asia/Singapore",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+interface ToggleProps {
+  checked: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+  label: string;
+}
+
+function Toggle({ checked, onToggle, disabled, label }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      className={`
+        relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-sm border transition-colors
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+        ${checked ? "border-accent bg-accent/20" : "border-strong-edge bg-elevated"}
+        ${disabled ? "cursor-not-allowed opacity-50" : ""}
+      `}
+    >
+      <span
+        className={`
+          absolute h-3 w-3 rounded-sm transition-transform duration-150
+          ${checked ? "translate-x-[18px] bg-accent" : "translate-x-1 bg-meta"}
+        `}
+      />
+    </button>
+  );
+}
+
+interface RadioProps {
+  checked: boolean;
+  onSelect: () => void;
+  disabled?: boolean;
+  label: string;
+}
+
+function Radio({ checked, onSelect, disabled, label }: RadioProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={onSelect}
+      disabled={disabled}
+      className={`
+        inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-full border transition-colors
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+        ${checked ? "border-accent bg-accent/15" : "border-strong-edge bg-elevated"}
+        ${disabled ? "cursor-not-allowed opacity-40" : ""}
+      `}
+    >
+      {checked && <span className="h-2 w-2 rounded-full bg-accent" />}
+    </button>
+  );
+}
+
+interface ModelRowProps {
+  model: AdminModelRow;
+}
+
+function ModelRow({ model }: ModelRowProps) {
+  const patch = usePatchModelFlags();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const handle = (
+    payload: Parameters<typeof patch.mutateAsync>[0]["patch"],
+  ) =>
+    patch
+      .mutateAsync({ modelId: model.modelId, patch: payload })
+      .catch((err) => {
+        addToast({
+          type: "error",
+          message: err instanceof Error ? err.message : "Failed to update model",
+        });
+      });
+
+  return (
+    <tr
+      className={`border-b border-accent/10 transition-colors ${
+        model.archived ? "opacity-60" : "hover:bg-elevated/40"
+      }`}
+    >
+      <td className="px-4 py-3">
+        <div className="flex flex-col">
+          <span className="font-mono text-sm font-semibold text-strong">
+            {model.modelId}
+          </span>
+          {model.displayName && model.displayName !== model.modelId && (
+            <span className="font-text text-xs text-meta">{model.displayName}</span>
+          )}
+          {model.archived && (
+            <span className="mt-1 inline-flex w-fit">
+              <Badge color="muted">archived</Badge>
+            </span>
+          )}
+        </div>
+      </td>
+
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Toggle
+            checked={model.enabledForPlayground}
+            disabled={model.archived || patch.isPending}
+            onToggle={() =>
+              handle({ enabledForPlayground: !model.enabledForPlayground })
+            }
+            label="Enable for playground"
+          />
+          <Radio
+            checked={model.defaultForPlayground}
+            disabled={
+              model.archived || !model.enabledForPlayground || patch.isPending
+            }
+            onSelect={() => handle({ defaultForPlayground: true })}
+            label="Default for playground"
+          />
+        </div>
+      </td>
+
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Toggle
+            checked={model.enabledForSkillGen}
+            disabled={model.archived || patch.isPending}
+            onToggle={() =>
+              handle({ enabledForSkillGen: !model.enabledForSkillGen })
+            }
+            label="Enable for skill-gen"
+          />
+          <Radio
+            checked={model.defaultForSkillGen}
+            disabled={
+              model.archived || !model.enabledForSkillGen || patch.isPending
+            }
+            onSelect={() => handle({ defaultForSkillGen: true })}
+            label="Default for skill-gen"
+          />
+        </div>
+      </td>
+
+      <td className="whitespace-nowrap px-4 py-3 font-mono text-[11px] text-meta">
+        {formatDateSGT(model.lastSyncedAt)}
+      </td>
+    </tr>
+  );
+}
+
+const TABLE_HEADERS = [
+  { key: "model", label: "Model" },
+  { key: "playground", label: "Playground · default" },
+  { key: "skillGen", label: "Skill-gen · default" },
+  { key: "synced", label: "Last synced" },
+];
+
+export function AdminModelsPage() {
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [query, setQuery] = useState("");
+  const { data, isLoading, error } = useAdminModels(includeArchived);
+  const refresh = useRefreshModels();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const items = useMemo(() => data?.items ?? [], [data]);
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (m) =>
+        m.modelId.toLowerCase().includes(q) ||
+        m.displayName.toLowerCase().includes(q),
+    );
+  }, [items, query]);
+
+  const active = filtered.filter((m) => !m.archived);
+  const archived = filtered.filter((m) => m.archived);
+
+  const handleRefresh = async () => {
+    try {
+      const out = await refresh.mutateAsync();
+      addToast({
+        type: "success",
+        message: `Catalog refreshed — ${out.added} added, ${out.updated} updated, ${out.archived} archived.`,
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : "Refresh failed",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-2xl font-bold uppercase tracking-tight text-strong">
+            Models
+          </h1>
+          <p className="mt-1 font-text text-meta">
+            Curate the LLM catalog exposed to playground and skill-gen surfaces.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="secondary"
+            onClick={() => setIncludeArchived((v) => !v)}
+            size="sm"
+          >
+            {includeArchived ? "Hide archived" : "Show archived"}
+          </Button>
+          <Button onClick={handleRefresh} loading={refresh.isPending} size="sm">
+            Refresh catalog
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Filter by model id…"
+          className="w-full max-w-sm rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-mono text-xs text-strong placeholder:text-meta/70 focus:border-accent focus:outline-none focus:bg-card"
+        />
+        <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-meta">
+          {filtered.length} / {items.length} models
+        </span>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <Card>
+          {isLoading ? (
+            <Skeleton lines={8} />
+          ) : error ? (
+            <p className="py-8 text-center font-text text-danger">
+              {error instanceof Error ? error.message : "Failed to load catalog"}
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="py-8 text-center font-text text-meta">
+              No models match. Hit "Refresh catalog" to pull from upstream.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-accent/20">
+                    {TABLE_HEADERS.map((h) => (
+                      <th
+                        key={h.key}
+                        className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta"
+                      >
+                        {h.label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {active.map((m) => (
+                    <ModelRow key={m.modelId} model={m} />
+                  ))}
+                  {includeArchived && archived.length > 0 && (
+                    <>
+                      <tr>
+                        <td colSpan={TABLE_HEADERS.length} className="px-4 pt-6">
+                          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                            [§ ARCHIVED — REMOVED FROM UPSTREAM]
+                          </p>
+                        </td>
+                      </tr>
+                      {archived.map((m) => (
+                        <ModelRow key={m.modelId} model={m} />
+                      ))}
+                    </>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </motion.div>
+    </div>
+  );
+}

--- a/ornn-web/src/pages/admin/AdminQuotaPage.tsx
+++ b/ornn-web/src/pages/admin/AdminQuotaPage.tsx
@@ -1,0 +1,346 @@
+/**
+ * Admin Quota page (#250).
+ *
+ * Lists the same user pool the existing /admin/users page uses (driven
+ * off the activity index) and decorates each row with both surfaces'
+ * counters. Two interaction modes:
+ *
+ *  - per-row "Grant" expand: opens GrantCreditsForm inline so the admin
+ *    doesn't lose context for adjacent rows.
+ *  - selection + "Grant credits to selected" CTA: bulk grant via modal.
+ *
+ * Below the user table, the audit-trail card shows the latest 50
+ * grants (admin, target, surface, amount, time, note) so admins can
+ * verify what was issued.
+ *
+ * @module pages/admin/AdminQuotaPage
+ */
+
+import { Fragment, useMemo, useState } from "react";
+import { motion } from "framer-motion";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { Pagination } from "@/components/ui/Pagination";
+import { GrantCreditsForm } from "@/components/admin/GrantCreditsForm";
+import { BulkGrantCreditsModal } from "@/components/admin/BulkGrantCreditsModal";
+import {
+  useAdminQuotaGrants,
+  useAdminQuotaUsers,
+} from "@/hooks/useQuota";
+import { useDebounce } from "@/hooks/useDebounce";
+
+const PAGE_SIZE = 20;
+
+function formatDateSGT(iso: string | undefined): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString("en-SG", {
+      timeZone: "Asia/Singapore",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function AdminQuotaPage() {
+  const [page, setPage] = useState(1);
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebounce(query, 300);
+  const [expandedUserId, setExpandedUserId] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkOpen, setBulkOpen] = useState(false);
+
+  const usersQuery = useAdminQuotaUsers({
+    page,
+    pageSize: PAGE_SIZE,
+    q: debouncedQuery || undefined,
+  });
+  const auditQuery = useAdminQuotaGrants({ page: 1, pageSize: 50 });
+
+  const items = usersQuery.data?.items ?? [];
+  const totalPages = usersQuery.data?.totalPages ?? 1;
+
+  const toggleSelected = (userId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  };
+
+  const allOnPageSelected =
+    items.length > 0 && items.every((u) => selectedIds.has(u.userId));
+
+  const togglePage = () => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allOnPageSelected) {
+        items.forEach((u) => next.delete(u.userId));
+      } else {
+        items.forEach((u) => next.add(u.userId));
+      }
+      return next;
+    });
+  };
+
+  const selectedArr = useMemo(() => Array.from(selectedIds), [selectedIds]);
+
+  const usersError = usersQuery.error;
+  const auditError = auditQuery.error;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-2xl font-bold uppercase tracking-tight text-strong">
+            Quota
+          </h1>
+          <p className="mt-1 font-text text-meta">
+            Per-user playground and skill-gen counters with admin-granted credits.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-meta">
+            {selectedIds.size} selected
+          </span>
+          <Button
+            size="sm"
+            disabled={selectedIds.size === 0}
+            onClick={() => setBulkOpen(true)}
+          >
+            Grant credits to selected
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(1);
+          }}
+          placeholder="Filter by email…"
+          className="w-full max-w-sm rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-mono text-xs text-strong placeholder:text-meta/70 focus:border-accent focus:outline-none focus:bg-card"
+        />
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <Card>
+          {usersQuery.isLoading ? (
+            <Skeleton lines={8} />
+          ) : usersError ? (
+            <p className="py-8 text-center font-text text-danger">
+              {usersError instanceof Error
+                ? usersError.message
+                : "Failed to load users"}
+            </p>
+          ) : items.length === 0 ? (
+            <p className="py-8 text-center font-text text-meta">
+              No users match.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-accent/20">
+                    <th className="px-3 py-3 text-left">
+                      <input
+                        type="checkbox"
+                        checked={allOnPageSelected}
+                        onChange={togglePage}
+                        aria-label="Select page"
+                        className="h-3.5 w-3.5 cursor-pointer accent-[var(--color-accent-primary)]"
+                      />
+                    </th>
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      User
+                    </th>
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Playground (used / credits)
+                    </th>
+                    <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Skill-gen (used / credits)
+                    </th>
+                    <th className="px-4 py-3"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((u) => {
+                    const expanded = expandedUserId === u.userId;
+                    return (
+                      <Fragment key={u.userId}>
+                        <tr className="border-b border-accent/10 hover:bg-elevated/40">
+                          <td className="px-3 py-3">
+                            <input
+                              type="checkbox"
+                              checked={selectedIds.has(u.userId)}
+                              onChange={() => toggleSelected(u.userId)}
+                              aria-label={`Select ${u.email}`}
+                              className="h-3.5 w-3.5 cursor-pointer accent-[var(--color-accent-primary)]"
+                            />
+                          </td>
+                          <td className="px-4 py-3">
+                            <p className="font-text text-sm text-strong">
+                              {u.displayName || "—"}
+                            </p>
+                            <p className="font-mono text-[11px] text-meta">
+                              {u.email}
+                            </p>
+                          </td>
+                          <td className="px-4 py-3 font-mono text-[12px] text-strong">
+                            {u.playground.monthlyUsed} used · daily{" "}
+                            {u.playground.dailyUsed} ·{" "}
+                            <span className="text-accent">
+                              +{u.playground.creditsBalance}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 font-mono text-[12px] text-strong">
+                            {u.skillGen.monthlyUsed} used · daily{" "}
+                            {u.skillGen.dailyUsed} ·{" "}
+                            <span className="text-accent">
+                              +{u.skillGen.creditsBalance}
+                            </span>
+                          </td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right">
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setExpandedUserId(expanded ? null : u.userId)
+                              }
+                              className="font-mono text-[11px] uppercase tracking-[0.14em] text-accent hover:text-accent-muted"
+                            >
+                              {expanded ? "Close" : "Grant"}
+                            </button>
+                          </td>
+                        </tr>
+                        {expanded && (
+                          <tr className="border-b border-accent/10 bg-elevated/20">
+                            <td />
+                            <td colSpan={4} className="px-4 py-4">
+                              <GrantCreditsForm
+                                userId={u.userId}
+                                email={u.email}
+                                displayName={u.displayName}
+                                onGranted={() => {
+                                  setExpandedUserId(null);
+                                }}
+                              />
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </motion.div>
+
+      {totalPages > 1 && (
+        <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+      )}
+
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3, delay: 0.05 }}
+      >
+        <Card>
+          <header className="mb-4">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+              [§ AUDIT TRAIL]
+            </p>
+            <h2 className="mt-1 font-display text-lg font-semibold uppercase tracking-tight text-strong">
+              Recent grants
+            </h2>
+          </header>
+          {auditQuery.isLoading ? (
+            <Skeleton lines={4} />
+          ) : auditError ? (
+            <p className="py-4 text-center font-text text-danger">
+              {auditError instanceof Error
+                ? auditError.message
+                : "Failed to load audit trail"}
+            </p>
+          ) : (auditQuery.data?.items.length ?? 0) === 0 ? (
+            <p className="py-4 text-center font-text text-meta">
+              No grants recorded yet.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-accent/20">
+                    <th className="px-4 py-2 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      When
+                    </th>
+                    <th className="px-4 py-2 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Admin
+                    </th>
+                    <th className="px-4 py-2 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Target
+                    </th>
+                    <th className="px-4 py-2 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Surface
+                    </th>
+                    <th className="px-4 py-2 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Amount
+                    </th>
+                    <th className="px-4 py-2 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Note
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {auditQuery.data?.items.map((row) => (
+                    <tr key={row._id} className="border-b border-accent/10">
+                      <td className="whitespace-nowrap px-4 py-2 font-mono text-[11px] text-meta">
+                        {formatDateSGT(row.createdAt)}
+                      </td>
+                      <td className="px-4 py-2 font-text text-xs text-strong">
+                        {row.adminDisplayName || row.adminEmail || row.adminUserId}
+                      </td>
+                      <td className="px-4 py-2 font-mono text-[11px] text-meta">
+                        {row.targetUserId}
+                      </td>
+                      <td className="px-4 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-strong">
+                        {row.surface === "playground" ? "playground" : "skill-gen"}
+                      </td>
+                      <td className="px-4 py-2 font-mono text-[12px] text-accent">
+                        +{row.amount}
+                      </td>
+                      <td className="px-4 py-2 font-text text-xs text-body">
+                        {row.note || "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </motion.div>
+
+      <BulkGrantCreditsModal
+        isOpen={bulkOpen}
+        onClose={() => setBulkOpen(false)}
+        userIds={selectedArr}
+      />
+    </div>
+  );
+}

--- a/ornn-web/src/pages/admin/index.ts
+++ b/ornn-web/src/pages/admin/index.ts
@@ -11,3 +11,5 @@ export { UsersPage } from "./UsersPage";
 export { AdminSkillsPage } from "./AdminSkillsPage";
 export { PlatformSettingsPage } from "./PlatformSettingsPage";
 export { MirrorPage } from "./MirrorPage";
+export { AdminModelsPage } from "./AdminModelsPage";
+export { AdminQuotaPage } from "./AdminQuotaPage";

--- a/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
@@ -4,7 +4,7 @@
  * @module pages/CreateSkillGenerativePage
  */
 
-import { useRef, useEffect, useMemo } from "react";
+import { useRef, useEffect, useMemo, useState, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { PageTransition } from "@/components/layout/PageTransition";
@@ -13,8 +13,12 @@ import { ChatInput } from "@/components/playground/ChatInput";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { ValidationErrorPanel } from "@/components/skill/ValidationErrorPanel";
 import { GenerationChatMessage } from "@/components/skill/GenerationChatMessage";
+import { ModelPicker } from "@/components/models/ModelPicker";
+import { OverLimitPage } from "@/components/quota/OverLimitPage";
+import { QuotaInline } from "@/components/quota/QuotaInline";
 import { useSkillGeneration } from "@/hooks/useSkillGeneration";
 import { useCreateSkill } from "@/hooks/useSkills";
+import { useMyQuota } from "@/hooks/useQuota";
 import { useToastStore } from "@/stores/toastStore";
 import { useAuthStore } from "@/stores/authStore";
 import { track } from "@/lib/analytics";
@@ -57,6 +61,24 @@ export function CreateSkillGenerativePage() {
   const generation = useSkillGeneration();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Caller quota — drives the soft warning + over-limit gate. Admins
+  // bypass via `quota.isAdmin` inside the components.
+  const { data: quotaSnapshot } = useMyQuota();
+  const skillGenSnap = quotaSnapshot?.skillGen;
+  const isOverLimit =
+    Boolean(skillGenSnap) &&
+    !quotaSnapshot?.isAdmin &&
+    skillGenSnap!.monthly.remaining + skillGenSnap!.credits.balance <= 0;
+
+  // Picked model — picker writes to localStorage, we just hold the
+  // resolved id so sendMessage can forward it.
+  const [pickedModelId, setPickedModelId] = useState<string | null>(null);
+
+  const handleSend = useCallback(
+    (content: string) => generation.sendMessage(content, pickedModelId ?? undefined),
+    [generation, pickedModelId],
+  );
 
   // Auto-scroll to bottom on new messages
   useEffect(() => {
@@ -131,6 +153,14 @@ export function CreateSkillGenerativePage() {
     ? t("generative.placeholder")
     : "Describe the skill you want to create... (Enter to send)";
 
+  if (isOverLimit && skillGenSnap) {
+    return (
+      <PageTransition>
+        <OverLimitPage surface="skillGen" snapshot={skillGenSnap} />
+      </PageTransition>
+    );
+  }
+
   return (
     <PageTransition>
       <div className="flex flex-col h-full">
@@ -143,6 +173,11 @@ export function CreateSkillGenerativePage() {
             <ArrowLeftIcon className="h-4 w-4" />
             <span className="font-text text-sm">{t("generative.backToModes")}</span>
           </Link>
+          <ModelPicker surface="skillGen" onChange={setPickedModelId} />
+        </div>
+
+        <div className="mb-2 shrink-0">
+          <QuotaInline surface="skillGen" />
         </div>
 
         {/* Main two-column layout — left chat narrower, right preview wider */}
@@ -177,7 +212,7 @@ export function CreateSkillGenerativePage() {
             {/* Chat input (fixed at bottom) */}
             <div className="shrink-0 border-t border-accent/10 px-1 pb-1">
               <ChatInput
-                onSend={generation.sendMessage}
+                onSend={handleSend}
                 onAbort={generation.abort}
                 disabled={isGenerating}
                 isStreaming={isGenerating}

--- a/ornn-web/src/services/generateStreamApi.ts
+++ b/ornn-web/src/services/generateStreamApi.ts
@@ -14,6 +14,7 @@ const API_BASE = config.apiBaseUrl;
 export interface GenerateStreamParams {
   messages: Array<{ role: string; content: string }>;
   model?: string;
+  modelId?: string;
 }
 
 export interface StreamHandle {
@@ -53,6 +54,7 @@ export function generateSkillStream(
       body: JSON.stringify({
         messages: params.messages,
         model: params.model,
+        modelId: params.modelId,
       }),
       signal: controller.signal,
     },

--- a/ornn-web/src/services/modelsApi.ts
+++ b/ornn-web/src/services/modelsApi.ts
@@ -1,0 +1,94 @@
+/**
+ * Models catalog HTTP client — wraps `/api/v1/me/models` (picker) and the
+ * `/api/v1/admin/models/*` catalog endpoints.
+ *
+ * Mirrors the backend types in `ornn-api/src/domains/models/types.ts`.
+ *
+ * @module services/modelsApi
+ */
+
+import { apiGet, apiPatch, apiPost } from "./apiClient";
+import type { Surface } from "./quotaApi";
+
+export interface PickerModel {
+  modelId: string;
+  displayName: string;
+  isDefault: boolean;
+}
+
+export interface PickerResult {
+  items: PickerModel[];
+  defaultModelId: string | null;
+}
+
+export async function fetchPickerModels(surface: Surface): Promise<PickerResult> {
+  const res = await apiGet<PickerResult>("/api/v1/me/models", { surface });
+  if (!res.data) {
+    throw new Error("Picker models response missing");
+  }
+  return res.data;
+}
+
+export interface AdminModelRow {
+  modelId: string;
+  displayName: string;
+  enabledForPlayground: boolean;
+  enabledForSkillGen: boolean;
+  defaultForPlayground: boolean;
+  defaultForSkillGen: boolean;
+  archived: boolean;
+  lastSyncedAt: string;
+  createdAt: string;
+}
+
+export interface AdminModelsList {
+  items: AdminModelRow[];
+  total: number;
+}
+
+export async function fetchAdminModels(includeArchived: boolean): Promise<AdminModelsList> {
+  const res = await apiGet<AdminModelsList>("/api/v1/admin/models", {
+    includeArchived: includeArchived ? "true" : "false",
+  });
+  if (!res.data) {
+    throw new Error("Admin model catalog missing");
+  }
+  return res.data;
+}
+
+export interface RefreshOutcome {
+  added: number;
+  updated: number;
+  archived: number;
+  total: number;
+  syncedAt: string;
+}
+
+export async function refreshModelCatalog(): Promise<RefreshOutcome> {
+  const res = await apiPost<RefreshOutcome>("/api/v1/admin/models/refresh", {});
+  if (!res.data) {
+    throw new Error("Refresh response missing");
+  }
+  return res.data;
+}
+
+export interface PatchFlagsInput {
+  enabledForPlayground?: boolean;
+  enabledForSkillGen?: boolean;
+  defaultForPlayground?: boolean;
+  defaultForSkillGen?: boolean;
+}
+
+export async function patchModelFlags(
+  modelId: string,
+  patch: PatchFlagsInput,
+): Promise<AdminModelRow> {
+  const res = await apiPatch<AdminModelRow>(
+    `/api/v1/admin/models/${encodeURIComponent(modelId)}`,
+    patch,
+  );
+  if (!res.data) {
+    throw new Error("Patch model response missing");
+  }
+  return res.data;
+}

--- a/ornn-web/src/services/playgroundStreamApi.ts
+++ b/ornn-web/src/services/playgroundStreamApi.ts
@@ -15,6 +15,7 @@ export interface ChatStreamParams {
   messages: Array<{ role: string; content: string }>;
   skillId?: string;
   envVars?: Record<string, string>;
+  modelId?: string;
 }
 
 export interface StreamHandle {
@@ -64,6 +65,7 @@ export function streamChat(
           messages: params.messages,
           skillId: params.skillId,
           envVars: params.envVars,
+          modelId: params.modelId,
         }),
         signal: controller.signal,
       });

--- a/ornn-web/src/services/quotaApi.ts
+++ b/ornn-web/src/services/quotaApi.ts
@@ -1,0 +1,157 @@
+/**
+ * Quota HTTP client — wraps `/api/v1/me/quota` (caller snapshot) and the
+ * `/api/v1/admin/quota/*` admin grant + audit endpoints.
+ *
+ * Mirrors the backend types in `ornn-api/src/domains/quota/types.ts` and
+ * `ornn-api/src/domains/quota/routes.ts` so the picker/UI consumes the
+ * same shape the API emits.
+ *
+ * @module services/quotaApi
+ */
+
+import { apiGet, apiPost } from "./apiClient";
+
+export type Surface = "playground" | "skillGen";
+
+export interface SurfaceSnapshot {
+  monthly: { limit: number; used: number; remaining: number };
+  daily: { limit: number; used: number; remaining: number };
+  credits: { balance: number };
+  warningThreshold: number;
+  warning: boolean;
+  monthlyResetAt: string;
+  dailyResetAt: string;
+}
+
+export interface QuotaSnapshot {
+  playground: SurfaceSnapshot;
+  skillGen: SurfaceSnapshot;
+  isAdmin: boolean;
+}
+
+export async function fetchMyQuota(): Promise<QuotaSnapshot> {
+  const res = await apiGet<QuotaSnapshot>("/api/v1/me/quota");
+  if (!res.data) {
+    throw new Error("Quota snapshot missing");
+  }
+  return res.data;
+}
+
+export interface AdminQuotaRow {
+  userId: string;
+  email: string;
+  displayName: string;
+  playground: { monthlyUsed: number; dailyUsed: number; creditsBalance: number };
+  skillGen: { monthlyUsed: number; dailyUsed: number; creditsBalance: number };
+}
+
+export interface AdminQuotaPage {
+  items: AdminQuotaRow[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+export async function fetchAdminQuotaUsers(params: {
+  page?: number;
+  pageSize?: number;
+  q?: string;
+}): Promise<AdminQuotaPage> {
+  const res = await apiGet<AdminQuotaPage>("/api/v1/admin/quota/users", {
+    page: params.page,
+    pageSize: params.pageSize,
+    q: params.q,
+  });
+  if (!res.data) {
+    throw new Error("Admin quota list missing");
+  }
+  return res.data;
+}
+
+export interface GrantInput {
+  userId: string;
+  surface: Surface;
+  amount: number;
+  note?: string;
+}
+
+export async function grantQuota(input: GrantInput): Promise<{ auditId: string }> {
+  const res = await apiPost<{ auditId: string; applied: number }>(
+    "/api/v1/admin/quota/grant",
+    input,
+  );
+  if (!res.data) {
+    throw new Error("Grant response missing");
+  }
+  return { auditId: res.data.auditId };
+}
+
+export interface BulkGrantInput {
+  userIds: string[];
+  surface: Surface;
+  amount: number;
+  note?: string;
+}
+
+export interface BulkGrantOutcome {
+  applied: number;
+  requested: number;
+  results: Array<{
+    userId: string;
+    ok: boolean;
+    auditId?: string;
+    reason?: string;
+  }>;
+}
+
+export async function bulkGrantQuota(
+  input: BulkGrantInput,
+): Promise<BulkGrantOutcome> {
+  const res = await apiPost<BulkGrantOutcome>(
+    "/api/v1/admin/quota/grant/bulk",
+    input,
+  );
+  if (!res.data) {
+    throw new Error("Bulk grant response missing");
+  }
+  return res.data;
+}
+
+export interface QuotaGrantAuditRow {
+  _id: string;
+  adminUserId: string;
+  adminEmail: string;
+  adminDisplayName: string;
+  targetUserId: string;
+  surface: Surface;
+  amount: number;
+  createdAt: string;
+  note?: string;
+}
+
+export interface QuotaGrantAuditPage {
+  items: QuotaGrantAuditRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export async function fetchAdminQuotaGrants(params: {
+  page?: number;
+  pageSize?: number;
+  userId?: string;
+  adminUserId?: string;
+}): Promise<QuotaGrantAuditPage> {
+  const res = await apiGet<QuotaGrantAuditPage>("/api/v1/admin/quota/grants", {
+    page: params.page,
+    pageSize: params.pageSize,
+    userId: params.userId,
+    adminUserId: params.adminUserId,
+  });
+  if (!res.data) {
+    throw new Error("Audit list missing");
+  }
+  return res.data;
+}


### PR DESCRIPTION
## Summary

Frontend for the Go Live Preparation milestone. Wires the per-user quota counters and admin-curated LLM catalog (backends shipped in #258) into ornn-web so the playground and skill-gen surfaces respect the new constraints and admins can curate them through the panel.

### #250 — Quota
- `QuotaChip` in the app-shell + admin nav: persistent counter pill, click → drawer with monthly base, daily ceiling, beta-credit balance, and reset times for both surfaces. Tone amber at 80%, red at zero. Admin-bypassed.
- In-context display + 80% soft-warning banner on the playground and skill-gen pages.
- `OverLimitPage` (CTA-forward, brand-consistent per DESIGN.md) when a surface is exhausted.
- `/admin/quota` page: per-user inline `GrantCreditsForm`, bulk-select `BulkGrantCreditsModal`, recent-grants audit-trail card.

### #251 — Models
- `ModelPicker` on the playground and skill-gen pages, fed by `/api/v1/me/models`, default-first ordering. Picker selection persists per-surface via `localStorage` (`ornn.preferredModel.playground`, `ornn.preferredModel.skillGen`); stored values that the admin later disables silently fall back to the surface default without clearing storage (so re-enabling restores the user pick).
- `/admin/models` page: catalog list with per-surface enable toggles, default radios, archived flag, refresh-from-upstream button, and search.
- Empty-state UI ("temporarily unavailable — contact admin") when the admin has zero models enabled for the surface.

### Glue
- `modelId` threaded through the playground and skill-gen SSE clients so the picker's choice reaches the backend resolver.
- New AdminLayout sidebar entries: Models, Quota.
- Tests: `usePreferredModel` stale-fallback (5 cases), `QuotaInline` render branches (4 cases). All 45 ornn-web tests pass.

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run build:web` passes
- [ ] `bun run test` — 45 web tests pass (8 files, including the 2 new ones)
- [ ] Local deploy: chip shows in nav for non-admins, hidden for admins
- [ ] Playground: model picker dropdown lists enabled models with default first; selection survives reload
- [ ] Playground: at 80% the soft banner replaces the inline stamp; at 0 the OverLimitPage takes over
- [ ] Skill-gen: same picker + quota behavior on `/skills/new/generate`
- [ ] `/admin/models` — refresh pulls catalog, toggles flip flags, default radio enforces single-default
- [ ] `/admin/quota` — per-user inline grant adds to balance, bulk-select grant fans out to N users, audit-trail rows appear
- [ ] Backend: requests carry `modelId` in the body; surface-disabled values get rejected upstream

Closes #250
Closes #251