### PR TITLE
[Feature] LLM provider admin config (encrypted) + additive quota grants + AgentSeal Python wrapper

### DIFF
--- a/.changeset/llm-config-encryption-and-quota-grant-refactor.md
+++ b/.changeset/llm-config-encryption-and-quota-grant-refactor.md
@@ -1,0 +1,16 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+feat: admin LLM provider config (encrypted at rest, mid-masked in UI), additive quota grants with period, AgentSeal Python wrapper, admin user collection, runtime LLM override.
+
+**LLM provider override (admin panel)** — `/admin/models` gets a `LlmProviderConfigCard` letting an admin paste a custom gateway URL + bearer key without redeploying. The key is encrypted with AES-256-GCM (`infra/crypto`, scrypt-derived from `ENCRYPTION_KEY`) before hitting Mongo and decrypted at the service boundary on each read; the UI mid-masks the persisted key (first 4 + last 4, bullets in the middle) so the operator can sanity-check which key is in place without exposing the body. Round-tripping the masked value preserves the existing key — the bullet character is the sentinel and is rejected if a fresh key would somehow contain one. Override takes effect on the next LLM call (no pod restart) via a `runtimeOverrideEnabled` resolver on `NyxLlmClient`.
+
+**Quota grants are additive with a period** — admin grants now stack on top of any existing balance instead of overwriting (`grant()` accepts `periodMonths`, persists to a `quota_grants` ledger with `consumed`/`expiresAt`). The admin quota table shows used/limit · daily · +bonus per user; the playground chip shows the effective remaining balance.
+
+**AgentSeal trust scanner** — replaced the broken `agentseal guard` CLI with a Python wrapper (`scripts/scan_skill.py`) that drives `agentseal.skill_scanner.SkillScanner` directly, plus a manual rescan button on the trust badge so an operator can re-run a stuck scan without re-publishing.
+
+**Admin user collection** — replaces `ORNN_ADMIN_EMAILS` env. Authenticated users with `ornn:admin:skill` are lazily inserted into `admin_users` by the auth middleware; routes that need an admin filter consult that collection.
+
+**New env var** — `ENCRYPTION_KEY` (32+ chars, generate with `openssl rand -hex 32`). When unset, the API falls back to a clearly-marked dev sentinel; production deployments **must** set this — rotating it makes every previously-encrypted secret unreadable.

--- a/deployment/.env.sample.ornn
+++ b/deployment/.env.sample.ornn
@@ -58,6 +58,16 @@ POSTHOG_ERROR_SAMPLE_RATE=0.1
 AGENTSEAL_ENABLED=true
 AGENTSEAL_TIMEOUT_MS=60000
 
+# -- At-rest secret encryption --
+# Master passphrase for AES-256-GCM encryption of admin-pasted secrets
+# (currently the admin LLM provider apiKey). Cluster-scoped: rotating
+# this value makes every previously-stored ciphertext unreadable, so
+# pick once per deployment and treat it as load-bearing. When unset
+# (dev only) the API falls back to a clearly-marked dev sentinel.
+# Generate a fresh value with: openssl rand -hex 32
+ENCRYPTION_KEY=<32+ char passphrase, e.g. openssl rand -hex 32>
+
+
 # Public origin used in mirror READMEs to link back to canonical Ornn.
 ORNN_PUBLIC_ORIGIN=<e.g. https://ornn.chrono-ai.fun>
 

--- a/deployment/ornn-api/secret.yaml
+++ b/deployment/ornn-api/secret.yaml
@@ -8,6 +8,11 @@ stringData:
   NYXID_SA_CLIENT_ID: "${NYXID_SA_CLIENT_ID}"
   NYXID_SA_CLIENT_SECRET: "${NYXID_SA_CLIENT_SECRET}"
   MONGODB_URI: "${MONGODB_URI}"
+  # Master passphrase for AES-256-GCM at-rest encryption of admin-pasted
+  # secrets (LLM provider apiKey, future operator secrets). Cluster-scoped:
+  # rotating it makes every previously-stored ciphertext unreadable, so
+  # treat it as load-bearing. Generate with `openssl rand -hex 32`.
+  ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
   # PostHog product analytics (#252). Empty string disables the SDK
   # and falls back to the noop tracker — dev/CI clusters don't pollute
   # the project dashboard.

--- a/ornn-api/Dockerfile
+++ b/ornn-api/Dockerfile
@@ -30,21 +30,30 @@ WORKDIR /app
 # global pip installs. Pin the version explicitly so trust scores are
 # reproducible across a known rule set; bumping it is intentional and
 # shows up in CHANGELOG.
-ARG AGENTSEAL_VERSION=0.5.0
+#
+# We don't use the agentseal CLI directly — its `guard` subcommand is
+# designed to scan installed agent configs on a developer's machine,
+# not arbitrary skill packages. Instead `scan_skill.py` (copied below)
+# imports `agentseal.skill_scanner.SkillScanner` and runs it per file
+# in an extracted skill ZIP. Ornn-api spawns this script as a subprocess.
+ARG AGENTSEAL_VERSION=0.9.6
 ENV AGENTSEAL_VERSION=${AGENTSEAL_VERSION}
 ENV AGENTSEAL_VENV=/opt/agentseal
 RUN apt-get update \
  && apt-get install -y --no-install-recommends python3 python3-venv \
  && python3 -m venv "$AGENTSEAL_VENV" \
  && "$AGENTSEAL_VENV/bin/pip" install --no-cache-dir "agentseal==${AGENTSEAL_VERSION}" \
- && ln -sf "$AGENTSEAL_VENV/bin/agentseal" /usr/local/bin/agentseal \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# Surface the canonical command path so ornn-api's config defaults work
-# without operator overrides. AGENTSEAL_COMMAND can still be overridden
-# at runtime by the deployment.
-ENV AGENTSEAL_COMMAND=/usr/local/bin/agentseal
+# Skill-scan wrapper — invoked by ornn-api as `python scan_skill.py <zip>`.
+COPY ornn-api/scripts/scan_skill.py /opt/agentseal/scan_skill.py
+
+# Surface the canonical interpreter + script paths so ornn-api's config
+# defaults work without operator overrides. Both can be overridden at
+# runtime by the deployment if a sidecar / different layout is preferred.
+ENV AGENTSEAL_PYTHON=/opt/agentseal/bin/python
+ENV AGENTSEAL_SCRIPT=/opt/agentseal/scan_skill.py
 
 COPY --from=install /app /app
 

--- a/ornn-api/scripts/reconcile-mirror.ts
+++ b/ornn-api/scripts/reconcile-mirror.ts
@@ -87,6 +87,7 @@ async function main(): Promise<void> {
         repo: config.mirror.repoName,
         branch: config.mirror.defaultBranch,
       },
+      encryptionKey: config.encryptionKey,
     });
 
     const auth = new GitHubAppAuth({

--- a/ornn-api/scripts/scan_skill.py
+++ b/ornn-api/scripts/scan_skill.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+scan_skill.py — Ornn-side wrapper around agentseal.skill_scanner.SkillScanner.
+
+The agentseal `guard` CLI is designed to scan installed agent
+configurations on a developer's machine, not arbitrary skill packages.
+For the Ornn registry, we want the **library** layer instead — the
+`SkillScanner` class — because it's the piece that actually runs
+agentseal's threat-detection rules against per-file content.
+
+Usage:
+    python scan_skill.py <skill-zip-path>
+
+Behavior:
+    1. Extract the ZIP into a temp directory.
+    2. Walk every text-like file (SKILL.md, CLAUDE.md, *.md, *.py, *.ts,
+       config files, …) up to a sane size cap.
+    3. Run `SkillScanner.scan_file(path)` on each.
+    4. Aggregate findings + compute a 0–100 trust score by deducting
+       severity-weighted penalties from a 100 floor.
+    5. Print one JSON line on stdout. Exit 0 on success.
+
+JSON shape (matches what `ornn-api/src/infra/agentseal/index.ts` parses):
+    {
+      "score": 0–100,
+      "findings": [
+        {
+          "code": str,
+          "title": str,
+          "severity": "critical"|"high"|"medium"|"low"|"info",
+          "description": str,
+          "evidence": str,        // truncated to 500 chars
+          "remediation": str,
+          "file": str             // path relative to the zip root
+        },
+        ...
+      ],
+      "scannedFiles": int,
+      "agentsealVersion": str,    // e.g. "agentseal-0.9.6"
+      "scannedAt": ISO-8601 UTC
+    }
+
+On any failure (bad zip, scanner crash, etc.) the script prints
+    {"error": "<message>"}
+and exits non-zero. The Node-side caller treats both non-zero exit and
+JSON without a numeric "score" field as a soft failure (publishes are
+never blocked — v1 is warn-only).
+"""
+
+import json
+import sys
+import tempfile
+import traceback
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from agentseal.skill_scanner import SkillScanner
+    from agentseal import __version__ as AGENTSEAL_VERSION
+except Exception as e:  # pragma: no cover — surfaces in stdout
+    print(json.dumps({"error": f"agentseal import failed: {e}"}))
+    sys.exit(2)
+
+
+# Severity → score penalty. Tuned so a single critical finding hurts
+# meaningfully but a handful of low/info findings still leave the skill
+# in a usable band. Adjust intentionally and bump CHANGELOG when you do
+# — score values are persisted on each skill version.
+SEVERITY_WEIGHTS = {
+    "critical": 25,
+    "high": 15,
+    "medium": 5,
+    "low": 2,
+    "info": 1,
+}
+
+
+# Pre-filter by extension so we don't open binary blobs (images, font
+# files, compiled wheels, etc.). The SkillScanner does its own per-file
+# filtering downstream too, but pre-filtering keeps the walk cheap.
+SCAN_EXTS = {
+    ".md", ".markdown", ".txt", ".rst",
+    ".py", ".js", ".ts", ".mjs", ".cjs", ".jsx", ".tsx",
+    ".json", ".yaml", ".yml", ".toml",
+    ".sh", ".bash", ".zsh",
+    ".cfg", ".ini", ".conf",
+}
+
+# Extensionless filenames worth scanning anyway.
+SCAN_FILENAMES = {
+    "SKILL.md", "CLAUDE.md", "AGENTS.md",
+    "claude.md", "agents.md", "skill.md",
+    ".cursorrules", ".aider.conf.yml", ".env.example",
+    "README.md", "readme.md",
+}
+
+# Files larger than this are not credible "skill files" — they're more
+# likely binary attachments. Match SkillScanner's own 10MB cap loosely.
+MAX_FILE_BYTES = 2 * 1024 * 1024
+
+
+def is_scannable(p: Path) -> bool:
+    """True if `p` is a text-like file under the size cap."""
+    if not p.is_file():
+        return False
+    try:
+        if p.stat().st_size > MAX_FILE_BYTES:
+            return False
+    except OSError:
+        return False
+    if p.name in SCAN_FILENAMES:
+        return True
+    return p.suffix.lower() in SCAN_EXTS
+
+
+def scan_directory(scanner: SkillScanner, root: Path) -> dict:
+    """Walk `root` recursively and aggregate per-file scan results."""
+    findings_out: list[dict] = []
+    scanned_count = 0
+    for p in sorted(root.rglob("*")):
+        if not is_scannable(p):
+            continue
+        try:
+            rel = str(p.relative_to(root))
+        except ValueError:
+            rel = str(p)
+        try:
+            result = scanner.scan_file(p)
+        except Exception as e:  # pragma: no cover
+            findings_out.append({
+                "code": "SKILL-SCAN-ERR",
+                "title": "Scanner error",
+                "severity": "info",
+                "description": f"Failed to scan {rel}: {e}",
+                "evidence": "",
+                "remediation": "",
+                "file": rel,
+            })
+            continue
+        scanned_count += 1
+        for f in result.findings:
+            findings_out.append({
+                "code": f.code,
+                "title": f.title,
+                "severity": f.severity,
+                "description": f.description,
+                "evidence": (f.evidence or "")[:500],
+                "remediation": f.remediation,
+                "file": rel,
+            })
+
+    score = 100
+    for f in findings_out:
+        score -= SEVERITY_WEIGHTS.get(f["severity"], 0)
+    score = max(0, min(100, score))
+
+    return {
+        "score": score,
+        "findings": findings_out,
+        "scannedFiles": scanned_count,
+        "agentsealVersion": f"agentseal-{AGENTSEAL_VERSION}",
+        "scannedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(json.dumps({"error": "usage: scan_skill.py <skill-zip-path>"}))
+        return 2
+
+    zip_path = Path(argv[1])
+    if not zip_path.exists():
+        print(json.dumps({"error": f"zip not found: {zip_path}"}))
+        return 2
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="agentseal-scan-") as tmpdir:
+            tmp = Path(tmpdir)
+            try:
+                with zipfile.ZipFile(zip_path) as zf:
+                    # Defend against zip-slip — refuse any entry that
+                    # would extract outside the temp dir.
+                    for member in zf.namelist():
+                        target = (tmp / member).resolve()
+                        if not str(target).startswith(str(tmp.resolve())):
+                            print(json.dumps({
+                                "error": f"zip-slip in entry: {member}",
+                            }))
+                            return 2
+                    zf.extractall(tmp)
+            except zipfile.BadZipFile as e:
+                print(json.dumps({"error": f"bad zip: {e}"}))
+                return 2
+
+            # Semantic layer requires sentence-transformers + a 90MB
+            # ONNX model that doesn't fit a slim runtime image. Pattern
+            # + dataflow detection is enough for v1; semantic can be
+            # added later by installing `agentseal[semantic]`.
+            scanner = SkillScanner(semantic=False)
+            result = scan_directory(scanner, tmp)
+            print(json.dumps(result, default=str))
+            return 0
+    except Exception as e:  # pragma: no cover
+        print(json.dumps({
+            "error": f"scan failed: {e}",
+            "traceback": traceback.format_exc(),
+        }))
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -18,6 +18,7 @@ const pkg = JSON.parse(readFileSync(join(import.meta.dir, "..", "package.json"),
 
 // Auth setup
 import { proxyAuthSetup, nyxidOrgLookupMiddleware } from "./middleware/nyxidAuth";
+import { AdminUsersRepository } from "./domains/admin-users/repository";
 import { requestIdMiddleware, getRequestId } from "./middleware/requestId";
 
 // Universal API audit (issue #245)
@@ -151,9 +152,14 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     logger,
   );
 
-  // ---- AgentSeal trust scanner (#253). Subprocess wrapper.
+  // ---- AgentSeal trust scanner (#253). Subprocess wrapper —
+  // `agentseal guard` doesn't accept skill packages, so we ship a small
+  // Python wrapper (`/opt/agentseal/scan_skill.py`) that imports
+  // `agentseal.skill_scanner.SkillScanner` directly and runs it per
+  // file in the extracted ZIP.
   const agentsealScanner = new AgentSealScanner({
-    command: config.agentsealCommand,
+    python: config.agentsealPython,
+    script: config.agentsealScript,
     timeoutMs: config.agentsealTimeoutMs,
     enabled: config.agentsealEnabled,
     logger,
@@ -188,11 +194,20 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     config.sandboxServiceUrl,
     needsSandboxProxyAuth ? getSaAccessToken : undefined,
   );
+  // The platform-settings service is wired ~80 lines below this point.
+  // We can't pass a `platformSettingsService` reference here (forward
+  // dependency), so we hold a mutable slot and the resolver closes over
+  // it. By the time the first LLM request fires, the slot is populated.
+  let llmOverrideSource: { getLlmProviderConfig: () => Promise<{ gatewayUrl: string; apiKey: string }> } | null = null;
   const nyxLlmClient = new NyxLlmClient({
     gatewayUrl: config.nyxLlmGatewayUrl,
     tokenUrl: config.nyxidTokenUrl,
     clientId: config.nyxidClientId,
     clientSecret: config.nyxidClientSecret,
+    overrideResolver: async () => {
+      if (!llmOverrideSource) return { gatewayUrl: "", apiKey: "" };
+      return llmOverrideSource.getLlmProviderConfig();
+    },
   });
 
   // ---- Repositories ----
@@ -202,6 +217,18 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const categoryRepo = new CategoryRepository(db);
   const tagRepo = new TagRepository(db);
   const activityRepo = new ActivityRepository(db);
+
+  // ---- Admin-users tracker ----
+  // Lazy display cache: every time we see a request authenticated with
+  // the admin permission, upsert the user into `admin_users`. Read by
+  // `/admin/quota/users` (and any other admin list endpoint that needs
+  // to mark known admins) so the UI can show "Unlimited" without
+  // round-tripping NyxID per row. NyxID remains authoritative on the
+  // hot path — this collection is never used for permission checks.
+  const adminUsersRepo = new AdminUsersRepository(db);
+  void adminUsersRepo.ensureIndexes().catch((err) =>
+    logger.warn({ err }, "admin_users indexes ensureIndexes failed — proceeding anyway"),
+  );
 
   // ---- Universal API audit (issue #245) ----
   // Built early so the middleware can mount on `apiApp` below. Indexes
@@ -278,16 +305,30 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
       repo: config.mirror.repoName,
       branch: config.mirror.defaultBranch,
     },
+    encryptionKey: config.encryptionKey,
   });
   const platformSettingsRoutes = createPlatformSettingsRoutes({ platformSettingsService });
+
+  // Now that platformSettingsService exists, hand it to the LLM client
+  // so admin overrides take effect on the next LLM call without a
+  // restart. The closure captured by `overrideResolver` above reads
+  // through this slot.
+  llmOverrideSource = platformSettingsService;
 
   // ---- Domain: Quota (per-user playground / skill-gen counters + admin grants) ----
   const quotaRepo = new QuotaRepository(db);
   void quotaRepo.ensureIndexes().catch((err) =>
     logger.warn({ err }, "quota indexes ensureIndexes failed — proceeding anyway"),
   );
-  const quotaService = new QuotaService({ repo: quotaRepo });
-  const quotaRoutes = createQuotaRoutes({ quotaService, activityRepo });
+  const quotaService = new QuotaService({
+    repo: quotaRepo,
+    notificationService,
+  });
+  const quotaRoutes = createQuotaRoutes({
+    quotaService,
+    activityRepo,
+    adminUsersRepo,
+  });
 
   // ---- Domain: Models (admin-curated Chrono LLM catalog + user picker) ----
   const modelsRepo = new ModelsRepository(db);
@@ -518,7 +559,23 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
 
   // ---- API routes — all traffic via NyxID proxy, trust proxy headers ----
   const apiApp = new Hono();
-  apiApp.use("*", proxyAuthSetup());
+  apiApp.use(
+    "*",
+    proxyAuthSetup({
+      // Lazy admin-user tracking: whenever we see a request authenticated
+      // with the admin permission, upsert the user. Fire-and-forget;
+      // failure is logged inside the repo and never bubbles up.
+      onAuthSeen: (auth) => {
+        if (auth.permissions.includes("ornn:admin:skill")) {
+          void adminUsersRepo.upsert({
+            userId: auth.userId,
+            email: auth.email,
+            displayName: auth.displayName,
+          });
+        }
+      },
+    }),
+  );
   // Universal API audit — runs after `proxyAuthSetup` so the
   // caller-type resolver can read `c.var.auth`. Fail-isolated: errors
   // inside the audit pipeline never propagate to the business response.

--- a/ornn-api/src/clients/nyxid/llm.ts
+++ b/ornn-api/src/clients/nyxid/llm.ts
@@ -152,21 +152,90 @@ export interface NyxLlmClientConfig {
   tokenUrl: string;
   clientId: string;
   clientSecret: string;
+  /**
+   * Optional async resolver of admin-overridable LLM provider config.
+   * Returned values WIN over the constructor-time env config:
+   *   - `gatewayUrl` (non-empty) replaces the env gateway.
+   *   - `apiKey` (non-empty) replaces the SA token-exchange flow with a
+   *     direct Bearer header.
+   *
+   * Resolved before every LLM request so admin updates take effect on
+   * the next call without restarting the pod. Caching is the resolver's
+   * responsibility (PlatformSettingsService caches platform settings
+   * for ~30s, which doubles as our LLM-config cache TTL).
+   *
+   * Failure of the resolver is non-fatal — we fall back to env. The
+   * scenario "DB is down" should never break LLM service.
+   */
+  overrideResolver?: () => Promise<LlmProviderOverride>;
+}
+
+/** Subset of fields the platform-settings layer surfaces as overrides. */
+export interface LlmProviderOverride {
+  gatewayUrl: string;
+  apiKey: string;
 }
 
 export class NyxLlmClient {
-  private readonly gatewayUrl: string;
+  private readonly envGatewayUrl: string;
   private readonly tokenUrl: string;
   private readonly clientId: string;
   private readonly clientSecret: string;
+  private readonly overrideResolver?: () => Promise<LlmProviderOverride>;
   private cachedToken: CachedToken | null = null;
 
   constructor(config: NyxLlmClientConfig) {
-    this.gatewayUrl = config.gatewayUrl;
+    this.envGatewayUrl = config.gatewayUrl;
     this.tokenUrl = config.tokenUrl;
     this.clientId = config.clientId;
     this.clientSecret = config.clientSecret;
-    logger.info({ gatewayUrl: config.gatewayUrl, tokenUrl: config.tokenUrl }, "NyxLlmClient initialized with SA credentials");
+    this.overrideResolver = config.overrideResolver;
+    logger.info(
+      {
+        gatewayUrl: config.gatewayUrl,
+        tokenUrl: config.tokenUrl,
+        runtimeOverrideEnabled: Boolean(config.overrideResolver),
+      },
+      "NyxLlmClient initialized with SA credentials",
+    );
+  }
+
+  /**
+   * Resolve the effective gateway URL + auth header for the current
+   * call. Reads the admin-overridable platform settings (when wired)
+   * and falls back to constructor-time env values on any failure.
+   */
+  private async resolveCallTarget(): Promise<{
+    gatewayUrl: string;
+    authHeader: string;
+  }> {
+    let override: LlmProviderOverride | null = null;
+    if (this.overrideResolver) {
+      try {
+        override = await this.overrideResolver();
+      } catch (err) {
+        logger.warn(
+          { err: (err as Error).message },
+          "LLM override resolver threw — falling back to env config",
+        );
+      }
+    }
+
+    const gatewayUrl =
+      override?.gatewayUrl && override.gatewayUrl.trim().length > 0
+        ? override.gatewayUrl.trim().replace(/\/+$/, "")
+        : this.envGatewayUrl;
+
+    if (override?.apiKey && override.apiKey.trim().length > 0) {
+      // Direct bearer key — skip SA token exchange entirely.
+      return {
+        gatewayUrl,
+        authHeader: `Bearer ${override.apiKey.trim()}`,
+      };
+    }
+
+    const token = await this.getAccessToken();
+    return { gatewayUrl, authHeader: `Bearer ${token}` };
   }
 
   /**
@@ -226,8 +295,8 @@ export class NyxLlmClient {
    * Returns an AsyncIterable of SSE events.
    */
   async *stream(params: NyxLlmStreamParams): AsyncIterable<ResponsesApiStreamEvent> {
-    const token = await this.getAccessToken();
-    logger.info({ model: params.model }, "Starting LLM stream request");
+    const { gatewayUrl, authHeader } = await this.resolveCallTarget();
+    logger.info({ model: params.model, gatewayUrl }, "Starting LLM stream request");
 
     const body: Record<string, unknown> = {
       model: params.model,
@@ -245,10 +314,10 @@ export class NyxLlmClient {
       body.tools = params.tools;
     }
 
-    const response = await fetch(`${this.gatewayUrl}/responses`, {
+    const response = await fetch(`${gatewayUrl}/responses`, {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${token}`,
+        "Authorization": authHeader,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
@@ -274,8 +343,8 @@ export class NyxLlmClient {
    * Returns the output array from the response.
    */
   async complete(params: NyxLlmCompleteParams): Promise<ResponsesApiOutput[]> {
-    const token = await this.getAccessToken();
-    logger.info({ model: params.model }, "Starting LLM complete request");
+    const { gatewayUrl, authHeader } = await this.resolveCallTarget();
+    logger.info({ model: params.model, gatewayUrl }, "Starting LLM complete request");
 
     const body: Record<string, unknown> = {
       model: params.model,
@@ -293,10 +362,10 @@ export class NyxLlmClient {
       body.tools = params.tools;
     }
 
-    const response = await fetch(`${this.gatewayUrl}/responses`, {
+    const response = await fetch(`${gatewayUrl}/responses`, {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${token}`,
+        "Authorization": authHeader,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),

--- a/ornn-api/src/domains/admin-users/repository.ts
+++ b/ornn-api/src/domains/admin-users/repository.ts
@@ -1,0 +1,81 @@
+/**
+ * Admin-users repository.
+ *
+ * Tracks every NyxID user we've seen carrying the `ornn:admin:skill`
+ * permission on Ornn. Populated lazily on every authenticated request
+ * (the proxy auth setup layer fires `upsert` when it sees the perm),
+ * read by admin-facing list endpoints (e.g. `/admin/quota/users`) so
+ * the UI can render an "Unlimited" stamp on those rows.
+ *
+ * NyxID is still the source of truth on the hot path — every admin
+ * action goes through `requirePermission("ornn:admin:skill")`. This
+ * collection is a *display cache*, not an authorization layer.
+ *
+ * @module domains/admin-users/repository
+ */
+
+import type { Db } from "mongodb";
+import pino from "pino";
+
+const logger = pino({ level: "info" }).child({ module: "adminUsersRepository" });
+
+const COLLECTION = "admin_users";
+
+export interface AdminUserDoc {
+  /** NyxID userId — primary key. */
+  _id: string;
+  email: string;
+  displayName: string;
+  /** First time we saw this user authenticate as an admin. */
+  firstSeenAt: Date;
+  /** Most recent time we saw the admin permission for this user. */
+  lastSeenAt: Date;
+}
+
+export class AdminUsersRepository {
+  constructor(private readonly db: Db) {}
+
+  async ensureIndexes(): Promise<void> {
+    await this.db.collection<AdminUserDoc>(COLLECTION).createIndex({ email: 1 });
+  }
+
+  /**
+   * Upsert a row for `user`, refreshing `lastSeenAt`. Fire-and-forget
+   * caller — never block the request path on a failed upsert.
+   */
+  async upsert(user: { userId: string; email: string; displayName: string }): Promise<void> {
+    const now = new Date();
+    try {
+      await this.db.collection<AdminUserDoc>(COLLECTION).updateOne(
+        { _id: user.userId },
+        {
+          $set: {
+            email: user.email,
+            displayName: user.displayName,
+            lastSeenAt: now,
+          },
+          $setOnInsert: {
+            _id: user.userId,
+            firstSeenAt: now,
+          },
+        },
+        { upsert: true },
+      );
+    } catch (err) {
+      logger.warn({ err, userId: user.userId }, "Failed to upsert admin-user record");
+    }
+  }
+
+  /** Set of userIds known to carry the admin permission. */
+  async listUserIds(): Promise<Set<string>> {
+    const rows = await this.db
+      .collection<AdminUserDoc>(COLLECTION)
+      .find({}, { projection: { _id: 1 } })
+      .toArray();
+    return new Set(rows.map((r) => r._id));
+  }
+
+  async list(): Promise<AdminUserDoc[]> {
+    return this.db.collection<AdminUserDoc>(COLLECTION).find().toArray();
+  }
+}

--- a/ornn-api/src/domains/notifications/service.ts
+++ b/ornn-api/src/domains/notifications/service.ts
@@ -122,6 +122,40 @@ export class NotificationService {
     });
   }
 
+  /**
+   * Recipient-side notification fired every time an admin grants credits
+   * (single or bulk path) to a user's playground / skill-gen surface.
+   * Surfaces the new balance so the user knows what they just received.
+   */
+  async notifyQuotaCreditsGranted(params: {
+    targetUserId: string;
+    surface: "playground" | "skillGen";
+    amount: number;
+    note?: string;
+    adminDisplayName: string;
+  }): Promise<void> {
+    const surfaceLabel =
+      params.surface === "playground" ? "playground" : "skill-generation";
+    const amountStr = params.amount.toLocaleString("en-US");
+    const title = `Admin granted you +${amountStr} ${surfaceLabel} credits`;
+    const body = params.note
+      ? `Granted by ${params.adminDisplayName}. Note: ${params.note}`
+      : `Granted by ${params.adminDisplayName}. Credits never expire and stack on top of your monthly base.`;
+    await this.emit(params.targetUserId, {
+      category: "quota.credits_granted",
+      title,
+      body,
+      // No deep link target today — settings/profile would be the
+      // closest match; leaving undefined so the bell renders the
+      // notification without a click affordance.
+      data: {
+        surface: params.surface,
+        amount: params.amount,
+        adminDisplayName: params.adminDisplayName,
+      },
+    });
+  }
+
   private async emit(
     userId: string,
     payload: {

--- a/ornn-api/src/domains/notifications/types.ts
+++ b/ornn-api/src/domains/notifications/types.ts
@@ -10,7 +10,8 @@
 
 export type NotificationCategory =
   | "audit.completed"
-  | "audit.risky_for_consumer";
+  | "audit.risky_for_consumer"
+  | "quota.credits_granted";
 
 export interface NotificationDocument {
   readonly _id: string;

--- a/ornn-api/src/domains/platform/routes.ts
+++ b/ornn-api/src/domains/platform/routes.ts
@@ -14,11 +14,28 @@ import {
   requirePermission,
 } from "../../middleware/nyxidAuth";
 import { AppError } from "../../shared/types/index";
+import { isMidMaskSentinel, midMaskSecret } from "../../infra/crypto";
 import type { PlatformSettingsService } from "./service";
 import type { PlatformSettings } from "./types";
 
 export interface PlatformSettingsRoutesConfig {
   readonly platformSettingsService: PlatformSettingsService;
+}
+
+/**
+ * Mid-mask the apiKey on response so the admin sees which key is in
+ * place (head + tail) without the body leaking through logs or
+ * `kubectl describe`. Bullet character is the sentinel for "preserve
+ * existing on PATCH" — legitimate keys never contain it.
+ */
+function maskLlmProvider(settings: PlatformSettings): PlatformSettings {
+  return {
+    ...settings,
+    llmProvider: {
+      gatewayUrl: settings.llmProvider.gatewayUrl,
+      apiKey: midMaskSecret(settings.llmProvider.apiKey),
+    },
+  };
 }
 
 export function createPlatformSettingsRoutes(
@@ -30,7 +47,7 @@ export function createPlatformSettingsRoutes(
 
   app.get("/admin/settings", auth, requirePermission("ornn:admin:skill"), async (c) => {
     const settings = await platformSettingsService.get();
-    return c.json({ data: settings, error: null });
+    return c.json({ data: maskLlmProvider(settings), error: null });
   });
 
   app.patch("/admin/settings", auth, requirePermission("ornn:admin:skill"), async (c) => {
@@ -51,12 +68,74 @@ export function createPlatformSettingsRoutes(
       patch.auditWaiverThreshold = Math.round(n * 10) / 10;
     }
 
+    if ("llmProvider" in body) {
+      const lp = body.llmProvider;
+      if (!lp || typeof lp !== "object") {
+        throw AppError.badRequest(
+          "INVALID_SETTING",
+          "'llmProvider' must be an object with optional gatewayUrl + apiKey",
+        );
+      }
+      const lpObj = lp as Record<string, unknown>;
+      const next = { gatewayUrl: "", apiKey: "" };
+
+      if ("gatewayUrl" in lpObj) {
+        const u = lpObj.gatewayUrl;
+        if (typeof u !== "string") {
+          throw AppError.badRequest(
+            "INVALID_SETTING",
+            "'llmProvider.gatewayUrl' must be a string (empty = use env default)",
+          );
+        }
+        const trimmed = u.trim();
+        if (trimmed.length > 0) {
+          try {
+            new URL(trimmed); // validate
+          } catch {
+            throw AppError.badRequest(
+              "INVALID_SETTING",
+              "'llmProvider.gatewayUrl' must be a valid URL",
+            );
+          }
+        }
+        next.gatewayUrl = trimmed;
+      } else {
+        // Preserve existing on partial PATCH.
+        const existing = await platformSettingsService.getLlmProviderConfig();
+        next.gatewayUrl = existing.gatewayUrl;
+      }
+
+      if ("apiKey" in lpObj) {
+        const k = lpObj.apiKey;
+        if (typeof k !== "string") {
+          throw AppError.badRequest(
+            "INVALID_SETTING",
+            "'llmProvider.apiKey' must be a string (empty = clear)",
+          );
+        }
+        // The mid-mask sentinel uses the bullet character (•) which is
+        // never present in a real bearer key. If the inbound value
+        // contains a bullet anywhere, the frontend round-tripped the
+        // existing display value — preserve the stored key as-is.
+        if (isMidMaskSentinel(k)) {
+          const existing = await platformSettingsService.getLlmProviderConfig();
+          next.apiKey = existing.apiKey;
+        } else {
+          next.apiKey = k.trim();
+        }
+      } else {
+        const existing = await platformSettingsService.getLlmProviderConfig();
+        next.apiKey = existing.apiKey;
+      }
+      patch.llmProvider = next;
+    }
+
     if (Object.keys(patch).length === 0) {
       throw AppError.badRequest("INVALID_SETTING", "No valid setting fields in body");
     }
 
     const updated = await platformSettingsService.patch(patch);
-    return c.json({ data: updated, error: null });
+    return c.json({ data: maskLlmProvider(updated), error: null });
   });
 
   return app;

--- a/ornn-api/src/domains/platform/service.ts
+++ b/ornn-api/src/domains/platform/service.ts
@@ -12,16 +12,27 @@
  *
  * @module domains/platform/service
  */
+import pino from "pino";
+import { decryptSecret, encryptSecret } from "../../infra/crypto";
 import type { PlatformSettingsRepository } from "./repository";
 import {
   DEFAULT_PLATFORM_SETTINGS,
   type GithubMirrorRepoConfig,
+  type LlmProviderConfig,
   type PlatformSettings,
 } from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "platformSettingsService" });
 
 export interface PlatformSettingsDefaults {
   /** GitHub mirror coordinates from the configmap. Never empty in prod. */
   githubMirror: GithubMirrorRepoConfig;
+  /**
+   * Master passphrase used to encrypt/decrypt at-rest secrets (LLM
+   * `apiKey`, etc.). Sourced from `ENCRYPTION_KEY` env. Required —
+   * the service never sees plaintext at the DB layer.
+   */
+  encryptionKey: string;
 }
 
 export class PlatformSettingsService {
@@ -40,12 +51,30 @@ export class PlatformSettingsService {
     const now = Date.now();
     if (this.cache && now < this.cache.expiresAt) return this.cache.settings;
     const stored = await this.repo.get();
+    // Decrypt the LLM provider apiKey at the service boundary — every
+    // downstream consumer sees plaintext. Failures are non-fatal: an
+    // unreadable secret degrades to "no apiKey set" so the rest of the
+    // system (including the admin UI) keeps working.
+    const llmRaw = stored.llmProvider ?? DEFAULT_PLATFORM_SETTINGS.llmProvider;
+    let llmApiKey = "";
+    try {
+      llmApiKey = decryptSecret(llmRaw.apiKey ?? "", this.defaults.encryptionKey);
+    } catch (err) {
+      logger.error(
+        { err: (err as Error).message },
+        "Failed to decrypt LLM provider apiKey — treating as unset",
+      );
+    }
     const settings: PlatformSettings = {
       auditWaiverThreshold:
         typeof stored.auditWaiverThreshold === "number"
           ? stored.auditWaiverThreshold
           : DEFAULT_PLATFORM_SETTINGS.auditWaiverThreshold,
       githubMirror: stored.githubMirror ?? this.defaults.githubMirror,
+      llmProvider: {
+        gatewayUrl: llmRaw.gatewayUrl ?? "",
+        apiKey: llmApiKey,
+      },
     };
     this.cache = { settings, expiresAt: now + this.cacheTtlMs };
     return settings;
@@ -60,8 +89,27 @@ export class PlatformSettingsService {
     return (await this.get()).githubMirror;
   }
 
+  /** Convenience accessor used by `NyxLlmClient` on every LLM call. */
+  async getLlmProviderConfig(): Promise<LlmProviderConfig> {
+    return (await this.get()).llmProvider;
+  }
+
   async patch(partial: Partial<PlatformSettings>): Promise<PlatformSettings> {
-    await this.repo.patch(partial);
+    // Encrypt the LLM apiKey before persisting. The patch layer sees
+    // plaintext from the route; the repo only ever stores ciphertext.
+    type MutablePatch = { -readonly [K in keyof PlatformSettings]?: PlatformSettings[K] };
+    const toStore: MutablePatch = { ...partial };
+    if (partial.llmProvider) {
+      const enc = encryptSecret(
+        partial.llmProvider.apiKey ?? "",
+        this.defaults.encryptionKey,
+      );
+      toStore.llmProvider = {
+        gatewayUrl: partial.llmProvider.gatewayUrl ?? "",
+        apiKey: enc,
+      };
+    }
+    await this.repo.patch(toStore);
     // Bust the cache so the next read pulls the fresh value through the
     // merge layer (which re-applies defaults for fields the admin
     // didn't set).

--- a/ornn-api/src/domains/platform/types.ts
+++ b/ornn-api/src/domains/platform/types.ts
@@ -25,6 +25,29 @@ export interface PlatformSettings {
    * trail, not a one-click in the admin UI.
    */
   readonly githubMirror: GithubMirrorRepoConfig;
+  /**
+   * LLM provider override. Empty fields fall back to env (the
+   * Chrono LLM gateway via NyxID SA token exchange). When `gatewayUrl`
+   * is set, every playground / skill-gen LLM call hits that endpoint
+   * instead. When `apiKey` is set, calls authenticate with that bearer
+   * token instead of the SA token-exchange flow — useful for pointing
+   * at OpenAI / Anthropic / a self-hosted proxy directly.
+   *
+   * Resolved on every LLM call (no pod restart needed), but cached for
+   * the same TTL the rest of platform settings use.
+   */
+  readonly llmProvider: LlmProviderConfig;
+}
+
+export interface LlmProviderConfig {
+  /** LLM gateway base URL. Empty string = use env `NYX_LLM_GATEWAY_URL`. */
+  readonly gatewayUrl: string;
+  /**
+   * Direct bearer API key. Empty string = use NyxID SA token-exchange
+   * flow against env credentials. Stored in MongoDB, redacted from the
+   * GET response (the API only echoes whether it's set).
+   */
+  readonly apiKey: string;
 }
 
 /**
@@ -50,5 +73,9 @@ export const DEFAULT_PLATFORM_SETTINGS: PlatformSettings = {
     owner: "",
     repo: "",
     branch: "",
+  },
+  llmProvider: {
+    gatewayUrl: "",
+    apiKey: "",
   },
 };

--- a/ornn-api/src/domains/quota/repository.ts
+++ b/ornn-api/src/domains/quota/repository.ts
@@ -321,7 +321,3 @@ export class QuotaRepository {
     return { items, total };
   }
 }
-
-function otherSurface(s: Surface): Surface {
-  return s === "playground" ? "skillGen" : "playground";
-}

--- a/ornn-api/src/domains/quota/repository.ts
+++ b/ornn-api/src/domains/quota/repository.ts
@@ -76,6 +76,13 @@ export class QuotaRepository {
       await this.grants.createIndex({ targetUserId: 1, createdAt: -1 });
       await this.grants.createIndex({ adminUserId: 1, createdAt: -1 });
       await this.grants.createIndex({ createdAt: -1 });
+      // Active-grants index — covers `sumActiveCredits` and
+      // `tryConsumeActiveGrant`. Sparse on `expiresAt` so non-expiring
+      // grants index without a fake date sentinel.
+      await this.grants.createIndex(
+        { targetUserId: 1, surface: 1, expiresAt: 1, createdAt: 1 },
+        { name: "active_grants_lookup" },
+      );
     } catch (err) {
       logger.warn({ err }, "quota indexes ensureIndexes failed — proceeding anyway");
     }
@@ -125,15 +132,15 @@ export class QuotaRepository {
   }
 
   /**
-   * Atomically increment a surface's `monthlyUsed` and `dailyUsed` by 1
-   * and (when monthly base is exhausted) decrement `creditsBalance`.
-   * Caller passes the already-decided `decrementCredit` flag so the
-   * service layer owns the deduction-order policy.
+   * Increment a surface's `monthlyUsed` and `dailyUsed` by 1. The
+   * service layer is responsible for separately consuming a credit
+   * (legacy bucket OR active grant ledger) when the monthly base is
+   * exhausted — see `tryDecrementLegacyCredits` and
+   * `tryConsumeActiveGrant`.
    */
-  async charge(params: {
+  async chargeMonthly(params: {
     userId: string;
     surface: Surface;
-    decrementCredit: boolean;
     now?: Date;
   }): Promise<void> {
     const now = params.now ?? new Date();
@@ -141,18 +148,13 @@ export class QuotaRepository {
     const monthly = currentMonthlyMarker(now);
     const daily = currentDailyMarker(now);
 
-    const inc: Record<string, number> = {
-      [`${surface}.monthlyUsed`]: 1,
-      [`${surface}.dailyUsed`]: 1,
-    };
-    if (params.decrementCredit) {
-      inc[`${surface}.creditsBalance`] = -1;
-    }
-
     await this.quotas.updateOne(
       { userId: params.userId },
       {
-        $inc: inc,
+        $inc: {
+          [`${surface}.monthlyUsed`]: 1,
+          [`${surface}.dailyUsed`]: 1,
+        },
         $set: {
           [`${surface}.monthlyResetMarker`]: monthly,
           [`${surface}.dailyResetMarker`]: daily,
@@ -164,44 +166,109 @@ export class QuotaRepository {
   }
 
   /**
-   * Add `amount` credits to a user's surface bucket. Atomic. Used by
-   * both the per-user grant route and bulk grant route.
+   * Atomically decrement `creditsBalance` (legacy non-expiring bucket)
+   * if positive. Returns true on success, false when no legacy balance
+   * was available — caller should fall through to the grant ledger.
    */
-  async addCredits(params: {
+  async tryDecrementLegacyCredits(params: {
     userId: string;
     surface: Surface;
-    amount: number;
     now?: Date;
-  }): Promise<void> {
+  }): Promise<boolean> {
     const now = params.now ?? new Date();
-    const monthly = currentMonthlyMarker(now);
-    const daily = currentDailyMarker(now);
-    const other = otherSurface(params.surface);
-    await this.quotas.updateOne(
-      { userId: params.userId },
+    const r = await this.quotas.updateOne(
       {
-        $inc: { [`${params.surface}.creditsBalance`]: params.amount },
-        $set: { updatedAt: now },
-        $setOnInsert: {
-          userId: params.userId,
-          [other]: freshSurfaceCounter(now),
-          [`${params.surface}.monthlyUsed`]: 0,
-          [`${params.surface}.dailyUsed`]: 0,
-          [`${params.surface}.monthlyResetMarker`]: monthly,
-          [`${params.surface}.dailyResetMarker`]: daily,
-        },
+        userId: params.userId,
+        [`${params.surface}.creditsBalance`]: { $gt: 0 },
       },
-      { upsert: true },
+      {
+        $inc: { [`${params.surface}.creditsBalance`]: -1 },
+        $set: { updatedAt: now },
+      },
     );
+    return r.modifiedCount === 1;
   }
 
-  async logGrant(params: {
+  /**
+   * Find the oldest active grant (consumed < amount AND not expired)
+   * for the user/surface and increment its `consumed` by 1. Atomic
+   * findOneAndUpdate so two parallel charges can't double-spend the
+   * same row's last credit.
+   *
+   * Returns true on success, false when no active grant has capacity.
+   */
+  async tryConsumeActiveGrant(params: {
+    userId: string;
+    surface: Surface;
+    now?: Date;
+  }): Promise<boolean> {
+    const now = params.now ?? new Date();
+    const r = await this.grants.findOneAndUpdate(
+      {
+        targetUserId: params.userId,
+        surface: params.surface,
+        $expr: { $lt: ["$consumed", "$amount"] },
+        $or: [{ expiresAt: null }, { expiresAt: { $gt: now } }],
+      },
+      { $inc: { consumed: 1 } },
+      // Sort oldest first so admins can predict expiry-vs-consumption
+      // ordering ("the credits I gave you 6 months ago drain first").
+      { sort: { createdAt: 1 }, returnDocument: "after" },
+    );
+    return r !== null;
+  }
+
+  /**
+   * Sum `(amount - consumed)` over all active grants for the user/
+   * surface. Active = not yet drained AND not yet expired.
+   */
+  async sumActiveCredits(
+    userId: string,
+    surface: Surface,
+    now: Date = new Date(),
+  ): Promise<number> {
+    const cursor = this.grants.aggregate<{ total: number }>([
+      {
+        $match: {
+          targetUserId: userId,
+          surface,
+          $expr: { $lt: ["$consumed", "$amount"] },
+          $or: [{ expiresAt: null }, { expiresAt: { $gt: now } }],
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          total: {
+            $sum: {
+              $subtract: [
+                "$amount",
+                { $ifNull: ["$consumed", 0] },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+    const rows = await cursor.toArray();
+    return rows[0]?.total ?? 0;
+  }
+
+  /**
+   * Insert a grant row. The grant is the only source of truth for
+   * credits — `creditsBalance` on the user counter doc is legacy and
+   * never written here. `expiresAt: null` = never expires.
+   *
+   * Returns the new grant `_id`.
+   */
+  async recordGrant(params: {
     adminUserId: string;
     adminEmail: string;
     adminDisplayName: string;
     targetUserId: string;
     surface: Surface;
     amount: number;
+    expiresAt: Date | null;
     note?: string;
     now?: Date;
   }): Promise<string> {
@@ -215,6 +282,8 @@ export class QuotaRepository {
       targetUserId: params.targetUserId,
       surface: params.surface,
       amount: params.amount,
+      consumed: 0,
+      expiresAt: params.expiresAt,
       createdAt: now,
       ...(params.note ? { note: params.note } : {}),
     };
@@ -225,8 +294,9 @@ export class QuotaRepository {
         targetUserId: params.targetUserId,
         surface: params.surface,
         amount: params.amount,
+        expiresAt: params.expiresAt,
       },
-      "Quota grant logged",
+      "Quota grant recorded (active credits ledger)",
     );
     return id;
   }

--- a/ornn-api/src/domains/quota/routes.ts
+++ b/ornn-api/src/domains/quota/routes.ts
@@ -26,6 +26,7 @@ import {
 import { validateBody, getValidatedBody } from "../../middleware/validate";
 import { AppError } from "../../shared/types/index";
 import type { ActivityRepository } from "../admin/activityRepository";
+import type { AdminUsersRepository } from "../admin-users/repository";
 import type { QuotaService } from "./service";
 import {
   QUOTA_ADMIN_PERMISSION,
@@ -39,10 +40,26 @@ const logger = pino({ level: "info" }).child({ module: "quotaRoutes" });
 
 const surfaceSchema = z.enum(SURFACES);
 
+/**
+ * Grant period in months. Optional — null/missing means the grant
+ * never expires (legacy behavior). When set, must be a positive
+ * integer ≤ 60 (5 years) — anything longer is almost certainly a
+ * typo and we'd rather force a deliberate retry than silently
+ * issue a 100-year grant.
+ */
+const periodMonthsSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(60)
+  .nullable()
+  .optional();
+
 const grantSchema = z.object({
   userId: z.string().min(1),
   surface: surfaceSchema,
   amount: z.number().int().positive().max(100_000),
+  periodMonths: periodMonthsSchema,
   note: z.string().max(500).optional(),
 });
 
@@ -50,16 +67,25 @@ const bulkGrantSchema = z.object({
   userIds: z.array(z.string().min(1)).min(1).max(500),
   surface: surfaceSchema,
   amount: z.number().int().positive().max(100_000),
+  periodMonths: periodMonthsSchema,
   note: z.string().max(500).optional(),
 });
 
 export interface QuotaRoutesConfig {
   readonly quotaService: QuotaService;
   readonly activityRepo: ActivityRepository;
+  /**
+   * Lazy display cache populated by the auth setup layer whenever it
+   * sees the admin permission on an authenticated request. Used here
+   * to mark `/admin/quota/users` rows with `isAdmin: true` so the UI
+   * can render an "Unlimited" stamp. NyxID remains authoritative on
+   * the hot path — this is purely a display hint.
+   */
+  readonly adminUsersRepo: AdminUsersRepository;
 }
 
 export function createQuotaRoutes(config: QuotaRoutesConfig): Hono<{ Variables: AuthVariables }> {
-  const { quotaService, activityRepo } = config;
+  const { quotaService, activityRepo, adminUsersRepo } = config;
   const app = new Hono<{ Variables: AuthVariables }>();
   const auth = nyxidAuthMiddleware();
 
@@ -93,10 +119,34 @@ export function createQuotaRoutes(config: QuotaRoutesConfig): Hono<{ Variables: 
       const userPool = await activityRepo.searchUsersByEmail(q, pageSize * 5);
       const slice = userPool.slice((page - 1) * pageSize, page * pageSize);
       const userIds = slice.map((u) => u.userId);
-      const quotaDocs = await Promise.all(
-        userIds.map((id) => quotaService.getUserQuota(id)),
+      const now = new Date();
+      const [quotaDocs, knownAdminUserIds] = await Promise.all([
+        Promise.all(userIds.map((id) => quotaService.getUserQuota(id))),
+        adminUsersRepo.listUserIds(),
+      ]);
+      // Active credits per (user, surface) from the ledger — sum of
+      // remaining capacity across non-expired grants. Computed in
+      // parallel so a 20-row page costs ~one Mongo aggregation
+      // round-trip per user not 40.
+      const activeCreditsByUser = await Promise.all(
+        userIds.map(async (id) => ({
+          playground: await quotaService.getCreditsBalance(id, "playground", now),
+          skillGen: await quotaService.getCreditsBalance(id, "skillGen", now),
+        })),
       );
-      const items = slice.map((u, i) => decorateAdminRow(u, quotaDocs[i]));
+      const limits = {
+        playground: quotaService.surfaceLimits("playground"),
+        skillGen: quotaService.surfaceLimits("skillGen"),
+      };
+      const items = slice.map((u, i) =>
+        decorateAdminRow(
+          u,
+          quotaDocs[i],
+          knownAdminUserIds.has(u.userId),
+          activeCreditsByUser[i],
+          limits,
+        ),
+      );
       return c.json({
         data: {
           items,
@@ -121,7 +171,7 @@ export function createQuotaRoutes(config: QuotaRoutesConfig): Hono<{ Variables: 
     async (c) => {
       const authCtx = getAuth(c);
       const body = getValidatedBody<z.infer<typeof grantSchema>>(c);
-      const { auditId } = await quotaService.grant({
+      const { auditId, expiresAt } = await quotaService.grant({
         admin: {
           userId: authCtx.userId,
           email: authCtx.email,
@@ -130,6 +180,7 @@ export function createQuotaRoutes(config: QuotaRoutesConfig): Hono<{ Variables: 
         targetUserId: body.userId,
         surface: body.surface,
         amount: body.amount,
+        periodMonths: body.periodMonths,
         note: body.note,
       });
       logger.info(
@@ -138,10 +189,20 @@ export function createQuotaRoutes(config: QuotaRoutesConfig): Hono<{ Variables: 
           targetUserId: body.userId,
           surface: body.surface,
           amount: body.amount,
+          periodMonths: body.periodMonths,
         },
         "Admin issued quota grant",
       );
-      return c.json({ data: { auditId, applied: 1 }, error: null });
+      return c.json(
+        {
+          data: {
+            auditId,
+            applied: 1,
+            expiresAt: expiresAt ? expiresAt.toISOString() : null,
+          },
+          error: null,
+        },
+      );
     },
   );
 
@@ -166,6 +227,7 @@ export function createQuotaRoutes(config: QuotaRoutesConfig): Hono<{ Variables: 
         targetUserIds: unique,
         surface: body.surface,
         amount: body.amount,
+        periodMonths: body.periodMonths,
         note: body.note,
       });
       const applied = results.filter((r) => r.ok).length;
@@ -230,34 +292,64 @@ interface AdminRow {
   userId: string;
   email: string;
   displayName: string;
+  /**
+   * True when the row's email is in the admin allow-list. Drives the UI
+   * to render an "Unlimited" stamp instead of usage counters + grant
+   * actions. NyxID remains authoritative on the hot path.
+   */
+  isAdmin: boolean;
   playground: SurfaceSummary;
   skillGen: SurfaceSummary;
 }
 
 interface SurfaceSummary {
+  /** Monthly usage so far this window. */
   monthlyUsed: number;
+  /** Original monthly base allotment — what this user gets each rollover. */
+  monthlyLimit: number;
+  /** Daily usage so far this window. */
   dailyUsed: number;
+  /** Daily ceiling for this surface. */
+  dailyLimit: number;
+  /**
+   * Total active credits = legacy non-expiring `creditsBalance` PLUS
+   * sum of unused capacity across all active grants in the ledger.
+   * This is the "granted bonus" the admin can see and add to.
+   */
   creditsBalance: number;
 }
 
 function decorateAdminRow(
   user: { userId: string; email: string; displayName: string },
   quota: UserQuotaDocument,
+  isAdmin: boolean,
+  active: { playground: number; skillGen: number },
+  limits: {
+    playground: { monthlyBase: number; dailyCeiling: number };
+    skillGen: { monthlyBase: number; dailyCeiling: number };
+  },
 ): AdminRow {
   return {
     userId: user.userId,
     email: user.email,
     displayName: user.displayName,
-    playground: summarize(quota.playground),
-    skillGen: summarize(quota.skillGen),
+    isAdmin,
+    playground: summarize(quota.playground, active.playground, limits.playground),
+    skillGen: summarize(quota.skillGen, active.skillGen, limits.skillGen),
   };
 }
 
-function summarize(c: SurfaceCounter): SurfaceSummary {
+function summarize(
+  c: SurfaceCounter,
+  activeCredits: number,
+  limits: { monthlyBase: number; dailyCeiling: number },
+): SurfaceSummary {
   return {
     monthlyUsed: c.monthlyUsed,
+    monthlyLimit: limits.monthlyBase,
     dailyUsed: c.dailyUsed,
-    creditsBalance: c.creditsBalance,
+    dailyLimit: limits.dailyCeiling,
+    creditsBalance: activeCredits,
   };
 }
 

--- a/ornn-api/src/domains/quota/service.ts
+++ b/ornn-api/src/domains/quota/service.ts
@@ -16,6 +16,7 @@
 
 import pino from "pino";
 import type { QuotaRepository } from "./repository";
+import type { NotificationService } from "../notifications/service";
 import {
   DEFAULT_QUOTA_LIMITS,
   type ChargeOutcome,
@@ -37,17 +38,26 @@ export interface QuotaServiceConfig {
   readonly repo: QuotaRepository;
   readonly limits?: QuotaLimits;
   readonly adminPermission?: string;
+  /**
+   * Optional. When provided, every successful single-user `grant` (and
+   * by extension `bulkGrant` rows) emits a `quota.credits_granted`
+   * notification to the recipient. Failure to enqueue is logged and
+   * swallowed — notifications must never block the grant path.
+   */
+  readonly notificationService?: NotificationService;
 }
 
 export class QuotaService {
   private readonly repo: QuotaRepository;
   private readonly limits: QuotaLimits;
   private readonly adminPermission: string;
+  private readonly notificationService?: NotificationService;
 
   constructor(config: QuotaServiceConfig) {
     this.repo = config.repo;
     this.limits = config.limits ?? DEFAULT_QUOTA_LIMITS;
     this.adminPermission = config.adminPermission ?? "ornn:admin:skill";
+    this.notificationService = config.notificationService;
   }
 
   isAdmin(permissions: readonly string[] | undefined): boolean {
@@ -76,15 +86,24 @@ export class QuotaService {
     const doc = await this.repo.getOrInit(params.userId, now);
     const counter = doc[params.surface];
     const limits = this.surfaceLimits(params.surface);
-    return decide(counter, limits, params.surface);
+    const activeCredits = await this.repo.sumActiveCredits(params.userId, params.surface, now);
+    const totalCredits = (counter.creditsBalance ?? 0) + activeCredits;
+    return decide(counter, limits, params.surface, totalCredits);
   }
 
   /**
    * Charge a completed call. Deduction order:
-   *   - If `monthlyUsed < monthlyBase`, charge the base bucket only.
-   *   - Otherwise, decrement a credit (`creditsBalance`).
-   *   - `monthlyUsed` is incremented in BOTH cases.
+   *   1. If `monthlyUsed < monthlyBase`, charge the base only — no credit
+   *      touch.
+   *   2. Else try the legacy `creditsBalance` (non-expiring bucket from
+   *      pre-ledger grants).
+   *   3. Else try the oldest active grant in the ledger (FIFO).
+   *
+   *   - `monthlyUsed` and `dailyUsed` are incremented in EVERY case
+   *     (admin sees a complete picture of usage even past the cap).
    *   - `outcome === "system_error"` is a no-op.
+   *   - If no credits are available past the base, charge still happens
+   *     (the `checkAllowed` guard should have prevented the call).
    */
   async chargeOnCompletion(params: {
     userId: string;
@@ -100,24 +119,57 @@ export class QuotaService {
     const doc = await this.repo.getOrInit(params.userId, now);
     const counter = doc[params.surface];
     const limits = this.surfaceLimits(params.surface);
-
     const baseExhausted = counter.monthlyUsed >= limits.monthlyBase;
-    const decrementCredit = baseExhausted && counter.creditsBalance > 0;
 
-    await this.repo.charge({
+    // Always increment monthly+daily counters — the user made a charged
+    // call regardless of which bucket pays.
+    await this.repo.chargeMonthly({
       userId: params.userId,
       surface: params.surface,
-      decrementCredit,
       now,
     });
-    logger.debug(
-      {
+
+    if (!baseExhausted) {
+      logger.debug(
+        { userId: params.userId, surface: params.surface, source: "monthly_base" },
+        "Quota charged",
+      );
+      return;
+    }
+
+    // Past the base — drain credits. Try legacy bucket first (cheap
+    // single-row update), then fall through to the active-grants ledger.
+    if (
+      await this.repo.tryDecrementLegacyCredits({
         userId: params.userId,
         surface: params.surface,
-        outcome: params.outcome,
-        decrementCredit,
-      },
-      "Quota charged",
+        now,
+      })
+    ) {
+      logger.debug(
+        { userId: params.userId, surface: params.surface, source: "legacy_credits" },
+        "Quota charged",
+      );
+      return;
+    }
+
+    if (
+      await this.repo.tryConsumeActiveGrant({
+        userId: params.userId,
+        surface: params.surface,
+        now,
+      })
+    ) {
+      logger.debug(
+        { userId: params.userId, surface: params.surface, source: "active_grant" },
+        "Quota charged",
+      );
+      return;
+    }
+
+    logger.warn(
+      { userId: params.userId, surface: params.surface },
+      "Charge happened past base but no credits available — checkAllowed guard should have caught this",
     );
   }
 
@@ -133,11 +185,31 @@ export class QuotaService {
     const now = params.now ?? new Date();
     const isAdmin = this.isAdmin(params.permissions);
     const doc = await this.repo.getOrInit(params.userId, now);
+    const [playgroundActive, skillGenActive] = await Promise.all([
+      this.repo.sumActiveCredits(params.userId, "playground", now),
+      this.repo.sumActiveCredits(params.userId, "skillGen", now),
+    ]);
     return {
-      playground: this.buildSurfaceSnapshot(doc.playground, "playground", now),
-      skillGen: this.buildSurfaceSnapshot(doc.skillGen, "skillGen", now),
+      playground: this.buildSurfaceSnapshot(doc.playground, "playground", now, playgroundActive),
+      skillGen: this.buildSurfaceSnapshot(doc.skillGen, "skillGen", now, skillGenActive),
       isAdmin,
     };
+  }
+
+  /**
+   * Compute the effective credits balance for a user/surface =
+   * legacy non-expiring `creditsBalance` + sum of unused capacity
+   * across all active grants in the ledger.
+   */
+  async getCreditsBalance(
+    userId: string,
+    surface: Surface,
+    now: Date = new Date(),
+  ): Promise<number> {
+    const doc = await this.repo.getOrInit(userId, now);
+    const legacy = doc[surface].creditsBalance ?? 0;
+    const active = await this.repo.sumActiveCredits(userId, surface, now);
+    return legacy + active;
   }
 
   async grant(params: {
@@ -145,39 +217,76 @@ export class QuotaService {
     targetUserId: string;
     surface: Surface;
     amount: number;
+    /**
+     * How many UTC months the grant stays active before the unused
+     * remainder drops out of the user's balance. `null` or `undefined`
+     * = never expires (legacy behavior). Must be a positive integer
+     * when set.
+     */
+    periodMonths?: number | null;
     note?: string;
     now?: Date;
-  }): Promise<{ auditId: string }> {
+  }): Promise<{ auditId: string; expiresAt: Date | null }> {
     const now = params.now ?? new Date();
     if (!Number.isInteger(params.amount) || params.amount <= 0) {
       throw new Error(`Grant amount must be a positive integer (got ${params.amount})`);
     }
-    await this.repo.addCredits({
-      userId: params.targetUserId,
-      surface: params.surface,
-      amount: params.amount,
-      now,
-    });
-    const auditId = await this.repo.logGrant({
+    let expiresAt: Date | null = null;
+    if (params.periodMonths !== undefined && params.periodMonths !== null) {
+      if (!Number.isInteger(params.periodMonths) || params.periodMonths <= 0) {
+        throw new Error(
+          `Grant period must be a positive integer number of months (got ${params.periodMonths})`,
+        );
+      }
+      expiresAt = addUtcMonths(now, params.periodMonths);
+    }
+
+    // Grant is **additive**: every call inserts a fresh ledger row, so
+    // repeat grants stack on top of existing credits and the audit row
+    // is the new credits' single source of truth (with `consumed` and
+    // `expiresAt` tracked per-grant).
+    const auditId = await this.repo.recordGrant({
       adminUserId: params.admin.userId,
       adminEmail: params.admin.email,
       adminDisplayName: params.admin.displayName,
       targetUserId: params.targetUserId,
       surface: params.surface,
       amount: params.amount,
+      expiresAt,
       note: params.note,
       now,
     });
+
     logger.info(
       {
         adminUserId: params.admin.userId,
         targetUserId: params.targetUserId,
         surface: params.surface,
         amount: params.amount,
+        expiresAt,
       },
-      "Credits granted",
+      "Credits granted (additive ledger row)",
     );
-    return { auditId };
+    // Fire-and-forget recipient notification. Failure to persist a
+    // notification must NEVER fail the grant — caller has already seen
+    // the credits land in their balance.
+    if (this.notificationService) {
+      this.notificationService
+        .notifyQuotaCreditsGranted({
+          targetUserId: params.targetUserId,
+          surface: params.surface,
+          amount: params.amount,
+          note: params.note,
+          adminDisplayName: params.admin.displayName,
+        })
+        .catch((err: unknown) => {
+          logger.warn(
+            { err, targetUserId: params.targetUserId },
+            "Failed to enqueue credits-granted notification",
+          );
+        });
+    }
+    return { auditId, expiresAt };
   }
 
   async bulkGrant(params: {
@@ -185,6 +294,7 @@ export class QuotaService {
     targetUserIds: readonly string[];
     surface: Surface;
     amount: number;
+    periodMonths?: number | null;
     note?: string;
     now?: Date;
   }): Promise<Array<{ userId: string; ok: boolean; auditId?: string; error?: string }>> {
@@ -197,6 +307,7 @@ export class QuotaService {
           targetUserId: userId,
           surface: params.surface,
           amount: params.amount,
+          periodMonths: params.periodMonths,
           note: params.note,
           now,
         });
@@ -227,12 +338,17 @@ export class QuotaService {
     counter: SurfaceCounter,
     surface: Surface,
     now: Date,
+    activeCredits: number,
   ): SurfaceSnapshot {
     const limits = this.surfaceLimits(surface);
     const baseRemaining = Math.max(0, limits.monthlyBase - counter.monthlyUsed);
-    const totalMonthlyRemaining = Math.max(0, baseRemaining + counter.creditsBalance);
+    // Credits = legacy non-expiring bucket + active grants (each with
+    // its own remaining capacity + expiry tracked in the ledger).
+    const totalCredits = (counter.creditsBalance ?? 0) + activeCredits;
+    const totalMonthlyRemaining = Math.max(0, baseRemaining + totalCredits);
     const dailyRemaining = Math.max(0, limits.dailyCeiling - counter.dailyUsed);
-    const warning = counter.monthlyUsed >= Math.floor(limits.monthlyBase * this.limits.warningThreshold);
+    const warning =
+      counter.monthlyUsed >= Math.floor(limits.monthlyBase * this.limits.warningThreshold);
     return {
       monthly: {
         limit: limits.monthlyBase,
@@ -244,7 +360,7 @@ export class QuotaService {
         used: counter.dailyUsed,
         remaining: dailyRemaining,
       },
-      credits: { balance: counter.creditsBalance },
+      credits: { balance: totalCredits },
       warningThreshold: this.limits.warningThreshold,
       warning,
       monthlyResetAt: nextMonthlyResetAt(now).toISOString(),
@@ -254,14 +370,42 @@ export class QuotaService {
 }
 
 /**
- * Pure decision function: given a counter and limits, can the caller
- * make another call? Exported separately so unit tests can exercise
- * the rules without spinning up a service or repository.
+ * Add `n` UTC months to `from`. Clamps day-of-month so e.g. Jan 31 +
+ * 1 month → Feb 28/29 instead of overflowing into March.
+ */
+function addUtcMonths(from: Date, n: number): Date {
+  const y = from.getUTCFullYear();
+  const m = from.getUTCMonth() + n;
+  const targetYear = y + Math.floor(m / 12);
+  const targetMonth = ((m % 12) + 12) % 12;
+  // Days-in-target-month — use UTC day 0 of the next month to get last day.
+  const daysInTarget = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+  const day = Math.min(from.getUTCDate(), daysInTarget);
+  return new Date(
+    Date.UTC(
+      targetYear,
+      targetMonth,
+      day,
+      from.getUTCHours(),
+      from.getUTCMinutes(),
+      from.getUTCSeconds(),
+      from.getUTCMilliseconds(),
+    ),
+  );
+}
+
+/**
+ * Pure decision function: given a counter, limits, and total credits
+ * available (legacy + ledger), can the caller make another call?
+ *
+ * Exported separately so unit tests can exercise the rules without
+ * spinning up a service or repository.
  */
 export function decide(
   counter: SurfaceCounter,
   limits: SurfaceLimits,
   surface: Surface,
+  totalCredits: number = counter.creditsBalance ?? 0,
 ): QuotaDecision {
   // Daily ceiling is a hard wall above the combined pool.
   if (counter.dailyUsed >= limits.dailyCeiling) {
@@ -274,7 +418,7 @@ export function decide(
     };
   }
   const baseRemaining = limits.monthlyBase - counter.monthlyUsed;
-  const hasCapacity = baseRemaining > 0 || counter.creditsBalance > 0;
+  const hasCapacity = baseRemaining > 0 || totalCredits > 0;
   if (!hasCapacity) {
     return {
       allowed: false,

--- a/ornn-api/src/domains/quota/types.ts
+++ b/ornn-api/src/domains/quota/types.ts
@@ -94,7 +94,24 @@ export interface UserQuotaDocument {
  */
 export type ChargeOutcome = "success" | "skill_error" | "system_error";
 
-/** Audit-trail entry for an admin grant. Bulk grants spawn N rows. */
+/**
+ * Single grant row — both the audit trail entry AND the active credit
+ * ledger. Each grant is **additive**: `amount` is added on top of the
+ * recipient's existing credits, never set/replaced. Bulk grants spawn
+ * N rows.
+ *
+ * Lifetime semantics:
+ *   - `expiresAt` is the absolute deadline (UTC). After it passes, the
+ *     grant's remaining (`amount - consumed`) drops out of the user's
+ *     active balance. Set to `null` for a grant that never expires.
+ *   - `consumed` is incremented (never decremented) when calls draw
+ *     against this grant. When `consumed === amount` the grant is
+ *     considered drained.
+ *
+ * Active balance for a user/surface is:
+ *   Σ (amount − consumed) over rows where consumed < amount AND
+ *     (expiresAt is null OR expiresAt > now)
+ */
 export interface QuotaGrantAudit {
   _id: string;
   adminUserId: string;
@@ -102,7 +119,13 @@ export interface QuotaGrantAudit {
   adminDisplayName: string;
   targetUserId: string;
   surface: Surface;
+  /** Original grant amount (immutable after insert). */
   amount: number;
+  /** How much of `amount` has been spent. Starts at 0. */
+  consumed: number;
+  /** Absolute UTC expiry. `null` = never expires. */
+  expiresAt: Date | null;
+  /** Audit timestamp (also the grant's start of life). */
   createdAt: Date;
   note?: string;
 }

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -1041,6 +1041,7 @@ export class SkillService {
       findings: result.findings,
       scannedAt: result.scannedAt,
       agentsealVersion: result.agentsealVersion,
+      scannedFiles: result.scannedFiles,
     });
     return {
       skillGuid: skill.guid,
@@ -1069,6 +1070,7 @@ export class SkillService {
         findings: result.findings,
         scannedAt: result.scannedAt,
         agentsealVersion: result.agentsealVersion,
+        scannedFiles: result.scannedFiles,
       });
     } catch (err) {
       logger.warn(

--- a/ornn-api/src/domains/skills/crud/skillVersionRepository.ts
+++ b/ornn-api/src/domains/skills/crud/skillVersionRepository.ts
@@ -46,12 +46,14 @@ export interface CreateSkillVersionData {
 export interface AgentsealScanRecord {
   /** 0–100 scan-time trust score. */
   score: number;
-  /** Raw findings array straight from `agentseal guard --output json`. */
+  /** Findings array from the per-file SkillScanner sweep. */
   findings: ReadonlyArray<Record<string, unknown>>;
   /** ISO timestamp of when the scan completed. */
   scannedAt: string;
   /** Pinned `agentseal` package version that produced this scan. */
   agentsealVersion: string;
+  /** Count of files actually walked (text-like, under size cap). */
+  scannedFiles?: number;
 }
 
 export class SkillVersionRepository {
@@ -266,10 +268,15 @@ function mapScan(raw: unknown): AgentsealScanRecord | null {
   if (score === null || findings === null || scannedAt === null || agentsealVersion === null) {
     return null;
   }
+  const scannedFiles =
+    typeof r.scannedFiles === "number" && Number.isFinite(r.scannedFiles)
+      ? Math.max(0, Math.round(r.scannedFiles))
+      : undefined;
   return {
     score,
     findings: findings as ReadonlyArray<Record<string, unknown>>,
     scannedAt,
     agentsealVersion,
+    ...(scannedFiles !== undefined ? { scannedFiles } : {}),
   };
 }

--- a/ornn-api/src/infra/agentseal/index.test.ts
+++ b/ornn-api/src/infra/agentseal/index.test.ts
@@ -1,66 +1,59 @@
 /**
  * Tests for the AgentSeal scanner.
  *
- * - `parseGuardOutput` is unit-tested against representative CLI shapes.
- * - Subprocess plumbing is exercised by pointing `command` at a small
- *   shell helper (`/bin/sh -c "..."`) so we don't need the real
- *   `agentseal` binary on the test machine.
+ * - `parseSkillScanOutput` is unit-tested against representative wrapper-script shapes.
+ * - Subprocess plumbing is exercised by pointing `python` at a small
+ *   shell shim that emits canned JSON, so we don't need agentseal on
+ *   the test machine.
  */
 
 import { describe, expect, test } from "bun:test";
-import { AgentSealScanner, parseGuardOutput } from "./index";
+import { AgentSealScanner, parseSkillScanOutput } from "./index";
 
-describe("parseGuardOutput", () => {
-  test("parses canonical CLI output with score + findings", () => {
+describe("parseSkillScanOutput", () => {
+  test("parses canonical wrapper output with score + findings", () => {
     const raw = JSON.stringify({
       score: 92,
-      findings: [{ rule: "extraction", severity: "low", message: "hi" }],
-      agentsealVersion: "0.5.0",
+      findings: [{ code: "SKILL-001", severity: "low", title: "hi" }],
+      agentsealVersion: "agentseal-0.9.6",
+      scannedAt: "2026-05-05T00:00:00.000Z",
     });
-    const parsed = parseGuardOutput(raw);
+    const parsed = parseSkillScanOutput(raw);
     expect(parsed).not.toBeNull();
     expect(parsed!.score).toBe(92);
     expect(parsed!.findings).toHaveLength(1);
-    expect(parsed!.agentsealVersion).toBe("0.5.0");
-  });
-
-  test("accepts trustScore as a fallback key", () => {
-    const raw = JSON.stringify({ trustScore: 78, findings: [], version: "0.4.2" });
-    const parsed = parseGuardOutput(raw)!;
-    expect(parsed.score).toBe(78);
-    expect(parsed.agentsealVersion).toBe("0.4.2");
+    expect(parsed!.agentsealVersion).toBe("agentseal-0.9.6");
+    expect(parsed!.scannedAt).toBe("2026-05-05T00:00:00.000Z");
   });
 
   test("clamps scores into [0, 100] and rounds floats", () => {
-    expect(parseGuardOutput(JSON.stringify({ score: 142, findings: [], agentsealVersion: "x" }))!.score).toBe(100);
-    expect(parseGuardOutput(JSON.stringify({ score: -5, findings: [], agentsealVersion: "x" }))!.score).toBe(0);
-    expect(parseGuardOutput(JSON.stringify({ score: 87.6, findings: [], agentsealVersion: "x" }))!.score).toBe(88);
-  });
-
-  test("strips ```json fences", () => {
-    const raw = "```json\n" + JSON.stringify({ score: 50, findings: [], agentsealVersion: "x" }) + "\n```";
-    const parsed = parseGuardOutput(raw)!;
-    expect(parsed.score).toBe(50);
+    expect(parseSkillScanOutput(JSON.stringify({ score: 142, findings: [], agentsealVersion: "x" }))!.score).toBe(100);
+    expect(parseSkillScanOutput(JSON.stringify({ score: -5, findings: [], agentsealVersion: "x" }))!.score).toBe(0);
+    expect(parseSkillScanOutput(JSON.stringify({ score: 87.6, findings: [], agentsealVersion: "x" }))!.score).toBe(88);
   });
 
   test("filters non-object findings", () => {
     const raw = JSON.stringify({
       score: 60,
-      findings: [{ rule: "ok" }, "bad", null, { rule: "ok2" }],
+      findings: [{ code: "ok" }, "bad", null, { code: "ok2" }],
       agentsealVersion: "x",
     });
-    const parsed = parseGuardOutput(raw)!;
+    const parsed = parseSkillScanOutput(raw)!;
     expect(parsed.findings).toHaveLength(2);
   });
 
   test("returns null on garbage", () => {
-    expect(parseGuardOutput("not-json")).toBeNull();
-    expect(parseGuardOutput("")).toBeNull();
-    expect(parseGuardOutput(JSON.stringify({ findings: [] }))).toBeNull(); // no score
+    expect(parseSkillScanOutput("not-json")).toBeNull();
+    expect(parseSkillScanOutput("")).toBeNull();
+    expect(parseSkillScanOutput(JSON.stringify({ findings: [] }))).toBeNull(); // no score
+  });
+
+  test("returns null when wrapper signals an error", () => {
+    expect(parseSkillScanOutput(JSON.stringify({ error: "bad zip" }))).toBeNull();
   });
 
   test("agentsealVersion falls back to 'unknown' when absent", () => {
-    const parsed = parseGuardOutput(JSON.stringify({ score: 30, findings: [] }))!;
+    const parsed = parseSkillScanOutput(JSON.stringify({ score: 30, findings: [] }))!;
     expect(parsed.agentsealVersion).toBe("unknown");
   });
 });
@@ -68,7 +61,8 @@ describe("parseGuardOutput", () => {
 describe("AgentSealScanner.scan", () => {
   test("returns null when disabled", async () => {
     const scanner = new AgentSealScanner({
-      command: "agentseal", // never invoked
+      python: "/bin/sh",
+      script: "/dev/null",
       timeoutMs: 1000,
       enabled: false,
     });
@@ -81,28 +75,21 @@ describe("AgentSealScanner.scan", () => {
   });
 
   test("parses output from a shim subprocess and stamps scannedAt", async () => {
-    // Use /bin/sh as the binary; emit canned JSON, ignore stdin.
-    // The "command" is interpreted as the binary; args are appended.
-    // We trick the test by pointing at /bin/sh and prepending -c to the
-    // arg list via a sub-binary that the scanner runs literally.
-    //
-    // Cleanest approach: write a tiny shell script that emits canned
-    // JSON regardless of args/stdin, and point `command` at it.
+    // Use a small shell shim as the "python" binary. It ignores the
+    // script + zip-path args and emits canned JSON.
     const script = "/tmp/agentseal-shim-success.sh";
     await Bun.write(
       script,
       [
         "#!/bin/sh",
-        // Read stdin into /dev/null so we don't deadlock when the parent
-        // pipes a few KB before close().
-        "cat > /dev/null",
-        'echo \'{"score": 73, "findings": [{"rule": "demo"}], "agentsealVersion": "0.5.0"}\'',
+        'echo \'{"score": 73, "findings": [{"code": "demo"}], "agentsealVersion": "agentseal-0.9.6", "scannedAt": "2026-05-05T00:00:00.000Z"}\'',
       ].join("\n") + "\n",
     );
     await Bun.$`chmod +x ${script}`.quiet();
 
     const scanner = new AgentSealScanner({
-      command: script,
+      python: script,
+      script: "/tmp/agentseal-shim-success.dummy.py",
       timeoutMs: 5000,
       enabled: true,
     });
@@ -114,18 +101,17 @@ describe("AgentSealScanner.scan", () => {
     expect(result).not.toBeNull();
     expect(result!.score).toBe(73);
     expect(result!.findings).toHaveLength(1);
-    expect(result!.agentsealVersion).toBe("0.5.0");
+    expect(result!.agentsealVersion).toBe("agentseal-0.9.6");
     expect(typeof result!.scannedAt).toBe("string");
     expect(new Date(result!.scannedAt).getTime()).toBeGreaterThan(0);
   });
 
-  test("returns null when subprocess exits non-zero", async () => {
+  test("returns null when subprocess exits non-zero with empty stdout", async () => {
     const script = "/tmp/agentseal-shim-fail.sh";
     await Bun.write(
       script,
       [
         "#!/bin/sh",
-        "cat > /dev/null",
         'echo "agentseal: failed" >&2',
         "exit 2",
       ].join("\n") + "\n",
@@ -133,7 +119,8 @@ describe("AgentSealScanner.scan", () => {
     await Bun.$`chmod +x ${script}`.quiet();
 
     const scanner = new AgentSealScanner({
-      command: script,
+      python: script,
+      script: "/tmp/dummy.py",
       timeoutMs: 5000,
       enabled: true,
     });
@@ -145,16 +132,43 @@ describe("AgentSealScanner.scan", () => {
     expect(result).toBeNull();
   });
 
-  test("returns null when output cannot be parsed", async () => {
-    const script = "/tmp/agentseal-shim-garbage.sh";
+  test("returns null when wrapper emits a structured error JSON", async () => {
+    const script = "/tmp/agentseal-shim-err-json.sh";
     await Bun.write(
       script,
-      ["#!/bin/sh", "cat > /dev/null", 'echo "not json"'].join("\n") + "\n",
+      [
+        "#!/bin/sh",
+        "echo '{\"error\": \"bad zip\"}'",
+        "exit 2",
+      ].join("\n") + "\n",
     );
     await Bun.$`chmod +x ${script}`.quiet();
 
     const scanner = new AgentSealScanner({
-      command: script,
+      python: script,
+      script: "/tmp/dummy.py",
+      timeoutMs: 5000,
+      enabled: true,
+    });
+    const result = await scanner.scan({
+      skillGuid: "g3b",
+      version: "1.0",
+      zipBuffer: new Uint8Array([1]),
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when output cannot be parsed", async () => {
+    const script = "/tmp/agentseal-shim-garbage.sh";
+    await Bun.write(
+      script,
+      ["#!/bin/sh", 'echo "not json"'].join("\n") + "\n",
+    );
+    await Bun.$`chmod +x ${script}`.quiet();
+
+    const scanner = new AgentSealScanner({
+      python: script,
+      script: "/tmp/dummy.py",
       timeoutMs: 5000,
       enabled: true,
     });
@@ -172,16 +186,16 @@ describe("AgentSealScanner.scan", () => {
       script,
       [
         "#!/bin/sh",
-        "cat > /dev/null",
         // Sleep longer than the timeout.
         "sleep 5",
-        'echo \'{"score": 50, "findings": [], "agentsealVersion": "0.5.0"}\'',
+        'echo \'{"score": 50, "findings": [], "agentsealVersion": "x"}\'',
       ].join("\n") + "\n",
     );
     await Bun.$`chmod +x ${script}`.quiet();
 
     const scanner = new AgentSealScanner({
-      command: script,
+      python: script,
+      script: "/tmp/dummy.py",
       timeoutMs: 200,
       enabled: true,
     });
@@ -193,9 +207,10 @@ describe("AgentSealScanner.scan", () => {
     expect(result).toBeNull();
   }, 10_000);
 
-  test("returns null when binary does not exist", async () => {
+  test("returns null when interpreter does not exist", async () => {
     const scanner = new AgentSealScanner({
-      command: "/nonexistent/path/agentseal-fake-binary",
+      python: "/nonexistent/path/python-fake-binary",
+      script: "/tmp/dummy.py",
       timeoutMs: 1000,
       enabled: true,
     });

--- a/ornn-api/src/infra/agentseal/index.ts
+++ b/ornn-api/src/infra/agentseal/index.ts
@@ -108,7 +108,7 @@ export class AgentSealScanner implements IAgentSealScanner {
 
     // Stage the ZIP on disk; the wrapper script extracts it itself.
     let workdir: string | null = null;
-    let zipPath: string | null = null;
+    let zipPath: string;
     try {
       workdir = await mkdtemp(join(tmpdir(), "ornn-agentseal-"));
       zipPath = join(workdir, "skill.zip");

--- a/ornn-api/src/infra/agentseal/index.ts
+++ b/ornn-api/src/infra/agentseal/index.ts
@@ -1,7 +1,7 @@
 /**
  * AgentSeal subprocess scanner (issue #253).
  *
- * Wraps `agentseal guard --output json` behind a tiny `IAgentSealScanner`
+ * Wraps `python scan_skill.py <zip-path>` behind a tiny `IAgentSealScanner`
  * interface so:
  *   1. The publish path can call it without knowing how the binary is
  *      invoked.
@@ -9,19 +9,29 @@
  *   3. Operators can flip `AGENTSEAL_ENABLED=false` and the implementation
  *      degrades to a no-scan that doesn't block publishing.
  *
- * Concurrency: each call spawns its own subprocess and pipes the package
- * bytes via stdin (`--package -`) so multiple publishes don't collide on
- * a shared workdir. The CLI is read-only against its arguments — no
- * side-effects on the host filesystem.
+ * Why a Python wrapper, not the agentseal CLI:
+ *   `agentseal guard` is designed to scan installed agent configs on a
+ *   developer's machine, NOT arbitrary skill packages. The `agentseal`
+ *   package does ship a library-level `SkillScanner` class that runs
+ *   the same threat-detection rules per file, which is exactly what we
+ *   want — the wrapper script (`ornn-api/scripts/scan_skill.py`) calls
+ *   that class on every text-like file in the extracted ZIP and emits
+ *   one JSON line.
  *
- * v1 is warn-only — failures (timeout, crash, malformed output) are
- * logged but never thrown into the publish path. The caller treats
- * `result === null` as "no scan available" and persists nothing.
+ * Concurrency: each call spawns its own subprocess + writes the ZIP to
+ * a unique temp file, so multiple publishes don't collide.
+ *
+ * v1 is warn-only — failures (timeout, crash, malformed output, missing
+ * binary) are logged but never thrown into the publish path. The caller
+ * treats `result === null` as "no scan available" and persists nothing.
  *
  * @module infra/agentseal
  */
 
 import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import pino, { type Logger } from "pino";
 
 const moduleLogger = pino({ level: "info" }).child({ module: "agentseal" });
@@ -31,19 +41,21 @@ export interface ScanInput {
   readonly skillGuid: string;
   /** Version label being scanned. */
   readonly version: string;
-  /** Raw ZIP bytes of the skill package. Piped to AgentSeal via stdin. */
+  /** Raw ZIP bytes of the skill package. Written to a temp file before scan. */
   readonly zipBuffer: Uint8Array;
 }
 
 export interface ScanResult {
   /** Trust score 0–100, clamped at parse time. */
   readonly score: number;
-  /** Raw findings array — passed through verbatim from the CLI. */
+  /** Raw findings array — passed through verbatim from the wrapper. */
   readonly findings: ReadonlyArray<Record<string, unknown>>;
   /** ISO timestamp of when the scan completed. */
   readonly scannedAt: string;
   /** Pinned `agentseal` package version that produced this scan. */
   readonly agentsealVersion: string;
+  /** Count of files the scanner actually walked (excluding binaries / oversized). */
+  readonly scannedFiles: number;
 }
 
 /**
@@ -57,8 +69,10 @@ export interface IAgentSealScanner {
 }
 
 export interface AgentSealScannerConfig {
-  /** Path or PATH name of the agentseal CLI. Defaults to `agentseal`. */
-  readonly command: string;
+  /** Path to the python interpreter (e.g. `/opt/agentseal/bin/python`). */
+  readonly python: string;
+  /** Path to `scan_skill.py` baked into the image. */
+  readonly script: string;
   /** Hard timeout, ms. Default 60_000 from config. */
   readonly timeoutMs: number;
   /** Master kill-switch. When false `scan()` short-circuits to null. */
@@ -67,13 +81,15 @@ export interface AgentSealScannerConfig {
 }
 
 export class AgentSealScanner implements IAgentSealScanner {
-  private readonly command: string;
+  private readonly python: string;
+  private readonly script: string;
   private readonly timeoutMs: number;
   private readonly enabled: boolean;
   private readonly logger: Logger;
 
   constructor(cfg: AgentSealScannerConfig) {
-    this.command = cfg.command;
+    this.python = cfg.python;
+    this.script = cfg.script;
     this.timeoutMs = cfg.timeoutMs;
     this.enabled = cfg.enabled;
     this.logger = (cfg.logger ?? moduleLogger).child({ module: "agentseal" });
@@ -89,9 +105,26 @@ export class AgentSealScanner implements IAgentSealScanner {
     }
 
     const startedAt = Date.now();
+
+    // Stage the ZIP on disk; the wrapper script extracts it itself.
+    let workdir: string | null = null;
+    let zipPath: string | null = null;
+    try {
+      workdir = await mkdtemp(join(tmpdir(), "ornn-agentseal-"));
+      zipPath = join(workdir, "skill.zip");
+      await writeFile(zipPath, Buffer.from(input.zipBuffer));
+    } catch (err) {
+      this.logger.error({ err, skillGuid: input.skillGuid }, "Failed to stage skill ZIP for scan");
+      // Best-effort cleanup
+      if (workdir) {
+        await rm(workdir, { recursive: true, force: true }).catch(() => {});
+      }
+      return null;
+    }
+
     let raw: string;
     try {
-      raw = await this.runGuardSubprocess(input);
+      raw = await this.runScannerSubprocess(zipPath);
     } catch (err) {
       this.logger.error(
         {
@@ -103,15 +136,22 @@ export class AgentSealScanner implements IAgentSealScanner {
         "AgentSeal subprocess failed",
       );
       return null;
+    } finally {
+      // Always clean up — never leak temp dirs even on success.
+      if (workdir) {
+        rm(workdir, { recursive: true, force: true }).catch((err) => {
+          this.logger.warn({ err, workdir }, "Failed to clean AgentSeal temp dir");
+        });
+      }
     }
 
-    const parsed = parseGuardOutput(raw);
+    const parsed = parseSkillScanOutput(raw);
     if (!parsed) {
       this.logger.warn(
         {
           skillGuid: input.skillGuid,
           version: input.version,
-          // Truncate to avoid mega-logs on misconfigured CLIs.
+          // Truncate to avoid mega-logs on misconfigured wrappers.
           rawSnippet: raw.slice(0, 500),
         },
         "AgentSeal output failed to parse — skipping persist",
@@ -122,8 +162,9 @@ export class AgentSealScanner implements IAgentSealScanner {
     const result: ScanResult = {
       score: parsed.score,
       findings: parsed.findings,
-      scannedAt: new Date().toISOString(),
+      scannedAt: parsed.scannedAt ?? new Date().toISOString(),
       agentsealVersion: parsed.agentsealVersion,
+      scannedFiles: parsed.scannedFiles,
     };
 
     this.logger.info(
@@ -141,17 +182,14 @@ export class AgentSealScanner implements IAgentSealScanner {
   }
 
   /**
-   * Spawn `agentseal guard --output json --package -`, pipe the ZIP via
-   * stdin, collect stdout, kill on timeout. Errors thrown here are
-   * caught and logged by `scan()`.
+   * Spawn `python scan_skill.py <zip-path>`, collect stdout, kill on
+   * timeout. Errors thrown here are caught and logged by `scan()`.
    */
-  private runGuardSubprocess(input: ScanInput): Promise<string> {
+  private runScannerSubprocess(zipPath: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-      const child = spawn(
-        this.command,
-        ["guard", "--output", "json", "--package", "-"],
-        { stdio: ["pipe", "pipe", "pipe"] },
-      );
+      const child = spawn(this.python, [this.script, zipPath], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
 
       let stdout = "";
       let stderr = "";
@@ -195,7 +233,11 @@ export class AgentSealScanner implements IAgentSealScanner {
         if (settled) return;
         settled = true;
         clearTimeout(killTimer);
-        if (code !== 0) {
+        // The wrapper emits JSON on both success (exit 0) and structured
+        // errors (non-zero). Surface stdout regardless so the parser can
+        // see the `error` field. If stdout is empty, fall back to stderr
+        // for the failure message.
+        if (code !== 0 && !stdout.trim()) {
           reject(
             new Error(
               `AgentSeal exited ${code}: ${stderr.slice(0, 500) || "<empty stderr>"}`,
@@ -205,39 +247,27 @@ export class AgentSealScanner implements IAgentSealScanner {
         }
         resolve(stdout);
       });
-
-      // Pipe the ZIP bytes in. AgentSeal's stdin reader closes when
-      // it sees EOF, so we end() once the buffer is written.
-      try {
-        child.stdin.write(Buffer.from(input.zipBuffer));
-        child.stdin.end();
-      } catch (err) {
-        if (settled) return;
-        settled = true;
-        clearTimeout(killTimer);
-        reject(err);
-      }
     });
   }
 }
 
+interface ParsedScan {
+  score: number;
+  findings: Array<Record<string, unknown>>;
+  agentsealVersion: string;
+  scannedAt?: string;
+  scannedFiles: number;
+}
+
 /**
- * Parse `agentseal guard --output json` output. The CLI's exact key
- * names have shifted between releases (`score` vs `trustScore`); we
- * accept either and clamp the score into 0–100.
+ * Parse the wrapper script's JSON output. Surfaces `null` on any shape
+ * mismatch so the caller can degrade silently without persisting bogus
+ * scores.
  *
  * Exported for tests.
  */
-export function parseGuardOutput(raw: string): ScanResult | null {
-  let stripped = raw.trim();
-  // Strip ```json … ``` fences if the CLI ever emits them.
-  if (stripped.startsWith("```")) {
-    const start = stripped.indexOf("\n");
-    const end = stripped.lastIndexOf("```");
-    if (start > -1 && end > start) {
-      stripped = stripped.slice(start + 1, end).trim();
-    }
-  }
+export function parseSkillScanOutput(raw: string): ParsedScan | null {
+  const stripped = raw.trim();
   if (!stripped) return null;
 
   let json: unknown;
@@ -249,14 +279,12 @@ export function parseGuardOutput(raw: string): ScanResult | null {
   if (!json || typeof json !== "object" || Array.isArray(json)) return null;
   const obj = json as Record<string, unknown>;
 
-  const rawScore =
-    typeof obj.score === "number"
-      ? obj.score
-      : typeof obj.trustScore === "number"
-        ? obj.trustScore
-        : null;
+  // Wrapper signals failure with `{"error": "..."}` and exits non-zero.
+  // Treat as soft failure — never persist.
+  if (typeof obj.error === "string") return null;
+
+  const rawScore = typeof obj.score === "number" ? obj.score : null;
   if (rawScore === null || Number.isNaN(rawScore)) return null;
-  // Clamp into 0–100 and round to integer for stable display.
   const score = Math.max(0, Math.min(100, Math.round(rawScore)));
 
   const rawFindings = Array.isArray(obj.findings) ? obj.findings : [];
@@ -268,16 +296,13 @@ export function parseGuardOutput(raw: string): ScanResult | null {
   }
 
   const agentsealVersion =
-    typeof obj.agentsealVersion === "string"
-      ? obj.agentsealVersion
-      : typeof obj.version === "string"
-        ? obj.version
-        : "unknown";
+    typeof obj.agentsealVersion === "string" ? obj.agentsealVersion : "unknown";
+  const scannedAt =
+    typeof obj.scannedAt === "string" ? obj.scannedAt : undefined;
+  const scannedFiles =
+    typeof obj.scannedFiles === "number" && Number.isFinite(obj.scannedFiles)
+      ? Math.max(0, Math.round(obj.scannedFiles))
+      : 0;
 
-  return {
-    score,
-    findings,
-    scannedAt: new Date(0).toISOString(), // placeholder; caller restamps
-    agentsealVersion,
-  };
+  return { score, findings, agentsealVersion, scannedAt, scannedFiles };
 }

--- a/ornn-api/src/infra/config.ts
+++ b/ornn-api/src/infra/config.ts
@@ -71,6 +71,7 @@ export interface SkillConfig {
    */
   readonly extraNyxidServices: readonly string[];
 
+
   // PostHog (server-side product analytics) — see #252
   /**
    * PostHog project API key. When absent the analytics module no-ops
@@ -94,14 +95,18 @@ export interface SkillConfig {
 
   // AgentSeal (subprocess-based skill scanner) — see #253
   /**
-   * Absolute path or PATH name of the `agentseal` CLI. Defaults to
-   * `agentseal`; container builds bake the binary into the image.
+   * Path to the python interpreter that has `agentseal` installed.
+   * Defaults to `/opt/agentseal/bin/python` per the Dockerfile.
    */
-  readonly agentsealCommand: string;
+  readonly agentsealPython: string;
   /**
-   * Hard timeout for a single `agentseal guard` run. The process is
-   * killed past this deadline and the scan is recorded as a failure.
-   * Default 60s.
+   * Path to the `scan_skill.py` wrapper baked into the image. Defaults
+   * to `/opt/agentseal/scan_skill.py` per the Dockerfile.
+   */
+  readonly agentsealScript: string;
+  /**
+   * Hard timeout for a single skill scan. The process is killed past
+   * this deadline and the scan is recorded as a failure. Default 60s.
    */
   readonly agentsealTimeoutMs: number;
   /**
@@ -166,6 +171,14 @@ export interface SkillConfig {
    * No-trailing-slash, validated.
    */
   readonly ornnPublicOrigin: string;
+
+  /**
+   * Master passphrase for AES-256-GCM at-rest secret encryption (LLM
+   * provider apiKey, future operator-pasted secrets). Falls back to a
+   * dev sentinel when `ENCRYPTION_KEY` is unset — production deployments
+   * MUST override.
+   */
+  readonly encryptionKey: string;
 }
 
 /** Parses "true"/"false"/"1"/"0" into a real boolean. */
@@ -219,6 +232,13 @@ const envSchema = z.object({
    */
   EXTRA_NYXID_SERVICES: z.string().default("NyxID"),
 
+  /**
+   * Master passphrase for the at-rest secret cipher (AES-256-GCM via
+   * scrypt-derived key). MUST be at least 32 chars in prod; a known
+   * dev sentinel is used when unset so local first-boot doesn't fail.
+   */
+  ENCRYPTION_KEY: z.string().min(0).default(""),
+
   // ---- PostHog (server-side product analytics, #252) ----
   POSTHOG_API_KEY: z.string().default(""),
   POSTHOG_PROJECT_ID: z.string().default(""),
@@ -226,7 +246,8 @@ const envSchema = z.object({
   POSTHOG_ERROR_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0.1),
 
   // ---- AgentSeal (skill trust scanner, #253) ----
-  AGENTSEAL_COMMAND: z.string().min(1).default("agentseal"),
+  AGENTSEAL_PYTHON: z.string().min(1).default("/opt/agentseal/bin/python"),
+  AGENTSEAL_SCRIPT: z.string().min(1).default("/opt/agentseal/scan_skill.py"),
   AGENTSEAL_TIMEOUT_MS: z.coerce.number().int().positive().default(60_000),
   /**
    * Toggle for the publish-time scan. Defaults to true — operators
@@ -339,12 +360,21 @@ export function loadConfig(): SkillConfig {
       .map((s) => s.trim())
       .filter((s) => s.length > 0),
 
+    // Dev sentinel — operators set ENCRYPTION_KEY=<32+ chars> in any
+    // non-dev cluster. We log a warning at boot when this fallback is
+    // active so it can't stay quietly insecure for long.
+    encryptionKey:
+      env.ENCRYPTION_KEY.trim().length > 0
+        ? env.ENCRYPTION_KEY.trim()
+        : "ornn-dev-encryption-key-DO-NOT-USE-IN-PRODUCTION-32chars",
+
     posthogApiKey: env.POSTHOG_API_KEY.trim() ? env.POSTHOG_API_KEY.trim() : null,
     posthogProjectId: env.POSTHOG_PROJECT_ID.trim() ? env.POSTHOG_PROJECT_ID.trim() : null,
     posthogHost: env.POSTHOG_HOST,
     posthogErrorSampleRate: env.POSTHOG_ERROR_SAMPLE_RATE,
 
-    agentsealCommand: env.AGENTSEAL_COMMAND,
+    agentsealPython: env.AGENTSEAL_PYTHON,
+    agentsealScript: env.AGENTSEAL_SCRIPT,
     agentsealTimeoutMs: env.AGENTSEAL_TIMEOUT_MS,
     // booleanFromEnv treats "missing" as false. AgentSeal should be ON
     // by default; ops opts OUT explicitly with `AGENTSEAL_ENABLED=false`.

--- a/ornn-api/src/infra/crypto.ts
+++ b/ornn-api/src/infra/crypto.ts
@@ -1,0 +1,114 @@
+/**
+ * Symmetric AES-256-GCM encryption helpers for at-rest secrets.
+ *
+ * Used by the platform-settings service to encrypt the LLM provider
+ * `apiKey` (and any future operator-pasted secrets) before they hit
+ * MongoDB. The DB only ever sees ciphertext; decryption happens at the
+ * service boundary on each call.
+ *
+ * Format on disk:
+ *   `v1:<iv-hex>:<authTag-hex>:<ciphertext-hex>`
+ *
+ * `v1:` is the version prefix. If we ever need to rotate the cipher
+ * (e.g. AES-GCM-SIV) we'll bump to `v2:` and decrypt-on-read can
+ * switch on the prefix; encrypt-on-write always emits the latest.
+ *
+ * Key derivation: `scryptSync(passphrase, salt, 32)` — slow on purpose
+ * so a leaked DB dump can't be dictionary-attacked easily. The
+ * passphrase is `ENCRYPTION_KEY` from env, the salt is a fixed
+ * project-scoped string (collisions only matter cross-deployment, not
+ * cross-row).
+ *
+ * @module infra/crypto
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
+
+const PREFIX = "v1";
+const SALT = "ornn-llm-provider-secret-salt";
+const KEY_BYTES = 32; // AES-256
+const IV_BYTES = 12; // GCM-recommended
+
+/** Cache derived keys keyed by raw passphrase — scrypt is slow. */
+const keyCache = new Map<string, Buffer>();
+
+function deriveKey(passphrase: string): Buffer {
+  let cached = keyCache.get(passphrase);
+  if (!cached) {
+    cached = scryptSync(passphrase, SALT, KEY_BYTES);
+    keyCache.set(passphrase, cached);
+  }
+  return cached;
+}
+
+/**
+ * Encrypt `plaintext` with the master passphrase. Returns the canonical
+ * `v1:iv:tag:ct` string. Empty input → empty output (we never encrypt
+ * empties; "no secret set" is a meaningful state at the DB layer).
+ */
+export function encryptSecret(plaintext: string, passphrase: string): string {
+  if (plaintext === "") return "";
+  if (!passphrase) {
+    throw new Error("encryptSecret: master passphrase is required");
+  }
+  const key = deriveKey(passphrase);
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `${PREFIX}:${iv.toString("hex")}:${authTag.toString("hex")}:${ct.toString("hex")}`;
+}
+
+/**
+ * Decrypt a `v1:`-prefixed blob. Legacy plaintext values (no prefix)
+ * are returned as-is so a deploy that introduces encryption doesn't
+ * break for rows written before it — they get re-encrypted on the next
+ * write. Throws when the prefix is recognized but the payload is
+ * malformed or auth-fails (tampered ciphertext).
+ */
+export function decryptSecret(value: string, passphrase: string): string {
+  if (value === "") return "";
+  if (!value.startsWith(`${PREFIX}:`)) {
+    // Pre-encryption row, or operator-injected raw value. Pass through
+    // — the next write will encrypt it.
+    return value;
+  }
+  if (!passphrase) {
+    throw new Error("decryptSecret: master passphrase is required");
+  }
+  const parts = value.split(":");
+  if (parts.length !== 4) {
+    throw new Error(`decryptSecret: malformed v1 payload (got ${parts.length} parts)`);
+  }
+  const [, ivHex, tagHex, ctHex] = parts;
+  const key = deriveKey(passphrase);
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivHex, "hex"));
+  decipher.setAuthTag(Buffer.from(tagHex, "hex"));
+  const pt = Buffer.concat([
+    decipher.update(Buffer.from(ctHex, "hex")),
+    decipher.final(),
+  ]);
+  return pt.toString("utf8");
+}
+
+/**
+ * Mid-mask a secret for display. Keeps the first 4 and last 4
+ * characters so the operator can sanity-check which key is in place
+ * without exposing the body. Anything ≤ 8 chars gets fully blurred.
+ *
+ * Output is purely cosmetic — the bullet character `•` is the
+ * sentinel the backend uses to detect "preserve existing on PATCH",
+ * so this string MUST never round-trip back as a real value.
+ */
+export function midMaskSecret(value: string): string {
+  if (!value) return "";
+  if (value.length <= 8) return "•".repeat(Math.max(value.length, 4));
+  const head = value.slice(0, 4);
+  const tail = value.slice(-4);
+  return `${head}${"•".repeat(Math.max(4, value.length - 8))}${tail}`;
+}
+
+/** True if `value` is the mid-mask sentinel (contains the bullet character). */
+export function isMidMaskSentinel(value: string): boolean {
+  return value.includes("•");
+}

--- a/ornn-api/src/middleware/nyxidAuth.ts
+++ b/ornn-api/src/middleware/nyxidAuth.ts
@@ -112,6 +112,24 @@ function decodeJwtPayload(token: string): IdentityAssertionPayload | null {
 // ---------------------------------------------------------------------------
 
 /**
+ * Optional callback fired immediately after `c.set("auth", ...)` on
+ * every request that successfully resolves an identity. Used by the
+ * admin-users tracker to lazily upsert a row whenever a user
+ * authenticates with the `ornn:admin:skill` permission, so admin
+ * lookups (`/admin/quota/users`, etc.) can mark known admins without
+ * a per-row NyxID round-trip.
+ *
+ * Implementations MUST return immediately (fire-and-forget). Failure
+ * to track must NEVER fail the request — log and swallow.
+ */
+export type AuthSeenHook = (auth: AuthContext) => void;
+
+export interface ProxyAuthSetupOptions {
+  /** Fired after the auth context is set on the request. */
+  onAuthSeen?: AuthSeenHook;
+}
+
+/**
  * NyxID proxy auth setup.
  *
  * Primary: decodes X-NyxID-Identity-Token JWT to extract userId, email,
@@ -119,8 +137,14 @@ function decodeJwtPayload(token: string): IdentityAssertionPayload | null {
  *
  * Fallback: reads X-NyxID-* headers (for backward compatibility or when
  * identity propagation mode is "headers").
+ *
+ * If `onAuthSeen` is provided, it's invoked synchronously after the
+ * auth context is set so callers can lazy-track which users have ever
+ * authenticated (e.g. populating `admin_users` for the admin UI).
+ * The callback must not throw.
  */
-export function proxyAuthSetup() {
+export function proxyAuthSetup(options: ProxyAuthSetupOptions = {}) {
+  const { onAuthSeen } = options;
   return createMiddleware<{ Variables: AuthVariables }>(async (c, next) => {
     // Capture the user's original access token if the proxy forwarded it.
     // Needed later to call NyxID /orgs on the caller's behalf. Optional —
@@ -146,6 +170,11 @@ export function proxyAuthSetup() {
           userAccessToken,
         };
         c.set("auth", auth);
+        try {
+          onAuthSeen?.(auth);
+        } catch (e) {
+          logger.warn({ error: (e as Error).message }, "onAuthSeen hook threw");
+        }
         logger.debug({ userId: auth.userId, roles: auth.roles }, "Authenticated via identity token");
         await next();
         return;
@@ -165,6 +194,11 @@ export function proxyAuthSetup() {
         userAccessToken,
       };
       c.set("auth", auth);
+      try {
+        onAuthSeen?.(auth);
+      } catch (e) {
+        logger.warn({ error: (e as Error).message }, "onAuthSeen hook threw");
+      }
       logger.debug({ userId: auth.userId }, "Authenticated via proxy headers (no RBAC data)");
     }
 

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -250,17 +250,19 @@ export interface SkillVersionDocument {
 }
 
 /**
- * Persisted-on-version-doc snapshot of an AgentSeal `guard` run.
+ * Persisted-on-version-doc snapshot of an AgentSeal scan run.
  */
 export interface AgentsealScanSnapshot {
-  /** 0–100. */
+  /** 0–100. Computed from severity-weighted finding penalties. */
   score: number;
-  /** Raw findings array from `agentseal guard --output json`. */
+  /** Findings array from the per-file SkillScanner sweep. */
   findings: ReadonlyArray<Record<string, unknown>>;
   /** ISO timestamp of completion. */
   scannedAt: string;
   /** Pinned AgentSeal package version. */
   agentsealVersion: string;
+  /** Count of files actually scanned in this run. Optional for back-compat. */
+  scannedFiles?: number;
 }
 
 export interface SkillMetadata {

--- a/ornn-web/src/components/admin/BulkGrantCreditsModal.tsx
+++ b/ornn-web/src/components/admin/BulkGrantCreditsModal.tsx
@@ -34,6 +34,7 @@ export function BulkGrantCreditsModal({
 }: BulkGrantCreditsModalProps) {
   const [surface, setSurface] = useState<Surface>("playground");
   const [amount, setAmount] = useState("10");
+  const [periodMonths, setPeriodMonths] = useState("");
   const [note, setNote] = useState("");
   const grant = useBulkGrantQuota();
   const addToast = useToastStore((s) => s.addToast);
@@ -44,8 +45,17 @@ export function BulkGrantCreditsModal({
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     const n = Number(amount);
+    const monthsRaw = periodMonths.trim();
+    const months = monthsRaw === "" ? null : Number(monthsRaw);
     if (!n || n <= 0) {
       addToast({ type: "warning", message: "Enter a positive credit amount." });
+      return;
+    }
+    if (months !== null && (!Number.isInteger(months) || months <= 0 || months > 60)) {
+      addToast({
+        type: "warning",
+        message: "Period must be a positive whole number of months (1–60), or empty for no expiry.",
+      });
       return;
     }
     if (tooMany) {
@@ -61,11 +71,13 @@ export function BulkGrantCreditsModal({
         userIds,
         surface,
         amount: n,
+        periodMonths: months,
         note: note || undefined,
       });
+      const period = months ? ` (${months} month${months === 1 ? "" : "s"})` : " (never expires)";
       addToast({
         type: "success",
-        message: `Granted +${n} ${surface === "playground" ? "playground" : "skill-gen"} credits to ${out.applied}/${out.requested} users.`,
+        message: `Granted +${n} ${surface === "playground" ? "playground" : "skill-gen"} credits${period} to ${out.applied}/${out.requested} users.`,
       });
       onClose();
     } catch (err) {
@@ -80,11 +92,12 @@ export function BulkGrantCreditsModal({
     <Modal isOpen={isOpen} onClose={onClose} title="Grant credits to selected">
       <form onSubmit={submit} className="space-y-4">
         <p className="font-text text-sm text-body">
-          Issue beta credits to{" "}
+          Issue credits to{" "}
           <strong className="text-strong">
             {selectionLabel ?? `${userIds.length} selected user${userIds.length === 1 ? "" : "s"}`}
           </strong>
-          . Beta credits are non-expiring and recorded in the audit trail.
+          . Each grant is <strong className="text-strong">additive</strong> — it stacks on top of any
+          existing credits the recipients already hold.
         </p>
 
         {tooMany && (
@@ -122,6 +135,25 @@ export function BulkGrantCreditsModal({
             />
           </label>
         </div>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+            Period (months) — optional
+          </span>
+          <input
+            type="number"
+            min={1}
+            max={60}
+            step={1}
+            value={periodMonths}
+            onChange={(e) => setPeriodMonths(e.target.value)}
+            placeholder="e.g. 3 — leave blank to never expire"
+            className="rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+          />
+          <span className="font-mono text-[10px] text-meta">
+            Unused credits drop out of each user's balance after this many months. Empty = never expires.
+          </span>
+        </label>
 
         <label className="flex flex-col gap-1.5">
           <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">

--- a/ornn-web/src/components/admin/GrantCreditsForm.tsx
+++ b/ornn-web/src/components/admin/GrantCreditsForm.tsx
@@ -32,6 +32,7 @@ export function GrantCreditsForm({
 }: GrantCreditsFormProps) {
   const [playground, setPlayground] = useState("");
   const [skillGen, setSkillGen] = useState("");
+  const [periodMonths, setPeriodMonths] = useState("");
   const [note, setNote] = useState("");
   const grant = useGrantQuota();
   const addToast = useToastStore((s) => s.addToast);
@@ -40,6 +41,8 @@ export function GrantCreditsForm({
     e.preventDefault();
     const pg = Number(playground);
     const sg = Number(skillGen);
+    const monthsRaw = periodMonths.trim();
+    const months = monthsRaw === "" ? null : Number(monthsRaw);
     if ((!pg || pg <= 0) && (!sg || sg <= 0)) {
       addToast({
         type: "warning",
@@ -47,12 +50,31 @@ export function GrantCreditsForm({
       });
       return;
     }
+    if (months !== null && (!Number.isInteger(months) || months <= 0 || months > 60)) {
+      addToast({
+        type: "warning",
+        message: "Period must be a positive whole number of months (1–60), or empty for no expiry.",
+      });
+      return;
+    }
     try {
       if (pg > 0) {
-        await grant.mutateAsync({ userId, surface: "playground", amount: pg, note: note || undefined });
+        await grant.mutateAsync({
+          userId,
+          surface: "playground",
+          amount: pg,
+          periodMonths: months,
+          note: note || undefined,
+        });
       }
       if (sg > 0) {
-        await grant.mutateAsync({ userId, surface: "skillGen", amount: sg, note: note || undefined });
+        await grant.mutateAsync({
+          userId,
+          surface: "skillGen",
+          amount: sg,
+          periodMonths: months,
+          note: note || undefined,
+        });
       }
       const summary = [
         pg > 0 ? `+${pg} playground` : null,
@@ -60,12 +82,14 @@ export function GrantCreditsForm({
       ]
         .filter(Boolean)
         .join(", ");
+      const period = months ? ` (${months} month${months === 1 ? "" : "s"})` : " (never expires)";
       addToast({
         type: "success",
-        message: `Granted ${summary} to ${displayName || email}.`,
+        message: `Granted ${summary}${period} to ${displayName || email}.`,
       });
       setPlayground("");
       setSkillGen("");
+      setPeriodMonths("");
       setNote("");
       onGranted?.();
     } catch (err) {
@@ -83,12 +107,15 @@ export function GrantCreditsForm({
     >
       <header className="mb-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
-          [§ GRANT — BETA CREDITS]
+          [§ GRANT — ADD CREDITS]
         </p>
         <p className="mt-1 font-text text-sm text-strong">
           {displayName || email}
         </p>
         <p className="font-mono text-[11px] text-meta">{email}</p>
+        <p className="mt-1.5 font-text text-[11px] text-meta">
+          Each grant is <span className="font-semibold text-strong">additive</span> — repeated grants stack on top of existing credits, never replace them.
+        </p>
       </header>
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -121,6 +148,25 @@ export function GrantCreditsForm({
           />
         </label>
       </div>
+
+      <label className="mt-3 flex flex-col gap-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+          Period (months) — optional
+        </span>
+        <input
+          type="number"
+          min={1}
+          max={60}
+          step={1}
+          value={periodMonths}
+          onChange={(e) => setPeriodMonths(e.target.value)}
+          placeholder="e.g. 3 — leave blank to never expire"
+          className="w-full rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+        />
+        <span className="font-mono text-[10px] text-meta">
+          After this many months, unused credits from this grant drop out of the user's balance. Empty = never expires.
+        </span>
+      </label>
 
       <label className="mt-3 flex flex-col gap-1.5">
         <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">

--- a/ornn-web/src/components/admin/LlmProviderConfigCard.tsx
+++ b/ornn-web/src/components/admin/LlmProviderConfigCard.tsx
@@ -1,0 +1,259 @@
+/**
+ * LlmProviderConfigCard — admin-only LLM provider override panel.
+ *
+ * Sits above the model catalog on `/admin/models`. Lets the admin
+ * override the default Chrono-LLM-via-NyxID gateway with a custom
+ * endpoint + bearer key (e.g. point Ornn at OpenAI direct, an
+ * Anthropic proxy, or a self-hosted vLLM).
+ *
+ * Empty fields fall back to env (`NYX_LLM_GATEWAY_URL` + the SA
+ * token-exchange flow). Changes take effect on the next LLM call —
+ * no pod restart needed (the resolver is wired into `NyxLlmClient`
+ * via `PlatformSettingsService`).
+ *
+ * @module components/admin/LlmProviderConfigCard
+ */
+
+import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToastStore } from "@/stores/toastStore";
+import {
+  fetchPlatformSettings,
+  updatePlatformSettings,
+  type LlmProviderConfig,
+} from "@/services/platformSettingsApi";
+
+/**
+ * The backend mid-masks any persisted apiKey on read using the bullet
+ * character `•` (`midMaskSecret` in `infra/crypto`). Real bearer keys
+ * never contain that character, so any incoming value containing one
+ * is the existing key being round-tripped — preserve it server-side.
+ */
+function isMask(v: string): boolean {
+  return v.includes("•");
+}
+
+export function LlmProviderConfigCard() {
+  const addToast = useToastStore((s) => s.addToast);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState<LlmProviderConfig>({ gatewayUrl: "", apiKey: "" });
+  const [persisted, setPersisted] = useState<LlmProviderConfig>({
+    gatewayUrl: "",
+    apiKey: "",
+  });
+  const [showKey, setShowKey] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const s = await fetchPlatformSettings();
+        if (cancelled) return;
+        setPersisted(s.llmProvider);
+        setForm(s.llmProvider);
+      } catch (err) {
+        addToast({
+          type: "error",
+          message: err instanceof Error ? err.message : "Failed to load LLM provider config",
+        });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [addToast]);
+
+  const dirty =
+    form.gatewayUrl !== persisted.gatewayUrl || form.apiKey !== persisted.apiKey;
+
+  async function handleSave() {
+    if (saving || !dirty) return;
+    // Trim before submit; unchanged mask is preserved server-side.
+    const payload: Partial<LlmProviderConfig> = {
+      gatewayUrl: form.gatewayUrl.trim(),
+      apiKey: form.apiKey,
+    };
+    if (payload.gatewayUrl && !isValidHttpUrl(payload.gatewayUrl)) {
+      addToast({ type: "error", message: "Gateway URL must be a valid http(s) URL" });
+      return;
+    }
+    setSaving(true);
+    try {
+      const updated = await updatePlatformSettings({ llmProvider: payload as LlmProviderConfig });
+      setPersisted(updated.llmProvider);
+      setForm(updated.llmProvider);
+      addToast({
+        type: "success",
+        message: "LLM provider config saved — takes effect on next LLM call",
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : "Failed to save LLM provider config",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleClearKey() {
+    setForm((f) => ({ ...f, apiKey: "" }));
+  }
+
+  function handleResetToEnv() {
+    setForm({ gatewayUrl: "", apiKey: "" });
+  }
+
+  return (
+    <Card>
+      <header className="mb-4 flex items-baseline justify-between">
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+            [§ LLM PROVIDER]
+          </p>
+          <h2 className="mt-1 font-display text-lg font-semibold uppercase tracking-tight text-strong">
+            LLM gateway override
+          </h2>
+        </div>
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+          {persisted.gatewayUrl || persisted.apiKey ? "Override active" : "Using env defaults"}
+        </span>
+      </header>
+
+      {loading ? (
+        <Skeleton lines={4} />
+      ) : (
+        <>
+          <p className="mb-4 font-text text-sm leading-relaxed text-body">
+            Override the default Chrono LLM gateway. Empty fields fall back
+            to the env values baked into the deployment
+            (<code className="font-mono text-xs text-meta">NYX_LLM_GATEWAY_URL</code> +
+            NyxID SA token-exchange). Changes take effect on the next
+            LLM call — no pod restart needed.
+          </p>
+
+          {/* Gateway URL */}
+          <div className="mb-4 flex flex-col gap-1.5">
+            <label
+              htmlFor="llm-provider-gateway-url"
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta"
+            >
+              Gateway URL
+            </label>
+            <input
+              id="llm-provider-gateway-url"
+              type="url"
+              value={form.gatewayUrl}
+              onChange={(e) => setForm((f) => ({ ...f, gatewayUrl: e.target.value }))}
+              placeholder="https://api.openai.com/v1   (empty = use env default)"
+              className="
+                w-full rounded-sm border border-subtle bg-elevated/40
+                px-3 py-2 font-mono text-xs text-strong
+                placeholder:text-meta/60
+                transition-colors duration-150
+                focus:border-accent focus:outline-none focus:bg-card
+              "
+            />
+            <p className="font-mono text-[10px] text-meta">
+              No trailing slash; the client appends <code>/responses</code>.
+            </p>
+          </div>
+
+          {/* API Key */}
+          <div className="mb-4 flex flex-col gap-1.5">
+            <label
+              htmlFor="llm-provider-api-key"
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta"
+            >
+              API key (Bearer)
+            </label>
+            <div className="flex items-stretch gap-2">
+              <input
+                id="llm-provider-api-key"
+                type={showKey ? "text" : "password"}
+                value={form.apiKey}
+                onChange={(e) => setForm((f) => ({ ...f, apiKey: e.target.value }))}
+                placeholder="sk-…   (empty = use SA token-exchange flow)"
+                className="
+                  flex-1 rounded-sm border border-subtle bg-elevated/40
+                  px-3 py-2 font-mono text-xs text-strong
+                  placeholder:text-meta/60
+                  transition-colors duration-150
+                  focus:border-accent focus:outline-none focus:bg-card
+                "
+              />
+              <button
+                type="button"
+                onClick={() => setShowKey((v) => !v)}
+                className="
+                  rounded-sm border border-subtle bg-elevated/40 px-2.5
+                  font-mono text-[10px] uppercase tracking-[0.14em] text-meta
+                  hover:border-accent hover:text-accent transition-colors
+                "
+              >
+                {showKey ? "Hide" : "Show"}
+              </button>
+              {form.apiKey && !isMask(form.apiKey) && (
+                <button
+                  type="button"
+                  onClick={handleClearKey}
+                  className="
+                    rounded-sm border border-subtle bg-elevated/40 px-2.5
+                    font-mono text-[10px] uppercase tracking-[0.14em] text-meta
+                    hover:border-danger hover:text-danger transition-colors
+                  "
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <p className="font-mono text-[10px] text-meta">
+              When set, the LLM client uses this Bearer token directly
+              and skips the NyxID SA token-exchange.
+              {isMask(form.apiKey) && " Showing first 4 + last 4 chars of the persisted key — leave masked to keep it, edit to replace."}
+            </p>
+          </div>
+
+          <footer className="mt-2 flex items-center justify-between border-t border-subtle pt-3">
+            <button
+              type="button"
+              onClick={handleResetToEnv}
+              disabled={saving || (!form.gatewayUrl && !form.apiKey)}
+              className="
+                font-mono text-[11px] uppercase tracking-[0.14em] text-meta
+                hover:text-accent transition-colors cursor-pointer
+                disabled:opacity-40 disabled:cursor-not-allowed
+              "
+            >
+              Reset to env defaults
+            </button>
+            <div className="flex items-center gap-3">
+              {dirty && (
+                <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-warning">
+                  Unsaved changes
+                </span>
+              )}
+              <Button size="sm" onClick={handleSave} disabled={saving || !dirty}>
+                {saving ? "Saving…" : "Save"}
+              </Button>
+            </div>
+          </footer>
+        </>
+      )}
+    </Card>
+  );
+}
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/ornn-web/src/components/agentseal/AgentSealTrustBadge.test.tsx
+++ b/ornn-web/src/components/agentseal/AgentSealTrustBadge.test.tsx
@@ -1,5 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+
+// The badge imports `apiPost` from `@/services/apiClient` for the rescan
+// button. That module's transitive `authStore` import calls
+// `useAuthStore.getState().initialize()` at load time, which crashes
+// under jsdom because Zustand's persist middleware can't write to
+// localStorage. Render tests for the badge don't need either.
+vi.mock("@/services/apiClient", () => ({ apiPost: vi.fn() }));
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: Object.assign(() => () => {}, {
+    getState: () => ({ addToast: () => {} }),
+  }),
+}));
+
 import { AgentSealTrustBadge } from "./AgentSealTrustBadge";
 import type { AgentSealScan } from "@/types/domain";
 
@@ -31,7 +44,7 @@ describe("AgentSealTrustBadge", () => {
 
   it("shows '0 findings' when the scan ran clean", () => {
     render(<AgentSealTrustBadge scan={makeScan({ findings: [] })} />);
-    expect(screen.getByRole("button", { name: /no findings/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /clean — 0 findings/i })).toBeInTheDocument();
   });
 
   it("expands the findings list when the toggle is clicked", () => {

--- a/ornn-web/src/components/agentseal/AgentSealTrustBadge.tsx
+++ b/ornn-web/src/components/agentseal/AgentSealTrustBadge.tsx
@@ -23,11 +23,25 @@ import {
   type AgentSealBand,
 } from "@/lib/agentsealBand";
 import type { AgentSealScan, AgentSealFinding } from "@/types/domain";
+import { apiPost } from "@/services/apiClient";
+import { useToastStore } from "@/stores/toastStore";
 
 export interface AgentSealTrustBadgeProps {
   scan: AgentSealScan | null | undefined;
   /** Optional; defaults to a sensible card class */
   className?: string;
+  /**
+   * Skill identifier — name or guid — required if `canRescan` is true.
+   * The rescan endpoint is keyed by `:idOrName/:version` per
+   * `POST /api/v1/admin/skills/:idOrName/versions/:version/agentseal-rescan`.
+   */
+  skillIdOrName?: string;
+  /** Version to rescan — required if `canRescan` is true. */
+  version?: string;
+  /** True when the caller has the admin permission. Drives the Rescan affordance. */
+  canRescan?: boolean;
+  /** Fired after a successful rescan so the parent can invalidate caches. */
+  onRescanned?: () => void;
 }
 
 /** Format the scan timestamp in SGT for consistency with the audit card. */
@@ -59,10 +73,51 @@ const SEVERITY_RANK: Record<AgentSealFinding["severity"], number> = {
 export function AgentSealTrustBadge({
   scan,
   className = "",
+  skillIdOrName,
+  version,
+  canRescan = false,
+  onRescanned,
 }: AgentSealTrustBadgeProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
+  const [rescanning, setRescanning] = useState(false);
   const findingsId = useId();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const canShowRescan = canRescan && Boolean(skillIdOrName) && Boolean(version);
+
+  async function handleRescan() {
+    if (!skillIdOrName || !version || rescanning) return;
+    setRescanning(true);
+    try {
+      const res = await apiPost<{ scan?: AgentSealScan | null }>(
+        `/api/v1/admin/skills/${encodeURIComponent(skillIdOrName)}/versions/${encodeURIComponent(version)}/agentseal-rescan`,
+        {},
+      );
+      if (res.error) {
+        const isDisabled = res.error.code === "AGENTSEAL_DISABLED";
+        addToast({
+          type: "error",
+          message: isDisabled
+            ? t("agentseal.rescanDisabled", "AgentSeal scanner is not configured on this deployment")
+            : (res.error.message ?? "Rescan failed"),
+        });
+        return;
+      }
+      addToast({
+        type: "success",
+        message: t("agentseal.rescanSuccess", "Trust score rescanned"),
+      });
+      onRescanned?.();
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: err instanceof Error ? err.message : "Rescan failed",
+      });
+    } finally {
+      setRescanning(false);
+    }
+  }
 
   // Unscanned variant — keep the silhouette so the right rail doesn't
   // jolt vertically when scrolling between scanned and unscanned skills.
@@ -72,9 +127,14 @@ export function AgentSealTrustBadge({
         className={`card-impression rounded-md border border-subtle bg-card p-5 ${className}`}
         aria-label={t("agentseal.cardLabel", "Trust score")}
       >
-        <h3 className="mb-3.5 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
-          <ShieldIcon className="h-[11px] w-[11px]" />
-          {t("agentseal.cardTitle", "Trust score")}
+        <h3 className="mb-3.5 flex items-center justify-between gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+          <span className="flex items-center gap-2">
+            <ShieldIcon className="h-[11px] w-[11px]" />
+            {t("agentseal.cardTitle", "Trust score")}
+          </span>
+          {canShowRescan && (
+            <RescanButton onClick={handleRescan} loading={rescanning} />
+          )}
         </h3>
         <div className="mb-3.5 flex items-center gap-3 rounded-sm border border-strong-edge bg-elevated/60 p-3 font-mono text-[11px] uppercase tracking-wider text-meta">
           <div
@@ -90,6 +150,17 @@ export function AgentSealTrustBadge({
             "agentseal.unscannedHint",
             "AgentSeal scans run on every new version publish. Older versions predate the scanner.",
           )}
+        </p>
+        <p className="mt-4 border-t border-dashed border-subtle pt-3 font-mono text-[10px] leading-relaxed text-meta">
+          {t("agentseal.attribution", "Trust auditing provided by")}{" "}
+          <a
+            href="https://agentseal.org"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-strong hover:text-accent transition-colors"
+          >
+            AgentSeal
+          </a>
         </p>
       </section>
     );
@@ -107,9 +178,14 @@ export function AgentSealTrustBadge({
       data-band={style.band}
       aria-label={t("agentseal.cardLabel", "Trust score")}
     >
-      <h3 className="mb-3.5 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
-        <ShieldIcon className="h-[11px] w-[11px]" />
-        {t("agentseal.cardTitle", "Trust score")}
+      <h3 className="mb-3.5 flex items-center justify-between gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+        <span className="flex items-center gap-2">
+          <ShieldIcon className="h-[11px] w-[11px]" />
+          {t("agentseal.cardTitle", "Trust score")}
+        </span>
+        {canShowRescan && (
+          <RescanButton onClick={handleRescan} loading={rescanning} />
+        )}
       </h3>
 
       {/* Score + band tile — identical silhouette to the audit-card
@@ -138,31 +214,79 @@ export function AgentSealTrustBadge({
         </div>
       </div>
 
-      <p className="font-mono text-[11px] leading-relaxed tracking-wide text-meta">
+      {/* Clean-result explainer — shown only when score is perfect AND
+          no findings. Tells the user what "100" actually verified. */}
+      {sortedFindings.length === 0 && score === 100 && (
+        <div className="mt-3 flex items-start gap-2 rounded-sm border border-success/30 bg-success-soft px-3 py-2">
+          <svg
+            className="mt-0.5 h-3 w-3 shrink-0 text-success"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+          <p className="font-text text-[11px] leading-relaxed text-success">
+            {t(
+              "agentseal.cleanScore",
+              "No malicious patterns, suspicious data flows, or known-bad hashes detected" +
+                (scan.scannedFiles ? ` across ${scan.scannedFiles} scanned file${scan.scannedFiles === 1 ? "" : "s"}` : "") +
+                ".",
+            )}
+          </p>
+        </div>
+      )}
+
+      <p className="mt-3 font-mono text-[11px] leading-relaxed tracking-wide text-meta">
         {t("agentseal.scannedAt", "Scanned {{date}}", {
           date: formatDateSGT(scan.scannedAt),
         })}
-        {scan.version && (
+        {typeof scan.scannedFiles === "number" && (
           <>
             {" · "}
-            {formatAgentSealVersion(scan.version)}
+            {scan.scannedFiles}{" "}
+            {scan.scannedFiles === 1 ? "file" : "files"}
           </>
         )}
       </p>
 
       {/* Findings disclosure. Always rendered (even at zero) so the
-          control is discoverable; collapsed by default. */}
+          control is discoverable; collapsed by default. The clean state
+          is success-toned to match the score band rather than ember,
+          so "no findings" reads as a positive signal. */}
       <div className="mt-3.5">
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
           aria-controls={findingsId}
-          className="inline-flex items-center gap-1 self-start py-1 font-mono text-[10px] uppercase tracking-widest text-accent transition-all hover:text-accent-muted hover:gap-2"
+          className={`inline-flex items-center gap-1.5 self-start py-1 font-mono text-[10px] uppercase tracking-widest transition-all hover:gap-2 ${
+            sortedFindings.length === 0
+              ? "text-success"
+              : "text-accent hover:text-accent-muted"
+          }`}
         >
+          {sortedFindings.length === 0 ? (
+            <svg
+              className="h-2.5 w-2.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          ) : null}
           <span>
             {sortedFindings.length === 0
-              ? t("agentseal.findingsClean", "No findings")
+              ? t("agentseal.findingsClean", "Clean — 0 findings")
               : t("agentseal.findingsCount", "{{n}} findings", {
                   n: sortedFindings.length,
                 })}
@@ -185,6 +309,27 @@ export function AgentSealTrustBadge({
           </ul>
         )}
       </div>
+
+      {/* Provider attribution — keeps the footer consistent across
+          scanned and unscanned variants and tells the user where the
+          score came from + which rule set produced it. */}
+      <p className="mt-4 border-t border-dashed border-subtle pt-3 font-mono text-[10px] leading-relaxed text-meta">
+        {t("agentseal.attribution", "Trust auditing provided by")}{" "}
+        <a
+          href="https://agentseal.org"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-strong hover:text-accent transition-colors"
+        >
+          AgentSeal
+        </a>
+        {scan.version && (
+          <>
+            {" · "}
+            {formatAgentSealVersion(scan.version)}
+          </>
+        )}
+      </p>
     </section>
   );
 }
@@ -284,6 +429,50 @@ function ChevronIcon({ className }: { className?: string }) {
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden>
       <polyline points="9 6 15 12 9 18" />
     </svg>
+  );
+}
+
+interface RescanButtonProps {
+  onClick: () => void;
+  loading: boolean;
+}
+
+/** Admin-only manual rescan trigger — sits in the trust-score card header. */
+function RescanButton({ onClick, loading }: RescanButtonProps) {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={loading}
+      title={t("agentseal.rescanTitle", "Re-run AgentSeal trust scan (admin)")}
+      className="
+        inline-flex items-center gap-1.5 rounded-sm border border-accent/40 bg-accent/5
+        px-2 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-accent
+        transition-colors duration-150 cursor-pointer
+        hover:bg-accent/10 hover:border-accent
+        disabled:opacity-60 disabled:cursor-progress
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+      "
+    >
+      <svg
+        className={`h-3 w-3 ${loading ? "animate-spin" : ""}`}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <polyline points="23 4 23 10 17 10" />
+        <polyline points="1 20 1 14 7 14" />
+        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+      </svg>
+      {loading
+        ? t("agentseal.rescanLoading", "Scanning…")
+        : t("agentseal.rescan", "Rescan")}
+    </button>
   );
 }
 

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -24,7 +24,6 @@ import { useThemeStore } from "@/stores/themeStore";
 import { logActivity } from "@/services/activityApi";
 import { Logo } from "@/components/brand/Logo";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
-import { QuotaChip } from "@/components/quota/QuotaChip";
 import { HighlighterMark } from "@/pages/landing/HighlighterMark";
 import { config } from "@/config";
 
@@ -249,7 +248,7 @@ export function Navbar({ className = "" }: NavbarProps) {
             {theme === "light" ? <MoonIcon className="h-4 w-4" /> : <SunIcon className="h-4 w-4" />}
           </button>
 
-          {isAuthenticated && <QuotaChip />}
+          {/* Quota indicators moved to RootLayout's breadcrumb rail. */}
           {isAuthenticated && <NotificationBell />}
 
           {isAuthenticated && user ? (

--- a/ornn-web/src/components/layout/RootLayout.tsx
+++ b/ornn-web/src/components/layout/RootLayout.tsx
@@ -2,6 +2,8 @@ import { Outlet, useLocation, useParams, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Navbar } from "./Navbar";
 import { ToastContainer } from "@/components/ui/Toast";
+import { QuotaChip } from "@/components/quota/QuotaChip";
+import { useIsAuthenticated } from "@/stores/authStore";
 import { useSkill } from "@/hooks/useSkills";
 
 /** Build breadcrumb segments from current route — every crumb is clickable */
@@ -95,39 +97,45 @@ function useBreadcrumbs() {
 
 export function RootLayout() {
   const crumbs = useBreadcrumbs();
+  const isAuthenticated = useIsAuthenticated();
 
   return (
     <div className="flex flex-col h-screen bg-page bg-grid overflow-hidden">
       <Navbar />
       {/* Breadcrumb navigation — hide when only root crumb. Width matches
           LandingNav (max-w-[1280px] mx-auto px-6 sm:px-8) so app-shell
-          horizontal rhythm aligns with the landing surface. */}
+          horizontal rhythm aligns with the landing surface. The right
+          rail hosts the QuotaChip (paired playground + skill-gen pills)
+          when authenticated. */}
       {crumbs.length > 1 && (
       <div className="mx-auto w-full max-w-[1280px] shrink-0 px-6 sm:px-8 pt-3 pb-2">
-        <nav className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.08em]">
-          {crumbs.map((crumb, i) => {
-            const isLast = i === crumbs.length - 1;
-            return (
-              <span key={i} className="flex items-center gap-2">
-                {i > 0 && (
-                  <span className="text-meta opacity-50 select-none">/</span>
-                )}
-                {isLast ? (
-                  <span className="text-accent font-medium">
-                    {crumb.label}
-                  </span>
-                ) : (
-                  <Link
-                    to={crumb.to ?? "#"}
-                    className="text-meta hover:text-strong transition-colors duration-150"
-                  >
-                    {crumb.label}
-                  </Link>
-                )}
-              </span>
-            );
-          })}
-        </nav>
+        <div className="flex items-center justify-between gap-4">
+          <nav className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.08em]">
+            {crumbs.map((crumb, i) => {
+              const isLast = i === crumbs.length - 1;
+              return (
+                <span key={i} className="flex items-center gap-2">
+                  {i > 0 && (
+                    <span className="text-meta opacity-50 select-none">/</span>
+                  )}
+                  {isLast ? (
+                    <span className="text-accent font-medium">
+                      {crumb.label}
+                    </span>
+                  ) : (
+                    <Link
+                      to={crumb.to ?? "#"}
+                      className="text-meta hover:text-strong transition-colors duration-150"
+                    >
+                      {crumb.label}
+                    </Link>
+                  )}
+                </span>
+              );
+            })}
+          </nav>
+          {isAuthenticated && <QuotaChip />}
+        </div>
       </div>
       )}
       <main className="mx-auto w-full max-w-[1280px] flex-1 min-h-0 px-6 sm:px-8 overflow-hidden">

--- a/ornn-web/src/components/models/ModelPicker.tsx
+++ b/ornn-web/src/components/models/ModelPicker.tsx
@@ -1,16 +1,18 @@
 /**
- * ModelPicker — surface-scoped model dropdown.
+ * ModelPicker — surface-scoped model dropdown, Forge-styled.
  *
- * Reads the admin-curated picker list for the surface, renders a native
- * `<select>` styled per the Forge Workshop input vocabulary, and writes
- * the choice through `usePreferredModel` so the next visit lands on the
- * same model. When the admin has nothing enabled for the surface, the
- * picker degrades into an inline empty-state stamp instead.
+ * Reads the admin-curated picker list for the surface, renders a custom
+ * popover dropdown (no native `<select>` so the open menu can match the
+ * rest of the Forge Workshop language — letterpress card-impression
+ * shadow, hairline border, ember accents, JetBrains Mono), and writes
+ * the choice through `usePreferredModel` so the next visit lands on
+ * the same model. When the admin has nothing enabled for the surface,
+ * the picker degrades into an inline empty-state stamp instead.
  *
  * @module components/models/ModelPicker
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { usePreferredModel } from "@/hooks/useModels";
 import type { Surface } from "@/services/quotaApi";
 
@@ -41,11 +43,74 @@ export function ModelPicker({
     isEmpty,
   } = usePreferredModel(surface);
 
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
   // Keep parent in sync with the resolved model — initial load and any
   // upstream change (e.g. admin disables the user's pick) flow back here.
   useEffect(() => {
     onChange?.(effectiveModelId);
   }, [effectiveModelId, onChange]);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (
+        triggerRef.current && !triggerRef.current.contains(e.target as Node) &&
+        menuRef.current && !menuRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  // Keyboard support: ESC closes, ↑/↓/Enter navigate options.
+  useEffect(() => {
+    if (!open) {
+      setActiveIndex(-1);
+      return;
+    }
+    // Seed activeIndex to the currently-selected option for smooth nav.
+    const selectedIdx = options.findIndex((o) => o.modelId === effectiveModelId);
+    setActiveIndex(selectedIdx >= 0 ? selectedIdx : 0);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(options.length - 1, i + 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(0, i - 1));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const opt = options[activeIndex];
+        if (opt) {
+          setPreferred(opt.modelId);
+          setOpen(false);
+          triggerRef.current?.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, options, effectiveModelId, activeIndex, setPreferred]);
+
+  const handlePick = useCallback(
+    (modelId: string) => {
+      setPreferred(modelId);
+      setOpen(false);
+      triggerRef.current?.focus();
+    },
+    [setPreferred],
+  );
 
   if (isLoading) {
     return (
@@ -69,32 +134,110 @@ export function ModelPicker({
     );
   }
 
+  const selected =
+    options.find((o) => o.modelId === effectiveModelId) ?? options[0];
+
   return (
-    <label className={`inline-flex items-center gap-2 ${className}`}>
+    <div className={`relative inline-flex items-center gap-2 ${className}`}>
       <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
         {label}
       </span>
-      <select
-        value={effectiveModelId ?? ""}
-        onChange={(e) => {
-          const next = e.target.value;
-          if (next) setPreferred(next);
-        }}
-        className="appearance-none rounded-sm border border-subtle bg-elevated/40 px-2.5 py-1.5 pr-7 font-mono text-[11px] text-strong transition-colors duration-150 focus:border-accent focus:outline-none focus:bg-card cursor-pointer"
-        style={{
-          backgroundImage:
-            "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23C94A0E' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")",
-          backgroundRepeat: "no-repeat",
-          backgroundPosition: "right 8px center",
-        }}
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`${label}: ${selected?.displayName ?? "—"}`}
+        className="
+          inline-flex min-w-[12rem] items-center justify-between gap-2 rounded-sm
+          border border-subtle bg-elevated/40 px-2.5 py-1.5
+          font-mono text-[11px] text-strong
+          transition-colors duration-150 cursor-pointer
+          hover:border-accent/60 hover:bg-card
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+          data-[open=true]:border-accent data-[open=true]:bg-card
+        "
+        data-open={open}
       >
-        {options.map((m) => (
-          <option key={m.modelId} value={m.modelId} className="bg-card text-strong">
-            {m.displayName}
-            {m.isDefault ? " — default" : ""}
-          </option>
-        ))}
-      </select>
-    </label>
+        <span className="truncate text-left">
+          {selected?.displayName ?? "—"}
+          {selected?.isDefault && (
+            <span className="text-meta"> — default</span>
+          )}
+        </span>
+        <svg
+          className={`h-3 w-3 shrink-0 text-accent transition-transform duration-150 ${open ? "rotate-180" : ""}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          role="listbox"
+          aria-label={`${label} options`}
+          className="
+            card-impression absolute right-0 top-[calc(100%+6px)] z-30
+            min-w-[16rem] max-h-[20rem] overflow-y-auto
+            rounded-sm border border-subtle bg-card p-1
+          "
+        >
+          {options.map((opt, idx) => {
+            const isSelected = opt.modelId === effectiveModelId;
+            const isActive = idx === activeIndex;
+            return (
+              <button
+                key={opt.modelId}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => handlePick(opt.modelId)}
+                onMouseEnter={() => setActiveIndex(idx)}
+                className={`
+                  flex w-full items-center gap-2.5 rounded-sm px-2.5 py-1.5
+                  text-left font-mono text-[11px] tracking-wide
+                  transition-colors duration-100 cursor-pointer
+                  ${isActive ? "bg-elevated text-strong" : "text-body hover:bg-elevated/70"}
+                  ${isSelected ? "text-accent" : ""}
+                `}
+              >
+                {/* Selection indicator — ember check at left */}
+                <span className="inline-flex w-3 shrink-0 items-center justify-center">
+                  {isSelected ? (
+                    <svg
+                      className="h-3 w-3 text-accent"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  ) : null}
+                </span>
+                <span className="flex-1 truncate">{opt.displayName}</span>
+                {opt.isDefault && (
+                  <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-meta">
+                    default
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }

--- a/ornn-web/src/components/playground/ChatInput.tsx
+++ b/ornn-web/src/components/playground/ChatInput.tsx
@@ -1,15 +1,13 @@
 /**
  * Chat Input Component.
  * Auto-resizing textarea with Enter=send, Shift+Enter=newline.
- * Shows stop button during streaming. Includes model selector dropdown.
+ * Shows stop button during streaming. Model selection lives in the
+ * page-level ModelPicker (top-right surface header).
  * @module components/playground/ChatInput
  */
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { usePlaygroundStore } from "@/stores/playgroundStore";
-import { AVAILABLE_MODELS, type AvailableModelId } from "@/types/playground";
-import { track } from "@/lib/analytics";
 
 export interface ChatInputProps {
   onSend: (content: string) => void;
@@ -33,9 +31,6 @@ export function ChatInput({
   const { t } = useTranslation();
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  const selectedModel = usePlaygroundStore((s) => s.selectedModel);
-  const setSelectedModel = usePlaygroundStore((s) => s.setSelectedModel);
 
   /** Resize textarea to fit content. */
   const adjustHeight = useCallback(() => {
@@ -70,30 +65,7 @@ export function ChatInput({
 
   return (
     <div className="px-2 pb-2 pt-2">
-      {/* Model selector */}
-      <div className="mb-2 flex items-center gap-2">
-        <label className="font-display text-[10px] uppercase tracking-wider text-meta">
-          {t("chatInput.model")}
-        </label>
-        <select
-          value={selectedModel}
-          onChange={(e) => {
-            const next = e.target.value as AvailableModelId;
-            setSelectedModel(next);
-            track("model.selected", { modelId: next, surface: "playground" });
-          }}
-          disabled={isStreaming}
-          className="neon-input cursor-pointer appearance-none rounded-md px-2 py-1 font-mono text-xs text-strong disabled:opacity-50"
-        >
-          {AVAILABLE_MODELS.map((m) => (
-            <option key={m.id} value={m.id} className="bg-page">
-              {m.label} ({m.provider})
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* Input row */}
+      {/* Input row — model selection lives in the page header (ModelPicker). */}
       <div className="flex items-end gap-2">
         <div className="relative flex-1">
           <textarea

--- a/ornn-web/src/components/quota/QuotaChip.tsx
+++ b/ornn-web/src/components/quota/QuotaChip.tsx
@@ -1,80 +1,137 @@
 /**
- * QuotaChip — ambient quota counter pill in the top nav.
+ * QuotaChip — ambient quota indicator that lives in the breadcrumb-row
+ * right rail (`RootLayout`) on every authenticated page.
  *
- * Shows the playground surface's remaining count by default (the
- * higher-volume surface). Click to open the QuotaSummary drawer with
- * the full breakdown across both surfaces. Hidden for admins (they
- * bypass the counter entirely) and for anonymous callers.
+ * Renders **both** surfaces as a paired pill group — playground and
+ * skill-generation — so the user sees their full quota posture at a
+ * glance without opening the drawer. Click any pill to expand the full
+ * `QuotaSummary` breakdown.
  *
- * The chip turns warning-toned when the playground surface crosses the
- * 80% threshold and danger-toned at zero. This visual state is kept in
- * lockstep with the soft-warning banner / over-limit page so the user
- * sees one consistent signal across the app.
+ * Each pill independently colors itself by its own surface state:
+ *   - admin:   ember "∞ Unlimited" stamp
+ *   - exhausted: danger tone
+ *   - warning (≥80% used): warning tone
+ *   - normal:  neutral tone
+ *
+ * Hidden entirely for anonymous callers.
  *
  * @module components/quota/QuotaChip
  */
 
 import { useState } from "react";
+import type { QuotaSnapshot, Surface, SurfaceSnapshot } from "@/services/quotaApi";
 import { useMyQuota } from "@/hooks/useQuota";
 import { QuotaSummary } from "./QuotaSummary";
+
+const SURFACE_LABEL: Record<Surface, string> = {
+  playground: "Playground",
+  skillGen: "Skill-gen",
+};
 
 function nfmt(n: number): string {
   return n.toLocaleString("en-US");
 }
 
-export function QuotaChip({ className = "" }: { className?: string }) {
+interface SurfacePillProps {
+  surface: Surface;
+  snapshot: SurfaceSnapshot;
+  isAdmin: boolean;
+  onOpen: () => void;
+}
+
+/** A single surface's pill — always part of the paired chip group. */
+function SurfacePill({ surface, snapshot, isAdmin, onOpen }: SurfacePillProps) {
+  if (isAdmin) {
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={`${SURFACE_LABEL[surface]} quota — admin unlimited`}
+        title={`${SURFACE_LABEL[surface]} · Unlimited (admin bypass)`}
+        className="
+          inline-flex h-7 items-center gap-1.5 rounded-sm border border-accent/40 bg-accent/5
+          px-2 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-accent
+          transition-colors duration-150 hover:bg-accent/10 cursor-pointer
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+        "
+      >
+        <span className="opacity-70">{SURFACE_LABEL[surface]}</span>
+        <span aria-hidden className="text-meta opacity-60">·</span>
+        <span aria-hidden className="text-base leading-none">∞</span>
+      </button>
+    );
+  }
+
+  const remaining = snapshot.monthly.remaining + snapshot.credits.balance;
+  const tone =
+    remaining <= 0 ? "danger" : snapshot.warning ? "warning" : "ok";
+
+  const toneClass =
+    tone === "danger"
+      ? "border-danger/50 text-danger hover:border-danger hover:bg-danger/5"
+      : tone === "warning"
+      ? "border-warning/50 text-warning hover:border-warning hover:bg-warning/5"
+      : "border-subtle text-strong hover:border-accent hover:bg-elevated/40";
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={`${SURFACE_LABEL[surface]} quota — ${nfmt(Math.max(0, remaining))} of ${nfmt(snapshot.monthly.limit)} remaining`}
+      title={`${SURFACE_LABEL[surface]}: ${nfmt(Math.max(0, remaining))} / ${nfmt(snapshot.monthly.limit)} this month`}
+      className={`
+        inline-flex h-7 items-center gap-1.5 rounded-sm border bg-transparent
+        px-2 font-mono text-[10px] font-semibold uppercase tracking-[0.12em]
+        transition-colors duration-150 cursor-pointer
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+        ${toneClass}
+      `}
+    >
+      <span className="opacity-70">{SURFACE_LABEL[surface]}</span>
+      <span aria-hidden className="opacity-50">·</span>
+      <span>{nfmt(Math.max(0, remaining))}</span>
+      <span className="text-meta opacity-70">/{nfmt(snapshot.monthly.limit)}</span>
+    </button>
+  );
+}
+
+interface QuotaChipProps {
+  className?: string;
+}
+
+export function QuotaChip({ className = "" }: QuotaChipProps) {
   const { data: quota } = useMyQuota();
   const [open, setOpen] = useState(false);
 
   if (!quota) return null;
-  if (quota.isAdmin) return null;
 
-  const playground = quota.playground;
-  const remaining = playground.monthly.remaining + playground.credits.balance;
-  const tone =
-    remaining <= 0 ? "danger" : playground.warning ? "warning" : "ok";
+  const isAdmin = quota.isAdmin;
 
-  const toneClass =
-    tone === "danger"
-      ? "border-danger/50 text-danger hover:border-danger"
-      : tone === "warning"
-      ? "border-warning/50 text-warning hover:border-warning"
-      : "border-strong-edge text-strong hover:border-accent";
-
+  // For admin, the drawer's per-surface bars don't carry useful info —
+  // but we still allow opening it so the visual "click → see detail"
+  // affordance remains consistent across modes.
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        aria-label="Quota usage details"
-        className={`
-          group inline-flex h-9 items-center gap-2 rounded-sm border bg-transparent
-          px-2.5 font-mono text-[10px] font-semibold uppercase tracking-[0.14em]
-          transition-colors duration-200
-          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
-          ${toneClass}
-          ${className}
-        `}
+      <div
+        role="group"
+        aria-label="Quota usage"
+        className={`inline-flex items-center gap-1.5 ${className}`}
       >
-        <svg
-          className="h-3.5 w-3.5 shrink-0 opacity-80"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M12 2v4M5 8l2.5 2.5M2 16h4M19 8l-2.5 2.5M22 16h-4" />
-          <circle cx="12" cy="16" r="6" />
-          <path d="M12 13v3l2 1" />
-        </svg>
-        <span>{nfmt(Math.max(0, remaining))}</span>
-        <span className="text-meta">/{nfmt(playground.monthly.limit)}</span>
-      </button>
+        <SurfacePill
+          surface="playground"
+          snapshot={quota.playground}
+          isAdmin={isAdmin}
+          onOpen={() => setOpen(true)}
+        />
+        <SurfacePill
+          surface="skillGen"
+          snapshot={quota.skillGen}
+          isAdmin={isAdmin}
+          onOpen={() => setOpen(true)}
+        />
+      </div>
 
-      <QuotaSummary isOpen={open} onClose={() => setOpen(false)} quota={quota} />
+      <QuotaSummary isOpen={open} onClose={() => setOpen(false)} quota={quota as QuotaSnapshot} />
     </>
   );
 }

--- a/ornn-web/src/components/quota/QuotaInline.test.tsx
+++ b/ornn-web/src/components/quota/QuotaInline.test.tsx
@@ -39,10 +39,13 @@ function snapshot(overrides: Partial<QuotaSnapshot["playground"]> = {}): QuotaSn
 }
 
 describe("QuotaInline", () => {
-  it("renders nothing for admins", () => {
+  it("renders an unlimited stamp for admins", () => {
     useMyQuota.mockReturnValue({ data: { ...snapshot(), isAdmin: true } });
-    const { container } = render(<QuotaInline surface="playground" />);
-    expect(container.firstChild).toBeNull();
+    render(<QuotaInline surface="playground" />);
+    expect(
+      screen.getByRole("status", { name: /admin — quota unlimited/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/unlimited playground/i)).toBeInTheDocument();
   });
 
   it("shows compact stamp under threshold", () => {

--- a/ornn-web/src/components/quota/QuotaInline.tsx
+++ b/ornn-web/src/components/quota/QuotaInline.tsx
@@ -2,13 +2,15 @@
  * QuotaInline — in-context surface display + soft 80% warning banner.
  *
  * Sits at the top of the playground / skill-gen pages and renders one of
- * three states based on the cached caller quota:
+ * four states based on the cached caller quota:
  *
- *  - admin-bypass:  rendered nothing (admins bypass the counter).
+ *  - admin-bypass:  compact "ADMIN · UNLIMITED" stamp (admins bypass
+ *                   the counter on the backend).
  *  - normal:        compact "X / Y left" stamp with reset hint.
  *  - warning:       full-width banner at 80% of monthly base, copy
  *                   directing the user to the QuotaChip drawer for
  *                   detail.
+ *  - exhausted:     rendered nothing (the over-limit page takes over).
  *
  * @module components/quota/QuotaInline
  */
@@ -36,7 +38,37 @@ function totalRemaining(s: SurfaceSnapshot): number {
 
 export function QuotaInline({ surface, className = "" }: QuotaInlineProps) {
   const { data: quota } = useMyQuota();
-  if (!quota || quota.isAdmin) return null;
+  if (!quota) return null;
+
+  // Admin bypass — show a stable "UNLIMITED" stamp so admins still get
+  // visual confirmation of their own quota state in the surface header.
+  if (quota.isAdmin) {
+    return (
+      <span
+        role="status"
+        aria-label="Admin — quota unlimited"
+        title="Admin · Unlimited usage"
+        className={`inline-flex items-center gap-2 rounded-sm border border-accent/40 bg-accent/5 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-accent ${className}`}
+      >
+        <svg
+          className="h-3 w-3 opacity-90"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M5 12h14" />
+          <path d="M19 5v14" />
+        </svg>
+        <span>Admin</span>
+        <span className="text-meta">·</span>
+        <span>Unlimited {SURFACE_LABEL[surface]}</span>
+      </span>
+    );
+  }
   const snap = surface === "playground" ? quota.playground : quota.skillGen;
 
   const remaining = totalRemaining(snap);

--- a/ornn-web/src/pages/NotificationsPage.tsx
+++ b/ornn-web/src/pages/NotificationsPage.tsx
@@ -18,6 +18,7 @@ import { PageTransition } from "@/components/layout/PageTransition";
 const CATEGORY_LABEL: Record<NotificationCategory, string> = {
   "audit.completed": "Audit",
   "audit.risky_for_consumer": "Audit",
+  "quota.credits_granted": "Quota",
 };
 
 function formatTimestamp(iso: string): string {

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -173,40 +173,61 @@ export function PlaygroundPage() {
   return (
     <PageTransition>
       <div className="flex flex-col h-full py-1">
-        {/* Surface header — quota inline + model picker. The 80% warning
-            banner replaces the inline stamp at threshold; admins see
-            nothing because both components self-skip. */}
-        <div className="mb-2 flex flex-wrap items-center justify-between gap-3 shrink-0">
-          <QuotaInline surface="playground" />
-          <ModelPicker
-            surface="playground"
-            onChange={setPickedModelId}
-            className="ml-auto"
-          />
+        {/* Surface header — bracketed section label on the left, quota
+            inline in the middle (admins skip), model picker pinned right.
+            The 80% warning banner replaces the inline stamp at threshold. */}
+        <div className="mb-3 flex flex-wrap items-center gap-3 shrink-0 border-b border-subtle pb-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+            [§&nbsp;PLAYGROUND]
+          </span>
+          <span aria-hidden="true" className="h-px w-6 bg-accent/40" />
+          <span className="font-mono text-[11px] text-strong truncate max-w-[24rem]" title={skillName}>
+            {skillName}
+          </span>
+          <div className="ml-auto flex items-center gap-3">
+            <QuotaInline surface="playground" />
+            <ModelPicker
+              surface="playground"
+              onChange={setPickedModelId}
+            />
+          </div>
         </div>
 
         {/* Two-column layout */}
         <div className="flex flex-1 min-h-0 gap-4">
           {/* Left: Chat (40%) */}
           <div className="flex w-[40%] shrink-0 flex-col min-w-0 min-h-0 rounded border border-accent/10 bg-elevated/30">
-            {/* Clear Chat button inside chat panel */}
-            <div className="flex items-center justify-end px-3 py-1 shrink-0">
+            {/* Chat panel header band — bracketed label on left, clear-chat ghost action on right */}
+            <div className="flex items-center justify-between px-3 py-1.5 shrink-0 border-b border-accent/10 bg-page/40">
+              <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-meta">
+                [&nbsp;CHAT&nbsp;]
+              </span>
               <button
                 type="button"
                 onClick={clearChat}
-                className="font-text text-xs text-meta hover:text-accent transition-colors cursor-pointer"
+                disabled={messages.length === 0}
+                className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta hover:text-accent transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {t("playground.clearChat")}
               </button>
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto space-y-3 px-3 py-2">
               {messages.length === 0 && !currentAssistantContent && (
-                <div className="flex flex-col items-center justify-center h-full text-center">
-                  <p className="font-text text-sm text-meta max-w-sm">
+                <div className="flex flex-col items-center justify-center h-full text-center px-4">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent/70 mb-2">
+                    [&nbsp;READY&nbsp;]
+                  </span>
+                  <span aria-hidden="true" className="h-px w-12 bg-accent/30 mb-3" />
+                  <p className="font-text text-sm text-strong max-w-sm leading-relaxed">
                     {needsEnvVars && !allEnvVarsFilled
                       ? t("playground.fillEnvVars")
                       : t("playground.askAbout", { name: skillName })}
                   </p>
+                  {!(needsEnvVars && !allEnvVarsFilled) && (
+                    <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta mt-3">
+                      Enter to send · Shift + Enter for newline
+                    </p>
+                  )}
                 </div>
               )}
 
@@ -273,8 +294,58 @@ export function PlaygroundPage() {
             </div>
           </div>
 
-          {/* Right: Env vars + Skill preview (60%) — fill height */}
-          <div className="flex-1 flex flex-col min-w-0 min-h-0 gap-4">
+          {/* Right: Skill info + Env vars + Skill preview (60%) — fill height */}
+          <div className="flex-1 flex flex-col min-w-0 min-h-0 gap-3">
+            {/* Compact skill info card — name, description, identity row.
+                Mirrors the SkillHeroStrip silhouette (icon + body) so the
+                playground reads as a sibling of the skill detail page,
+                without the heavy hero CTA chrome. */}
+            {skill && (
+              <Card>
+                <div className="flex items-start gap-3">
+                  <div
+                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-sm border border-strong-edge bg-warning-soft text-accent"
+                    aria-hidden
+                  >
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="16 18 22 12 16 6" />
+                      <polyline points="8 6 2 12 8 18" />
+                    </svg>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                      <h2 className="font-display text-base font-semibold leading-tight text-strong tracking-tight">
+                        {skill.name}
+                      </h2>
+                      <span className="inline-flex items-center rounded-sm border border-strong-edge px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-strong">
+                        v{skill.version}
+                      </span>
+                      {typeof (skill.metadata as Record<string, unknown> | null)?.category === "string" && (
+                        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                          {(skill.metadata as Record<string, unknown>).category as string}
+                        </span>
+                      )}
+                    </div>
+                    {skill.description && (
+                      <p className="mt-1.5 font-text text-xs leading-relaxed text-body line-clamp-3">
+                        {skill.description}
+                      </p>
+                    )}
+                    {skill.tags && skill.tags.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-x-2 gap-y-0.5 font-mono text-[10px] text-meta">
+                        {skill.tags.slice(0, 6).map((tag) => (
+                          <span key={tag}>#{tag}</span>
+                        ))}
+                        {skill.tags.length > 6 && (
+                          <span>+{skill.tags.length - 6} more</span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </Card>
+            )}
+
             {/* Env vars form (only for runtime-based skills with env vars) */}
             {needsEnvVars && (
               <Card>
@@ -308,23 +379,37 @@ export function PlaygroundPage() {
               </Card>
             )}
 
-            {/* Skill preview — fill remaining height */}
-            <div className="flex-1 min-h-0 flex flex-col">
-              {packageLoading ? (
-                <Card><Skeleton lines={8} /></Card>
-              ) : packageFiles.length > 0 ? (
-                <SkillPackagePreview
-                  files={packageFiles}
-                  fileContents={packageContents}
-                  metadata={null}
-                  editable={false}
-                  className="h-full"
-                />
-              ) : (
-                <div className="flex items-center justify-center h-32">
-                  <p className="font-text text-xs text-meta">{t("playground.noPackage")}</p>
-                </div>
-              )}
+            {/* Skill preview — fill remaining height. Bracketed [PACKAGE]
+                label wraps the existing files+viewer combo so it reads
+                as a sibling of the [CHAT] panel on the left. */}
+            <div className="flex-1 min-h-0 flex flex-col rounded border border-accent/10 bg-elevated/30 overflow-hidden">
+              <div className="flex items-center justify-between px-3 py-1.5 shrink-0 border-b border-accent/10 bg-page/40">
+                <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-meta">
+                  [&nbsp;PACKAGE&nbsp;]
+                </span>
+                {skill && (
+                  <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta truncate" title={skill.name}>
+                    {skill.name}@v{skill.version}
+                  </span>
+                )}
+              </div>
+              <div className="flex-1 min-h-0 flex flex-col">
+                {packageLoading ? (
+                  <Card><Skeleton lines={8} /></Card>
+                ) : packageFiles.length > 0 ? (
+                  <SkillPackagePreview
+                    files={packageFiles}
+                    fileContents={packageContents}
+                    metadata={null}
+                    editable={false}
+                    className="h-full"
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-32">
+                    <p className="font-text text-xs text-meta">{t("playground.noPackage")}</p>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/ornn-web/src/pages/admin/AdminModelsPage.tsx
+++ b/ornn-web/src/pages/admin/AdminModelsPage.tsx
@@ -17,6 +17,7 @@ import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Badge } from "@/components/ui/Badge";
+import { LlmProviderConfigCard } from "@/components/admin/LlmProviderConfigCard";
 import { useToastStore } from "@/stores/toastStore";
 import {
   useAdminModels,
@@ -260,6 +261,16 @@ export function AdminModelsPage() {
           </Button>
         </div>
       </div>
+
+      {/* LLM provider override — sits above the catalog so admins see
+          which gateway the models are actually being served from. */}
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.25, delay: 0.05 }}
+      >
+        <LlmProviderConfigCard />
+      </motion.div>
 
       <div className="flex items-center gap-3">
         <input

--- a/ornn-web/src/pages/admin/AdminQuotaPage.tsx
+++ b/ornn-web/src/pages/admin/AdminQuotaPage.tsx
@@ -75,16 +75,21 @@ export function AdminQuotaPage() {
     });
   };
 
+  // Admin rows are excluded from selection — granting credits to an
+  // admin (who already bypasses the counter) is meaningless. Both the
+  // per-row checkbox and the "Select page" header skip them.
+  const grantableItems = items.filter((u) => !u.isAdmin);
   const allOnPageSelected =
-    items.length > 0 && items.every((u) => selectedIds.has(u.userId));
+    grantableItems.length > 0 &&
+    grantableItems.every((u) => selectedIds.has(u.userId));
 
   const togglePage = () => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
       if (allOnPageSelected) {
-        items.forEach((u) => next.delete(u.userId));
+        grantableItems.forEach((u) => next.delete(u.userId));
       } else {
-        items.forEach((u) => next.add(u.userId));
+        grantableItems.forEach((u) => next.add(u.userId));
       }
       return next;
     });
@@ -117,6 +122,37 @@ export function AdminQuotaPage() {
           >
             Grant credits to selected
           </Button>
+        </div>
+      </div>
+
+      {/* Admin self-quota banner — admins bypass the counter on the
+          backend; surface that here so the page reads unambiguously as
+          "manage other users' quotas, your own is unlimited". */}
+      <div
+        role="status"
+        className="flex items-center gap-3 rounded border border-accent/30 bg-accent/5 px-4 py-3"
+      >
+        <svg
+          className="h-4 w-4 shrink-0 text-accent"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M5 12h14" />
+          <path d="M19 5v14" />
+        </svg>
+        <div className="flex-1">
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-accent">
+            Admin · Unlimited
+          </p>
+          <p className="mt-0.5 font-text text-xs leading-relaxed text-body">
+            Your own playground and skill-gen usage bypasses every counter and
+            ceiling. This page manages quota for everyone else.
+          </p>
         </div>
       </div>
 
@@ -169,10 +205,10 @@ export function AdminQuotaPage() {
                       User
                     </th>
                     <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
-                      Playground (used / credits)
+                      Playground · used / limit · +bonus
                     </th>
                     <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
-                      Skill-gen (used / credits)
+                      Skill-gen · used / limit · +bonus
                     </th>
                     <th className="px-4 py-3"></th>
                   </tr>
@@ -184,49 +220,126 @@ export function AdminQuotaPage() {
                       <Fragment key={u.userId}>
                         <tr className="border-b border-accent/10 hover:bg-elevated/40">
                           <td className="px-3 py-3">
-                            <input
-                              type="checkbox"
-                              checked={selectedIds.has(u.userId)}
-                              onChange={() => toggleSelected(u.userId)}
-                              aria-label={`Select ${u.email}`}
-                              className="h-3.5 w-3.5 cursor-pointer accent-[var(--color-accent-primary)]"
-                            />
+                            {u.isAdmin ? (
+                              // Admins can't be selected — bulk grant skips them.
+                              <span className="inline-block h-3.5 w-3.5" aria-hidden />
+                            ) : (
+                              <input
+                                type="checkbox"
+                                checked={selectedIds.has(u.userId)}
+                                onChange={() => toggleSelected(u.userId)}
+                                aria-label={`Select ${u.email}`}
+                                className="h-3.5 w-3.5 cursor-pointer accent-[var(--color-accent-primary)]"
+                              />
+                            )}
                           </td>
                           <td className="px-4 py-3">
-                            <p className="font-text text-sm text-strong">
-                              {u.displayName || "—"}
-                            </p>
+                            <div className="flex items-center gap-2">
+                              <p className="font-text text-sm text-strong">
+                                {u.displayName || "—"}
+                              </p>
+                              {u.isAdmin && (
+                                <span
+                                  title="Admin · ornn:admin:skill"
+                                  className="inline-flex items-center gap-1 rounded-sm border border-accent/40 bg-accent/5 px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-accent"
+                                >
+                                  Admin
+                                </span>
+                              )}
+                            </div>
                             <p className="font-mono text-[11px] text-meta">
                               {u.email}
                             </p>
                           </td>
-                          <td className="px-4 py-3 font-mono text-[12px] text-strong">
-                            {u.playground.monthlyUsed} used · daily{" "}
-                            {u.playground.dailyUsed} ·{" "}
-                            <span className="text-accent">
-                              +{u.playground.creditsBalance}
-                            </span>
-                          </td>
-                          <td className="px-4 py-3 font-mono text-[12px] text-strong">
-                            {u.skillGen.monthlyUsed} used · daily{" "}
-                            {u.skillGen.dailyUsed} ·{" "}
-                            <span className="text-accent">
-                              +{u.skillGen.creditsBalance}
-                            </span>
-                          </td>
-                          <td className="whitespace-nowrap px-4 py-3 text-right">
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setExpandedUserId(expanded ? null : u.userId)
-                              }
-                              className="font-mono text-[11px] uppercase tracking-[0.14em] text-accent hover:text-accent-muted"
+                          {u.isAdmin ? (
+                            <td
+                              colSpan={2}
+                              className="px-4 py-3 font-mono text-[11px] uppercase tracking-[0.14em] text-accent"
                             >
-                              {expanded ? "Close" : "Grant"}
-                            </button>
+                              <span className="inline-flex items-center gap-2">
+                                <svg
+                                  className="h-3 w-3"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="2"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  aria-hidden
+                                >
+                                  <path d="M5 12h14" />
+                                  <path d="M19 5v14" />
+                                </svg>
+                                Unlimited — quota bypassed for both surfaces
+                              </span>
+                            </td>
+                          ) : (
+                            <>
+                              <td className="px-4 py-3 font-mono text-[12px] text-strong">
+                                <span title="Used / monthly base limit">
+                                  {u.playground.monthlyUsed}
+                                  <span className="text-meta">
+                                    {" "}/ {u.playground.monthlyLimit}
+                                  </span>
+                                </span>
+                                <span className="text-meta opacity-60">{" · "}</span>
+                                <span
+                                  className="text-meta"
+                                  title="Daily used / daily ceiling"
+                                >
+                                  d {u.playground.dailyUsed}/{u.playground.dailyLimit}
+                                </span>
+                                <span className="text-meta opacity-60">{" · "}</span>
+                                <span
+                                  className="text-accent"
+                                  title="Active granted bonus credits"
+                                >
+                                  +{u.playground.creditsBalance}
+                                </span>
+                              </td>
+                              <td className="px-4 py-3 font-mono text-[12px] text-strong">
+                                <span title="Used / monthly base limit">
+                                  {u.skillGen.monthlyUsed}
+                                  <span className="text-meta">
+                                    {" "}/ {u.skillGen.monthlyLimit}
+                                  </span>
+                                </span>
+                                <span className="text-meta opacity-60">{" · "}</span>
+                                <span
+                                  className="text-meta"
+                                  title="Daily used / daily ceiling"
+                                >
+                                  d {u.skillGen.dailyUsed}/{u.skillGen.dailyLimit}
+                                </span>
+                                <span className="text-meta opacity-60">{" · "}</span>
+                                <span
+                                  className="text-accent"
+                                  title="Active granted bonus credits"
+                                >
+                                  +{u.skillGen.creditsBalance}
+                                </span>
+                              </td>
+                            </>
+                          )}
+                          <td className="whitespace-nowrap px-4 py-3 text-right">
+                            {u.isAdmin ? (
+                              <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-meta/60">
+                                —
+                              </span>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  setExpandedUserId(expanded ? null : u.userId)
+                                }
+                                className="font-mono text-[11px] uppercase tracking-[0.14em] text-accent hover:text-accent-muted"
+                              >
+                                {expanded ? "Close" : "Grant"}
+                              </button>
+                            )}
                           </td>
                         </tr>
-                        {expanded && (
+                        {expanded && !u.isAdmin && (
                           <tr className="border-b border-accent/10 bg-elevated/20">
                             <td />
                             <td colSpan={4} className="px-4 py-4">

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -622,8 +622,17 @@ export function SkillDetailPage() {
             {/* ── AgentSeal trust score (#253) ── third-party-verifiable
                 security signal. Sits next to the Audit card so the two
                 trust signals read as siblings; both follow the same tile
-                silhouette inside their card. */}
-            <AgentSealTrustBadge scan={skill.agentsealScan ?? null} />
+                silhouette inside their card. Admins see a Rescan button
+                in the card header to manually re-trigger the scan
+                (catches false positives, picks up newer AgentSeal rules
+                without waiting for a new publish). */}
+            <AgentSealTrustBadge
+              scan={skill.agentsealScan ?? null}
+              skillIdOrName={skill.name || skill.guid}
+              version={skill.version}
+              canRescan={isAdmin(user)}
+              onRescanned={() => refetch()}
+            />
 
             {/* ── Versions card ── */}
             {versionList.length > 0 && (

--- a/ornn-web/src/services/platformSettingsApi.ts
+++ b/ornn-web/src/services/platformSettingsApi.ts
@@ -1,19 +1,36 @@
 /**
  * Client for platform settings — admin-only config like the audit
- * waiver threshold.
+ * waiver threshold and the LLM provider override.
  *
  * @module services/platformSettingsApi
  */
 
 import { apiGet, apiPatch } from "./apiClient";
 
+export interface LlmProviderConfig {
+  /** Empty string ⇒ env default (Chrono LLM via NyxID gateway). */
+  gatewayUrl: string;
+  /**
+   * Empty ⇒ NyxID SA token-exchange flow. Non-empty ⇒ direct Bearer.
+   * The GET response masks the value to "••••••••" when set; echo
+   * that mask back on PATCH to preserve the existing value.
+   */
+  apiKey: string;
+}
+
 export interface PlatformSettings {
   auditWaiverThreshold: number;
+  llmProvider: LlmProviderConfig;
 }
+
+const DEFAULT_SETTINGS: PlatformSettings = {
+  auditWaiverThreshold: 6.0,
+  llmProvider: { gatewayUrl: "", apiKey: "" },
+};
 
 export async function fetchPlatformSettings(): Promise<PlatformSettings> {
   const res = await apiGet<PlatformSettings>("/api/v1/admin/settings");
-  return res.data ?? { auditWaiverThreshold: 6.0 };
+  return res.data ?? DEFAULT_SETTINGS;
 }
 
 export async function updatePlatformSettings(

--- a/ornn-web/src/services/quotaApi.ts
+++ b/ornn-web/src/services/quotaApi.ts
@@ -41,8 +41,32 @@ export interface AdminQuotaRow {
   userId: string;
   email: string;
   displayName: string;
-  playground: { monthlyUsed: number; dailyUsed: number; creditsBalance: number };
-  skillGen: { monthlyUsed: number; dailyUsed: number; creditsBalance: number };
+  /**
+   * True when this user carries the `ornn:admin:skill` permission per
+   * the lazily-tracked `admin_users` collection (populated by the auth
+   * setup layer whenever an admin authenticates). Drives the UI to
+   * render "Admin · Unlimited" instead of usage counters and disables
+   * the per-row Grant action.
+   */
+  isAdmin: boolean;
+  playground: AdminQuotaSurfaceStatus;
+  skillGen: AdminQuotaSurfaceStatus;
+}
+
+export interface AdminQuotaSurfaceStatus {
+  /** Calls used in the current monthly window. */
+  monthlyUsed: number;
+  /** Original monthly base — what the user gets each rollover. */
+  monthlyLimit: number;
+  /** Calls used in the current daily window. */
+  dailyUsed: number;
+  /** Daily ceiling for this surface. */
+  dailyLimit: number;
+  /**
+   * Total active granted credits = legacy non-expiring bucket PLUS
+   * sum of unused capacity across active grants in the ledger.
+   */
+  creditsBalance: number;
 }
 
 export interface AdminQuotaPage {
@@ -73,24 +97,33 @@ export interface GrantInput {
   userId: string;
   surface: Surface;
   amount: number;
+  /**
+   * How many UTC months the grant stays active before unused capacity
+   * drops out of the balance. Omit / set null to grant credits that
+   * never expire.
+   */
+  periodMonths?: number | null;
   note?: string;
 }
 
-export async function grantQuota(input: GrantInput): Promise<{ auditId: string }> {
-  const res = await apiPost<{ auditId: string; applied: number }>(
+export async function grantQuota(
+  input: GrantInput,
+): Promise<{ auditId: string; expiresAt: string | null }> {
+  const res = await apiPost<{ auditId: string; applied: number; expiresAt: string | null }>(
     "/api/v1/admin/quota/grant",
     input,
   );
   if (!res.data) {
     throw new Error("Grant response missing");
   }
-  return { auditId: res.data.auditId };
+  return { auditId: res.data.auditId, expiresAt: res.data.expiresAt ?? null };
 }
 
 export interface BulkGrantInput {
   userIds: string[];
   surface: Surface;
   amount: number;
+  periodMonths?: number | null;
   note?: string;
 }
 

--- a/ornn-web/src/types/domain.ts
+++ b/ornn-web/src/types/domain.ts
@@ -112,8 +112,10 @@ export interface AgentSealScan {
   findings: AgentSealFinding[];
   /** ISO-8601 timestamp the scan completed. */
   scannedAt: string;
-  /** AgentSeal toolkit version, e.g. "agentseal-0.4.1". */
+  /** AgentSeal toolkit version, e.g. "agentseal-0.9.6". */
   version: string;
+  /** Number of files actually walked by the scanner. */
+  scannedFiles?: number;
 }
 
 /**

--- a/ornn-web/src/types/notifications.ts
+++ b/ornn-web/src/types/notifications.ts
@@ -8,7 +8,8 @@
 
 export type NotificationCategory =
   | "audit.completed"
-  | "audit.risky_for_consumer";
+  | "audit.risky_for_consumer"
+  | "quota.credits_granted";
 
 export interface Notification {
   _id: string;


### PR DESCRIPTION
## Summary

Final go-live-prep bundle. Three independent threads, shipped together because they touch the same admin surface and have already been smoke-tested end-to-end on the local cluster:

- **Admin LLM provider override** at `/admin/models` — paste a custom gateway URL + bearer key without a redeploy. Key is encrypted at rest with AES-256-GCM (`infra/crypto`, scrypt-derived from `ENCRYPTION_KEY`) and mid-masked on read so the operator can sanity-check which key is in place without exposing the body. Round-tripping the masked value preserves the existing key (bullet `•` is the sentinel — real bearer keys never contain it). Override takes effect on the next LLM call via a runtime resolver on `NyxLlmClient` — no pod restart.
- **Additive quota grants with a period** — `grant()` accepts `periodMonths`, persists to a `quota_grants` ledger with `consumed`/`expiresAt`. Repeated grants stack instead of overwriting. Charge order: monthly base → legacy `creditsBalance` → oldest active grant (FIFO). Admin table shows used/limit · daily · +bonus per user; playground chip shows the effective remaining balance.
- **AgentSeal Python wrapper** — replaced the broken `agentseal guard` CLI with `scripts/scan_skill.py` driving `agentseal.skill_scanner.SkillScanner` directly (the CLI scans the developer's local agent configs, not arbitrary skill packages). Manual rescan button on the trust badge so an operator can re-run a stuck scan without re-publishing.
- **`admin_users` collection** — replaces `ORNN_ADMIN_EMAILS` env. The auth middleware lazily inserts authenticated users with `ornn:admin:skill` so admin filters consult the DB, not env config.

### New env var

`ENCRYPTION_KEY` — master passphrase for AES-256-GCM at-rest encryption of admin-pasted secrets. 32+ chars (`openssl rand -hex 32`). When unset the API falls back to a clearly-marked dev sentinel; production deployments **must** override — rotating it makes every previously-encrypted secret unreadable. Wired through `deployment/ornn-api/secret.yaml` (`envFrom` already covers both the `ornn-api` Deployment and the `ornn-mirror-reconcile` CronJob).

### Closes / relates

Closes #258 (admin model selection), relates to the go-live-prep milestone (#250, #251, #253).

## Test plan

- [x] `bunx tsc --noEmit` clean on both packages (only the pre-existing `posthog-node` Bun-resolver warning remains)
- [x] Local k8s rebuild + rollout — both pods healthy, `/readyz` 200, no crashes on startup, `runtimeOverrideEnabled: true` in API logs
- [ ] CI passes
- [ ] Manual: paste a key in `/admin/models` → confirm DB row stores `v1:iv:tag:ct` ciphertext, UI shows `sk-1•••••••cdef`, re-saving without edits preserves the persisted key
- [ ] Manual: grant 100 to a user, verify their balance increments (not overwrites); grant another 50, balance is 150
- [ ] Manual: trigger trust-badge rescan on an existing skill, verify the score updates