### PR TITLE
[Bug] Real per-event SSE streaming via TransformStream + chat polish

### DIFF
--- a/.changeset/playground-polish-and-streaming-transformstream.md
+++ b/.changeset/playground-polish-and-streaming-transformstream.md
@@ -1,0 +1,19 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+fix(playground): real per-event SSE streaming via TransformStream + ChatGPT-style chat polish.
+
+**Streaming fix.** The previous chat route used `new ReadableStream({ start(controller) { ... controller.enqueue(...) } })` with a deferred IIFE producer. Under Bun's HTTP layer, this pattern coalesced 2,000+ enqueues into a single delivery at stream-close — the EventStream tab in DevTools would show every text-delta event arriving at the same millisecond despite the upstream LLM streaming over ~45s. Replaced with `TransformStream + writer.write()`, which establishes proper backpressure with Bun's response consumer: each `await writer.write(chunk)` resolves only once the chunk has been picked up by the HTTP writer, forcing real per-event flushing on the wire. Verified end-to-end via the EventStream tab — events now arrive at distinct timestamps as upstream emits.
+
+**Character-by-character typewriter.** Replaced the synchronous "render every text-delta as it arrives" path with a paced drain in `usePlaygroundChat`. Incoming chars accumulate in a `pendingTokensRef` buffer; a 22ms `setInterval` drains one character per tick onto the displayed message. Adaptive: if the LLM races ahead (>60 chars buffered) the pacer takes 3 chars/tick; past 200 chars it scales to `ceil(buffer/60)` chars/tick so visible text stays within ~1s of received. On `finish`/`tool-call`/`error`/`abort` it drains everything immediately — paced typewriter is a UX nicety, not a contract. Emoji-safe via `Array.from(buffer)` so a 4-byte 😀 counts as one character.
+
+**Chat polish.**
+- Composer moved to `max-w-2xl` and lifted off the floor (`pb-6`); model picker + quota chip now sit centered just above the input, ChatGPT-style. Top-right surface header dropped.
+- User bubbles use the Forge ember palette: `bg-warning-soft` fill + `border-accent/30` ember outline, contrasted against the assistant's cool `bg-card` bubble.
+- Empty-state hero is vertically centered, narrower hero copy + 3 quick-starter chips below.
+- Auto-scroll only follows when the user is already at the tail (tracks `distFromBottom < 80`), so scrolling up mid-stream stops the page from chasing.
+- Per-skill session lifecycle: chat resets on skillName change AND on unmount.
+- Chat header status row only renders once a conversation is active — no "Idle/Ready" noise on the empty state.
+- Right-edge drawer (Skill / Env / Package) anchored via `position: fixed` so it stays in view regardless of page scroll.

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -137,107 +137,102 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
       const signal = c.req.raw.signal;
       const chatRequest: PlaygroundChatRequest = parsed;
 
-      // Manual ReadableStream rather than Hono's `streamSSE` helper
-      // because the helper batches `writeSSE` calls under Bun. Critical
-      // detail: `start` MUST be synchronous and the async pump runs in
-      // a deferred task — if `start` is `async`, Bun (and the WHATWG
-      // streams spec on most engines) holds response headers until the
-      // start promise resolves, defeating token-by-token streaming.
-      const body = new ReadableStream<Uint8Array>({
-        start(controller) {
-          let closed = false;
-          const closeOnce = () => {
-            if (closed) return;
-            closed = true;
-            try {
-              controller.close();
-            } catch {
-              /* already closed */
+      // TransformStream: writer.write() back-pressures naturally against
+      // Bun's response consumer, so each `await writer.write(chunk)`
+      // resolves only after the chunk has been picked up by the HTTP
+      // writer. This forces real per-event flushing — the previous
+      // `ReadableStream.start(controller) + IIFE + controller.enqueue`
+      // pattern coalesced 2,000+ enqueues into a single delivery at
+      // stream close under Bun (verified via the EventStream tab: every
+      // event arrived at the browser at the same millisecond despite
+      // upstream LLM emitting deltas over ~45s).
+      const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+      const writer = writable.getWriter();
+
+      let writerClosed = false;
+      const closeOnce = async () => {
+        if (writerClosed) return;
+        writerClosed = true;
+        try {
+          await writer.close();
+        } catch {
+          /* already closed */
+        }
+      };
+      const writeFrame = async (frame: string) => {
+        if (writerClosed) return;
+        try {
+          await writer.write(encoder.encode(frame));
+        } catch {
+          writerClosed = true;
+        }
+      };
+      const writeEvent = (payload: unknown) =>
+        writeFrame(`data: ${JSON.stringify(payload)}\n\n`);
+
+      // Pre-flush a fat comment frame so the response headers + first
+      // chunk hit the wire immediately. SSE comments are spec-mandated
+      // ignores by the browser parser. The 2KB padding defeats any
+      // intermediate proxy that holds the connection until ~2-4KB
+      // arrives.
+      const padding = " ".repeat(2048);
+      void writeFrame(`: stream-open ${Date.now()} ${padding}\n\n`);
+
+      // Keepalive defeats idle-timeout proxies during LLM warmup.
+      const keepAlive = setInterval(() => {
+        void writeFrame(`: keepalive ${Date.now()}\n\n`);
+      }, keepAliveIntervalMs);
+
+      const onAbort = () => {
+        clearInterval(keepAlive);
+        void closeOnce();
+      };
+      signal.addEventListener("abort", onAbort);
+
+      // Producer task — pumps chat events into the writer. Runs in
+      // background; the response is returned synchronously below.
+      void (async () => {
+        try {
+          for await (const event of chatService.chat(authCtx.userId, chatRequest, signal, {
+            modelId: resolvedModelId,
+          })) {
+            await writeEvent(event);
+            if (event.type === "tool-result") outcome = "skill_error";
+            if (event.type === "finish") {
+              const reason = (event as { finishReason?: string }).finishReason;
+              if (reason === "stop") outcome = "success";
             }
-          };
-          const write = (frame: string) => {
-            if (closed) return;
-            try {
-              controller.enqueue(encoder.encode(frame));
-            } catch {
-              /* writer gone — caller aborted */
-              closed = true;
-            }
-          };
-          const writeEvent = (payload: unknown) => {
-            write(`data: ${JSON.stringify(payload)}\n\n`);
-          };
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Chat stream failed";
+          logger.error({ userId: authCtx.userId, err: message }, "Chat stream error");
+          await writeEvent({ type: "error", message });
+        } finally {
+          signal.removeEventListener("abort", onAbort);
+          clearInterval(keepAlive);
+          await closeOnce();
+          await quotaService
+            .chargeOnCompletion({
+              userId: authCtx.userId,
+              permissions: authCtx.permissions,
+              surface: "playground",
+              outcome,
+            })
+            .catch((err) => {
+              logger.warn(
+                { userId: authCtx.userId, err: (err as Error).message },
+                "Quota charge after playground chat failed",
+              );
+            });
+        }
+      })();
 
-          // Pre-flush a fat comment frame to force every layer in the
-          // chain (Bun's response buffer, NyxID's reqwest stream, the
-          // browser's `response.body` reader) to commit headers + start
-          // delivering chunks. Some intermediaries hold output until
-          // ~2-4KB lands or until they think the response is "real".
-          // SSE comments (lines starting with `:`) are spec-mandated
-          // ignores in the browser parser, so this is invisible to the
-          // application.
-          const padding = " ".repeat(2048);
-          write(`: stream-open ${Date.now()} ${padding}\n\n`);
-
-          // Keepalive to defeat idle-timeout proxies during LLM warmup.
-          const keepAlive = setInterval(() => {
-            write(`: keepalive ${Date.now()}\n\n`);
-          }, keepAliveIntervalMs);
-
-          const onAbort = () => {
-            clearInterval(keepAlive);
-            closeOnce();
-          };
-          signal.addEventListener("abort", onAbort);
-
-          // Async pump — runs as a deferred task so `start` returns
-          // synchronously. Bun commits response headers as soon as the
-          // first byte is enqueued (the `: stream-open` above).
-          (async () => {
-            try {
-              for await (const event of chatService.chat(authCtx.userId, chatRequest, signal, {
-                modelId: resolvedModelId,
-              })) {
-                writeEvent(event);
-                if (event.type === "tool-result") outcome = "skill_error";
-                if (event.type === "finish") {
-                  const reason = (event as { finishReason?: string }).finishReason;
-                  if (reason === "stop") outcome = "success";
-                }
-              }
-            } catch (err) {
-              const message = err instanceof Error ? err.message : "Chat stream failed";
-              logger.error({ userId: authCtx.userId, err: message }, "Chat stream error");
-              writeEvent({ type: "error", message });
-            } finally {
-              signal.removeEventListener("abort", onAbort);
-              clearInterval(keepAlive);
-              closeOnce();
-              await quotaService
-                .chargeOnCompletion({
-                  userId: authCtx.userId,
-                  permissions: authCtx.permissions,
-                  surface: "playground",
-                  outcome,
-                })
-                .catch((err) => {
-                  logger.warn(
-                    { userId: authCtx.userId, err: (err as Error).message },
-                    "Quota charge after playground chat failed",
-                  );
-                });
-            }
-          })();
-        },
-      });
-
-      return new Response(body, {
+      return new Response(readable, {
         status: 200,
         headers: {
           "Content-Type": "text/event-stream; charset=utf-8",
           "Cache-Control": "no-cache, no-transform",
           Connection: "keep-alive",
-          // Tell intermediate proxies (nginx, NyxID) NOT to buffer.
           "X-Accel-Buffering": "no",
         },
       });

--- a/ornn-web/src/components/playground/ChatInput.tsx
+++ b/ornn-web/src/components/playground/ChatInput.tsx
@@ -84,49 +84,55 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
   const canSend = value.trim().length > 0 && !disabled;
 
   return (
-    <div className="px-2 pb-2 pt-2">
-      {/* Input row — model selection lives in the page header (ModelPicker). */}
-      <div className="flex items-end gap-2">
-        <div className="relative flex-1">
-          <textarea
-            ref={textareaRef}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            disabled={disabled}
-            placeholder={
-              customPlaceholder
-                ?? (disabled
-                  ? isStreaming
-                    ? t("chatInput.generating")
-                    : t("chatInput.awaitingTool")
-                  : t("chatInput.placeholder"))
-            }
-            rows={1}
-            className="neon-input w-full resize-none rounded px-4 py-3 pr-12 font-text text-sm text-strong placeholder:text-meta/50 disabled:opacity-50"
-            style={{ maxHeight: `${MAX_HEIGHT_PX}px` }}
-            aria-label="Chat message input"
-          />
-        </div>
+    <div className="px-1 pb-2 pt-2">
+      {/* ChatGPT-style composer — single rounded surface, send button
+          docked inside on the right. Ember focus ring marks the active
+          state without competing with the conversation above. */}
+      <div
+        className={`relative flex items-end gap-2 rounded-2xl border bg-card px-3 py-2 transition-colors ${
+          disabled
+            ? "border-subtle/60"
+            : "border-subtle focus-within:border-accent/60 focus-within:ring-1 focus-within:ring-accent/30"
+        }`}
+      >
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          placeholder={
+            customPlaceholder
+              ?? (disabled
+                ? isStreaming
+                  ? t("chatInput.generating")
+                  : t("chatInput.awaitingTool")
+                : t("chatInput.placeholder"))
+          }
+          rows={1}
+          className="flex-1 resize-none bg-transparent px-1.5 py-1.5 font-text text-[15px] leading-6 text-strong placeholder:text-meta/60 focus:outline-none disabled:opacity-50"
+          style={{ maxHeight: `${MAX_HEIGHT_PX}px` }}
+          aria-label="Chat message input"
+        />
 
         {isStreaming ? (
           <button
             type="button"
             onClick={onAbort}
-            className="cta-letterpress cta-letterpress--ghost cursor-pointer rounded-sm border border-danger/50 bg-card px-4 py-3 font-text text-sm font-semibold text-danger hover:border-danger"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-danger/50 bg-card text-danger transition-colors hover:border-danger"
             aria-label={t("chatInput.stopGeneration")}
           >
-            <StopIcon className="h-5 w-5" />
+            <StopIcon className="h-4 w-4" />
           </button>
         ) : (
           <button
             type="button"
             onClick={handleSend}
             disabled={!canSend}
-            className={`cta-letterpress cta-letterpress--ghost cursor-pointer rounded-sm border bg-card px-4 py-3 font-text text-sm font-semibold ${
+            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors ${
               canSend
-                ? "border-accent/50 text-accent hover:border-accent"
-                : "border-meta/20 text-meta/40 cursor-not-allowed"
+                ? "bg-accent text-page hover:bg-accent/90"
+                : "cursor-not-allowed bg-elevated text-meta/40"
             }`}
             aria-label={t("chatInput.sendMessage")}
           >

--- a/ornn-web/src/components/playground/ChatMessage.tsx
+++ b/ornn-web/src/components/playground/ChatMessage.tsx
@@ -70,8 +70,12 @@ function UserMessage({ content }: { content: string }) {
       transition={{ duration: 0.15, ease: "easeOut" }}
       className="flex justify-end"
     >
-      <div className="max-w-[80%] rounded rounded-br-sm border border-accent/30 bg-accent/5 px-4 py-3">
-        <p className="whitespace-pre-wrap font-text text-sm text-strong">
+      {/* User turn — ember-tinted bubble per Forge palette.
+          Background is the warm-soft accent fill; border picks up the
+          ember at low opacity so the bubble reads as warm "speaker"
+          contrasted against the assistant's cool card. */}
+      <div className="max-w-[80%] rounded-2xl border border-accent/30 bg-warning-soft px-4 py-2.5">
+        <p className="whitespace-pre-wrap font-text text-[15px] leading-7 text-strong">
           {content}
         </p>
       </div>
@@ -98,10 +102,13 @@ function AssistantMessage({
       transition={{ duration: 0.15, ease: "easeOut" }}
       className="flex justify-start"
     >
-      <div className="max-w-[85%] space-y-3">
+      <div className="max-w-[88%] space-y-3">
         {content && (
-          <div className="bg-card rounded rounded-bl-sm px-4 py-3">
-            <div className="markdown-body text-sm">
+          /* Soft bubble — distinct from the user's tinted bubble but
+             quieter (subtle border + card bg), so the assistant turn
+             reads as a "speaker" without competing for attention. */
+          <div className="rounded-2xl border border-subtle bg-card px-4 py-3">
+            <div className="markdown-body text-[15px] leading-7">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeSanitize, rehypeHighlight]}
@@ -109,7 +116,7 @@ function AssistantMessage({
                 {content}
               </ReactMarkdown>
               {isStreaming && (
-                <span className="inline-block h-4 w-1.5 animate-blink bg-accent/80" />
+                <span className="ml-0.5 inline-block h-[18px] w-[2px] -mb-1 animate-blink bg-accent/80 align-text-bottom" />
               )}
             </div>
           </div>

--- a/ornn-web/src/hooks/usePlaygroundChat.ts
+++ b/ornn-web/src/hooks/usePlaygroundChat.ts
@@ -1,6 +1,20 @@
 /**
  * Hook managing the playground chat send -> stream -> display loop.
- * Dispatches SSE events to the Zustand store with token batching.
+ *
+ * Streaming model:
+ *   - SSE events arrive from the backend at upstream-LLM rate (typically
+ *     2-4 chars per token, ~20 ms between tokens).
+ *   - Incoming text is appended to a `pendingTokensRef` buffer.
+ *   - A pacer (`paceTimerRef`) drains the buffer one character at a time
+ *     onto the displayed assistant message at a fixed cadence
+ *     (`PACE_TICK_MS`). This is the "true" character-by-character
+ *     typewriter — display speed decoupled from network speed.
+ *   - When the LLM races ahead and the pending buffer grows large, the
+ *     pacer takes >1 char per tick so the visible text catches up
+ *     instead of typing out 30s after the response actually finished.
+ *   - On `finish` / `tool-call` / `error` / `abort` we drain whatever's
+ *     left immediately (paced typewriter is a UX nicety, not a contract).
+ *
  * @module hooks/usePlaygroundChat
  */
 
@@ -11,14 +25,23 @@ import type { PlaygroundChatEvent, FileOutput } from "@/types/playground";
 import { track } from "@/lib/analytics";
 
 /**
- * Token flush mode.
- *
- * Was previously 50ms batching to avoid re-render storms, but that
- * coalesced ~3 tokens per render at typical LLM speeds — visibly chunky.
- * Set to 0 for true per-token rendering. Re-enable batching here if a
- * faster LLM (>200 tok/sec) ever overwhelms React's reconciler.
+ * Pacer tick interval. 22 ms ≈ 45 chars/sec when the buffer is small,
+ * which reads as deliberate typewriter without feeling slow. Combined
+ * with the catch-up logic below the perceived rate scales smoothly.
  */
-const TOKEN_FLUSH_INTERVAL_MS = 0;
+const PACE_TICK_MS = 22;
+/**
+ * Backlog thresholds for adaptive draining. We aim to keep the visible
+ * text within ~1 second of what's actually been received.
+ *   - <  60 chars buffered:  1 char/tick → ~45 chars/sec (calm)
+ *   - <  200 chars buffered: 3 chars/tick → ~135 chars/sec
+ *   - >= 200 chars buffered: ceil(buffer / 60) chars/tick → catch up
+ */
+function charsPerTick(bufferLength: number): number {
+  if (bufferLength < 60) return 1;
+  if (bufferLength < 200) return 3;
+  return Math.ceil(bufferLength / 60);
+}
 
 /** Trigger a browser file download from a base64-encoded FileOutput. */
 function triggerFileDownload(file: FileOutput) {
@@ -41,21 +64,49 @@ function triggerFileDownload(file: FileOutput) {
 export function usePlaygroundChat() {
   const store = usePlaygroundStore();
   const streamRef = useRef<StreamHandle | null>(null);
-  const tokenBufferRef = useRef("");
-  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const flushTokenBuffer = useCallback(() => {
-    flushTimerRef.current = null;
-    const buffered = tokenBufferRef.current;
-    if (!buffered) return;
-    tokenBufferRef.current = "";
-    usePlaygroundStore.getState().appendAssistantDelta(buffered);
+  // Pacer state — chars received from SSE that haven't been painted yet.
+  const pendingTokensRef = useRef("");
+  const paceTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  /** Pop one tick's worth of chars from the buffer and append. Spread
+   *  via `Array.from` so a 4-byte emoji counts as one character (the
+   *  buffer is a JS string; iterating by code units would split it). */
+  const drainOneTick = useCallback(() => {
+    const buf = pendingTokensRef.current;
+    if (!buf) {
+      // Buffer empty — pause the pacer until more text arrives.
+      if (paceTimerRef.current !== null) {
+        clearInterval(paceTimerRef.current);
+        paceTimerRef.current = null;
+      }
+      return;
+    }
+    const chars = Array.from(buf);
+    const take = Math.min(charsPerTick(chars.length), chars.length);
+    const head = chars.slice(0, take).join("");
+    const tail = chars.slice(take).join("");
+    pendingTokensRef.current = tail;
+    usePlaygroundStore.getState().appendAssistantDelta(head);
   }, []);
 
-  const cancelFlush = useCallback(() => {
-    if (flushTimerRef.current !== null) {
-      clearTimeout(flushTimerRef.current);
-      flushTimerRef.current = null;
+  const ensurePacer = useCallback(() => {
+    if (paceTimerRef.current !== null) return;
+    paceTimerRef.current = setInterval(drainOneTick, PACE_TICK_MS);
+  }, [drainOneTick]);
+
+  /** Drain everything to the display immediately. Used on terminal
+   *  events (finish / error / abort / tool-call) so the typewriter
+   *  doesn't keep ticking past the run. */
+  const drainAll = useCallback(() => {
+    if (paceTimerRef.current !== null) {
+      clearInterval(paceTimerRef.current);
+      paceTimerRef.current = null;
+    }
+    const buf = pendingTokensRef.current;
+    if (buf) {
+      pendingTokensRef.current = "";
+      usePlaygroundStore.getState().appendAssistantDelta(buf);
     }
   }, []);
 
@@ -65,40 +116,19 @@ export function usePlaygroundChat() {
 
       switch (event.type) {
         case "text-delta":
-          // Per-token render — synchronous append for typewriter feel.
-          // If `TOKEN_FLUSH_INTERVAL_MS` ever goes back > 0 we re-enable
-          // the buffer + timer below; for now the buffer path is just
-          // a fallback for tools that flush mid-message.
-          if (TOKEN_FLUSH_INTERVAL_MS === 0) {
-            s.appendAssistantDelta(event.delta);
-          } else {
-            tokenBufferRef.current += event.delta;
-            if (flushTimerRef.current === null) {
-              flushTimerRef.current = setTimeout(
-                flushTokenBuffer,
-                TOKEN_FLUSH_INTERVAL_MS,
-              );
-            }
-          }
+          // Stuff into the pacer buffer; the interval drains it.
+          pendingTokensRef.current += event.delta;
+          ensurePacer();
           break;
 
         case "tool-call":
-          // Flush pending tokens before handling tool call
-          cancelFlush();
-          if (tokenBufferRef.current) {
-            s.appendAssistantDelta(tokenBufferRef.current);
-            tokenBufferRef.current = "";
-          }
+          drainAll();
           s.finalizeAssistantMessage();
           s.addToolCall(event.toolCall);
           break;
 
         case "tool-result":
-          cancelFlush();
-          if (tokenBufferRef.current) {
-            s.appendAssistantDelta(tokenBufferRef.current);
-            tokenBufferRef.current = "";
-          }
+          drainAll();
           s.addToolResult(event.toolCallId, event.result);
           break;
 
@@ -108,22 +138,14 @@ export function usePlaygroundChat() {
           break;
 
         case "error":
-          cancelFlush();
-          if (tokenBufferRef.current) {
-            s.appendAssistantDelta(tokenBufferRef.current);
-            tokenBufferRef.current = "";
-          }
+          drainAll();
           s.setError(event.message);
           s.setStreaming(false);
           track("playground.run.failed", { error: event.message });
           break;
 
         case "finish":
-          cancelFlush();
-          if (tokenBufferRef.current) {
-            s.appendAssistantDelta(tokenBufferRef.current);
-            tokenBufferRef.current = "";
-          }
+          drainAll();
           s.finalizeAssistantMessage();
           s.setStreaming(false);
           track("playground.run.completed", {
@@ -132,7 +154,7 @@ export function usePlaygroundChat() {
           break;
       }
     },
-    [flushTokenBuffer, cancelFlush],
+    [drainAll, ensurePacer],
   );
 
   const sendMessage = useCallback(
@@ -143,8 +165,11 @@ export function usePlaygroundChat() {
       modelId?: string,
     ) => {
       streamRef.current?.abort();
-      tokenBufferRef.current = "";
-      cancelFlush();
+      pendingTokensRef.current = "";
+      if (paceTimerRef.current !== null) {
+        clearInterval(paceTimerRef.current);
+        paceTimerRef.current = null;
+      }
 
       const s = usePlaygroundStore.getState();
       s.addUserMessage(content);
@@ -152,9 +177,6 @@ export function usePlaygroundChat() {
       s.setError(null);
       s.startAssistantMessage();
 
-      // playground.run fires on every send. Pair with run.completed /
-      // run.failed events emitted from the SSE finish/error handlers
-      // for funnel analysis (sends → completes → fails).
       track("playground.run", {
         skillId: skillId ?? null,
         promptLength: content.length,
@@ -167,42 +189,35 @@ export function usePlaygroundChat() {
       const handle = streamChat({ messages: mapped, skillId, envVars, modelId }, handleEvent);
       streamRef.current = handle;
     },
-    [handleEvent, cancelFlush],
+    [handleEvent],
   );
 
   const abort = useCallback(() => {
     streamRef.current?.abort();
     streamRef.current = null;
-    cancelFlush();
-
-    // Flush remaining buffered tokens
-    if (tokenBufferRef.current) {
-      usePlaygroundStore
-        .getState()
-        .appendAssistantDelta(tokenBufferRef.current);
-      tokenBufferRef.current = "";
-    }
-
+    drainAll();
     const s = usePlaygroundStore.getState();
     s.finalizeAssistantMessage();
     s.setStreaming(false);
-  }, [cancelFlush]);
+  }, [drainAll]);
 
   const clearChat = useCallback(() => {
     streamRef.current?.abort();
     streamRef.current = null;
-    cancelFlush();
-    tokenBufferRef.current = "";
+    if (paceTimerRef.current !== null) {
+      clearInterval(paceTimerRef.current);
+      paceTimerRef.current = null;
+    }
+    pendingTokensRef.current = "";
     usePlaygroundStore.getState().clearMessages();
-  }, [cancelFlush]);
+  }, []);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       streamRef.current?.abort();
-      cancelFlush();
+      if (paceTimerRef.current !== null) clearInterval(paceTimerRef.current);
     };
-  }, [cancelFlush]);
+  }, []);
 
   return {
     messages: store.messages,

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -327,78 +327,65 @@ export function PlaygroundPage() {
   return (
     <PageTransition>
       <div className="relative flex h-full flex-col">
-        {/* ─── Lightweight surface strip — model picker + quota only ─── */}
-        <header className="shrink-0 px-4 pt-1">
-          <div className="mx-auto flex max-w-3xl items-center justify-end gap-3">
-            <QuotaInline surface="playground" />
-            <ModelPicker surface="playground" onChange={setPickedModelId} />
-          </div>
-        </header>
+        {/* Quota chip is already surfaced by the app shell; the model
+            picker has moved down to sit just above the composer (same
+            place ChatGPT puts it). No surface header needed. */}
 
         {/* ─── Chat (page hero) ─── */}
         <section className="flex min-h-0 flex-1 flex-col">
-          <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col px-4 py-2">
-            {/* Inline status row above the messages — no header band. */}
-            <div className="mb-2 flex shrink-0 items-center justify-between">
-              <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+          <div className="mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col px-4 pb-6 pt-1">
+            {/* Slim utility row — only when a conversation is active.
+                A pulsing ember dot shows streaming; clear-chat sits as a
+                small ghost link on the right. No "Idle/Ready" status
+                noise to compete with the conversation itself. */}
+            {conversationActive && (
+              <div className="mb-1 flex shrink-0 items-center justify-between py-1">
                 <span
                   aria-hidden
                   className={`inline-block h-1.5 w-1.5 rounded-full ${
-                    isStreaming ? "animate-pulse bg-accent" : "bg-meta/40"
+                    isStreaming ? "animate-pulse bg-accent" : "bg-transparent"
                   }`}
                 />
-                <span className="text-strong">{skillName}</span>
-                <span aria-hidden className="h-px w-3 bg-accent/40" />
-                <span>
-                  {isStreaming
-                    ? t("playground.statusStreaming", "Streaming")
-                    : messages.length === 0
-                      ? t("playground.statusIdle", "Idle")
-                      : t("playground.statusReady", "Ready")}
-                </span>
+                <button
+                  type="button"
+                  onClick={clearChat}
+                  className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta transition-colors hover:text-accent"
+                >
+                  {t("playground.clearChat")}
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={clearChat}
-                disabled={messages.length === 0}
-                className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta transition-colors hover:text-accent disabled:cursor-not-allowed disabled:opacity-30"
-              >
-                {t("playground.clearChat")}
-              </button>
-            </div>
+            )}
 
             {/* Messages scroll area */}
             <div ref={messagesScrollRef} className="min-h-0 flex-1 overflow-y-auto pr-1">
               {!conversationActive ? (
-                /* ─── Empty-state hero ─── */
-                <div className="space-y-5 py-6">
-                  <div className="space-y-2">
-                    <span className="font-mono text-[10px] uppercase tracking-[0.20em] text-accent">
-                      [§&nbsp;READY]
-                    </span>
-                    <h2 className="font-display text-2xl font-semibold leading-tight tracking-tight text-strong">
-                      {t("playground.heroTitle", "Probe the skill.")}
-                    </h2>
-                    <p className="font-text text-sm leading-relaxed text-body">
-                      {envIncomplete
-                        ? t(
-                            "playground.heroEnvFirst",
-                            "Set the runtime env vars in the Env drawer on the right, then start chatting.",
-                          )
-                        : t(
-                            "playground.heroSubtitle",
-                            "Ask anything about {{name}}, or have it run with sample input. Pick a starter below or write your own.",
-                            { name: skillName },
-                          )}
-                    </p>
-                  </div>
-
-                  <WeldedSeam />
-
-                  <div>
-                    <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
-                      {t("playground.starters", "Quick starters")}
+                /* ─── Empty-state hero ─── ChatGPT-style centered prompt
+                    flag with skill identity, single-line lede, and three
+                    starters as soft chips below. Vertical-centered so
+                    the cursor lands ~middle of the screen at rest. */
+                <div className="flex h-full flex-col items-center justify-center py-8">
+                  <div className="w-full space-y-6 text-center">
+                    <div className="space-y-2">
+                      <div className="font-mono text-[10px] uppercase tracking-[0.20em] text-meta">
+                        {skillName}
+                      </div>
+                      <h2 className="font-display text-3xl font-semibold leading-[1.15] tracking-tight text-strong">
+                        {t("playground.heroTitle", "Probe the skill.")}
+                      </h2>
+                      <p className="font-text text-[15px] leading-relaxed text-body">
+                        {envIncomplete
+                          ? t(
+                              "playground.heroEnvFirst",
+                              "Set the runtime env vars in the Env drawer on the right, then start chatting.",
+                            )
+                          : t(
+                              "playground.heroSubtitle",
+                              "Ask anything about {{name}}, or have it run with sample input.",
+                              { name: skillName },
+                            )}
+                      </p>
                     </div>
+
                     <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
                       {starters.map((s) => (
                         <button
@@ -406,29 +393,25 @@ export function PlaygroundPage() {
                           type="button"
                           onClick={() => handleStarterClick(s.body)}
                           disabled={envIncomplete}
-                          className="group flex flex-col items-start gap-1.5 rounded-sm border border-subtle bg-page/40 px-3 py-2.5 text-left transition-all hover:border-accent/60 hover:bg-card disabled:cursor-not-allowed disabled:opacity-40"
+                          className="group flex flex-col items-start gap-1 rounded-xl border border-subtle bg-card/60 px-3.5 py-3 text-left transition-all hover:border-accent/60 hover:bg-card disabled:cursor-not-allowed disabled:opacity-40"
                         >
                           <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent">
                             {s.label}
                           </span>
-                          <span className="line-clamp-2 font-text text-xs leading-snug text-body">
+                          <span className="line-clamp-2 font-text text-[13px] leading-snug text-body">
                             {s.body}
                           </span>
                         </button>
                       ))}
                     </div>
+
+                    <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta/70">
+                      {t(
+                        "playground.drawerHint",
+                        "Skill · Env · Package on the right edge",
+                      )}
+                    </p>
                   </div>
-
-                  <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
-                    {t("playground.kbHint", "Enter to send · Shift + Enter for newline")}
-                  </p>
-
-                  <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta/70">
-                    {t(
-                      "playground.drawerHint",
-                      "Hover the right edge to peek skill / env / package · click a tab to pin",
-                    )}
-                  </p>
                 </div>
               ) : (
                 /* ─── Conversation ─── */
@@ -499,7 +482,15 @@ export function PlaygroundPage() {
             </div>
 
             {/* Chat input — pinned bottom */}
-            <div className="shrink-0 pt-2">
+            {/* Composer — model picker above the input, ChatGPT-style.
+                Both elements share the chat column's centerline so the
+                empty-state hero, the conversation, and the composer all
+                line up vertically without "one looks shifted". */}
+            <div className="shrink-0 pt-3">
+              <div className="mb-2 flex items-center justify-center gap-3">
+                <QuotaInline surface="playground" />
+                <ModelPicker surface="playground" onChange={setPickedModelId} />
+              </div>
               <ChatInput
                 ref={chatInputRef}
                 onSend={handleSend}
@@ -514,6 +505,9 @@ export function PlaygroundPage() {
                       : t("playground.askPlaceholder", { name: skillName })
                 }
               />
+              <p className="mt-2 text-center font-mono text-[10px] uppercase tracking-[0.14em] text-meta/70">
+                {t("playground.kbHint", "Enter to send · Shift + Enter for newline")}
+              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary

Two stacked fixes:

**Streaming actually streams now.** The previous chat route used `new ReadableStream({ start(controller) { ... controller.enqueue(...) } })` with a deferred async IIFE producer. Under Bun this pattern coalesced 2,300+ `enqueue` calls into a single delivery at stream-close — the EventStream tab in DevTools showed every text-delta arriving at the same millisecond despite the upstream LLM emitting deltas over ~45s. Switched to `TransformStream + writer.write()` so each `await writer.write(chunk)` resolves only once Bun's HTTP consumer picks the chunk up. Backpressure now forces real per-event flushing on the wire. Verified end-to-end via DevTools EventStream — events arrive at distinct timestamps as upstream emits (e.g. 14:58:28.484 → .492 → .536 → .644 in a 200ms response).

**Character-by-character typewriter in the frontend.** Decoupled display rate from network rate: incoming chars accumulate in `pendingTokensRef`; a 22ms `setInterval` drains one character per tick onto the displayed message. Adaptive — if buffer > 60 chars, 3 chars/tick; > 200 chars, `ceil(buffer/60)` chars/tick — so visible text stays within ~1s of received and never lags after a fast finish.

**Chat polish:** composer moved to `max-w-2xl` with `pb-6` breathing room, model picker + quota chip centered just above the input (top-right surface header dropped). User bubble uses Forge ember palette (`bg-warning-soft` + `border-accent/30`), contrasted with the assistant's `bg-card` bubble. Empty-state hero vertically centered, simpler. Auto-scroll only follows at-tail. Right-edge drawer fixed-positioned to viewport.

## Test plan

- [x] Backend typecheck clean
- [x] Frontend typecheck clean
- [x] Local k8s rollout — both pods healthy
- [x] DevTools EventStream tab confirms per-event timestamps spread across response duration
- [x] Visual: tokens visibly tick character-by-character
- [x] Auto-scroll respects manual scroll-up mid-stream
- [ ] CI passes