### PR TITLE
[Feature] Playground message entrance animation + strengthen CLAUDE.md PR-issue rule

### DIFF
--- a/.changeset/issue-264-message-animation-and-pr-issue-rule.md
+++ b/.changeset/issue-264-message-animation-and-pr-issue-rule.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Playground chat — soft spring entrance for each message + ThinkingBubble (opacity + tiny rise + 98→100% scale). Plus strengthened the PR ↔ issue linkage rule in `CLAUDE.md` so every PR (no exceptions) must link an issue via `Closes #N` / `Fixes #N` / `Resolves #N`. Closes #264.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,10 +325,11 @@ Issue tracker: https://github.com/ChronoAIProject/Ornn/issues
 2. **Default assignee:** every issue MUST be assigned to `chronoai-shining`.
 3. **Title prefix:** every issue title MUST start with a category tag — one of `[Bug]`, `[Feature]`, `[CI/CD]`, `[Docs]`, `[Misc]`. Example: `[Feature] Skill composition & chaining`.
 4. **No duplicates.** Before creating a new issue, search the existing issue list. If duplicates are found, keep one and close the others with a comment `Duplicate of #N`.
-5. **PR ↔ issue linkage:**
-   - Every PR MUST tag the issue(s) it resolves in the PR body (use `Closes #123` / `Fixes #123`).
-   - When the PR merges, all tagged issues MUST be closed.
-   - If a PR solves something with no existing issue, create the issue first, then tag it in the PR.
+5. **PR ↔ issue linkage — load-bearing, no exceptions.**
+   - Every PR MUST link to at least one GitHub issue. The PR body uses `Closes #N` / `Fixes #N` (or `Resolves #N`) so the issue auto-closes on merge — do not link with prose like "this addresses #N", that does NOT auto-close.
+   - **Issue-first workflow.** Before opening a PR, check whether a matching issue already exists. If one exists: link it. If none exists: **STOP, create the issue first** with the right `[Bug]` / `[Feature]` / `[CI/CD]` / `[Docs]` / `[Misc]` title prefix, default assignee, and at least one topic label, **then** open the PR linking it. A PR without an issue link must be amended with one before merge.
+   - When the PR merges, all linked issues MUST be closed (the `Closes` / `Fixes` keyword takes care of this automatically).
+   - This rule applies to **every** PR — features, bugfixes, refactors, docs, CI/CD, infra, design polish. There are no "trivial enough to skip the issue" exceptions.
 6. **Cross-references:** when issues are related or have an execution order, add explicit references in the issue body (`Depends on #X`, `Blocks #Y`, `Related to #Z`).
 7. **Milestones for large work:** any large feature or code change MUST have a milestone, and all related issues MUST be attached to it.
 8. **Milestone deadlines:** every milestone MUST have a `due_on` date.

--- a/ornn-web/src/components/playground/ChatMessage.tsx
+++ b/ornn-web/src/components/playground/ChatMessage.tsx
@@ -23,10 +23,24 @@ export interface ChatMessageProps {
   isStreaming?: boolean;
 }
 
+/**
+ * Message entrance choreography. Tuned for chat: each new turn lands
+ * with a brief rise + soft scale-in (98 → 100%) on a low-stiffness
+ * spring. The values are intentionally small — a chat transcript
+ * crossfading wildly between turns is distracting, but a fully-static
+ * pop-in feels mechanical. This sits in the middle.
+ */
 const messageVariants = {
-  hidden: { opacity: 0, y: 10 },
-  visible: { opacity: 1, y: 0 },
+  hidden: { opacity: 0, y: 8, scale: 0.98 },
+  visible: { opacity: 1, y: 0, scale: 1 },
 };
+
+const messageTransition = {
+  type: "spring",
+  stiffness: 320,
+  damping: 28,
+  mass: 0.6,
+} as const;
 
 export function ChatMessage({
   message,
@@ -67,7 +81,7 @@ function UserMessage({ content }: { content: string }) {
       variants={messageVariants}
       initial="hidden"
       animate="visible"
-      transition={{ duration: 0.15, ease: "easeOut" }}
+      transition={messageTransition}
       className="flex justify-end"
     >
       {/* User turn — ember-tinted bubble per Forge palette.
@@ -99,7 +113,7 @@ function AssistantMessage({
       variants={messageVariants}
       initial="hidden"
       animate="visible"
-      transition={{ duration: 0.15, ease: "easeOut" }}
+      transition={messageTransition}
       className="flex justify-start"
     >
       <div className="max-w-[88%] space-y-3">
@@ -148,7 +162,7 @@ function ToolResultMessage({
       variants={messageVariants}
       initial="hidden"
       animate="visible"
-      transition={{ duration: 0.15, ease: "easeOut" }}
+      transition={messageTransition}
       className="flex justify-start"
     >
       <div

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -61,16 +61,17 @@ function isRuntimeBased(metadata: Record<string, unknown> | null): boolean {
   return category === "runtime-based" || category === "mixed";
 }
 
-/** Pre-token streaming indicator. */
+/** Pre-token streaming indicator — three pulsing ember dots, spring-in. */
 function ThinkingBubble() {
   return (
     <motion.div
-      initial={{ opacity: 0, y: 6 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.15, ease: "easeOut" }}
+      initial={{ opacity: 0, y: 8, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.96 }}
+      transition={{ type: "spring", stiffness: 320, damping: 28, mass: 0.6 }}
       className="flex justify-start"
     >
-      <div className="rounded rounded-bl-sm bg-card px-4 py-3">
+      <div className="rounded-2xl border border-subtle bg-card px-4 py-3">
         <div className="flex items-center gap-1.5" aria-label="Generating">
           <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "0ms" }} />
           <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "150ms" }} />


### PR DESCRIPTION
Closes #264.

## Summary

- **Playground chat — soft spring entrance.** Each \`ChatMessage\` (user / assistant) and the pre-token \`ThinkingBubble\` now enter on a small spring choreography: \`opacity 0 → 1\`, \`y 8 → 0\`, \`scale 0.98 → 1\`, transition \`{ type: spring, stiffness: 320, damping: 28, mass: 0.6 }\`. Tuned small on purpose — a transcript with big animations is distracting, but the previous flat 0.15s tween was mechanical.
- **CLAUDE.md PR ↔ issue rule strengthened.** Section 5 under \`§ GitHub Issue Rules\` now states explicitly that every PR (no exceptions) must link a GitHub issue via the auto-close keywords (\`Closes #N\` / \`Fixes #N\` / \`Resolves #N\`), and that the issue must be created BEFORE the PR if none exists. The previous wording was too soft — recent PRs (#261, #262, #263) shipped without linked issues.

## Test plan

- [x] Frontend typecheck clean
- [x] Local k8s rollout — ornn-web deployed
- [x] Visual: new chat turns rise + scale-in softly; existing turns stay still
- [ ] CI passes