### PR TITLE
[Feature] Generative skill page — match Playground UI/UX language

### DIFF
--- a/.changeset/issue-266-generative-page-playground-design.md
+++ b/.changeset/issue-266-generative-page-playground-design.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Generative skill creation page now uses the same UI/UX language as the Playground: chat is the page hero (centered `max-w-2xl`), composer pinned at the bottom of the chat column with the model picker + quota chip centered above, ember-tinted user bubble + cool assistant bubble (15px / leading-7), spring entrance choreography on each turn, smart auto-scroll that respects manual scroll-up, and a right-edge slide-in drawer hosting the package preview + Save / Start-over actions. The drawer is **pinned-open by default** here because the package preview IS the work product (not auxiliary context like in the Playground). Closes #266.

--- a/ornn-web/src/components/skill/GenerationChatMessage.tsx
+++ b/ornn-web/src/components/skill/GenerationChatMessage.tsx
@@ -1,6 +1,14 @@
 /**
  * Chat Message Component for Generative Mode.
- * Renders user/assistant message bubbles with streaming and completion states.
+ *
+ * Visual language matches `components/playground/ChatMessage` so the two
+ * LLM surfaces feel like one product:
+ *   - User bubble:   ember-tinted (`bg-warning-soft` + `border-accent/30`).
+ *   - Assistant bubble: cool (`bg-card` + `border-subtle`).
+ *   - Both: `rounded-2xl`, 15px / leading-7.
+ *   - Spring entrance: opacity + tiny rise + 98→100% scale, low-stiffness
+ *     spring so each new turn lands softly without distracting.
+ *
  * @module components/skill/GenerationChatMessage
  */
 
@@ -12,9 +20,16 @@ export interface GenerationChatMessageProps {
 }
 
 const messageVariants = {
-  hidden: { opacity: 0, y: 10 },
-  visible: { opacity: 1, y: 0 },
+  hidden: { opacity: 0, y: 8, scale: 0.98 },
+  visible: { opacity: 1, y: 0, scale: 1 },
 };
+
+const messageTransition = {
+  type: "spring",
+  stiffness: 320,
+  damping: 28,
+  mass: 0.6,
+} as const;
 
 export function GenerationChatMessage({ message }: GenerationChatMessageProps) {
   if (message.role === "user") {
@@ -44,11 +59,11 @@ function UserBubble({ content }: { content: string }) {
       variants={messageVariants}
       initial="hidden"
       animate="visible"
-      transition={{ duration: 0.15, ease: "easeOut" }}
+      transition={messageTransition}
       className="flex justify-end"
     >
-      <div className="max-w-[80%] rounded rounded-br-sm border border-accent/30 bg-accent/5 px-4 py-3">
-        <p className="whitespace-pre-wrap font-text text-sm text-strong">
+      <div className="max-w-[80%] rounded-2xl border border-accent/30 bg-warning-soft px-4 py-2.5">
+        <p className="whitespace-pre-wrap font-text text-[15px] leading-7 text-strong">
           {content}
         </p>
       </div>
@@ -62,19 +77,23 @@ function StreamingBubble({ content }: { content: string }) {
       variants={messageVariants}
       initial="hidden"
       animate="visible"
-      transition={{ duration: 0.15, ease: "easeOut" }}
+      transition={messageTransition}
       className="flex justify-start"
     >
-      <div className="bg-card max-w-[85%] rounded rounded-bl-sm px-4 py-3">
+      <div className="max-w-[88%] rounded-2xl border border-subtle bg-card px-4 py-3">
         {content ? (
-          <pre className="whitespace-pre-wrap font-mono text-xs text-strong/80">
+          /* Structured generation output (JSON + file contents) — keep
+             monospace + smaller font so multi-file streams remain
+             scannable; the generative artifact isn't free prose. */
+          <pre className="whitespace-pre-wrap font-mono text-xs leading-6 text-strong/85">
             {content}
-            <span className="inline-block h-4 w-1.5 animate-blink bg-accent/80" />
+            <span className="ml-0.5 inline-block h-[14px] w-[2px] -mb-0.5 animate-blink bg-accent/80 align-text-bottom" />
           </pre>
         ) : (
           <div className="flex items-center gap-2">
-            <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-warning border-t-transparent" />
-            <span className="font-text text-xs text-meta">Generating...</span>
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "0ms" }} />
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "150ms" }} />
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "300ms" }} />
           </div>
         )}
       </div>
@@ -96,21 +115,24 @@ function CompleteBubble({
       variants={messageVariants}
       initial="hidden"
       animate="visible"
-      transition={{ duration: 0.15, ease: "easeOut" }}
+      transition={messageTransition}
       className="flex justify-start"
     >
-      <div className="bg-card max-w-[85%] rounded rounded-bl-sm px-4 py-3">
+      <div className="max-w-[88%] rounded-2xl border border-subtle bg-card px-4 py-3">
         {skillName ? (
           <div className="space-y-1">
-            <p className="font-text text-sm text-strong">
-              Generated: <span className="font-semibold text-success">{skillName}</span>
+            <p className="font-text text-[15px] leading-7 text-strong">
+              Generated:{" "}
+              <span className="font-semibold text-success">{skillName}</span>
             </p>
             {skillDescription && (
-              <p className="font-text text-xs text-meta">{skillDescription}</p>
+              <p className="font-text text-[13px] leading-6 text-meta">
+                {skillDescription}
+              </p>
             )}
           </div>
         ) : (
-          <p className="whitespace-pre-wrap font-text text-sm text-strong">
+          <p className="whitespace-pre-wrap font-text text-[15px] leading-7 text-strong">
             {content}
           </p>
         )}
@@ -125,11 +147,13 @@ function ErrorBubble({ content }: { content: string }) {
       variants={messageVariants}
       initial="hidden"
       animate="visible"
-      transition={{ duration: 0.15, ease: "easeOut" }}
+      transition={messageTransition}
       className="flex justify-start"
     >
-      <div className="max-w-[85%] rounded rounded-bl-sm border border-danger/30 bg-danger/5 px-4 py-3">
-        <p className="font-text text-sm text-danger">{content.replace(/^Error:\s*/, "")}</p>
+      <div className="max-w-[88%] rounded-2xl border border-danger/30 bg-danger/5 px-4 py-3">
+        <p className="font-text text-[15px] leading-7 text-danger">
+          {content.replace(/^Error:\s*/, "")}
+        </p>
       </div>
     </motion.div>
   );

--- a/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
@@ -1,15 +1,29 @@
 /**
  * Create Skill Generative Page.
- * Two-column layout: multi-turn chat (left) + LLM config & package preview (right).
+ *
+ * UI/UX language matches the Playground: chat is the page hero (single
+ * centered column at `max-w-2xl`), composer pinned to the bottom of the
+ * chat column with the model picker + quota chip centered above, and a
+ * right-edge slide-in drawer for the work-product (the generated skill
+ * package preview + Save action).
+ *
+ * Different from Playground:
+ *   - The drawer is **pinned open by default** because the package
+ *     preview IS the artifact being built — not auxiliary context.
+ *   - Drawer hosts the Save / Start over actions inline with the
+ *     preview.
+ *   - Streaming output stays in monospace (the generative artifact is
+ *     structured JSON + file contents, not free prose).
+ *
  * @module pages/CreateSkillGenerativePage
  */
 
 import { useRef, useEffect, useMemo, useState, useCallback } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { motion } from "framer-motion";
+import { useNavigate } from "react-router-dom";
+import { motion, AnimatePresence } from "framer-motion";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { Button } from "@/components/ui/Button";
-import { ChatInput } from "@/components/playground/ChatInput";
+import { ChatInput, type ChatInputHandle } from "@/components/playground/ChatInput";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { ValidationErrorPanel } from "@/components/skill/ValidationErrorPanel";
 import { GenerationChatMessage } from "@/components/skill/GenerationChatMessage";
@@ -29,27 +43,48 @@ import {
   type FrontmatterValidationError,
 } from "@/utils/skillFrontmatterSchema";
 
-/** Arrow left icon */
-function ArrowLeftIcon({ className }: { className?: string }) {
+/** Welded-seam horizontal divider with a rivet dot in the middle. */
+function WeldedSeam({ className = "" }: { className?: string }) {
   return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-    </svg>
+    <div className={`flex items-center gap-2 ${className}`} aria-hidden>
+      <span className="h-px flex-1 bg-strong-edge/40" />
+      <span className="h-1 w-1 rounded-full bg-accent/40" />
+      <span className="h-px flex-1 bg-strong-edge/40" />
+    </div>
   );
 }
 
-/** Sparkle/AI icon */
-function SparkleIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-        d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
-      />
-    </svg>
-  );
+interface PromptStarter {
+  label: string;
+  body: string;
+}
+
+type TFunc = ReturnType<typeof import("react-i18next").useTranslation>["t"];
+
+function defaultPromptStarters(t: TFunc): PromptStarter[] {
+  return [
+    {
+      label: t("generative.starter1Label", "Slack notifier"),
+      body: t(
+        "generative.starter1Body",
+        "Build a skill that posts a formatted message to a Slack channel via webhook. Take channel + message as inputs.",
+      ),
+    },
+    {
+      label: t("generative.starter2Label", "Fetch GitHub PRs"),
+      body: t(
+        "generative.starter2Body",
+        "Build a skill that lists open pull requests for a given GitHub repo, sorted by latest activity.",
+      ),
+    },
+    {
+      label: t("generative.starter3Label", "CSV → JSON"),
+      body: t(
+        "generative.starter3Body",
+        "Build a skill that reads a CSV file and outputs a JSON array, inferring types per column.",
+      ),
+    },
+  ];
 }
 
 export function CreateSkillGenerativePage() {
@@ -61,9 +96,11 @@ export function CreateSkillGenerativePage() {
   const generation = useSkillGeneration();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesScrollRef = useRef<HTMLDivElement>(null);
+  const chatInputRef = useRef<ChatInputHandle>(null);
+  const stickToBottomRef = useRef(true);
 
-  // Caller quota — drives the soft warning + over-limit gate. Admins
-  // bypass via `quota.isAdmin` inside the components.
+  // Caller quota — drives the soft warning + over-limit gate.
   const { data: quotaSnapshot } = useMyQuota();
   const skillGenSnap = quotaSnapshot?.skillGen;
   const isOverLimit =
@@ -71,8 +108,6 @@ export function CreateSkillGenerativePage() {
     !quotaSnapshot?.isAdmin &&
     skillGenSnap!.monthly.remaining + skillGenSnap!.credits.balance <= 0;
 
-  // Picked model — picker writes to localStorage, we just hold the
-  // resolved id so sendMessage can forward it.
   const [pickedModelId, setPickedModelId] = useState<string | null>(null);
 
   const handleSend = useCallback(
@@ -80,12 +115,27 @@ export function CreateSkillGenerativePage() {
     [generation, pickedModelId],
   );
 
-  // Auto-scroll to bottom on new messages
+  const handleStarterClick = useCallback((body: string) => {
+    chatInputRef.current?.setValue(body);
+  }, []);
+
+  // Smart auto-scroll — only follow when the user is at the tail.
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    const el = messagesScrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      stickToBottomRef.current = distFromBottom < 80;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+  useEffect(() => {
+    if (!stickToBottomRef.current) return;
+    messagesEndRef.current?.scrollIntoView({ behavior: "auto" });
   }, [generation.chatMessages]);
 
-  // Validate frontmatter whenever SKILL.md content changes in preview
+  // Validate frontmatter whenever SKILL.md content changes in preview.
   const skillMdContent = generation.fileContents.get("SKILL.md") ?? "";
   const validationErrors = useMemo<FrontmatterValidationError[]>(() => {
     if (!skillMdContent) return [];
@@ -100,10 +150,7 @@ export function CreateSkillGenerativePage() {
 
   const handleSave = async () => {
     if (hasFrontmatterErrors) {
-      addToast({
-        type: "error",
-        message: t("generative.fixErrors"),
-      });
+      addToast({ type: "error", message: t("generative.fixErrors") });
       return;
     }
 
@@ -113,11 +160,9 @@ export function CreateSkillGenerativePage() {
     const JSZip = (await import("jszip")).default;
     const zip = new JSZip();
     const root = metadata.name || "skill";
-
     for (const [id, content] of generation.fileContents) {
       zip.file(`${root}/${id}`, content);
     }
-
     const blob = await zip.generateAsync({ type: "blob" });
     const zipFile = new File([blob], `${metadata.name || "skill"}.zip`, {
       type: "application/zip",
@@ -125,14 +170,8 @@ export function CreateSkillGenerativePage() {
 
     try {
       const skill = await createMutation.mutateAsync({ zipFile });
-      track("skill.created", {
-        skillId: skill.guid,
-        source: "generative",
-      });
-      track("skill.published", {
-        skillId: skill.guid,
-        source: "generative",
-      });
+      track("skill.created", { skillId: skill.guid, source: "generative" });
+      track("skill.published", { skillId: skill.guid, source: "generative" });
       addToast({
         type: "success",
         message: t("generative.saveSuccess", { name: skill.name }),
@@ -145,13 +184,54 @@ export function CreateSkillGenerativePage() {
     }
   };
 
+  // ── Drawer state — same primitive as the playground, but the drawer
+  // for the generative artifact is pinned-open by default since the
+  // preview IS the work product.
+  const [hoverDrawerOpen, setHoverDrawerOpen] = useState(false);
+  const [pinnedOpen, setPinnedOpen] = useState(true);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const openHover = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    setHoverDrawerOpen(true);
+  }, []);
+  const scheduleHoverClose = useCallback(() => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = setTimeout(() => {
+      setHoverDrawerOpen(false);
+      closeTimerRef.current = null;
+    }, 220);
+  }, []);
+  const togglePin = useCallback(() => {
+    setPinnedOpen((cur) => !cur);
+    setHoverDrawerOpen(false);
+  }, []);
+
+  // Esc closes a pinned drawer.
+  useEffect(() => {
+    if (!pinnedOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPinnedOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [pinnedOpen]);
+
   const isGenerating = generation.phase === "generating";
   const hasMessages = generation.chatMessages.length > 0;
   const hasPreview = generation.metadata !== null;
+  const conversationActive = hasMessages || isGenerating;
+  const drawerOpen = pinnedOpen || hoverDrawerOpen;
+  const starters = defaultPromptStarters(t);
 
   const chatInputPlaceholder = isGenerating
     ? t("generative.placeholder")
-    : "Describe the skill you want to create... (Enter to send)";
+    : t(
+        "generative.askPlaceholder",
+        "Describe the skill you want to create…",
+      );
 
   if (isOverLimit && skillGenSnap) {
     return (
@@ -163,108 +243,269 @@ export function CreateSkillGenerativePage() {
 
   return (
     <PageTransition>
-      <div className="flex flex-col h-full">
-        {/* Header row */}
-        <div className="flex items-center justify-between py-2 shrink-0">
-          <Link
-            to="/skills/new"
-            className="flex items-center gap-2 text-meta hover:text-accent transition-colors"
-          >
-            <ArrowLeftIcon className="h-4 w-4" />
-            <span className="font-text text-sm">{t("generative.backToModes")}</span>
-          </Link>
-          <ModelPicker surface="skillGen" onChange={setPickedModelId} />
-        </div>
-
-        <div className="mb-2 shrink-0">
-          <QuotaInline surface="skillGen" />
-        </div>
-
-        {/* Main two-column layout — left chat narrower, right preview wider */}
-        <div className="flex flex-1 min-h-0 gap-4 pb-2">
-          {/* Left: Chat panel (35%) */}
-          <div className="flex w-[35%] shrink-0 flex-col min-w-0 min-h-0 rounded border border-accent/10 bg-elevated/30">
-            {/* Chat messages area — scrolls independently */}
-            <div className="flex-1 min-h-0 overflow-y-auto space-y-4 px-3 py-3">
-              {!hasMessages && (
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  className="flex flex-col items-center justify-center h-full text-center"
+      <div className="relative flex h-full flex-col">
+        {/* ─── Chat (page hero) ─── */}
+        <section className="flex min-h-0 flex-1 flex-col">
+          <div className="mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col px-4 pb-6 pt-1">
+            {/* Slim utility row — only when conversation has started */}
+            {conversationActive && (
+              <div className="mb-1 flex shrink-0 items-center justify-between py-1">
+                <span
+                  aria-hidden
+                  className={`inline-block h-1.5 w-1.5 rounded-full ${
+                    isGenerating ? "animate-pulse bg-accent" : "bg-transparent"
+                  }`}
+                />
+                <button
+                  type="button"
+                  onClick={generation.reset}
+                  disabled={!hasMessages || isGenerating}
+                  className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta transition-colors hover:text-accent disabled:cursor-not-allowed disabled:opacity-30"
                 >
-                  <SparkleIcon className="h-12 w-12 text-accent/30 mb-4" />
-                  <p className="font-text text-sm text-meta max-w-sm">
-                    {t("generative.desc")}
-                  </p>
-                  <p className="font-text text-xs text-meta/60 mt-3">
-                    {t("generative.note")}
-                  </p>
-                </motion.div>
+                  {t("generative.startOver", "Start over")}
+                </button>
+              </div>
+            )}
+
+            {/* Messages scroll area */}
+            <div ref={messagesScrollRef} className="min-h-0 flex-1 overflow-y-auto pr-1">
+              {!conversationActive ? (
+                /* ─── Empty-state hero ─── */
+                <div className="flex h-full flex-col items-center justify-center py-8">
+                  <div className="w-full space-y-6 text-center">
+                    <div className="space-y-2">
+                      <div className="font-mono text-[10px] uppercase tracking-[0.20em] text-meta">
+                        {t("generative.eyebrow", "Generative skill builder")}
+                      </div>
+                      <h2 className="font-display text-3xl font-semibold leading-[1.15] tracking-tight text-strong">
+                        {t("generative.heroTitle", "Describe a skill. Build it.")}
+                      </h2>
+                      <p className="font-text text-[15px] leading-relaxed text-body">
+                        {t(
+                          "generative.heroSubtitle",
+                          "Tell the model what the skill should do. It drafts the package; you iterate; you save.",
+                        )}
+                      </p>
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                      {starters.map((s) => (
+                        <button
+                          key={s.label}
+                          type="button"
+                          onClick={() => handleStarterClick(s.body)}
+                          className="group flex flex-col items-start gap-1 rounded-xl border border-subtle bg-card/60 px-3.5 py-3 text-left transition-all hover:border-accent/60 hover:bg-card"
+                        >
+                          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent">
+                            {s.label}
+                          </span>
+                          <span className="line-clamp-2 font-text text-[13px] leading-snug text-body">
+                            {s.body}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+
+                    <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta/70">
+                      {t(
+                        "generative.drawerHint",
+                        "Package preview + Save on the right edge",
+                      )}
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                /* ─── Conversation ─── */
+                <div className="space-y-3 py-3">
+                  {generation.chatMessages.map((msg) => (
+                    <GenerationChatMessage key={msg.id} message={msg} />
+                  ))}
+                  <div ref={messagesEndRef} />
+                </div>
               )}
-
-              {generation.chatMessages.map((msg) => (
-                <GenerationChatMessage key={msg.id} message={msg} />
-              ))}
-
-              <div ref={messagesEndRef} />
             </div>
 
-            {/* Chat input (fixed at bottom) */}
-            <div className="shrink-0 border-t border-accent/10 px-1 pb-1">
+            {/* Composer — model picker + quota above, ChatGPT-style. */}
+            <div className="shrink-0 pt-3">
+              <div className="mb-2 flex items-center justify-center gap-3">
+                <QuotaInline surface="skillGen" />
+                <ModelPicker surface="skillGen" onChange={setPickedModelId} />
+              </div>
               <ChatInput
+                ref={chatInputRef}
                 onSend={handleSend}
                 onAbort={generation.abort}
                 disabled={isGenerating}
                 isStreaming={isGenerating}
                 placeholder={chatInputPlaceholder}
               />
+              <p className="mt-2 text-center font-mono text-[10px] uppercase tracking-[0.14em] text-meta/70">
+                {t("playground.kbHint", "Enter to send · Shift + Enter for newline")}
+              </p>
             </div>
           </div>
+        </section>
 
-          {/* Right: Config + Preview panel (65%) — scrolls independently */}
-          <div className="flex-1 flex flex-col min-w-0 min-h-0">
-            {hasPreview ? (
-              <div className="flex flex-col gap-4 flex-1 min-h-0 overflow-y-auto">
-                {hasFrontmatterErrors && (
-                  <ValidationErrorPanel
-                    errors={validationErrors}
-                    title="Validation Errors"
-                  />
-                )}
-
-                <SkillPackagePreview
-                  files={generation.parsedFiles}
-                  fileContents={generation.fileContents}
-                  metadata={generation.metadata}
-                  editable
-                  onContentChange={generation.updateFileContent}
-                  onFileDelete={generation.deleteFile}
-                  authorName={user?.displayName ?? undefined}
-                />
-
-                <div className="flex items-center justify-between shrink-0 py-2">
-                  <Button variant="secondary" size="sm" onClick={generation.reset}>
-                    {t("generative.startOver")}
-                  </Button>
-                  <Button
-                    onClick={handleSave}
-                    loading={createMutation.isPending}
-                    disabled={hasFrontmatterErrors}
-                    className="border-success/50 text-success hover:border-success"
-                  >
-                    {t("generative.saveSkill")}
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <div className="flex items-center justify-center h-full">
-                <p className="font-text text-xs text-meta">
-                  {t("generative.emptyPreview")}
-                </p>
-              </div>
+        {/* ─── Right-edge rail — single tab (Package + actions) ─── */}
+        <div
+          className="fixed right-0 top-1/2 z-40 flex -translate-y-1/2 flex-col gap-1"
+          onMouseLeave={scheduleHoverClose}
+        >
+          <button
+            type="button"
+            onMouseEnter={openHover}
+            onClick={togglePin}
+            className={`group relative flex items-center gap-1.5 rounded-l-sm border-y border-l px-2.5 py-3 transition-all ${
+              drawerOpen
+                ? "border-accent/60 bg-card text-accent"
+                : "border-subtle bg-card/80 text-meta hover:border-accent/40 hover:text-strong"
+            }`}
+            aria-label="Skill package drawer"
+          >
+            <span
+              className="font-mono text-[10px] uppercase tracking-[0.18em]"
+              style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
+            >
+              {t("generative.tabPackage", "Package")}
+            </span>
+            {hasFrontmatterErrors && (
+              <span
+                className="absolute -left-1 top-2 h-1.5 w-1.5 rounded-full bg-warning"
+                aria-hidden
+              />
             )}
-          </div>
+            {pinnedOpen && (
+              <span
+                className="absolute -left-px inset-y-2 w-px bg-accent"
+                aria-hidden
+              />
+            )}
+          </button>
         </div>
+
+        {/* ─── Drawer overlay ─── */}
+        <AnimatePresence>
+          {drawerOpen && (
+            <>
+              {pinnedOpen && (
+                <motion.div
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.15 }}
+                  onClick={() => setPinnedOpen(false)}
+                  className="fixed inset-0 z-30 bg-page/30 backdrop-blur-[1px]"
+                />
+              )}
+
+              <motion.aside
+                initial={{ x: "100%" }}
+                animate={{ x: 0 }}
+                exit={{ x: "100%" }}
+                transition={{ duration: 0.18, ease: "easeOut" }}
+                onMouseEnter={openHover}
+                onMouseLeave={scheduleHoverClose}
+                className="card-impression fixed right-10 top-4 bottom-4 z-40 flex w-[520px] max-w-[calc(100vw-3rem)] flex-col rounded-md border border-subtle bg-card"
+                role="complementary"
+                aria-label="Skill package preview"
+              >
+                {/* Drawer header */}
+                <div className="flex shrink-0 items-center justify-between gap-2 border-b border-subtle bg-elevated/50 px-4 py-2">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+                      [§&nbsp;PACKAGE]
+                    </span>
+                    {pinnedOpen && (
+                      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                        {t("generative.pinned", "Pinned")}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={togglePin}
+                      className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta transition-colors hover:text-accent"
+                    >
+                      {pinnedOpen
+                        ? t("generative.unpin", "Unpin")
+                        : t("generative.pin", "Pin")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setPinnedOpen(false);
+                        setHoverDrawerOpen(false);
+                      }}
+                      aria-label="Close drawer"
+                      className="font-mono text-[12px] text-meta transition-colors hover:text-accent"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+
+                {/* Drawer body */}
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  {hasPreview ? (
+                    <div className="flex flex-col gap-4 p-4">
+                      {hasFrontmatterErrors && (
+                        <ValidationErrorPanel
+                          errors={validationErrors}
+                          title={t(
+                            "generative.validationTitle",
+                            "Validation Errors",
+                          )}
+                        />
+                      )}
+
+                      <SkillPackagePreview
+                        files={generation.parsedFiles}
+                        fileContents={generation.fileContents}
+                        metadata={generation.metadata}
+                        editable
+                        onContentChange={generation.updateFileContent}
+                        onFileDelete={generation.deleteFile}
+                        authorName={user?.displayName ?? undefined}
+                      />
+
+                      <WeldedSeam />
+
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <Button variant="secondary" size="sm" onClick={generation.reset}>
+                          {t("generative.startOver", "Start over")}
+                        </Button>
+                        <Button
+                          onClick={handleSave}
+                          loading={createMutation.isPending}
+                          disabled={hasFrontmatterErrors}
+                          className="border-success/50 text-success hover:border-success"
+                        >
+                          {t("generative.saveSkill", "Save skill")}
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex h-full flex-col items-center justify-center px-6 text-center">
+                      <p className="font-text text-sm text-body">
+                        {t(
+                          "generative.emptyPreviewHero",
+                          "Package preview lands here once the model drafts a skill.",
+                        )}
+                      </p>
+                      <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-meta/70">
+                        {t(
+                          "generative.emptyPreviewHint",
+                          "Send a prompt on the left to start.",
+                        )}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </motion.aside>
+            </>
+          )}
+        </AnimatePresence>
       </div>
     </PageTransition>
   );


### PR DESCRIPTION
Closes #266.

## Summary

Apply the Playground's design language to the Generative skill creation page so both LLM-driven surfaces feel like one product.

**Same as Playground:**
- Chat is the page hero — single centered column at `max-w-2xl`, composer pinned to the bottom of the chat column with model picker + quota chip centered above (no top-right surface header).
- User bubble: ember-tinted (`bg-warning-soft + border-accent/30 + rounded-2xl`). Assistant bubble: cool (`bg-card + border-subtle + rounded-2xl`). 15px / leading-7.
- Spring entrance choreography on every message: opacity + 8px rise + 98→100% scale, stiffness 320 / damping 28 / mass 0.6.
- Smart auto-scroll: tracks `distFromBottom < 80`; manual scroll-up isn't yanked back.
- Empty state: vertically centered "Describe a skill. Build it." hero + 3 quick-starter chips that pre-fill the input.
- Right-edge slide-in drawer for the work-product (package preview + Save / Start-over).

**Different from Playground (intentional):**
- Drawer **pinned-open by default** because the package preview IS the artifact being built, not auxiliary context.
- Streaming bubble keeps monospace render — the generative output is structured JSON + file contents, not free prose.

## Test plan

- [x] Frontend typecheck clean
- [x] Local k8s rollout — ornn-web deployed
- [x] Visual: empty state has the centered hero + 3 starter chips; clicking a starter fills the input
- [x] Sending a prompt opens the streaming bubble; package preview appears in the drawer
- [x] Save action lives inside the drawer alongside the preview
- [ ] CI passes