### PR TITLE
[Bug] Extras section — accept empty Base URL on rows (#279)

### DIFF
--- a/.changeset/four-balloons-train.md
+++ b/.changeset/four-balloons-train.md
@@ -1,0 +1,7 @@
+---
+"ornn-web": patch
+---
+
+fix(web): make Extras section's per-row Base URL accept empty string (#279).
+
+The admin **Extras** section's per-row `Base URL` input rejected the empty string with `Invalid url; Must be http(s)`, even though the backend (`extras.ts:optionalHttpUrl`) has always accepted it. Frontend Zod schema now matches the backend's empty-or-http(s) semantics: operators can register a service by name only and fill in the gateway later. `Scopes` was already optional; the field labels now say so explicitly.

--- a/ornn-web/src/pages/admin/settings/sections/ExtrasSection.tsx
+++ b/ornn-web/src/pages/admin/settings/sections/ExtrasSection.tsx
@@ -25,10 +25,23 @@ const Schema = z
     extraNyxidServices: z.array(
       z.object({
         name: z.string().regex(NAME_RE, "Must match ^[a-z0-9-]{1,64}$"),
-        baseUrl: z
-          .string()
-          .url()
-          .regex(/^https?:\/\//, "Must be http(s)"),
+        // Empty string is the unset state (matches backend `optionalHttpUrl`
+        // in extras.ts) — operators can register a service by name only and
+        // fill in the gateway later. When set, must be a parseable http(s)
+        // URL (#279).
+        baseUrl: z.string().refine(
+          (v) => {
+            if (v === "") return true;
+            if (!/^https?:\/\//.test(v)) return false;
+            try {
+              new URL(v);
+              return true;
+            } catch {
+              return false;
+            }
+          },
+          { message: "Must be a http(s) URL or empty" },
+        ),
         scopes: z.array(z.string()).optional(),
       }),
     ),
@@ -128,7 +141,7 @@ export function ExtrasSection() {
                 </label>
                 <label className="sm:col-span-5 flex flex-col gap-1.5">
                   <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
-                    Base URL
+                    Base URL (optional)
                   </span>
                   <input
                     type="text"
@@ -139,7 +152,7 @@ export function ExtrasSection() {
                 </label>
                 <label className="sm:col-span-3 flex flex-col gap-1.5">
                   <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
-                    Scopes (comma-separated)
+                    Scopes (comma-separated, optional)
                   </span>
                   <input
                     type="text"


### PR DESCRIPTION
## Summary

Closes #279.

The admin **Extras** section's per-row \`Base URL\` validator rejected the empty string with \`Invalid url; Must be http(s)\`, despite the backend (\`extras.ts:optionalHttpUrl\`) always having accepted it. Frontend Zod schema now matches the backend: empty OR a parseable http(s) URL. Operators can register a service by name only and wire up the gateway later.

## Commits

1. \`fix(web): allow empty Base URL on Extras-section rows (#279)\` — schema fix + label tweak (\"Base URL (optional)\", \"Scopes (comma-separated, optional)\").
2. \`chore: changeset for #279\` — patch bump on ornn-web.

## Test plan

- [ ] Open **Admin → Settings → Extras**, add a row with a name only (e.g. \`nyxid\`), leave Base URL and Scopes empty, click Save → no validation errors, row persists.
- [ ] Add a row with an invalid URL (\`ftp://...\`) — validation rejects with \"Must be a http(s) URL or empty\".
- [ ] Frontend: \`bun run lint && bun run test\` (51/51).

🤖 Generated with [Claude Code](https://claude.com/claude-code)