### PR TITLE
[Bug] Relax Extras name regex to allow mixed case (#284)

### DIFF
--- a/.changeset/thick-hotels-tan.md
+++ b/.changeset/thick-hotels-tan.md
@@ -1,0 +1,8 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+fix: relax Extras section's service-name regex to allow mixed case + dot/underscore (#284).
+
+Was lowercase-only (`^[a-z0-9-]{1,64}$`), which rejected the legacy `EXTRA_NYXID_SERVICES` env var's own default value (`NyxID`) and any common service identifier with mixed case. Now matches the typical service-id shape: `^[A-Za-z0-9._-]{1,64}$` — covers `NyxID`, `twitter-api`, `openai_v2`, `v1.beta`. Spaces still rejected (the value flows into URL path segments where space encoding is fragile).

--- a/ornn-api/src/domains/settings/sections/extras.ts
+++ b/ornn-api/src/domains/settings/sections/extras.ts
@@ -7,13 +7,19 @@ import { z } from "zod";
 import { PUBLIC_URL_REFUSAL, requirePublicUrl } from "../../../infra/url";
 import type { SectionMeta } from "./index";
 
-const SERVICE_NAME_RE = /^[a-z0-9-]{1,64}$/;
+// Common service-id pattern: any case, digits, dot/dash/underscore.
+// Permits canonical names like `NyxID`, `twitter-api`, `openai_v2`,
+// `v1.beta`. Spaces are still rejected so the value is safe to flow
+// into URL path segments without encoding gymnastics. (#284 — was
+// `^[a-z0-9-]{1,64}$`, lowercase-only, which rejected the legacy
+// `EXTRA_NYXID_SERVICES=NyxID` default.)
+const SERVICE_NAME_RE = /^[A-Za-z0-9._-]{1,64}$/;
 const optionalHttpUrl = z.string().refine(requirePublicUrl, {
   message: PUBLIC_URL_REFUSAL,
 });
 
 const extraServiceSchema = z.object({
-  name: z.string().regex(SERVICE_NAME_RE, "name must match ^[a-z0-9-]{1,64}$"),
+  name: z.string().regex(SERVICE_NAME_RE, "name must match ^[A-Za-z0-9._-]{1,64}$"),
   baseUrl: optionalHttpUrl,
   scopes: z.array(z.string()).optional(),
 });

--- a/ornn-api/src/domains/settings/sections/sections.test.ts
+++ b/ornn-api/src/domains/settings/sections/sections.test.ts
@@ -214,15 +214,26 @@ describe("section schemas", () => {
   });
 
   // -------- extras --------
-  it("UT-SCHEMA-EXTRAS-001: service name regex", () => {
+  it("UT-SCHEMA-EXTRAS-001: service name regex (#284 — case-insensitive + dot/underscore)", () => {
+    // Mixed-case + dash + underscore + dot all permitted (covers
+    // canonical names: NyxID, twitter-api, openai_v2, v1.beta).
+    for (const name of ["valid-svc1", "NyxID", "openai_v2", "v1.beta"]) {
+      expect(
+        extrasSection.schema.safeParse({
+          extraNyxidServices: [{ name, baseUrl: "" }],
+        }).success,
+      ).toBe(true);
+    }
+    // Spaces still rejected — value flows into URL path segments.
     expect(
       extrasSection.schema.safeParse({
-        extraNyxidServices: [{ name: "valid-svc1", baseUrl: "" }],
+        extraNyxidServices: [{ name: "has space", baseUrl: "" }],
       }).success,
-    ).toBe(true);
+    ).toBe(false);
+    // Empty + over-length still rejected.
     expect(
       extrasSection.schema.safeParse({
-        extraNyxidServices: [{ name: "INVALID", baseUrl: "" }],
+        extraNyxidServices: [{ name: "", baseUrl: "" }],
       }).success,
     ).toBe(false);
     expect(

--- a/ornn-web/src/pages/admin/settings/sections/ExtrasSection.tsx
+++ b/ornn-web/src/pages/admin/settings/sections/ExtrasSection.tsx
@@ -18,13 +18,18 @@ import {
   type ExtrasSection as EX,
 } from "@/services/settingsApi";
 
-const NAME_RE = /^[a-z0-9-]{1,64}$/;
+// Mirror of backend `extras.ts:SERVICE_NAME_RE` — common service-id
+// pattern: any case, digits, dot/dash/underscore. Covers canonical
+// names like `NyxID`, `twitter-api`, `openai_v2`, `v1.beta`. Spaces
+// are deliberately excluded so the value is safe to flow into URL
+// path segments without encoding gymnastics. (#284)
+const NAME_RE = /^[A-Za-z0-9._-]{1,64}$/;
 
 const Schema = z
   .object({
     extraNyxidServices: z.array(
       z.object({
-        name: z.string().regex(NAME_RE, "Must match ^[a-z0-9-]{1,64}$"),
+        name: z.string().regex(NAME_RE, "Must match ^[A-Za-z0-9._-]{1,64}$"),
         // Empty string is the unset state (matches backend `optionalHttpUrl`
         // in extras.ts) — operators can register a service by name only and
         // fill in the gateway later. When set, must be a parseable http(s)


### PR DESCRIPTION
## Summary

Closes #284.

The Extras section's service-name regex was lowercase-only (\`^[a-z0-9-]{1,64}\$\`), which rejected the legacy \`EXTRA_NYXID_SERVICES\` env var's own default value \`NyxID\` and any common service identifier with mixed case. Relaxed to \`^[A-Za-z0-9._-]{1,64}\$\` — covers \`NyxID\`, \`twitter-api\`, \`openai_v2\`, \`v1.beta\`. Spaces still rejected (the value flows into URL path segments where space encoding is fragile).

## Commits

1. \`fix(api): relax extras service-name regex to allow mixed case + dot/underscore (#284)\` — schema + UT-SCHEMA-EXTRAS-001 expanded with four valid mixed-case names plus explicit space + empty + over-length rejections
2. \`fix(web): relax extras service-name regex to match backend (#284)\` — frontend Zod schema mirrors backend
3. \`chore: changeset for #284\` — patch on both packages

Backend regex relaxes first so the server is at least as permissive as the form before the form starts sending mixed-case names.

## Test plan

- [ ] **Admin → Settings → Extras** → add a row, type \`NyxID\`, leave Base URL empty → save succeeds.
- [ ] Same flow with \`has space\` → form rejects with \"Must match ^[A-Za-z0-9._-]{1,64}\$\".
- [ ] Backend: \`bun test\` (UT-SCHEMA-EXTRAS-001 expanded — 17/17 sections tests pass, 547/547 backend total).
- [ ] Frontend: \`bun run lint && bun run test\` — typecheck + 51/51 vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)