### PR TITLE
[Chore] Audit + clean env-var surface (#287)

### DIFF
--- a/.changeset/pretty-webs-bet.md
+++ b/.changeset/pretty-webs-bet.md
@@ -1,0 +1,18 @@
+---
+"ornn-api": patch
+---
+
+chore(deploy): audit + clean env-var surface (#287).
+
+Three categories of cleanup against `deployment/ornn-api/{deployment.yaml, mirror-cronjob.yaml}` and `deployment/.env.sample.ornn`:
+
+1. **Removed 11 stale env vars** that no code consumes anymore — each was migrated into `platform_settings` admin sections in earlier rounds (#268, #269, #270, #271): `NYX_LLM_GATEWAY_URL`, `STORAGE_SERVICE_URL`, `STORAGE_BUCKET`, `SANDBOX_SERVICE_URL`, `DEFAULT_LLM_MODEL`, `LLM_MAX_OUTPUT_TOKENS`, `LLM_TEMPERATURE`, `SSE_KEEP_ALIVE_INTERVAL_MS`, `EXTRA_NYXID_SERVICES`, `AGENTSEAL_ENABLED`, `AGENTSEAL_TIMEOUT_MS`.
+2. **Added 3 missing env vars** that code reads but the manifests were not plumbing through: `AGENTSEAL_PYTHON`, `AGENTSEAL_SCRIPT`, `ORNN_URL_ALLOWLIST_CIDR`.
+3. **Renamed 3 vars** to drop a useless alias layer — `.env.ornn` keys now match the actual container env-var names: `ORNN_API_PORT → PORT`, `ORNN_API_LOG_LEVEL → LOG_LEVEL`, `ORNN_API_LOG_PRETTY → LOG_PRETTY`.
+
+**Operator action required.** After pulling this release, update local `deployment/.env.ornn`:
+- Rename `ORNN_API_PORT` → `PORT`, `ORNN_API_LOG_LEVEL` → `LOG_LEVEL`, `ORNN_API_LOG_PRETTY` → `LOG_PRETTY`.
+- Add `AGENTSEAL_PYTHON` (default `/opt/agentseal/bin/python`), `AGENTSEAL_SCRIPT` (default `/opt/agentseal/scan_skill.py`), and `ORNN_URL_ALLOWLIST_CIDR` (operator-explicit comma-separated allowlist of trusted hostnames + IPv4 CIDRs).
+- Remove the 11 stale vars listed above — they have no effect anymore.
+
+ornn-web's configmap + entrypoint were already clean — no change to web manifests.

--- a/deployment/.env.sample.ornn
+++ b/deployment/.env.sample.ornn
@@ -1,6 +1,16 @@
 # ============================================================
 # Ornn Environment Variables
-# Copy to .env.ornn and fill in actual values
+# Copy to .env.ornn and fill in actual values.
+#
+# Every key in this file maps 1:1 to a manifest placeholder under
+# deployment/ornn-{api,web}/*.yaml AND to either:
+#   • an env var the api reads at boot (cross-checked vs config.ts +
+#     infra/url.ts), or
+#   • an env var the web image's entrypoint substitutes into
+#     /config.js / nginx upstream config (cross-checked vs
+#     ornn-web/docker-entrypoint.d/40-envsubst-config-js.sh).
+# Adding or renaming a key here without touching code/manifest is a
+# bug — keep the three sides in lockstep.
 # ============================================================
 
 # -- Kubernetes --
@@ -16,14 +26,14 @@ MINIO_HOST_ALIAS_IP=<minio-service-cluster-ip>
 # -- ornn-api (runtime env vars — bootstrap-only) --
 # Per Architecture §7.1, only values needed to bring the process up
 # and authenticate the very first DB+settings read live in env. All
-# operator-flippable knobs (LLM gateway/model/temp/tokens, NyxID base
-# URL + paths, storage/sandbox URLs + bucket, SSE keep-alive, AgentSeal
-# enabled/timeout, extra NyxID services) live in `platform_settings`
-# and are edited via /admin/settings.
+# operator-flippable knobs (LLM gateway/model/temp/tokens, NyxID
+# connection coords, storage/sandbox URLs + bucket, SSE keep-alive,
+# AgentSeal enabled/timeout, extra NyxID services) live in
+# `platform_settings` and are edited via /admin/settings.
 ORNN_API_IMAGE=<ornn-api-image>
-ORNN_API_PORT=<port>
-ORNN_API_LOG_LEVEL=<log-level>
-ORNN_API_LOG_PRETTY=<true-or-false>
+PORT=<port>
+LOG_LEVEL=<log-level>
+LOG_PRETTY=<true-or-false>
 # NyxID service-account credentials (machine-to-machine, client_credentials grant).
 # Used by ornn-api to mint SA tokens for server-side NyxID calls (org lookups, etc).
 # Distinct from the OAuth public client used by the browser (see below).
@@ -35,9 +45,21 @@ MONGODB_DB=<mongodb-database-name>
 MAX_PACKAGE_SIZE_BYTES=<max-package-size>
 ALLOWED_ORIGINS=<comma-separated-origins, e.g. https://app.ornn.xyz,http://localhost:5173>
 
+# Public origin used in mirror READMEs to link back to canonical Ornn.
+ORNN_PUBLIC_ORIGIN=<e.g. https://ornn.chrono-ai.fun>
+
+# SSRF allowlist for any admin-curated outbound URL fields (LLM
+# provider gateway/token URLs, etc.). Comma-separated mix of bare
+# hostnames + IPv4 CIDRs. The URL validator (`infra/url.ts`) refuses
+# private/loopback/link-local hosts by default; entries here are
+# operator-explicit overrides. Empty value = strict default.
+# Local cluster needs internal service hostnames + RFC1918 + loopback;
+# in prod, scope this to the specific known-dependency hostnames only.
+ORNN_URL_ALLOWLIST_CIDR=<comma-separated, e.g. nyxid-backend,mongodb,10.0.0.0/8,127.0.0.0/8>
+
 # -- PostHog (server-side product analytics + per-request audit) --
 # Bootstrap fallback only — once admin saves Settings → Telemetry
-# (issue #271), the DB section overrides these on the next ornn-api
+# (#271), the DB section overrides these on the next ornn-api
 # restart. Empty key + POSTHOG_ENABLED=false → noop tracker (dev/CI).
 POSTHOG_ENABLED=false
 POSTHOG_API_KEY=<posthog-project-api-key-or-empty>
@@ -58,35 +80,33 @@ AGENTSEAL_SCRIPT=/opt/agentseal/scan_skill.py
 # (LLM provider apiKey, GitHub App private key, NyxID client secret).
 # Cluster-scoped: rotating this value makes every previously-stored
 # ciphertext unreadable, so pick once per deployment and treat it as
-# load-bearing. When unset (dev only) the API falls back to a
-# clearly-marked dev sentinel. Generate with: openssl rand -hex 32
+# load-bearing. Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=<32+ char passphrase, e.g. openssl rand -hex 32>
 
-# Public origin used in mirror READMEs to link back to canonical Ornn.
-ORNN_PUBLIC_ORIGIN=<e.g. https://ornn.chrono-ai.fun>
-
 # -- Settings now in DB, not env --
-# The following knobs moved out of env and into the `platform_settings`
-# collection in this release. Edit via /admin/settings/<section>:
+# These knobs moved out of env into `platform_settings`. Edit via
+# /admin/settings/<section>:
 #   • playground.{defaultProviderId, defaultModelId, sseKeepAliveMs}
 #   • skill-generation.{defaultProviderId, defaultModelId, sseKeepAliveMs}
 #   • mirror.{enabled, owner, repo, branch, appId, installationId, appPrivateKey}
-#   • integrations/nyxid.{tokenUrl, clientId, clientSecret, baseFrontendUrl,
-#       baseApiUrl, myServicesPath, myProfilePath, myOrganizationPath,
-#       servicesListApiPath}
+#   • integrations/nyxid.{tokenUrl, clientId, clientSecret, baseApiUrl}
 #   • integrations/services.{chronoStorageUrl, chronoStorageBucket,
 #       chronoSandboxUrl}
 #   • skill-audit.{llmAuditEnabled, llmAuditDefaultProviderId,
 #       riskThreshold, agentSealEnabled, agentSealTimeoutMs}
 #   • quota.{defaultPlaygroundMonthly, defaultSkillGenMonthly}
-#   • extras.{extraNyxidServices: [{name, baseUrl, scopes?}]}
+#   • extras.{extraNyxidServices: [{name, baseUrl?, scopes?}]}
 # LLM providers are managed under /admin/settings/llm-providers
 # (separate `llm_providers` collection, one doc per provider).
-# Removed env vars: NYX_LLM_GATEWAY_URL, DEFAULT_LLM_MODEL,
-# LLM_MAX_OUTPUT_TOKENS, LLM_TEMPERATURE, SSE_KEEP_ALIVE_INTERVAL_MS,
-# STORAGE_SERVICE_URL, STORAGE_BUCKET, SANDBOX_SERVICE_URL,
-# EXTRA_NYXID_SERVICES, AGENTSEAL_TIMEOUT_MS, AGENTSEAL_ENABLED,
-# NYXID_BASE_URL.
+#
+# Env vars removed in past releases — keep noted so old `.env.ornn`
+# copies can be reconciled without surprise:
+#   NYX_LLM_GATEWAY_URL, DEFAULT_LLM_MODEL, LLM_MAX_OUTPUT_TOKENS,
+#   LLM_TEMPERATURE, SSE_KEEP_ALIVE_INTERVAL_MS, STORAGE_SERVICE_URL,
+#   STORAGE_BUCKET, SANDBOX_SERVICE_URL, EXTRA_NYXID_SERVICES,
+#   AGENTSEAL_TIMEOUT_MS, AGENTSEAL_ENABLED, NYXID_BASE_URL,
+#   ORNN_API_PORT (now PORT), ORNN_API_LOG_LEVEL (now LOG_LEVEL),
+#   ORNN_API_LOG_PRETTY (now LOG_PRETTY).
 
 # -- ornn-web (runtime env vars — injected via ConfigMap at container start) --
 ORNN_WEB_IMAGE=<ornn-web-image>

--- a/deployment/ornn-api/deployment.yaml
+++ b/deployment/ornn-api/deployment.yaml
@@ -30,59 +30,48 @@ spec:
           ports:
             - containerPort: 3802
           # Operator-flippable settings (kill switches, repo coords,
-          # credentials) live in the platform_settings DB collection
-          # and are managed via the admin UI — no configmap.
-          # Only true bootstrap secrets (DB / NyxID SA / encryption
-          # passphrase) come from the Secret. Everything else here is
-          # plain operational env baked into the manifest.
+          # credentials, model + provider config, storage + sandbox
+          # endpoints) live in the platform_settings DB collection and
+          # are managed via the admin UI — see #268, #269, #270, #271.
+          # The Secret carries the six bootstrap-only secrets. Every
+          # entry below is plain operational env consumed by code
+          # (cross-checked against config.ts + infra/url.ts) — no
+          # vestigial keys.
           env:
             - name: PORT
-              value: "${ORNN_API_PORT}"
+              value: "${PORT}"
             - name: LOG_LEVEL
-              value: "${ORNN_API_LOG_LEVEL}"
+              value: "${LOG_LEVEL}"
             - name: LOG_PRETTY
-              value: "${ORNN_API_LOG_PRETTY}"
+              value: "${LOG_PRETTY}"
             - name: NYXID_SA_TOKEN_URL
               value: "${NYXID_SA_TOKEN_URL}"
-            - name: NYX_LLM_GATEWAY_URL
-              value: "${NYX_LLM_GATEWAY_URL}"
             - name: MONGODB_DB
               value: "${MONGODB_DB}"
-            - name: STORAGE_SERVICE_URL
-              value: "${STORAGE_SERVICE_URL}"
-            - name: STORAGE_BUCKET
-              value: "${STORAGE_BUCKET}"
-            - name: SANDBOX_SERVICE_URL
-              value: "${SANDBOX_SERVICE_URL}"
-            - name: DEFAULT_LLM_MODEL
-              value: "${DEFAULT_LLM_MODEL}"
-            - name: LLM_MAX_OUTPUT_TOKENS
-              value: "${LLM_MAX_OUTPUT_TOKENS}"
-            - name: LLM_TEMPERATURE
-              value: "${LLM_TEMPERATURE}"
-            - name: SSE_KEEP_ALIVE_INTERVAL_MS
-              value: "${SSE_KEEP_ALIVE_INTERVAL_MS}"
             - name: MAX_PACKAGE_SIZE_BYTES
               value: "${MAX_PACKAGE_SIZE_BYTES}"
             - name: ALLOWED_ORIGINS
               value: "${ALLOWED_ORIGINS}"
-            - name: EXTRA_NYXID_SERVICES
-              value: "${EXTRA_NYXID_SERVICES}"
+            - name: ORNN_PUBLIC_ORIGIN
+              value: "${ORNN_PUBLIC_ORIGIN}"
+            - name: ORNN_URL_ALLOWLIST_CIDR
+              value: "${ORNN_URL_ALLOWLIST_CIDR}"
+            # AgentSeal subprocess paths — runner is opt-in via the
+            # admin skill-audit section, but the binary paths must
+            # exist as env so the runner knows where to spawn.
+            - name: AGENTSEAL_PYTHON
+              value: "${AGENTSEAL_PYTHON}"
+            - name: AGENTSEAL_SCRIPT
+              value: "${AGENTSEAL_SCRIPT}"
             # PostHog values are bootstrap fallback only — once admin
             # saves the telemetry settings section, those win on
-            # restart (issue #271).
+            # restart (#271).
             - name: POSTHOG_ENABLED
               value: "${POSTHOG_ENABLED}"
             - name: POSTHOG_HOST
               value: "${POSTHOG_HOST}"
             - name: POSTHOG_ERROR_SAMPLE_RATE
               value: "${POSTHOG_ERROR_SAMPLE_RATE}"
-            - name: AGENTSEAL_ENABLED
-              value: "${AGENTSEAL_ENABLED}"
-            - name: AGENTSEAL_TIMEOUT_MS
-              value: "${AGENTSEAL_TIMEOUT_MS}"
-            - name: ORNN_PUBLIC_ORIGIN
-              value: "${ORNN_PUBLIC_ORIGIN}"
           envFrom:
             - secretRef:
                 name: ornn-api-secret

--- a/deployment/ornn-api/mirror-cronjob.yaml
+++ b/deployment/ornn-api/mirror-cronjob.yaml
@@ -29,53 +29,41 @@ spec:
               # credentials) lives in the platform_settings DB row —
               # the script reads + self-gates on every run, so when
               # disabled or incomplete it logs and exits 0.
+              # Same env shape as ornn-api/deployment.yaml — kept in
+              # lockstep so a mis-set var on either side doesn't drift
+              # only the runtime path. Cross-checked against config.ts
+              # + infra/url.ts: every key below has a code consumer.
               env:
                 - name: PORT
-                  value: "${ORNN_API_PORT}"
+                  value: "${PORT}"
                 - name: LOG_LEVEL
-                  value: "${ORNN_API_LOG_LEVEL}"
+                  value: "${LOG_LEVEL}"
                 - name: LOG_PRETTY
-                  value: "${ORNN_API_LOG_PRETTY}"
+                  value: "${LOG_PRETTY}"
                 - name: NYXID_SA_TOKEN_URL
                   value: "${NYXID_SA_TOKEN_URL}"
-                - name: NYX_LLM_GATEWAY_URL
-                  value: "${NYX_LLM_GATEWAY_URL}"
                 - name: MONGODB_DB
                   value: "${MONGODB_DB}"
-                - name: STORAGE_SERVICE_URL
-                  value: "${STORAGE_SERVICE_URL}"
-                - name: STORAGE_BUCKET
-                  value: "${STORAGE_BUCKET}"
-                - name: SANDBOX_SERVICE_URL
-                  value: "${SANDBOX_SERVICE_URL}"
-                - name: DEFAULT_LLM_MODEL
-                  value: "${DEFAULT_LLM_MODEL}"
-                - name: LLM_MAX_OUTPUT_TOKENS
-                  value: "${LLM_MAX_OUTPUT_TOKENS}"
-                - name: LLM_TEMPERATURE
-                  value: "${LLM_TEMPERATURE}"
-                - name: SSE_KEEP_ALIVE_INTERVAL_MS
-                  value: "${SSE_KEEP_ALIVE_INTERVAL_MS}"
                 - name: MAX_PACKAGE_SIZE_BYTES
                   value: "${MAX_PACKAGE_SIZE_BYTES}"
                 - name: ALLOWED_ORIGINS
                   value: "${ALLOWED_ORIGINS}"
-                - name: EXTRA_NYXID_SERVICES
-                  value: "${EXTRA_NYXID_SERVICES}"
+                - name: ORNN_PUBLIC_ORIGIN
+                  value: "${ORNN_PUBLIC_ORIGIN}"
+                - name: ORNN_URL_ALLOWLIST_CIDR
+                  value: "${ORNN_URL_ALLOWLIST_CIDR}"
+                - name: AGENTSEAL_PYTHON
+                  value: "${AGENTSEAL_PYTHON}"
+                - name: AGENTSEAL_SCRIPT
+                  value: "${AGENTSEAL_SCRIPT}"
                 # Bootstrap fallback only — admin telemetry section
-                # is canonical (issue #271).
+                # is canonical (#271).
                 - name: POSTHOG_ENABLED
                   value: "${POSTHOG_ENABLED}"
                 - name: POSTHOG_HOST
                   value: "${POSTHOG_HOST}"
                 - name: POSTHOG_ERROR_SAMPLE_RATE
                   value: "${POSTHOG_ERROR_SAMPLE_RATE}"
-                - name: AGENTSEAL_ENABLED
-                  value: "${AGENTSEAL_ENABLED}"
-                - name: AGENTSEAL_TIMEOUT_MS
-                  value: "${AGENTSEAL_TIMEOUT_MS}"
-                - name: ORNN_PUBLIC_ORIGIN
-                  value: "${ORNN_PUBLIC_ORIGIN}"
               envFrom:
                 - secretRef:
                     name: ornn-api-secret


### PR DESCRIPTION
## Summary

Closes #287.

The env surface drifted across recent consolidations (#268 / #269 / #270 / #271 / #275). This PR brings \`deployment/ornn-api/{deployment.yaml, mirror-cronjob.yaml}\` and \`deployment/.env.sample.ornn\` back into 1:1 alignment with the actual code consumers.

## What changed

| Category | Vars |
|---|---|
| **Removed (11)** — no code reads them anymore | \`NYX_LLM_GATEWAY_URL\`, \`STORAGE_SERVICE_URL\`, \`STORAGE_BUCKET\`, \`SANDBOX_SERVICE_URL\`, \`DEFAULT_LLM_MODEL\`, \`LLM_MAX_OUTPUT_TOKENS\`, \`LLM_TEMPERATURE\`, \`SSE_KEEP_ALIVE_INTERVAL_MS\`, \`EXTRA_NYXID_SERVICES\`, \`AGENTSEAL_ENABLED\`, \`AGENTSEAL_TIMEOUT_MS\` |
| **Added (3)** — code reads them, manifest was missing | \`AGENTSEAL_PYTHON\`, \`AGENTSEAL_SCRIPT\`, \`ORNN_URL_ALLOWLIST_CIDR\` |
| **Renamed (3)** — drop unnecessary alias layer | \`ORNN_API_PORT\` → \`PORT\`, \`ORNN_API_LOG_LEVEL\` → \`LOG_LEVEL\`, \`ORNN_API_LOG_PRETTY\` → \`LOG_PRETTY\` |

\`secret.yaml\` already correctly carries the six bootstrap secrets — no change. \`ornn-web\`'s configmap + envsubst whitelist were already clean — no change.

## Lockstep contract

Added a header comment on \`.env.sample.ornn\` documenting the contract: every key in this file maps to a manifest placeholder AND a code consumer. Adding or renaming a key without touching the other two sides is a bug.

## Commits

Per the commit-size rule:

1. \`chore(deploy): clean api deployment.yaml env surface\` — drop 11, add 3, rename 3
2. \`chore(deploy): mirror cronjob env in lockstep with deployment.yaml\` — same change shape
3. \`chore(deploy): align .env.sample.ornn with cleaned manifests\` — match new manifest shape, update 'Settings now in DB' summary, add lockstep header
4. \`chore: changeset for #287\` — patch on ornn-api, with operator-action-required notes

## Operator action required

After pulling, update local \`deployment/.env.ornn\`:

- Rename: \`ORNN_API_PORT\` → \`PORT\`, \`ORNN_API_LOG_LEVEL\` → \`LOG_LEVEL\`, \`ORNN_API_LOG_PRETTY\` → \`LOG_PRETTY\`
- Add: \`AGENTSEAL_PYTHON\`, \`AGENTSEAL_SCRIPT\`, \`ORNN_URL_ALLOWLIST_CIDR\`
- Drop: the 11 stale vars listed above

The changeset captures these notes verbatim so operators porting an old \`.env.ornn\` don't have to reverse-engineer the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)