### PR TITLE
[Bug] /admin/users 500 — split sort wire payload into sort + dir (#290)

### DIFF
--- a/.changeset/bumpy-cases-punch.md
+++ b/.changeset/bumpy-cases-punch.md
@@ -1,0 +1,7 @@
+---
+"ornn-web": patch
+---
+
+fix(web): unbreak admin **Users** page — split sort wire payload into `sort` + `dir` (#290).
+
+Frontend was sending `sort=lastActiveAt:desc` as a single combined query param, but the backend's Zod schema (`admin-users/routes.ts`) takes `sort=<field>` and `dir=<asc|desc>` as two separate params. The combined value bounced off the field-name enum with `Invalid enum value`, returning 500 to both Admin Users and Normal Users tables. UI table state stays on the convenient `field:dir` shape; the API client now splits before constructing the HTTP request.

--- a/ornn-web/src/services/adminUsersApi.ts
+++ b/ornn-web/src/services/adminUsersApi.ts
@@ -54,12 +54,18 @@ export async function fetchAdminUsers(params: {
   pageSize?: number;
   sort?: AdminUsersSort;
 }): Promise<AdminUsersPage> {
+  // Backend takes `sort` (field) and `dir` (asc|desc) as two separate
+  // query params. Frontend stores them as one `field:dir` value for
+  // UI ergonomics (single-source of table state). Split at the wire
+  // boundary.
+  const [sortField, sortDir] = params.sort ? params.sort.split(":") : [undefined, undefined];
   const res = await apiGet<AdminUsersPage>("/api/v1/admin/users", {
     role: params.role,
     q: params.q,
     page: params.page,
     pageSize: params.pageSize,
-    sort: params.sort,
+    sort: sortField,
+    dir: sortDir,
   });
   if (!res.data) {
     throw new Error("Admin users list missing");


### PR DESCRIPTION
## Summary

Closes #290.

The admin **Users** page surfaced \"Internal server error\" because \`fetchAdminUsers\` sent the table's combined UI-state value (\`sort=lastActiveAt:desc\`) as a single query param, but the backend's Zod schema at \`admin-users/routes.ts:57-62\` takes \`sort=<field>\` and \`dir=<asc|desc>\` as two separate params. The combined value bounced off the field-name enum and the route returned 500 to both Admin Users and Normal Users tables.

## Fix

Split at the wire boundary in \`adminUsersApi.fetchAdminUsers\`. UI table state stays single-source on the combined \`field:dir\` value (used by \`AdminUsersTable\` header click handlers + the \`AdminUsersSort\` type catalog); the API client decomposes just before the HTTP call.

## Test plan

- [ ] Admin → Users → both Admin Users and Normal Users tables load (no 500).
- [ ] Click any sortable column header → query param flips between \`asc\`/\`desc\` and the response sort matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)