### PR TITLE
[Bug] ornn-web crashloops — chmod +x the new envsh script

### DIFF
--- a/.changeset/fix-ornn-web-envsh-not-executable.md
+++ b/.changeset/fix-ornn-web-envsh-not-executable.md
@@ -1,0 +1,7 @@
+---
+"ornn-web": patch
+---
+
+Fix ornn-web crash on first deploy after the URL consolidation in #295. `15-derive-nyxid-api-host.envsh` shipped without exec bit, so the nginx entrypoint silently skipped it (it sources `*.envsh` only when executable), `NYXID_API_HOST` never got exported, and nginx refused to start with `unknown "nyxid_api_host" variable`. Added the missing `chmod +x` in the Dockerfile.
+
+Closes #296.

--- a/ornn-web/Dockerfile
+++ b/ornn-web/Dockerfile
@@ -40,10 +40,11 @@ COPY --from=build /app/ornn-web/dist /usr/share/nginx/html
 # (sourced ahead of script 20).
 COPY ornn-web/nginx.conf.template /etc/nginx/templates/default.conf.template
 # Sourced before 20- so the host derivation propagates to envsubst.
+# Must be executable — the nginx entrypoint skips non-executable .envsh files.
 COPY ornn-web/docker-entrypoint.d/15-derive-nyxid-api-host.envsh /docker-entrypoint.d/15-derive-nyxid-api-host.envsh
 # Runtime frontend config: generate /config.js from its template and
 # inject window.__ORNN_CONFIG__ at container startup.
 COPY ornn-web/docker-entrypoint.d/40-envsubst-config-js.sh /docker-entrypoint.d/40-envsubst-config-js.sh
-RUN chmod +x /docker-entrypoint.d/40-envsubst-config-js.sh
+RUN chmod +x /docker-entrypoint.d/15-derive-nyxid-api-host.envsh /docker-entrypoint.d/40-envsubst-config-js.sh
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Closes #296.

## Summary

- Add missing `chmod +x` for `/docker-entrypoint.d/15-derive-nyxid-api-host.envsh` in the ornn-web Dockerfile.
- Without the exec bit, the nginx entrypoint silently skips the script, `NYXID_API_HOST` never gets exported, and nginx fails to start with `unknown "nyxid_api_host" variable`. Regression from #295.

## Test plan

- [x] Local docker-desktop k8s: rebuild image, roll deployment, ornn-web Running and serving 200.
- [ ] CI green