### PR TITLE
[Chore] PostHog hardening — respect DNT + mask all session-replay text

### DIFF
--- a/.changeset/posthog-respect-dnt-mask-all-text.md
+++ b/.changeset/posthog-respect-dnt-mask-all-text.md
@@ -1,0 +1,10 @@
+---
+"ornn-web": patch
+---
+
+PostHog browser hardening:
+
+- **`respect_dnt: true`** — opt out of capture when the browser sends Do-Not-Track. GDPR/CCPA affinity, complements the cookie banner.
+- **`maskTextSelector: "*"`** in session-recording config (replaces the narrower `[data-ph-mask], input[type='password']` selector). Every rendered text node is now masked in replays — skill content, user names, emails, activity feeds. Trade-off: replays lose visual fidelity but no longer carry PII. Opt specific elements back in with `data-ph-no-mask` when an element is genuinely public chrome.
+
+Closes #304.

--- a/ornn-web/src/lib/analytics.ts
+++ b/ornn-web/src/lib/analytics.ts
@@ -103,13 +103,24 @@ export function initAnalytics(): void {
       api_host: config.posthogHost,
       // Auto-pageview is on per #252.
       capture_pageview: true,
+      // Honor the browser's Do-Not-Track signal — if the user has DNT on,
+      // PostHog opts out of capture before any event fires. Free GDPR/CCPA
+      // affinity; complements the cookie banner rather than replacing it.
+      respect_dnt: true,
       // Session replay — gated by consent at the wrapper level. PostHog's
       // own opt-in flag mirrors that so the SDK doesn't even start the
       // recorder until we say so.
       disable_session_recording: !hasConsent(),
       session_recording: {
+        // Privacy-first defaults: mask every input AND every rendered text
+        // node. Skill content, user names, emails, activity feeds are all
+        // user-data; we'd rather lose visual fidelity in replays than
+        // risk PII leaking to PostHog. PostHog's own no-text idiom is
+        // `maskTextSelector: "*"` — it applies the standard mask to every
+        // matching element. Opt back in per element with `data-ph-no-mask`
+        // (PostHog's allowlist hook) when a piece of UI is public chrome.
         maskAllInputs: true,
-        maskTextSelector: "[data-ph-mask], input[type='password']",
+        maskTextSelector: "*",
       },
       // Defer personhood until `identify()` runs on login — anonymous
       // distinct IDs are fine for funnel attribution.


### PR DESCRIPTION
Closes #304.

## Summary

- \`respect_dnt: true\` on \`posthog.init\` — DNT users opt out before any event fires.
- \`session_recording.maskTextSelector: \"*\"\` — masks every rendered text node, not just inputs. Closes the PII-leak path for skill content, user names, emails, activity-feed entries that the previous narrower selector left visible.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test\` — 50/50 pass
- [ ] CI green

## Behavior change worth flagging

Session replays will look mostly redacted (\"xxxx\" placeholders for text). They're still useful for click/navigation flows but no longer for visual debugging. To opt an element back in (header logo text, button labels, code-snippet placeholders), add \`data-ph-no-mask\`.