### PR TITLE
feat: admin-issued redeem codes for quota grants

### DIFF
--- a/.changeset/redemption-codes.md
+++ b/.changeset/redemption-codes.md
@@ -1,0 +1,18 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+Admin-issued redeem codes for quota grants.
+
+Admins mint single-use, time-bounded codes that carry a multi-surface grant bundle (playground / skillGen). Each code is 16 chars from a confusable-stripped alphabet; the redeem endpoint canonicalises to upper-case at the boundary so users can paste in any case. End users redeem from Settings → Redeem code; the grant lands on the caller's current-month bucket via the existing `QuotaService.grant()` path so existing audit + notification fanout fires.
+
+Lifecycle: `active → redeemed | invalidated`. Concurrent redemptions of the same code are race-safe — a single atomic `findOneAndUpdate` on `(code, status: "active", expiresAt > now)` is the pivot. Admins can invalidate any `active` code; redeemed and already-invalidated codes return 409.
+
+New surfaces:
+
+- `POST /api/v1/admin/redemption-codes` (mint), `GET` (list/filter/search), `GET /:id` (detail), `POST /:id/invalidate`. Gated on `QUOTA_ADMIN_PERMISSION`.
+- `POST /api/v1/me/redemption-codes/redeem`, `GET /api/v1/me/redemption-codes/history`. Per-error-code messages on the user form (`NOT_FOUND` / `EXPIRED` / `INVALIDATED` / `ALREADY_REDEEMED`).
+- Admin page at `/admin/redemption-codes`; user form on the Settings page.
+
+Closes #306.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -121,6 +121,7 @@ import { createQuotaRoutes } from "./domains/quota/routes";
 import { RedemptionCodeRepository } from "./domains/redemption-codes/repository";
 import { RedemptionCodeService } from "./domains/redemption-codes/service";
 import { createAdminRedemptionCodesRoutes } from "./domains/admin/redemption-codes/routes";
+import { createMeRedemptionCodesRoutes } from "./domains/redemption-codes/me-routes";
 
 // Domain: Admin (engineer-1): dashboard, users, quota admin.
 import { AdminDashboardService } from "./domains/admin/dashboard/service";
@@ -826,6 +827,9 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const adminRedemptionCodesRoutes = createAdminRedemptionCodesRoutes({
     redemptionCodeService,
   });
+  const meRedemptionCodesRoutes = createMeRedemptionCodesRoutes({
+    redemptionCodeService,
+  });
 
   apiApp.route("/", skillRoutes);
   apiApp.route("/", mirrorRoutes);
@@ -845,6 +849,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   apiApp.route("/", llmProvidersRoutes);
   apiApp.route("/", settingsExportImportRoutes);
   apiApp.route("/", quotaRoutes);
+  apiApp.route("/", meRedemptionCodesRoutes);
   apiApp.route("/", llmPickerRoutes);
   apiApp.route("/", formatRoutes);
   apiApp.route("/", createMeRoutes({

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -117,6 +117,9 @@ import { QuotaRepository } from "./domains/quota/repository";
 import { QuotaService } from "./domains/quota/service";
 import { createQuotaRoutes } from "./domains/quota/routes";
 
+// Domain: Redemption codes (admin-issued single-use quota grants)
+import { RedemptionCodeRepository } from "./domains/redemption-codes/repository";
+
 // Domain: Admin (engineer-1): dashboard, users, quota admin.
 import { AdminDashboardService } from "./domains/admin/dashboard/service";
 import { createAdminDashboardRoutes } from "./domains/admin/dashboard/routes";
@@ -539,6 +542,12 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const quotaRepo = new QuotaRepository(db);
   void quotaRepo.ensureIndexes().catch((err) =>
     logger.warn({ err }, "quota indexes ensureIndexes failed — proceeding anyway"),
+  );
+
+  // ---- Domain: Redemption codes (single-use admin-issued quota grants) ----
+  const redemptionCodeRepo = new RedemptionCodeRepository(db);
+  void redemptionCodeRepo.ensureIndexes().catch((err) =>
+    logger.warn({ err }, "redemption_codes indexes ensureIndexes failed — proceeding anyway"),
   );
   const quotaService = new QuotaService({
     repo: quotaRepo,

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -119,6 +119,8 @@ import { createQuotaRoutes } from "./domains/quota/routes";
 
 // Domain: Redemption codes (admin-issued single-use quota grants)
 import { RedemptionCodeRepository } from "./domains/redemption-codes/repository";
+import { RedemptionCodeService } from "./domains/redemption-codes/service";
+import { createAdminRedemptionCodesRoutes } from "./domains/admin/redemption-codes/routes";
 
 // Domain: Admin (engineer-1): dashboard, users, quota admin.
 import { AdminDashboardService } from "./domains/admin/dashboard/service";
@@ -817,6 +819,13 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     quotaService,
     userDirectoryRepo,
   });
+  const redemptionCodeService = new RedemptionCodeService({
+    repo: redemptionCodeRepo,
+    quotaService,
+  });
+  const adminRedemptionCodesRoutes = createAdminRedemptionCodesRoutes({
+    redemptionCodeService,
+  });
 
   apiApp.route("/", skillRoutes);
   apiApp.route("/", mirrorRoutes);
@@ -830,6 +839,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   apiApp.route("/", adminDashboardRoutes);
   apiApp.route("/", adminUsersRoutes);
   apiApp.route("/", adminQuotaRoutes);
+  apiApp.route("/", adminRedemptionCodesRoutes);
   apiApp.route("/", platformSettingsRoutes);
   apiApp.route("/", settingsRoutes);
   apiApp.route("/", llmProvidersRoutes);

--- a/ornn-api/src/domains/admin/redemption-codes/routes.test.ts
+++ b/ornn-api/src/domains/admin/redemption-codes/routes.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Admin redemption-code routes — mount + dispatch tests.
+ *
+ * Mirrors the pattern in `domains/admin/quota/routes.test.ts`: a real
+ * mongodb-memory-server, a Hono app with a synthetic auth middleware
+ * that reads `x-test-perms`, and `app.request()` for dispatch.
+ *
+ * @module domains/admin/redemption-codes/routes.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db } from "mongodb";
+import { QuotaRepository } from "../../quota/repository";
+import { QuotaService } from "../../quota/service";
+import { RedemptionCodeRepository } from "../../redemption-codes/repository";
+import { RedemptionCodeService } from "../../redemption-codes/service";
+import type { AuthVariables } from "../../../middleware/nyxidAuth";
+import { createAdminRedemptionCodesRoutes } from "./routes";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: RedemptionCodeRepository;
+let quotaService: QuotaService;
+let service: RedemptionCodeService;
+let app: Hono<{ Variables: AuthVariables }>;
+
+const ADMIN_PERM = "ornn:admin:skill";
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("admin_redemption_codes_routes_test");
+  repo = new RedemptionCodeRepository(db);
+  await repo.ensureIndexes();
+  const quotaRepo = new QuotaRepository(db);
+  await quotaRepo.ensureIndexes();
+  quotaService = new QuotaService({
+    repo: quotaRepo,
+    defaults: {
+      async getQuotaDefaults() {
+        return { defaultPlaygroundMonthly: 100, defaultSkillGenMonthly: 10 };
+      },
+    },
+  });
+  service = new RedemptionCodeService({ repo, quotaService });
+  const router = createAdminRedemptionCodesRoutes({ redemptionCodeService: service });
+
+  app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    const permsHeader = c.req.header("x-test-perms") ?? "";
+    const permissions = permsHeader.length > 0 ? permsHeader.split(",") : [];
+    c.set("auth", {
+      userId: "admin1",
+      email: "admin@x.test",
+      displayName: "Admin",
+      roles: [],
+      permissions,
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    const e = err as { statusCode?: number; code?: string; message: string };
+    if (e.statusCode && e.code) {
+      return c.json(
+        { data: null, error: { code: e.code, message: e.message } },
+        e.statusCode as never,
+      );
+    }
+    return c.json(
+      { data: null, error: { code: "INTERNAL", message: e.message } },
+      500,
+    );
+  });
+  app.route("/", router);
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("redemption_codes").deleteMany({});
+  await db.collection("quota_buckets").deleteMany({});
+  await db.collection("quota_grants_audit").deleteMany({});
+});
+
+function authHeaders(perms: string[] = [ADMIN_PERM]) {
+  return { "x-test-perms": perms.join(",") };
+}
+
+function plusDays(n: number): Date {
+  return new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+}
+
+describe("POST /admin/redemption-codes", () => {
+  test("admin with permission → 200 returns code", async () => {
+    const res = await app.request("/admin/redemption-codes", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...authHeaders() },
+      body: JSON.stringify({
+        grants: [{ surface: "playground", amount: 5 }],
+        note: "demo",
+        expiresAt: plusDays(7).toISOString(),
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { code: { code: string; status: string; grants: unknown[] } };
+    };
+    expect(json.data.code.code.length).toBe(16);
+    expect(json.data.code.status).toBe("active");
+    expect(json.data.code.grants.length).toBe(1);
+  });
+
+  test("non-admin → 403", async () => {
+    const res = await app.request("/admin/redemption-codes", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...authHeaders([]) },
+      body: JSON.stringify({
+        grants: [{ surface: "playground", amount: 5 }],
+        expiresAt: plusDays(1).toISOString(),
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("expiresAt in past → 400 zod", async () => {
+    const res = await app.request("/admin/redemption-codes", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...authHeaders() },
+      body: JSON.stringify({
+        grants: [{ surface: "playground", amount: 5 }],
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /admin/redemption-codes/:id/invalidate", () => {
+  test("active → 200", async () => {
+    const minted = await service.mint({
+      admin: { userId: "admin1", email: "admin@x", displayName: "Admin" },
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    const res = await app.request(
+      `/admin/redemption-codes/${minted._id}/invalidate`,
+      { method: "POST", headers: authHeaders() },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { code: { status: string } } };
+    expect(json.data.code.status).toBe("invalidated");
+  });
+
+  test("on redeemed code → 409 ALREADY_REDEEMED", async () => {
+    const minted = await service.mint({
+      admin: { userId: "admin1", email: "admin@x", displayName: "Admin" },
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    await service.redeem({
+      code: minted.code,
+      redeemer: { userId: "u1", email: "u1@x", displayName: "U" },
+      permissions: [],
+    });
+    const res = await app.request(
+      `/admin/redemption-codes/${minted._id}/invalidate`,
+      { method: "POST", headers: authHeaders() },
+    );
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("REDEMPTION_CODE_ALREADY_REDEEMED");
+  });
+
+  test("on already-invalidated → 409 ALREADY_INVALIDATED", async () => {
+    const minted = await service.mint({
+      admin: { userId: "admin1", email: "admin@x", displayName: "Admin" },
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    await service.invalidate({
+      id: minted._id,
+      admin: { userId: "admin1", email: "admin@x", displayName: "Admin" },
+    });
+    const res = await app.request(
+      `/admin/redemption-codes/${minted._id}/invalidate`,
+      { method: "POST", headers: authHeaders() },
+    );
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("REDEMPTION_CODE_ALREADY_INVALIDATED");
+  });
+
+  test("unknown id → 404", async () => {
+    const res = await app.request(
+      `/admin/redemption-codes/ffffffffffffffffffffffff/invalidate`,
+      { method: "POST", headers: authHeaders() },
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /admin/redemption-codes", () => {
+  test("returns paginated list", async () => {
+    for (let i = 0; i < 3; i++) {
+      await service.mint({
+        admin: { userId: "admin1", email: "admin@x", displayName: "Admin" },
+        grants: [{ surface: "playground", amount: 1 }],
+        expiresAt: plusDays(7),
+      });
+    }
+    const res = await app.request("/admin/redemption-codes?page=1&pageSize=10", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { items: unknown[]; total: number; totalPages: number };
+    };
+    expect(json.data.total).toBe(3);
+    expect(json.data.items.length).toBe(3);
+  });
+});

--- a/ornn-api/src/domains/admin/redemption-codes/routes.ts
+++ b/ornn-api/src/domains/admin/redemption-codes/routes.ts
@@ -1,0 +1,221 @@
+/**
+ * Admin redemption-code HTTP surface.
+ *
+ *   POST   /api/v1/admin/redemption-codes              — mint
+ *   GET    /api/v1/admin/redemption-codes              — paginated list
+ *   GET    /api/v1/admin/redemption-codes/:id          — detail
+ *   POST   /api/v1/admin/redemption-codes/:id/invalidate
+ *
+ * All gated on `QUOTA_ADMIN_PERMISSION` — issuance is a deferred quota
+ * grant, so it sits at the same trust level as direct grants.
+ *
+ * @module domains/admin/redemption-codes/routes
+ */
+
+import { Hono } from "hono";
+import pino from "pino";
+import {
+  type AuthVariables,
+  getAuth,
+  nyxidAuthMiddleware,
+  requirePermission,
+} from "../../../middleware/nyxidAuth";
+import { validateBody, getValidatedBody } from "../../../middleware/validate";
+import { AppError } from "../../../shared/types/index";
+import { QUOTA_ADMIN_PERMISSION } from "../../quota/types";
+import type { RedemptionCodeService } from "../../redemption-codes/service";
+import {
+  REDEMPTION_CODE_STATUSES,
+  mintCodeSchema,
+  type MintCodeInput,
+  type RedemptionCodeDoc,
+  type RedemptionCodeStatus,
+} from "../../redemption-codes/types";
+
+const logger = pino({ level: "info" }).child({ module: "adminRedemptionCodeRoutes" });
+
+const PAGE_SIZE_MAX = 100;
+const PAGE_SIZE_DEFAULT = 20;
+
+export interface AdminRedemptionCodesRoutesConfig {
+  readonly redemptionCodeService: RedemptionCodeService;
+}
+
+function serializeCode(doc: RedemptionCodeDoc): Record<string, unknown> {
+  return {
+    id: doc._id,
+    code: doc.code,
+    grants: doc.grants,
+    note: doc.note ?? null,
+    status: doc.status,
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt.toISOString() : String(doc.createdAt),
+    createdBy: doc.createdBy,
+    expiresAt: doc.expiresAt instanceof Date ? doc.expiresAt.toISOString() : String(doc.expiresAt),
+    redeemedAt:
+      doc.redeemedAt instanceof Date ? doc.redeemedAt.toISOString() : doc.redeemedAt ?? null,
+    redeemedBy: doc.redeemedBy ?? null,
+    invalidatedAt:
+      doc.invalidatedAt instanceof Date
+        ? doc.invalidatedAt.toISOString()
+        : doc.invalidatedAt ?? null,
+    invalidatedBy: doc.invalidatedBy ?? null,
+  };
+}
+
+function mapInvalidateError(message: string): AppError {
+  if (message.startsWith("NOT_FOUND:")) {
+    return new AppError(404, "REDEMPTION_CODE_NOT_FOUND", "Redemption code not found");
+  }
+  if (message.startsWith("ALREADY_REDEEMED:")) {
+    return new AppError(
+      409,
+      "REDEMPTION_CODE_ALREADY_REDEEMED",
+      "Redeemed codes cannot be invalidated",
+    );
+  }
+  if (message.startsWith("ALREADY_INVALIDATED:")) {
+    return new AppError(
+      409,
+      "REDEMPTION_CODE_ALREADY_INVALIDATED",
+      "Code is already invalidated",
+    );
+  }
+  return AppError.internalError("REDEMPTION_CODE_INVALIDATE_FAILED", message);
+}
+
+export function createAdminRedemptionCodesRoutes(
+  config: AdminRedemptionCodesRoutesConfig,
+): Hono<{ Variables: AuthVariables }> {
+  const { redemptionCodeService } = config;
+  const app = new Hono<{ Variables: AuthVariables }>();
+  const auth = nyxidAuthMiddleware();
+
+  // POST /admin/redemption-codes — mint
+  app.post(
+    "/admin/redemption-codes",
+    auth,
+    requirePermission(QUOTA_ADMIN_PERMISSION),
+    validateBody(mintCodeSchema, "INVALID_REDEMPTION_CODE_BODY"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const body = getValidatedBody<MintCodeInput>(c);
+      try {
+        const doc = await redemptionCodeService.mint({
+          admin: {
+            userId: authCtx.userId,
+            email: authCtx.email,
+            displayName: authCtx.displayName,
+          },
+          grants: body.grants,
+          note: body.note,
+          expiresAt: new Date(body.expiresAt),
+        });
+        logger.info(
+          {
+            codeId: doc._id,
+            adminUserId: authCtx.userId,
+            grantCount: doc.grants.length,
+            expiresAt: doc.expiresAt.toISOString(),
+          },
+          "Admin minted redemption code",
+        );
+        return c.json({ data: { code: serializeCode(doc) }, error: null });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.startsWith("INVALID_GRANTS:") || msg.startsWith("INVALID_EXPIRES_AT:")) {
+          throw AppError.badRequest("INVALID_REDEMPTION_CODE_BODY", msg);
+        }
+        throw AppError.internalError("REDEMPTION_CODE_MINT_FAILED", msg);
+      }
+    },
+  );
+
+  // GET /admin/redemption-codes — list
+  app.get(
+    "/admin/redemption-codes",
+    auth,
+    requirePermission(QUOTA_ADMIN_PERMISSION),
+    async (c) => {
+      const statusParam = c.req.query("status");
+      let status: RedemptionCodeStatus | undefined;
+      if (statusParam) {
+        if (!(REDEMPTION_CODE_STATUSES as readonly string[]).includes(statusParam)) {
+          throw AppError.badRequest(
+            "INVALID_STATUS",
+            `status must be one of ${REDEMPTION_CODE_STATUSES.join(", ")}`,
+          );
+        }
+        status = statusParam as RedemptionCodeStatus;
+      }
+      const search = (c.req.query("search") ?? c.req.query("q") ?? "").trim() || undefined;
+      const page = Math.max(1, Number(c.req.query("page")) || 1);
+      const pageSize = Math.min(
+        PAGE_SIZE_MAX,
+        Math.max(1, Number(c.req.query("pageSize")) || PAGE_SIZE_DEFAULT),
+      );
+      const result = await redemptionCodeService.list({ page, pageSize, status, search });
+      return c.json({
+        data: {
+          items: result.items.map(serializeCode),
+          total: result.total,
+          page: result.page,
+          pageSize: result.pageSize,
+          totalPages: Math.max(1, Math.ceil(result.total / result.pageSize)),
+        },
+        error: null,
+      });
+    },
+  );
+
+  // GET /admin/redemption-codes/:id — detail
+  app.get(
+    "/admin/redemption-codes/:id",
+    auth,
+    requirePermission(QUOTA_ADMIN_PERMISSION),
+    async (c) => {
+      const id = c.req.param("id");
+      if (!id) {
+        throw AppError.badRequest("INVALID_REDEMPTION_CODE_ID", "id is required");
+      }
+      const doc = await redemptionCodeService.findById(id);
+      if (!doc) {
+        throw new AppError(404, "REDEMPTION_CODE_NOT_FOUND", "Redemption code not found");
+      }
+      return c.json({ data: { code: serializeCode(doc) }, error: null });
+    },
+  );
+
+  // POST /admin/redemption-codes/:id/invalidate
+  app.post(
+    "/admin/redemption-codes/:id/invalidate",
+    auth,
+    requirePermission(QUOTA_ADMIN_PERMISSION),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const id = c.req.param("id");
+      if (!id) {
+        throw AppError.badRequest("INVALID_REDEMPTION_CODE_ID", "id is required");
+      }
+      try {
+        const doc = await redemptionCodeService.invalidate({
+          id,
+          admin: {
+            userId: authCtx.userId,
+            email: authCtx.email,
+            displayName: authCtx.displayName,
+          },
+        });
+        logger.info(
+          { codeId: doc._id, adminUserId: authCtx.userId },
+          "Admin invalidated redemption code",
+        );
+        return c.json({ data: { code: serializeCode(doc) }, error: null });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw mapInvalidateError(msg);
+      }
+    },
+  );
+
+  return app;
+}

--- a/ornn-api/src/domains/redemption-codes/me-routes.test.ts
+++ b/ornn-api/src/domains/redemption-codes/me-routes.test.ts
@@ -1,0 +1,225 @@
+/**
+ * /me/redemption-codes routes — happy path + each documented error
+ * status mapping.
+ *
+ * @module domains/redemption-codes/me-routes.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db } from "mongodb";
+import { QuotaRepository } from "../quota/repository";
+import { QuotaService } from "../quota/service";
+import { RedemptionCodeRepository } from "./repository";
+import { RedemptionCodeService } from "./service";
+import { createMeRedemptionCodesRoutes } from "./me-routes";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: RedemptionCodeRepository;
+let quotaService: QuotaService;
+let service: RedemptionCodeService;
+let app: Hono<{ Variables: AuthVariables }>;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("me_redemption_codes_routes_test");
+  repo = new RedemptionCodeRepository(db);
+  await repo.ensureIndexes();
+  const quotaRepo = new QuotaRepository(db);
+  await quotaRepo.ensureIndexes();
+  quotaService = new QuotaService({
+    repo: quotaRepo,
+    defaults: {
+      async getQuotaDefaults() {
+        return { defaultPlaygroundMonthly: 100, defaultSkillGenMonthly: 10 };
+      },
+    },
+  });
+  service = new RedemptionCodeService({ repo, quotaService });
+
+  app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    const userId = c.req.header("x-test-user") ?? "user1";
+    c.set("auth", {
+      userId,
+      email: `${userId}@x.test`,
+      displayName: userId,
+      roles: [],
+      permissions: [],
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    const e = err as { statusCode?: number; code?: string; message: string };
+    if (e.statusCode && e.code) {
+      return c.json(
+        { data: null, error: { code: e.code, message: e.message } },
+        e.statusCode as never,
+      );
+    }
+    return c.json(
+      { data: null, error: { code: "INTERNAL", message: e.message } },
+      500,
+    );
+  });
+  app.route("/", createMeRedemptionCodesRoutes({ redemptionCodeService: service }));
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("redemption_codes").deleteMany({});
+  await db.collection("quota_buckets").deleteMany({});
+  await db.collection("quota_grants_audit").deleteMany({});
+});
+
+function plusDays(n: number): Date {
+  return new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+}
+
+async function mintActive(amount = 5): Promise<string> {
+  const doc = await service.mint({
+    admin: { userId: "admin1", email: "admin@x", displayName: "Admin" },
+    grants: [{ surface: "playground", amount }],
+    expiresAt: plusDays(7),
+  });
+  return doc.code;
+}
+
+describe("POST /me/redemption-codes/redeem", () => {
+  test("happy path → 200 + grant applied", async () => {
+    const code = await mintActive(5);
+    const res = await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { codeId: string; grants: Array<{ surface: string; amount: number }> };
+    };
+    expect(json.data.grants.length).toBe(1);
+    expect(json.data.grants[0].surface).toBe("playground");
+    expect(json.data.grants[0].amount).toBe(5);
+
+    const audits = await db.collection("quota_grants_audit").countDocuments();
+    expect(audits).toBe(1);
+  });
+
+  test("trims and uppercases the code", async () => {
+    const code = await mintActive();
+    const res = await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: `  ${code.toLowerCase()}  ` }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("unknown code → 404 REDEMPTION_CODE_NOT_FOUND", async () => {
+    const res = await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: "ZZZZZZZZZZZZZZZZ" }),
+    });
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("REDEMPTION_CODE_NOT_FOUND");
+  });
+
+  test("expired → 410 REDEMPTION_CODE_EXPIRED", async () => {
+    const code = await mintActive();
+    await db
+      .collection("redemption_codes")
+      .updateOne({ code }, { $set: { expiresAt: new Date(Date.now() - 1000) } });
+    const res = await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    expect(res.status).toBe(410);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("REDEMPTION_CODE_EXPIRED");
+  });
+
+  test("invalidated → 410 REDEMPTION_CODE_INVALIDATED", async () => {
+    const minted = await service.mint({
+      admin: { userId: "admin1", email: "admin@x", displayName: "Admin" },
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    await service.invalidate({
+      id: minted._id,
+      admin: { userId: "admin1", email: "admin@x", displayName: "Admin" },
+    });
+    const res = await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: minted.code }),
+    });
+    expect(res.status).toBe(410);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("REDEMPTION_CODE_INVALIDATED");
+  });
+
+  test("already-redeemed → 409 REDEMPTION_CODE_ALREADY_REDEEMED", async () => {
+    const code = await mintActive();
+    await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-test-user": "u1" },
+      body: JSON.stringify({ code }),
+    });
+    const res = await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-test-user": "u2" },
+      body: JSON.stringify({ code }),
+    });
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("REDEMPTION_CODE_ALREADY_REDEEMED");
+  });
+});
+
+describe("GET /me/redemption-codes/history", () => {
+  test("returns codes redeemed by caller, newest first", async () => {
+    const codeA = await mintActive(1);
+    const codeB = await mintActive(2);
+    await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-test-user": "u1" },
+      body: JSON.stringify({ code: codeA }),
+    });
+    await app.request("/me/redemption-codes/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-test-user": "u1" },
+      body: JSON.stringify({ code: codeB }),
+    });
+    const res = await app.request("/me/redemption-codes/history?page=1&pageSize=10", {
+      headers: { "x-test-user": "u1" },
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { items: Array<{ code: string }>; total: number };
+    };
+    expect(json.data.total).toBe(2);
+  });
+
+  test("empty for caller who hasn't redeemed", async () => {
+    const res = await app.request("/me/redemption-codes/history", {
+      headers: { "x-test-user": "ghost" },
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { items: unknown[]; total: number } };
+    expect(json.data.total).toBe(0);
+    expect(json.data.items).toEqual([]);
+  });
+});

--- a/ornn-api/src/domains/redemption-codes/me-routes.ts
+++ b/ornn-api/src/domains/redemption-codes/me-routes.ts
@@ -1,0 +1,156 @@
+/**
+ * Caller-scoped redemption-code routes.
+ *
+ *   POST /api/v1/me/redemption-codes/redeem    — consume a code.
+ *   GET  /api/v1/me/redemption-codes/history   — paginated history.
+ *
+ * No admin permission required — any authenticated caller can redeem.
+ * Quirk: admins reach `quotaService.grant()` here too, which lands a
+ * grant on their (otherwise-bypassed) bucket. Functionally a no-op
+ * because `chargeOnCompletion` early-returns for admins; we don't
+ * special-case it.
+ *
+ * @module domains/redemption-codes/me-routes
+ */
+
+import { Hono } from "hono";
+import pino from "pino";
+import {
+  type AuthVariables,
+  getAuth,
+  nyxidAuthMiddleware,
+} from "../../middleware/nyxidAuth";
+import { validateBody, getValidatedBody } from "../../middleware/validate";
+import { AppError } from "../../shared/types/index";
+import type { RedemptionCodeService } from "./service";
+import { redeemSchema, type RedeemInput, type RedemptionCodeDoc } from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "meRedemptionCodeRoutes" });
+
+const HISTORY_PAGE_SIZE_MAX = 100;
+const HISTORY_PAGE_SIZE_DEFAULT = 20;
+
+export interface MeRedemptionCodesRoutesConfig {
+  readonly redemptionCodeService: RedemptionCodeService;
+}
+
+function mapRedeemError(message: string): AppError {
+  if (message.startsWith("NOT_FOUND:")) {
+    return new AppError(404, "REDEMPTION_CODE_NOT_FOUND", "Code not found");
+  }
+  if (message.startsWith("EXPIRED:")) {
+    return new AppError(410, "REDEMPTION_CODE_EXPIRED", "This code has expired");
+  }
+  if (message.startsWith("ALREADY_INVALIDATED:")) {
+    return new AppError(
+      410,
+      "REDEMPTION_CODE_INVALIDATED",
+      "This code has been revoked",
+    );
+  }
+  if (message.startsWith("ALREADY_REDEEMED:")) {
+    return new AppError(
+      409,
+      "REDEMPTION_CODE_ALREADY_REDEEMED",
+      "This code has already been redeemed",
+    );
+  }
+  return AppError.internalError("REDEMPTION_CODE_REDEEM_FAILED", message);
+}
+
+function serializeHistoryItem(doc: RedemptionCodeDoc): Record<string, unknown> {
+  return {
+    id: doc._id,
+    code: doc.code,
+    grants: doc.grants,
+    note: doc.note ?? null,
+    redeemedAt:
+      doc.redeemedAt instanceof Date ? doc.redeemedAt.toISOString() : doc.redeemedAt ?? null,
+    expiresAt: doc.expiresAt instanceof Date ? doc.expiresAt.toISOString() : String(doc.expiresAt),
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt.toISOString() : String(doc.createdAt),
+  };
+}
+
+export function createMeRedemptionCodesRoutes(
+  config: MeRedemptionCodesRoutesConfig,
+): Hono<{ Variables: AuthVariables }> {
+  const { redemptionCodeService } = config;
+  const app = new Hono<{ Variables: AuthVariables }>();
+  const auth = nyxidAuthMiddleware();
+
+  // POST /me/redemption-codes/redeem
+  app.post(
+    "/me/redemption-codes/redeem",
+    auth,
+    validateBody(redeemSchema, "INVALID_REDEEM_BODY"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const body = getValidatedBody<RedeemInput>(c);
+      try {
+        const result = await redemptionCodeService.redeem({
+          code: body.code,
+          redeemer: {
+            userId: authCtx.userId,
+            email: authCtx.email,
+            displayName: authCtx.displayName,
+          },
+          permissions: authCtx.permissions,
+        });
+        logger.info(
+          {
+            codeId: result.code._id,
+            redeemerUserId: authCtx.userId,
+            grantCount: result.appliedGrants.length,
+          },
+          "User redeemed code",
+        );
+        return c.json({
+          data: {
+            codeId: result.code._id,
+            redeemedAt:
+              result.code.redeemedAt instanceof Date
+                ? result.code.redeemedAt.toISOString()
+                : new Date().toISOString(),
+            grants: result.appliedGrants.map((g) => ({
+              surface: g.surface,
+              amount: g.amount,
+              monthMarker: g.monthMarker,
+              newAdminGrant: g.newAdminGrant,
+            })),
+          },
+          error: null,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw mapRedeemError(msg);
+      }
+    },
+  );
+
+  // GET /me/redemption-codes/history
+  app.get("/me/redemption-codes/history", auth, async (c) => {
+    const authCtx = getAuth(c);
+    const page = Math.max(1, Number(c.req.query("page")) || 1);
+    const pageSize = Math.min(
+      HISTORY_PAGE_SIZE_MAX,
+      Math.max(1, Number(c.req.query("pageSize")) || HISTORY_PAGE_SIZE_DEFAULT),
+    );
+    const list = await redemptionCodeService.listRedeemedByUser(
+      authCtx.userId,
+      page,
+      pageSize,
+    );
+    return c.json({
+      data: {
+        items: list.items.map(serializeHistoryItem),
+        total: list.total,
+        page,
+        pageSize,
+        totalPages: Math.max(1, Math.ceil(list.total / pageSize)),
+      },
+      error: null,
+    });
+  });
+
+  return app;
+}

--- a/ornn-api/src/domains/redemption-codes/repository.ts
+++ b/ornn-api/src/domains/redemption-codes/repository.ts
@@ -1,0 +1,167 @@
+/**
+ * Mongo persistence for redemption codes.
+ *
+ *   `redemption_codes` — one document per minted code. Lifecycle:
+ *     active → redeemed   (via `tryClaimForRedeem`)
+ *     active → invalidated (via `tryInvalidate`)
+ *
+ * Both transitions are atomic `findOneAndUpdate` pivots so concurrent
+ * redeems / invalidates of the same code produce exactly one winner.
+ *
+ * @module domains/redemption-codes/repository
+ */
+
+import type { Collection, Db } from "mongodb";
+import pino from "pino";
+import {
+  type ActorMeta,
+  type RedemptionCodeDoc,
+  type RedemptionCodeStatus,
+} from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "redemptionCodeRepository" });
+
+/**
+ * Escape a user-supplied string before embedding in a `$regex`. Same
+ * trick as `String.raw.replace`-based escapers — covers the standard
+ * regex meta chars MongoDB recognises.
+ */
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export class RedemptionCodeRepository {
+  private readonly codes: Collection<RedemptionCodeDoc>;
+
+  constructor(db: Db) {
+    this.codes = db.collection<RedemptionCodeDoc>("redemption_codes");
+  }
+
+  get collection(): Collection<RedemptionCodeDoc> {
+    return this.codes;
+  }
+
+  async ensureIndexes(): Promise<void> {
+    try {
+      await this.codes.createIndex({ code: 1 }, { unique: true, name: "code_unique" });
+      await this.codes.createIndex(
+        { status: 1, createdAt: -1 },
+        { name: "status_recent" },
+      );
+      await this.codes.createIndex(
+        { "redeemedBy.userId": 1, redeemedAt: -1 },
+        { name: "redeemed_by_user" },
+      );
+      await this.codes.createIndex(
+        { "createdBy.userId": 1, createdAt: -1 },
+        { name: "created_by_admin" },
+      );
+    } catch (err) {
+      logger.warn({ err }, "redemption_codes ensureIndexes failed — proceeding anyway");
+    }
+  }
+
+  async insertCode(doc: RedemptionCodeDoc): Promise<void> {
+    await this.codes.insertOne(doc);
+  }
+
+  async findByCode(code: string): Promise<RedemptionCodeDoc | null> {
+    return this.codes.findOne({ code });
+  }
+
+  async findById(id: string): Promise<RedemptionCodeDoc | null> {
+    return this.codes.findOne({ _id: id });
+  }
+
+  /**
+   * Atomic `active → redeemed` pivot. The filter requires `status:
+   * "active"` AND `expiresAt > now`, so an expired or already-claimed
+   * code yields null even on the same millisecond. Returns the post-
+   * update doc on success, null otherwise.
+   */
+  async tryClaimForRedeem(params: {
+    code: string;
+    redeemedBy: ActorMeta;
+    now: Date;
+  }): Promise<RedemptionCodeDoc | null> {
+    const result = await this.codes.findOneAndUpdate(
+      { code: params.code, status: "active", expiresAt: { $gt: params.now } },
+      {
+        $set: {
+          status: "redeemed",
+          redeemedAt: params.now,
+          redeemedBy: params.redeemedBy,
+        },
+      },
+      { returnDocument: "after" },
+    );
+    return result ?? null;
+  }
+
+  /**
+   * Atomic `active → invalidated` pivot. Returns the post-update doc
+   * on success, null when the code isn't active anymore.
+   */
+  async tryInvalidate(params: {
+    id: string;
+    invalidatedBy: ActorMeta;
+    now: Date;
+  }): Promise<RedemptionCodeDoc | null> {
+    const result = await this.codes.findOneAndUpdate(
+      { _id: params.id, status: "active" },
+      {
+        $set: {
+          status: "invalidated",
+          invalidatedAt: params.now,
+          invalidatedBy: params.invalidatedBy,
+        },
+      },
+      { returnDocument: "after" },
+    );
+    return result ?? null;
+  }
+
+  async list(params: {
+    page: number;
+    pageSize: number;
+    status?: RedemptionCodeStatus;
+    search?: string;
+  }): Promise<{ items: RedemptionCodeDoc[]; total: number }> {
+    const filter: Record<string, unknown> = {};
+    if (params.status) filter.status = params.status;
+    const search = params.search?.trim();
+    if (search) {
+      const escaped = escapeRegex(search);
+      filter.$or = [
+        { code: { $regex: `^${escapeRegex(search.toUpperCase())}` } },
+        { note: { $regex: escaped, $options: "i" } },
+      ];
+    }
+    const total = await this.codes.countDocuments(filter);
+    const offset = (params.page - 1) * params.pageSize;
+    const items = await this.codes
+      .find(filter)
+      .sort({ createdAt: -1 })
+      .skip(offset)
+      .limit(params.pageSize)
+      .toArray();
+    return { items, total };
+  }
+
+  async listRedeemedByUser(
+    userId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<{ items: RedemptionCodeDoc[]; total: number }> {
+    const filter = { "redeemedBy.userId": userId };
+    const total = await this.codes.countDocuments(filter);
+    const offset = (page - 1) * pageSize;
+    const items = await this.codes
+      .find(filter)
+      .sort({ redeemedAt: -1 })
+      .skip(offset)
+      .limit(pageSize)
+      .toArray();
+    return { items, total };
+  }
+}

--- a/ornn-api/src/domains/redemption-codes/service.test.ts
+++ b/ornn-api/src/domains/redemption-codes/service.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Unit tests for RedemptionCodeService.
+ *
+ * The substantive coverage (race-condition pivot, each rejection
+ * branch, mint-retry on duplicate insert) lands in commit 6 alongside
+ * the integration tests. This file is the placeholder so the test
+ * harness picks the path up immediately.
+ *
+ * @module domains/redemption-codes/service.test
+ */
+
+import { describe, it } from "bun:test";
+import { RedemptionCodeService } from "./service";
+
+describe("RedemptionCodeService", () => {
+  it("module is importable", () => {
+    // Placeholder — full suite added in commit 6.
+    void RedemptionCodeService;
+  });
+});

--- a/ornn-api/src/domains/redemption-codes/service.test.ts
+++ b/ornn-api/src/domains/redemption-codes/service.test.ts
@@ -1,20 +1,245 @@
 /**
- * Unit tests for RedemptionCodeService.
- *
- * The substantive coverage (race-condition pivot, each rejection
- * branch, mint-retry on duplicate insert) lands in commit 6 alongside
- * the integration tests. This file is the placeholder so the test
- * harness picks the path up immediately.
+ * RedemptionCodeService — lifecycle, error branches, and the
+ * parallel-redeem race that motivates `tryClaimForRedeem`.
  *
  * @module domains/redemption-codes/service.test
  */
 
-import { describe, it } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db } from "mongodb";
+import { QuotaRepository } from "../quota/repository";
+import { QuotaService } from "../quota/service";
+import { RedemptionCodeRepository } from "./repository";
 import { RedemptionCodeService } from "./service";
+import type { ActorMeta } from "./types";
 
-describe("RedemptionCodeService", () => {
-  it("module is importable", () => {
-    // Placeholder — full suite added in commit 6.
-    void RedemptionCodeService;
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: RedemptionCodeRepository;
+let quotaService: QuotaService;
+let service: RedemptionCodeService;
+
+const ADMIN: ActorMeta = {
+  userId: "admin1",
+  email: "admin@x.test",
+  displayName: "Admin",
+};
+const REDEEMER: ActorMeta = {
+  userId: "user1",
+  email: "user@x.test",
+  displayName: "User One",
+};
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("redemption_codes_service_test");
+  repo = new RedemptionCodeRepository(db);
+  await repo.ensureIndexes();
+  const quotaRepo = new QuotaRepository(db);
+  await quotaRepo.ensureIndexes();
+  quotaService = new QuotaService({
+    repo: quotaRepo,
+    defaults: {
+      async getQuotaDefaults() {
+        return { defaultPlaygroundMonthly: 100, defaultSkillGenMonthly: 10 };
+      },
+    },
+  });
+  service = new RedemptionCodeService({ repo, quotaService });
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("redemption_codes").deleteMany({});
+  await db.collection("quota_buckets").deleteMany({});
+  await db.collection("quota_grants_audit").deleteMany({});
+});
+
+function plusDays(n: number, base: Date = new Date()): Date {
+  return new Date(base.getTime() + n * 24 * 60 * 60 * 1000);
+}
+
+describe("RedemptionCodeService.mint", () => {
+  test("produces unique 16-char code over restricted alphabet", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    expect(doc.code.length).toBe(16);
+    expect(/^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]+$/.test(doc.code)).toBe(true);
+    expect(doc.status).toBe("active");
+    expect(doc.grants).toEqual([{ surface: "playground", amount: 5 }]);
+    expect(doc.createdBy).toEqual(ADMIN);
+  });
+
+  test("rejects duplicate surface in grants", async () => {
+    await expect(
+      service.mint({
+        admin: ADMIN,
+        grants: [
+          { surface: "playground", amount: 5 },
+          { surface: "playground", amount: 7 },
+        ],
+        expiresAt: plusDays(1),
+      }),
+    ).rejects.toThrow(/duplicate surface/i);
+  });
+
+  test("rejects expiresAt in the past", async () => {
+    await expect(
+      service.mint({
+        admin: ADMIN,
+        grants: [{ surface: "playground", amount: 5 }],
+        expiresAt: plusDays(-1),
+      }),
+    ).rejects.toThrow(/INVALID_EXPIRES_AT/);
+  });
+});
+
+describe("RedemptionCodeService.redeem — happy path", () => {
+  test("transitions code to redeemed and applies all grants", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [
+        { surface: "playground", amount: 5 },
+        { surface: "skillGen", amount: 3 },
+      ],
+      expiresAt: plusDays(7),
+    });
+    const result = await service.redeem({
+      code: doc.code,
+      redeemer: REDEEMER,
+      permissions: [],
+    });
+    expect(result.code.status).toBe("redeemed");
+    expect(result.code.redeemedBy).toEqual(REDEEMER);
+    expect(result.appliedGrants.length).toBe(2);
+    const surfaces = result.appliedGrants.map((g) => g.surface).sort();
+    expect(surfaces).toEqual(["playground", "skillGen"]);
+    const audits = await db.collection("quota_grants_audit").countDocuments();
+    expect(audits).toBe(2);
+  });
+});
+
+describe("RedemptionCodeService.redeem — race", () => {
+  test("two parallel redemptions of the same code → exactly one wins", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    const a: ActorMeta = { userId: "uA", email: "a@x", displayName: "A" };
+    const b: ActorMeta = { userId: "uB", email: "b@x", displayName: "B" };
+    const results = await Promise.allSettled([
+      service.redeem({ code: doc.code, redeemer: a, permissions: [] }),
+      service.redeem({ code: doc.code, redeemer: b, permissions: [] }),
+    ]);
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled.length).toBe(1);
+    expect(rejected.length).toBe(1);
+    const reason = (rejected[0] as PromiseRejectedResult).reason as Error;
+    expect(reason.message).toMatch(/ALREADY_REDEEMED/);
+  });
+});
+
+describe("RedemptionCodeService.redeem — rejection branches", () => {
+  test("expired code → EXPIRED:", async () => {
+    const past = new Date(Date.now() - 1000);
+    // mint with future expiry, then back-date via repo
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(1),
+    });
+    await repo.collection.updateOne(
+      { _id: doc._id },
+      { $set: { expiresAt: past } },
+    );
+    await expect(
+      service.redeem({ code: doc.code, redeemer: REDEEMER, permissions: [] }),
+    ).rejects.toThrow(/EXPIRED:/);
+  });
+
+  test("already-redeemed code → ALREADY_REDEEMED:", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    await service.redeem({ code: doc.code, redeemer: REDEEMER, permissions: [] });
+    await expect(
+      service.redeem({ code: doc.code, redeemer: REDEEMER, permissions: [] }),
+    ).rejects.toThrow(/ALREADY_REDEEMED/);
+  });
+
+  test("invalidated code → ALREADY_INVALIDATED:", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    await service.invalidate({ id: doc._id, admin: ADMIN });
+    await expect(
+      service.redeem({ code: doc.code, redeemer: REDEEMER, permissions: [] }),
+    ).rejects.toThrow(/ALREADY_INVALIDATED/);
+  });
+
+  test("unknown code → NOT_FOUND:", async () => {
+    await expect(
+      service.redeem({ code: "ZZZZZZZZZZZZZZZZ", redeemer: REDEEMER, permissions: [] }),
+    ).rejects.toThrow(/NOT_FOUND/);
+  });
+});
+
+describe("RedemptionCodeService.invalidate", () => {
+  test("active → invalidated", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    const updated = await service.invalidate({ id: doc._id, admin: ADMIN });
+    expect(updated.status).toBe("invalidated");
+    expect(updated.invalidatedBy).toEqual(ADMIN);
+  });
+
+  test("already-redeemed → ALREADY_REDEEMED:", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    await service.redeem({ code: doc.code, redeemer: REDEEMER, permissions: [] });
+    await expect(service.invalidate({ id: doc._id, admin: ADMIN })).rejects.toThrow(
+      /ALREADY_REDEEMED/,
+    );
+  });
+
+  test("already-invalidated → ALREADY_INVALIDATED:", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 5 }],
+      expiresAt: plusDays(7),
+    });
+    await service.invalidate({ id: doc._id, admin: ADMIN });
+    await expect(service.invalidate({ id: doc._id, admin: ADMIN })).rejects.toThrow(
+      /ALREADY_INVALIDATED/,
+    );
+  });
+
+  test("unknown id → NOT_FOUND:", async () => {
+    await expect(
+      service.invalidate({ id: "ffffffffffffffffffffffff", admin: ADMIN }),
+    ).rejects.toThrow(/NOT_FOUND/);
   });
 });

--- a/ornn-api/src/domains/redemption-codes/service.ts
+++ b/ornn-api/src/domains/redemption-codes/service.ts
@@ -204,6 +204,14 @@ export class RedemptionCodeService {
     return this.repo.findByCode(code);
   }
 
+  async listRedeemedByUser(
+    userId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<{ items: RedemptionCodeDoc[]; total: number }> {
+    return this.repo.listRedeemedByUser(userId, page, pageSize);
+  }
+
   async invalidate(params: InvalidateParams): Promise<RedemptionCodeDoc> {
     const now = params.now ?? new Date();
     const updated = await this.repo.tryInvalidate({

--- a/ornn-api/src/domains/redemption-codes/service.ts
+++ b/ornn-api/src/domains/redemption-codes/service.ts
@@ -1,0 +1,300 @@
+/**
+ * Redemption-code lifecycle service.
+ *
+ *   mint        — admin issues a new code carrying ≥1 surface grants.
+ *   list        — paginated admin browse (with status + search filter).
+ *   invalidate  — admin retires an active code.
+ *   redeem      — caller consumes a code, applying grants to their own
+ *                 current-month buckets via `QuotaService.grant`.
+ *
+ * The single-use guarantee comes from `repo.tryClaimForRedeem` (atomic
+ * `findOneAndUpdate`). Grant fan-out happens AFTER the claim — if a
+ * mid-loop grant fails we deliberately don't roll back the code's
+ * `redeemed` status: the code is consumed, the admin can manually
+ * top-up the missing surface from the audit log.
+ *
+ * @module domains/redemption-codes/service
+ */
+
+import { randomBytes } from "node:crypto";
+import { ObjectId } from "mongodb";
+import pino from "pino";
+import { isDuplicateKeyError } from "../../shared/types/index";
+import type { Surface } from "../quota/types";
+import type { QuotaService } from "../quota/service";
+import type { RedemptionCodeRepository } from "./repository";
+import {
+  REDEMPTION_CODE_ALPHABET,
+  REDEMPTION_CODE_LENGTH,
+  type ActorMeta,
+  type RedemptionCodeDoc,
+  type RedemptionCodeStatus,
+  type RedemptionGrantEntry,
+} from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "redemptionCodeService" });
+
+const MINT_RETRY_LIMIT = 5;
+
+export interface RedemptionCodeServiceConfig {
+  repo: RedemptionCodeRepository;
+  quotaService: QuotaService;
+}
+
+export interface MintParams {
+  admin: ActorMeta;
+  grants: RedemptionGrantEntry[];
+  note?: string;
+  expiresAt: Date;
+  now?: Date;
+}
+
+export interface ListParams {
+  page: number;
+  pageSize: number;
+  status?: RedemptionCodeStatus;
+  search?: string;
+}
+
+export interface ListResult {
+  items: RedemptionCodeDoc[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface InvalidateParams {
+  id: string;
+  admin: ActorMeta;
+  now?: Date;
+}
+
+export interface RedeemParams {
+  code: string;
+  redeemer: ActorMeta;
+  permissions: readonly string[] | undefined;
+  now?: Date;
+}
+
+export interface AppliedGrant {
+  surface: Surface;
+  amount: number;
+  auditId: string;
+  monthMarker: string;
+  newAdminGrant: number;
+}
+
+export interface RedeemResult {
+  code: RedemptionCodeDoc;
+  appliedGrants: AppliedGrant[];
+}
+
+/**
+ * Service-level error sentinels. Routes pattern-match on the message
+ * prefix to map to the right HTTP status + error code. Using prefix
+ * strings rather than a custom subclass keeps this layer independent
+ * of the AppError type.
+ */
+export const REDEEM_ERROR_PREFIXES = [
+  "NOT_FOUND",
+  "EXPIRED",
+  "ALREADY_REDEEMED",
+  "ALREADY_INVALIDATED",
+] as const;
+
+export class RedemptionCodeService {
+  private readonly repo: RedemptionCodeRepository;
+  private readonly quotaService: QuotaService;
+
+  constructor(config: RedemptionCodeServiceConfig) {
+    this.repo = config.repo;
+    this.quotaService = config.quotaService;
+  }
+
+  /**
+   * Generate one candidate code. The `% alphabet.length` step
+   * introduces a sub-1.5% modulo bias (256 % 31), which is harmless
+   * for human-shareable IDs since the unique index + retry loop
+   * absorbs collisions regardless.
+   */
+  private generateCode(): string {
+    const bytes = randomBytes(REDEMPTION_CODE_LENGTH);
+    let out = "";
+    for (let i = 0; i < REDEMPTION_CODE_LENGTH; i++) {
+      out += REDEMPTION_CODE_ALPHABET[bytes[i] % REDEMPTION_CODE_ALPHABET.length];
+    }
+    return out;
+  }
+
+  async mint(params: MintParams): Promise<RedemptionCodeDoc> {
+    const now = params.now ?? new Date();
+
+    if (!Array.isArray(params.grants) || params.grants.length === 0) {
+      throw new Error("INVALID_GRANTS: grants must be non-empty");
+    }
+    const surfaces = new Set(params.grants.map((g) => g.surface));
+    if (surfaces.size !== params.grants.length) {
+      throw new Error("INVALID_GRANTS: duplicate surface in grants");
+    }
+    for (const g of params.grants) {
+      if (!Number.isInteger(g.amount) || g.amount <= 0) {
+        throw new Error(`INVALID_GRANTS: grant amount must be a positive integer (got ${g.amount})`);
+      }
+    }
+    if (!(params.expiresAt instanceof Date) || Number.isNaN(params.expiresAt.getTime())) {
+      throw new Error("INVALID_EXPIRES_AT: expiresAt must be a valid Date");
+    }
+    if (params.expiresAt.getTime() <= now.getTime()) {
+      throw new Error("INVALID_EXPIRES_AT: expiresAt must be in the future");
+    }
+
+    let lastErr: unknown = null;
+    for (let attempt = 0; attempt < MINT_RETRY_LIMIT; attempt++) {
+      const code = this.generateCode();
+      const doc: RedemptionCodeDoc = {
+        _id: new ObjectId().toHexString(),
+        code,
+        grants: params.grants.map((g) => ({ surface: g.surface, amount: g.amount })),
+        note: params.note,
+        createdAt: now,
+        createdBy: params.admin,
+        expiresAt: params.expiresAt,
+        status: "active",
+      };
+      try {
+        await this.repo.insertCode(doc);
+        logger.info(
+          {
+            codeId: doc._id,
+            createdBy: params.admin.userId,
+            expiresAt: doc.expiresAt.toISOString(),
+            grantCount: doc.grants.length,
+          },
+          "Redemption code minted",
+        );
+        return doc;
+      } catch (err) {
+        lastErr = err;
+        if (isDuplicateKeyError(err)) {
+          logger.warn(
+            { attempt, codeId: doc._id },
+            "Redemption code collision — retrying",
+          );
+          continue;
+        }
+        throw err;
+      }
+    }
+    logger.error({ err: lastErr }, "Redemption code mint exhausted retries");
+    throw new Error(
+      `Failed to generate unique redemption code after ${MINT_RETRY_LIMIT} attempts`,
+    );
+  }
+
+  async list(params: ListParams): Promise<ListResult> {
+    const { items, total } = await this.repo.list(params);
+    return { items, total, page: params.page, pageSize: params.pageSize };
+  }
+
+  async findById(id: string): Promise<RedemptionCodeDoc | null> {
+    return this.repo.findById(id);
+  }
+
+  async findByCode(code: string): Promise<RedemptionCodeDoc | null> {
+    return this.repo.findByCode(code);
+  }
+
+  async invalidate(params: InvalidateParams): Promise<RedemptionCodeDoc> {
+    const now = params.now ?? new Date();
+    const updated = await this.repo.tryInvalidate({
+      id: params.id,
+      invalidatedBy: params.admin,
+      now,
+    });
+    if (updated) {
+      logger.info(
+        { codeId: updated._id, invalidatedBy: params.admin.userId },
+        "Redemption code invalidated",
+      );
+      return updated;
+    }
+    const existing = await this.repo.findById(params.id);
+    if (!existing) {
+      throw new Error(`NOT_FOUND: redemption code ${params.id}`);
+    }
+    if (existing.status === "redeemed") {
+      throw new Error(
+        `ALREADY_REDEEMED: code ${params.id} was already redeemed; cannot invalidate`,
+      );
+    }
+    if (existing.status === "invalidated") {
+      throw new Error(`ALREADY_INVALIDATED: code ${params.id} is already invalidated`);
+    }
+    throw new Error(`NOT_FOUND: redemption code ${params.id} could not be invalidated`);
+  }
+
+  async redeem(params: RedeemParams): Promise<RedeemResult> {
+    const now = params.now ?? new Date();
+    const claimed = await this.repo.tryClaimForRedeem({
+      code: params.code,
+      redeemedBy: params.redeemer,
+      now,
+    });
+
+    if (!claimed) {
+      const existing = await this.repo.findByCode(params.code);
+      if (!existing) {
+        throw new Error(`NOT_FOUND: unknown redemption code`);
+      }
+      if (existing.status === "invalidated") {
+        throw new Error(`ALREADY_INVALIDATED: this code has been invalidated`);
+      }
+      if (existing.status === "redeemed") {
+        throw new Error(`ALREADY_REDEEMED: this code has already been redeemed`);
+      }
+      if (existing.expiresAt.getTime() <= now.getTime()) {
+        throw new Error(`EXPIRED: this code expired on ${existing.expiresAt.toISOString()}`);
+      }
+      // Should not happen — race with another concurrent claim winning.
+      throw new Error(`ALREADY_REDEEMED: this code has already been redeemed`);
+    }
+
+    const codePrefix = claimed.code.slice(0, 4);
+    const applied: AppliedGrant[] = [];
+    for (const grant of claimed.grants) {
+      // The redeemer is passed as both `admin` and `targetUserId` —
+      // grant() requires admin metadata for the audit row. The audit
+      // entry transparently shows a self-grant; the note carries the
+      // code prefix so it's clear this came from a redemption.
+      // Deliberately NO rollback if a later grant fails: the code is
+      // already consumed by the atomic pivot above. An admin can
+      // top-up the missing surface manually from the audit log.
+      const result = await this.quotaService.grant({
+        admin: params.redeemer,
+        targetUserId: params.redeemer.userId,
+        surface: grant.surface,
+        amount: grant.amount,
+        note: `Redeemed code ${codePrefix}…`,
+        now,
+      });
+      applied.push({
+        surface: grant.surface,
+        amount: grant.amount,
+        auditId: result.auditId,
+        monthMarker: result.monthMarker,
+        newAdminGrant: result.newAdminGrant,
+      });
+    }
+
+    logger.info(
+      {
+        codeId: claimed._id,
+        redeemerUserId: params.redeemer.userId,
+        surfaces: claimed.grants.map((g) => g.surface),
+      },
+      "Redemption code redeemed",
+    );
+
+    return { code: claimed, appliedGrants: applied };
+  }
+}

--- a/ornn-api/src/domains/redemption-codes/types.ts
+++ b/ornn-api/src/domains/redemption-codes/types.ts
@@ -1,0 +1,135 @@
+/**
+ * Admin-issued redemption codes — types + Zod schemas.
+ *
+ * A redemption code is a single-use, server-minted token that an admin
+ * hands to a user. Redeeming it applies one or more quota grants to the
+ * caller's current-month bucket(s). Each code is consumable exactly
+ * once across all users (atomic active → redeemed transition); admins
+ * can also retire an unused code via active → invalidated.
+ *
+ * Codes are stored canonical-uppercase. Lookup is case-insensitive: the
+ * boundary Zod schema upper-cases incoming user input so the unique
+ * index does the right thing without needing collation.
+ *
+ * @module domains/redemption-codes/types
+ */
+
+import { z } from "zod";
+import { SURFACES, type Surface } from "../quota/types";
+
+/**
+ * Length of the random portion of a redemption code. 16 chars over a
+ * 31-symbol alphabet ≈ 79 bits of entropy — comfortable for a single-
+ * use token even before the unique index catches collisions.
+ */
+export const REDEMPTION_CODE_LENGTH = 16;
+
+/**
+ * Base32-ish alphabet, ambiguous glyphs removed: `0/O/1/I/L`. Length
+ * 31. Picked so an admin can read a code over a phone call without
+ * misreads, and a user typing it from a screenshot can't confuse a
+ * zero for a capital O.
+ */
+export const REDEMPTION_CODE_ALPHABET =
+  "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+export type RedemptionCodeStatus = "active" | "redeemed" | "invalidated";
+
+/**
+ * One slot in the multi-surface grant bundle a code carries. A code may
+ * carry up to one entry per surface; the service refuses duplicates so
+ * the redeem path can apply each grant independently.
+ */
+export interface RedemptionGrantEntry {
+  surface: Surface;
+  amount: number;
+}
+
+/**
+ * Snapshot of the actor at the moment they touched a code. Persisted
+ * verbatim so audit views don't need a second NyxID round-trip per row.
+ */
+export interface ActorMeta {
+  userId: string;
+  email: string;
+  displayName: string;
+}
+
+export interface RedemptionCodeDoc {
+  /** ObjectId hex string. */
+  _id: string;
+  /** Canonical uppercase code, unique. */
+  code: string;
+  grants: RedemptionGrantEntry[];
+  note?: string;
+  createdAt: Date;
+  createdBy: ActorMeta;
+  expiresAt: Date;
+  status: RedemptionCodeStatus;
+  redeemedAt?: Date;
+  redeemedBy?: ActorMeta;
+  invalidatedAt?: Date;
+  invalidatedBy?: ActorMeta;
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+export const grantEntrySchema = z.object({
+  surface: z.enum(SURFACES),
+  amount: z.number().int().positive().max(100_000),
+});
+
+export const mintCodeSchema = z.object({
+  grants: z
+    .array(grantEntrySchema)
+    .min(1)
+    .max(SURFACES.length)
+    .refine(
+      (entries) => new Set(entries.map((e) => e.surface)).size === entries.length,
+      "Duplicate surface in grants",
+    ),
+  note: z.string().max(500).optional(),
+  expiresAt: z
+    .string()
+    .datetime()
+    .refine(
+      (d) => new Date(d) > new Date(),
+      "expiresAt must be in the future",
+    ),
+});
+
+/**
+ * Body schema for `POST /me/redemption-codes/redeem`. Trims + uppercases
+ * at the boundary so the service compares against the canonical form
+ * stored on the doc.
+ */
+export const redeemSchema = z.object({
+  code: z
+    .string()
+    .min(1)
+    .max(64)
+    .transform((s) => s.trim().toUpperCase()),
+});
+
+export const REDEMPTION_CODE_STATUSES = [
+  "active",
+  "redeemed",
+  "invalidated",
+] as const;
+
+/**
+ * Query-string schema for `GET /admin/redemption-codes`. `z.coerce` on
+ * pagination because query params arrive as strings.
+ */
+export const listFilterSchema = z.object({
+  status: z.enum(REDEMPTION_CODE_STATUSES).optional(),
+  q: z.string().max(64).optional(),
+  page: z.coerce.number().int().positive().max(10_000).optional(),
+  pageSize: z.coerce.number().int().positive().max(200).optional(),
+});
+
+export type MintCodeInput = z.infer<typeof mintCodeSchema>;
+export type RedeemInput = z.infer<typeof redeemSchema>;
+export type ListFilterInput = z.infer<typeof listFilterSchema>;

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -126,6 +126,9 @@ const AdminSkillsPage = lazy(() =>
 const AdminQuotaManagementPage = lazy(() =>
   import("@/pages/admin").then((m) => ({ default: m.QuotaManagementPage })),
 );
+const AdminRedemptionCodesPage = lazy(() =>
+  import("@/pages/admin").then((m) => ({ default: m.RedemptionCodesPage })),
+);
 
 // Settings layout + section components live under pages/admin/settings.
 const SettingsLayout = lazy(() =>
@@ -245,6 +248,10 @@ const router = createBrowserRouter(
             <Route path="/admin/users-legacy" element={<AdminUsersLegacyPage />} />
             <Route path="/admin/skills" element={<AdminSkillsPage />} />
             <Route path="/admin/quota" element={<AdminQuotaManagementPage />} />
+            <Route
+              path="/admin/redemption-codes"
+              element={<AdminRedemptionCodesPage />}
+            />
 
             {/* /admin/mirror keeps working but redirects to the new
                 settings/mirror section so existing deep-links + bookmarks

--- a/ornn-web/src/components/admin/redemption-codes/MintRedemptionCodeModal.test.tsx
+++ b/ornn-web/src/components/admin/redemption-codes/MintRedemptionCodeModal.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for `MintRedemptionCodeModal` — covers the client-side guards
+ * that mirror the backend zod (no duplicate surface, future expiry,
+ * positive integer amount) and the success state where the generated
+ * code becomes the only thing the modal shows.
+ *
+ * @module components/admin/redemption-codes/MintRedemptionCodeModal.test
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { RedemptionCode } from "@/services/redemptionCodesApi";
+
+const mintMutateAsync = vi.fn();
+const useMintCode = vi.fn();
+const addToast = vi.fn();
+
+vi.mock("@/hooks/useRedemptionCodes", () => ({
+  useMintCode: () => useMintCode(),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
+}));
+
+import { MintRedemptionCodeModal } from "./MintRedemptionCodeModal";
+
+function mintedCode(): RedemptionCode {
+  return {
+    id: "1",
+    code: "ABCD-EFGH-IJKL-MNOP",
+    grants: [
+      { surface: "playground", amount: 100 },
+      { surface: "skillGen", amount: 50 },
+    ],
+    note: "test",
+    status: "active",
+    createdAt: "2026-05-08T10:00:00.000Z",
+    createdBy: { userId: "u1", email: "a@b.c", displayName: "Admin" },
+    expiresAt: "2026-06-08T10:00:00.000Z",
+    redeemedAt: null,
+    redeemedBy: null,
+    invalidatedAt: null,
+    invalidatedBy: null,
+  };
+}
+
+beforeEach(() => {
+  mintMutateAsync.mockReset();
+  addToast.mockReset();
+  useMintCode.mockReturnValue({
+    mutateAsync: mintMutateAsync,
+    isPending: false,
+  });
+});
+
+describe("MintRedemptionCodeModal", () => {
+  it("rejects submit when amount is invalid (zero / non-positive)", async () => {
+    render(<MintRedemptionCodeModal isOpen={true} onClose={() => {}} />);
+
+    const amountInput = screen.getByLabelText(/grant 1 amount/i);
+    fireEvent.change(amountInput, { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: /^mint code$/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /positive whole number/i,
+    );
+    expect(mintMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("disables surfaces already used in another grant row", async () => {
+    render(<MintRedemptionCodeModal isOpen={true} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /\+ add grant/i }));
+
+    const select1 = screen.getByLabelText(/grant 1 surface/i) as HTMLSelectElement;
+    const select2 = screen.getByLabelText(/grant 2 surface/i) as HTMLSelectElement;
+
+    // Each select only offers the surface(s) not already chosen on the other row.
+    const options1 = within(select1).getAllByRole("option") as HTMLOptionElement[];
+    const options2 = within(select2).getAllByRole("option") as HTMLOptionElement[];
+    expect(options1.map((o) => o.value)).toEqual(["playground"]);
+    expect(options2.map((o) => o.value)).toEqual(["skillGen"]);
+  });
+
+  it("blocks submission when expiresAt is in the past", async () => {
+    render(<MintRedemptionCodeModal isOpen={true} onClose={() => {}} />);
+
+    const expires = screen.getByLabelText(/expires at/i) as HTMLInputElement;
+    fireEvent.change(expires, { target: { value: "2000-01-01T00:00" } });
+    fireEvent.click(screen.getByRole("button", { name: /^mint code$/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /expiration must be in the future/i,
+    );
+    expect(mintMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("renders a copyable success state once the code is minted", async () => {
+    mintMutateAsync.mockResolvedValue({ code: mintedCode() });
+
+    render(<MintRedemptionCodeModal isOpen={true} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /^mint code$/i }));
+
+    await waitFor(() => expect(mintMutateAsync).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText("ABCD-EFGH-IJKL-MNOP"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^copy code$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^done$/i })).toBeInTheDocument();
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+  });
+});

--- a/ornn-web/src/components/admin/redemption-codes/MintRedemptionCodeModal.tsx
+++ b/ornn-web/src/components/admin/redemption-codes/MintRedemptionCodeModal.tsx
@@ -263,7 +263,7 @@ export function MintRedemptionCodeModal({
           </div>
         </div>
       ) : (
-        <form onSubmit={submit} className="space-y-5">
+        <form onSubmit={submit} noValidate className="space-y-5">
           <fieldset className="space-y-3">
             <legend className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
               Grants

--- a/ornn-web/src/components/admin/redemption-codes/MintRedemptionCodeModal.tsx
+++ b/ornn-web/src/components/admin/redemption-codes/MintRedemptionCodeModal.tsx
@@ -1,0 +1,399 @@
+/**
+ * MintRedemptionCodeModal — admin form to mint a single redemption code.
+ *
+ * After the POST succeeds we DON'T close the modal: the generated code
+ * is the whole point and the admin needs to copy it before dismissing.
+ * The modal swaps to a "success" state showing the code in a large copy
+ * card with a single "Done" CTA.
+ *
+ * Form rules (mirror backend zod):
+ *   - 1..2 grants, no duplicate surfaces
+ *   - amount is positive integer ≤ 100,000
+ *   - note ≤ 500 chars (optional)
+ *   - expiresAt must be > now
+ *
+ * @module components/admin/redemption-codes/MintRedemptionCodeModal
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { useToastStore } from "@/stores/toastStore";
+import { useMintCode } from "@/hooks/useRedemptionCodes";
+import type {
+  MintCodeRequest,
+  RedemptionCode,
+  Surface,
+} from "@/services/redemptionCodesApi";
+
+const MAX_AMOUNT = 100_000;
+const MAX_NOTE = 500;
+
+const SURFACE_OPTIONS: Array<{ value: Surface; label: string }> = [
+  { value: "playground", label: "Playground" },
+  { value: "skillGen", label: "Skill generation" },
+];
+
+const PRESET_DAYS: Array<{ days: number; label: string }> = [
+  { days: 7, label: "+7 days" },
+  { days: 30, label: "+30 days" },
+  { days: 90, label: "+90 days" },
+];
+
+interface GrantRow {
+  surface: Surface | "";
+  amount: string;
+}
+
+const EMPTY_GRANT: GrantRow = { surface: "playground", amount: "100" };
+
+/** Build the local-time string accepted by `<input type="datetime-local">`. */
+function isoToLocalInputValue(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function daysFromNowIso(days: number): string {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function localInputToIso(local: string): string | null {
+  if (!local) return null;
+  const d = new Date(local);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+export interface MintRedemptionCodeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function MintRedemptionCodeModal({
+  isOpen,
+  onClose,
+}: MintRedemptionCodeModalProps) {
+  const [grants, setGrants] = useState<GrantRow[]>([{ ...EMPTY_GRANT }]);
+  const [note, setNote] = useState("");
+  const [expiresLocal, setExpiresLocal] = useState<string>(
+    isoToLocalInputValue(daysFromNowIso(30)),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [minted, setMinted] = useState<RedemptionCode | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const mint = useMintCode();
+  const addToast = useToastStore((s) => s.addToast);
+
+  useEffect(() => {
+    if (isOpen) {
+      setGrants([{ ...EMPTY_GRANT }]);
+      setNote("");
+      setExpiresLocal(isoToLocalInputValue(daysFromNowIso(30)));
+      setError(null);
+      setMinted(null);
+      setCopied(false);
+    }
+  }, [isOpen]);
+
+  const usedSurfaces = useMemo(
+    () => new Set(grants.map((g) => g.surface).filter(Boolean) as Surface[]),
+    [grants],
+  );
+
+  const updateGrant = (idx: number, patch: Partial<GrantRow>) => {
+    setGrants((prev) =>
+      prev.map((g, i) => (i === idx ? { ...g, ...patch } : g)),
+    );
+  };
+
+  const addGrantRow = () => {
+    if (grants.length >= SURFACE_OPTIONS.length) return;
+    const remaining = SURFACE_OPTIONS.find(
+      (opt) => !usedSurfaces.has(opt.value),
+    );
+    setGrants((prev) => [
+      ...prev,
+      { surface: remaining?.value ?? "", amount: "100" },
+    ]);
+  };
+
+  const removeGrantRow = (idx: number) => {
+    setGrants((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== idx)));
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (grants.length === 0) {
+      setError("Add at least one grant.");
+      return;
+    }
+    const seen = new Set<Surface>();
+    const normalized: MintCodeRequest["grants"] = [];
+    for (const row of grants) {
+      if (!row.surface) {
+        setError("Pick a surface for every grant row.");
+        return;
+      }
+      if (seen.has(row.surface)) {
+        setError("Each grant must target a different surface.");
+        return;
+      }
+      seen.add(row.surface);
+      const n = Number(row.amount);
+      if (!Number.isInteger(n) || n <= 0 || n > MAX_AMOUNT) {
+        setError(
+          `Amount must be a positive whole number (1..${MAX_AMOUNT.toLocaleString()}).`,
+        );
+        return;
+      }
+      normalized.push({ surface: row.surface, amount: n });
+    }
+
+    if (note.length > MAX_NOTE) {
+      setError(`Note must be ${MAX_NOTE} characters or fewer.`);
+      return;
+    }
+
+    const expiresIso = localInputToIso(expiresLocal);
+    if (!expiresIso) {
+      setError("Pick an expiration date.");
+      return;
+    }
+    if (new Date(expiresIso).getTime() <= Date.now()) {
+      setError("Expiration must be in the future.");
+      return;
+    }
+
+    setError(null);
+    try {
+      const res = await mint.mutateAsync({
+        grants: normalized,
+        note: note.trim() || undefined,
+        expiresAt: expiresIso,
+      });
+      setMinted(res.code);
+      addToast({
+        type: "success",
+        message: "Redemption code minted. Copy it before closing.",
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Mint failed");
+    }
+  };
+
+  const onCopyMinted = async () => {
+    if (!minted) return;
+    try {
+      await navigator.clipboard.writeText(minted.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setError("Copy failed — select the code manually.");
+    }
+  };
+
+  const onPickPreset = (days: number) => {
+    setExpiresLocal(isoToLocalInputValue(daysFromNowIso(days)));
+  };
+
+  const title = minted ? "Code minted" : "Mint redemption code";
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      {minted ? (
+        <div className="space-y-4">
+          <div className="rounded border border-accent/40 bg-accent/5 p-4">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+              Code (single-use, share once)
+            </p>
+            <p className="mt-2 break-all font-mono text-lg font-semibold text-accent">
+              {minted.code}
+            </p>
+            <button
+              type="button"
+              onClick={onCopyMinted}
+              className="mt-3 inline-flex items-center gap-2 rounded-sm border border-accent-muted bg-accent px-3 py-1.5 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-page hover:bg-accent-muted"
+            >
+              {copied ? "Copied" : "Copy code"}
+            </button>
+          </div>
+
+          <dl className="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                Grants
+              </dt>
+              <dd className="mt-1 space-y-1 font-mono text-[11px] text-strong">
+                {minted.grants.map((g) => (
+                  <div key={g.surface}>
+                    {SURFACE_OPTIONS.find((s) => s.value === g.surface)?.label ??
+                      g.surface}
+                    {" "}+{g.amount.toLocaleString("en-US")}
+                  </div>
+                ))}
+              </dd>
+            </div>
+            <div>
+              <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                Expires
+              </dt>
+              <dd className="mt-1 font-mono text-[11px] text-strong">
+                {new Date(minted.expiresAt).toLocaleString()}
+              </dd>
+            </div>
+          </dl>
+
+          {error && (
+            <p
+              role="alert"
+              className="rounded border border-danger/40 bg-danger-soft px-3 py-2 font-mono text-[11px] text-danger"
+            >
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end">
+            <Button size="sm" onClick={onClose}>
+              Done
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={submit} className="space-y-5">
+          <fieldset className="space-y-3">
+            <legend className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+              Grants
+            </legend>
+            {grants.map((row, idx) => {
+              const availableForThisRow = SURFACE_OPTIONS.filter(
+                (opt) =>
+                  opt.value === row.surface || !usedSurfaces.has(opt.value),
+              );
+              return (
+                <div key={idx} className="flex flex-wrap items-end gap-2">
+                  <label className="flex flex-col gap-1.5">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Surface
+                    </span>
+                    <select
+                      value={row.surface}
+                      onChange={(e) =>
+                        updateGrant(idx, {
+                          surface: e.target.value as Surface,
+                        })
+                      }
+                      aria-label={`Grant ${idx + 1} surface`}
+                      className="rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+                    >
+                      {availableForThisRow.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      Amount
+                    </span>
+                    <input
+                      type="number"
+                      min={1}
+                      max={MAX_AMOUNT}
+                      step={1}
+                      value={row.amount}
+                      onChange={(e) =>
+                        updateGrant(idx, { amount: e.target.value })
+                      }
+                      aria-label={`Grant ${idx + 1} amount`}
+                      className="w-32 rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => removeGrantRow(idx)}
+                    aria-label={`Remove grant ${idx + 1}`}
+                    disabled={grants.length <= 1}
+                    className="h-9 rounded-sm border border-subtle bg-elevated/40 px-3 font-mono text-[14px] text-meta hover:text-danger disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    −
+                  </button>
+                </div>
+              );
+            })}
+            <button
+              type="button"
+              onClick={addGrantRow}
+              disabled={grants.length >= SURFACE_OPTIONS.length}
+              className="font-mono text-[11px] uppercase tracking-[0.14em] text-accent hover:text-accent-muted disabled:cursor-not-allowed disabled:text-meta/60"
+            >
+              + Add grant
+            </button>
+          </fieldset>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Note (optional, ≤ {MAX_NOTE} chars)
+            </span>
+            <textarea
+              maxLength={MAX_NOTE}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Reason for issuing — surfaced in admin audit"
+              rows={3}
+              className="rounded-sm border border-subtle bg-card px-3 py-2 font-text text-sm text-strong focus:border-accent focus:outline-none"
+            />
+          </label>
+
+          <div className="flex flex-col gap-2">
+            <label className="flex flex-col gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                Expires at
+              </span>
+              <input
+                type="datetime-local"
+                value={expiresLocal}
+                onChange={(e) => setExpiresLocal(e.target.value)}
+                className="rounded-sm border border-subtle bg-card px-3 py-2 font-mono text-sm text-strong focus:border-accent focus:outline-none"
+              />
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {PRESET_DAYS.map((p) => (
+                <button
+                  key={p.days}
+                  type="button"
+                  onClick={() => onPickPreset(p.days)}
+                  className="rounded-sm border border-subtle bg-elevated/40 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-meta hover:border-accent hover:text-accent"
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {error && (
+            <p
+              role="alert"
+              className="rounded border border-danger/40 bg-danger-soft px-3 py-2 font-mono text-[11px] text-danger"
+            >
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" size="sm" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button size="sm" type="submit" loading={mint.isPending}>
+              Mint code
+            </Button>
+          </div>
+        </form>
+      )}
+    </Modal>
+  );
+}

--- a/ornn-web/src/components/admin/redemption-codes/RedemptionCodeDetailDrawer.tsx
+++ b/ornn-web/src/components/admin/redemption-codes/RedemptionCodeDetailDrawer.tsx
@@ -1,0 +1,254 @@
+/**
+ * RedemptionCodeDetailDrawer — read-only side panel for a single code.
+ *
+ * Shows the full code, grant breakdown, note, and the create / redeem /
+ * invalidate audit metadata when present. Mirrors the spring slide-in
+ * pattern from QuotaUserDetailDrawer.
+ *
+ * @module components/admin/redemption-codes/RedemptionCodeDetailDrawer
+ */
+
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/Badge";
+import type {
+  ActorMeta,
+  RedemptionCode,
+  RedemptionCodeStatus,
+  Surface,
+} from "@/services/redemptionCodesApi";
+
+const SURFACE_LABEL: Record<Surface, string> = {
+  playground: "Playground",
+  skillGen: "Skill generation",
+};
+
+const STATUS_BADGE: Record<
+  RedemptionCodeStatus,
+  { color: "cyan" | "green" | "muted"; label: string }
+> = {
+  active: { color: "cyan", label: "Active" },
+  redeemed: { color: "green", label: "Redeemed" },
+  invalidated: { color: "muted", label: "Invalidated" },
+};
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function ActorLine({ actor }: { actor: ActorMeta }) {
+  return (
+    <div>
+      <p className="font-text text-sm text-strong">
+        {actor.displayName || actor.email}
+      </p>
+      <p className="font-mono text-[11px] text-meta">{actor.email}</p>
+    </div>
+  );
+}
+
+export interface RedemptionCodeDetailDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  code: RedemptionCode | null;
+}
+
+export function RedemptionCodeDetailDrawer({
+  isOpen,
+  onClose,
+  code,
+}: RedemptionCodeDetailDrawerProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCopied(false);
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  const onCopy = async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // silent — user can select-and-copy manually
+    }
+  };
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && code && (
+        <div className="fixed inset-0 z-50">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="absolute inset-0 bg-black/55 backdrop-blur-[2px]"
+            onClick={onClose}
+          />
+          <motion.aside
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ type: "spring", stiffness: 240, damping: 28, mass: 0.9 }}
+            role="dialog"
+            aria-label="Redemption code detail"
+            className="card-impression absolute right-0 top-0 flex h-full w-full max-w-[480px] flex-col gap-5 overflow-y-auto border-l border-subtle bg-page p-6 sm:p-8"
+          >
+            <header className="flex items-baseline justify-between">
+              <div>
+                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                  [§ REDEMPTION CODE]
+                </p>
+                <h2 className="mt-1 font-display text-xl font-semibold tracking-tight text-strong">
+                  Code detail
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className="-mr-2 -mt-2 inline-flex h-8 w-8 items-center justify-center rounded-sm text-meta transition-colors hover:bg-elevated hover:text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </header>
+
+            <div className="rounded border border-accent/30 bg-accent/5 p-4">
+              <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                Code
+              </p>
+              <p className="mt-1 break-all font-mono text-base font-semibold text-accent">
+                {code.code}
+              </p>
+              <button
+                type="button"
+                onClick={onCopy}
+                className="mt-2 font-mono text-[11px] uppercase tracking-[0.14em] text-meta hover:text-accent"
+              >
+                {copied ? "Copied" : "Copy code"}
+              </button>
+            </div>
+
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                Status
+              </p>
+              <div className="mt-1">
+                <Badge color={STATUS_BADGE[code.status].color}>
+                  {STATUS_BADGE[code.status].label}
+                </Badge>
+              </div>
+            </div>
+
+            <section>
+              <h3 className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                Grants
+              </h3>
+              <ul className="space-y-1.5">
+                {code.grants.map((g) => (
+                  <li
+                    key={g.surface}
+                    className="flex items-baseline justify-between rounded-sm border border-subtle bg-elevated/40 px-3 py-1.5 font-mono text-[11px]"
+                  >
+                    <span className="text-body">{SURFACE_LABEL[g.surface]}</span>
+                    <span className="text-strong">
+                      +{g.amount.toLocaleString("en-US")}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            {code.note && (
+              <section>
+                <h3 className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                  Note
+                </h3>
+                <p className="rounded border border-subtle bg-elevated/40 p-3 font-text text-sm text-body">
+                  {code.note}
+                </p>
+              </section>
+            )}
+
+            <section className="space-y-3">
+              <div>
+                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                  Created
+                </p>
+                <p className="mt-1 font-mono text-[11px] text-body">
+                  {formatDateTime(code.createdAt)}
+                </p>
+                <div className="mt-1">
+                  <ActorLine actor={code.createdBy} />
+                </div>
+              </div>
+              <div>
+                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                  Expires
+                </p>
+                <p className="mt-1 font-mono text-[11px] text-body">
+                  {formatDateTime(code.expiresAt)}
+                </p>
+              </div>
+              {code.redeemedAt && code.redeemedBy && (
+                <div>
+                  <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                    Redeemed
+                  </p>
+                  <p className="mt-1 font-mono text-[11px] text-body">
+                    {formatDateTime(code.redeemedAt)}
+                  </p>
+                  <div className="mt-1">
+                    <ActorLine actor={code.redeemedBy} />
+                  </div>
+                </div>
+              )}
+              {code.invalidatedAt && code.invalidatedBy && (
+                <div>
+                  <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                    Invalidated
+                  </p>
+                  <p className="mt-1 font-mono text-[11px] text-body">
+                    {formatDateTime(code.invalidatedAt)}
+                  </p>
+                  <div className="mt-1">
+                    <ActorLine actor={code.invalidatedBy} />
+                  </div>
+                </div>
+              )}
+            </section>
+          </motion.aside>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/ornn-web/src/components/admin/redemption-codes/RedemptionCodesTable.tsx
+++ b/ornn-web/src/components/admin/redemption-codes/RedemptionCodesTable.tsx
@@ -1,0 +1,205 @@
+/**
+ * RedemptionCodesTable — admin list of minted codes.
+ *
+ * Columns: Code (mono + copy), Grants (chips), Expires, Created by,
+ * Status badge, Actions. Row click opens the detail drawer; the
+ * Invalidate action is row-only on `active` rows.
+ *
+ * @module components/admin/redemption-codes/RedemptionCodesTable
+ */
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/Badge";
+import { Skeleton } from "@/components/ui/Skeleton";
+import type {
+  RedemptionCode,
+  RedemptionCodeStatus,
+  RedemptionGrantEntry,
+  Surface,
+} from "@/services/redemptionCodesApi";
+
+const SURFACE_LABEL: Record<Surface, string> = {
+  playground: "Playground",
+  skillGen: "Skill generation",
+};
+
+const STATUS_BADGE: Record<
+  RedemptionCodeStatus,
+  { color: "cyan" | "green" | "muted" | "red"; label: string }
+> = {
+  active: { color: "cyan", label: "Active" },
+  redeemed: { color: "green", label: "Redeemed" },
+  invalidated: { color: "muted", label: "Invalidated" },
+};
+
+function formatDateTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function GrantChips({ grants }: { grants: RedemptionGrantEntry[] }) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {grants.map((g) => (
+        <Badge key={g.surface} color="magenta">
+          {SURFACE_LABEL[g.surface]} +{g.amount.toLocaleString("en-US")}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function CodeCell({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // clipboard refusal: silent — hover state still surfaces the code
+    }
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <span className="font-mono text-[12px] text-strong">{code}</span>
+      <button
+        type="button"
+        onClick={onCopy}
+        aria-label="Copy code"
+        className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta hover:text-accent"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+export interface RedemptionCodesTableProps {
+  rows: RedemptionCode[];
+  isLoading: boolean;
+  errorMessage?: string | null;
+  invalidatingId?: string | null;
+  onRowClick: (code: RedemptionCode) => void;
+  onInvalidateClick: (code: RedemptionCode) => void;
+}
+
+export function RedemptionCodesTable({
+  rows,
+  isLoading,
+  errorMessage,
+  invalidatingId,
+  onRowClick,
+  onInvalidateClick,
+}: RedemptionCodesTableProps) {
+  if (isLoading) {
+    return <Skeleton lines={8} />;
+  }
+  if (errorMessage) {
+    return (
+      <p className="py-8 text-center font-text text-danger">{errorMessage}</p>
+    );
+  }
+  if (rows.length === 0) {
+    return (
+      <p className="py-8 text-center font-text text-meta">
+        No redemption codes match.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-accent/20">
+            <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Code
+            </th>
+            <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Grants
+            </th>
+            <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Expires
+            </th>
+            <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Created by
+            </th>
+            <th className="px-4 py-3 text-left font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+              Status
+            </th>
+            <th className="px-4 py-3" />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const statusMeta = STATUS_BADGE[row.status];
+            const canInvalidate = row.status === "active";
+            const tooltip = canInvalidate
+              ? undefined
+              : "Cannot invalidate redeemed/invalidated codes";
+            const isThisInvalidating = invalidatingId === row.id;
+            return (
+              <tr
+                key={row.id}
+                onClick={() => onRowClick(row)}
+                className="cursor-pointer border-b border-accent/10 hover:bg-elevated/40"
+              >
+                <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                  <CodeCell code={row.code} />
+                </td>
+                <td className="px-4 py-3">
+                  <GrantChips grants={row.grants} />
+                </td>
+                <td className="px-4 py-3 font-mono text-[11px] text-body">
+                  {formatDateTime(row.expiresAt)}
+                </td>
+                <td className="px-4 py-3">
+                  <p className="font-text text-sm text-strong">
+                    {row.createdBy.displayName || row.createdBy.email}
+                  </p>
+                  <p className="font-mono text-[11px] text-meta">
+                    {row.createdBy.email}
+                  </p>
+                </td>
+                <td className="px-4 py-3">
+                  <Badge color={statusMeta.color}>{statusMeta.label}</Badge>
+                </td>
+                <td
+                  className="whitespace-nowrap px-4 py-3 text-right"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    type="button"
+                    title={tooltip}
+                    aria-label="Invalidate code"
+                    disabled={!canInvalidate || isThisInvalidating}
+                    onClick={() => onInvalidateClick(row)}
+                    className={`font-mono text-[11px] uppercase tracking-[0.14em] ${
+                      canInvalidate
+                        ? "text-danger hover:text-danger/80"
+                        : "cursor-not-allowed text-meta/60"
+                    } ${isThisInvalidating ? "opacity-60" : ""}`}
+                  >
+                    {isThisInvalidating ? "Invalidating…" : "Invalidate"}
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ornn-web/src/components/layout/AdminLayout.tsx
+++ b/ornn-web/src/components/layout/AdminLayout.tsx
@@ -45,6 +45,15 @@ const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    path: "/admin/redemption-codes",
+    label: "Redemption codes",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 5l-3 3m0 0l-3-3m3 3V3m6 14a3 3 0 11-6 0 3 3 0 016 0zM9 7a2 2 0 11-4 0 2 2 0 014 0z" />
+      </svg>
+    ),
+  },
+  {
     path: "/admin/skills",
     label: "Skills",
     icon: (
@@ -76,6 +85,8 @@ function getBreadcrumbs(pathname: string): Array<{ label: string; path?: string 
     breadcrumbs.push({ label: "Users" });
   } else if (pathname.startsWith("/admin/quota")) {
     breadcrumbs.push({ label: "Quota" });
+  } else if (pathname.startsWith("/admin/redemption-codes")) {
+    breadcrumbs.push({ label: "Redemption codes" });
   } else if (pathname.startsWith("/admin/skills")) {
     breadcrumbs.push({ label: "Skills" });
   } else if (pathname.startsWith("/admin/settings")) {

--- a/ornn-web/src/components/settings/RedeemCodeSection.test.tsx
+++ b/ornn-web/src/components/settings/RedeemCodeSection.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Tests for `RedeemCodeSection` — covers the happy-path success
+ * panel, per-error-code message mapping, and the empty-input guard
+ * (which must short-circuit before any network call).
+ *
+ * @module components/settings/RedeemCodeSection.test
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type {
+  RedeemAppliedGrant,
+  RedemptionHistoryItem,
+} from "@/services/redemptionCodesApi";
+
+const redeemMutateAsync = vi.fn();
+const useRedeemCode = vi.fn();
+const useMyRedemptionHistory = vi.fn();
+
+vi.mock("@/hooks/useRedemptionCodes", () => ({
+  useRedeemCode: () => useRedeemCode(),
+  useMyRedemptionHistory: () => useMyRedemptionHistory(),
+}));
+
+// Side-step the apiClient → authStore → zustand persist chain (needs
+// jsdom localStorage at import time). The component uses
+// `instanceof ApiClientError`; the stub below is the class
+// `instanceof` will check against in tests. Defined inside the factory
+// because `vi.mock` is hoisted above any module-scope declarations.
+vi.mock("@/services/apiClient", () => {
+  class StubApiClientError extends Error {
+    code: string;
+    statusCode: number;
+    constructor(code: string, message: string, statusCode: number) {
+      super(message);
+      this.name = "ApiClientError";
+      this.code = code;
+      this.statusCode = statusCode;
+    }
+  }
+  return { ApiClientError: StubApiClientError, ApiError: StubApiClientError };
+});
+
+// Re-import the mocked class to use as the constructor in tests.
+import { ApiClientError as StubApiClientError } from "@/services/apiClient";
+
+import { RedeemCodeSection } from "./RedeemCodeSection";
+
+function defaultGrants(): RedeemAppliedGrant[] {
+  return [
+    {
+      surface: "playground",
+      amount: 100,
+      monthMarker: "2026-05",
+      newAdminGrant: 100,
+    },
+    {
+      surface: "skillGen",
+      amount: 50,
+      monthMarker: "2026-05",
+      newAdminGrant: 50,
+    },
+  ];
+}
+
+beforeEach(() => {
+  redeemMutateAsync.mockReset();
+  useRedeemCode.mockReturnValue({
+    mutateAsync: redeemMutateAsync,
+    isPending: false,
+  });
+  useMyRedemptionHistory.mockReturnValue({
+    data: { items: [], total: 0, page: 1, pageSize: 5, totalPages: 1 },
+  });
+});
+
+describe("RedeemCodeSection", () => {
+  it("shows the initial help text before any submit", () => {
+    render(<RedeemCodeSection />);
+    expect(
+      screen.getByText(/got a code from the team/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the success panel with grant breakdown after a successful redeem", async () => {
+    redeemMutateAsync.mockResolvedValue({
+      codeId: "abc",
+      redeemedAt: "2026-05-08T10:00:00.000Z",
+      grants: defaultGrants(),
+    });
+
+    render(<RedeemCodeSection />);
+    fireEvent.change(screen.getByLabelText(/redemption code/i), {
+      target: { value: "ABC123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /redeem/i }));
+
+    await waitFor(() => {
+      expect(redeemMutateAsync).toHaveBeenCalledWith("ABC123");
+    });
+    expect(
+      await screen.findByText(/playground \+100, skill generation \+50/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/active until end of month/i)).toBeInTheDocument();
+  });
+
+  it("rejects empty / whitespace-only input without calling the network", () => {
+    render(<RedeemCodeSection />);
+    const button = screen.getByRole("button", { name: /redeem/i });
+    // Submit button is disabled while the trimmed value is empty so a
+    // submit can't even fire — the safest possible empty-input guard.
+    expect(button).toBeDisabled();
+
+    const input = screen.getByLabelText(/redemption code/i);
+    fireEvent.change(input, { target: { value: "   " } });
+    expect(button).toBeDisabled();
+    expect(redeemMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["REDEMPTION_CODE_NOT_FOUND", /code not found/i],
+    ["REDEMPTION_CODE_EXPIRED", /this code has expired/i],
+    ["REDEMPTION_CODE_INVALIDATED", /revoked/i],
+    ["REDEMPTION_CODE_ALREADY_REDEEMED", /already been used/i],
+  ])("maps error code %s to the right message", async (code, pattern) => {
+    redeemMutateAsync.mockRejectedValue(
+      new StubApiClientError(code, "server message", 410),
+    );
+
+    render(<RedeemCodeSection />);
+    fireEvent.change(screen.getByLabelText(/redemption code/i), {
+      target: { value: "BAD" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /redeem/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(pattern);
+  });
+
+  it("falls back to the default message for unrecognized error codes", async () => {
+    redeemMutateAsync.mockRejectedValue(
+      new StubApiClientError("SOMETHING_ELSE", "server message", 500),
+    );
+    render(<RedeemCodeSection />);
+    fireEvent.change(screen.getByLabelText(/redemption code/i), {
+      target: { value: "BAD" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /redeem/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /couldn't redeem this code/i,
+    );
+  });
+
+  it("renders the recently-redeemed list when history is non-empty", () => {
+    const item: RedemptionHistoryItem = {
+      id: "1",
+      code: "ABCD-EFGH-IJKL-MNOP",
+      grants: [{ surface: "playground", amount: 25 }],
+      note: null,
+      redeemedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-06-01T00:00:00.000Z",
+      createdAt: "2026-05-01T00:00:00.000Z",
+    };
+    useMyRedemptionHistory.mockReturnValue({
+      data: { items: [item], total: 1, page: 1, pageSize: 5, totalPages: 1 },
+    });
+
+    render(<RedeemCodeSection />);
+    expect(screen.getByText(/recently redeemed/i)).toBeInTheDocument();
+    expect(screen.getByText("ABCD-EFGH-IJKL-MNOP")).toBeInTheDocument();
+    expect(screen.getByText(/playground \+25/i)).toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/components/settings/RedeemCodeSection.tsx
+++ b/ornn-web/src/components/settings/RedeemCodeSection.tsx
@@ -1,0 +1,243 @@
+/**
+ * RedeemCodeSection — caller-facing redeem form for the Settings page.
+ *
+ * Single text input + submit. Per-error-code messaging maps the
+ * backend `code` to a user-facing line so the user knows whether to
+ * retype, contact admin, or accept the code is gone. On success we
+ * show a green panel listing the per-surface grants and clear it
+ * after 8s.
+ *
+ * Optional "Recently redeemed" section uses
+ * `useMyRedemptionHistory` and only renders when the list is
+ * non-empty.
+ *
+ * @module components/settings/RedeemCodeSection
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { Button } from "@/components/ui/Button";
+import { ApiClientError } from "@/services/apiClient";
+import {
+  useMyRedemptionHistory,
+  useRedeemCode,
+} from "@/hooks/useRedemptionCodes";
+import type {
+  RedeemAppliedGrant,
+  RedemptionHistoryItem,
+  Surface,
+} from "@/services/redemptionCodesApi";
+
+const SURFACE_LABEL: Record<Surface, string> = {
+  playground: "Playground",
+  skillGen: "Skill generation",
+};
+
+const ERROR_MESSAGES: Record<string, string> = {
+  REDEMPTION_CODE_NOT_FOUND: "Code not found. Double-check the spelling.",
+  REDEMPTION_CODE_EXPIRED: "This code has expired.",
+  REDEMPTION_CODE_INVALIDATED:
+    "This code has been revoked. Contact admin if you think this is wrong.",
+  REDEMPTION_CODE_ALREADY_REDEEMED:
+    "This code has already been used. Each code is single-use.",
+};
+
+const DEFAULT_ERROR =
+  "Couldn't redeem this code. Please try again or contact admin.";
+
+const SUCCESS_AUTO_CLEAR_MS = 8_000;
+
+function formatGrantSummary(grants: RedeemAppliedGrant[]): string {
+  return grants
+    .map((g) => `${SURFACE_LABEL[g.surface]} +${g.amount.toLocaleString("en-US")}`)
+    .join(", ");
+}
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function HistoryRow({ item }: { item: RedemptionHistoryItem }) {
+  const summary = item.grants
+    .map(
+      (g) => `${SURFACE_LABEL[g.surface]} +${g.amount.toLocaleString("en-US")}`,
+    )
+    .join(", ");
+  return (
+    <li className="flex flex-col gap-1 rounded-sm border border-subtle bg-elevated/30 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p className="font-mono text-[11px] text-strong">{item.code}</p>
+        <p className="font-text text-xs text-body">{summary}</p>
+      </div>
+      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+        {formatDateTime(item.redeemedAt)}
+      </p>
+    </li>
+  );
+}
+
+export function RedeemCodeSection() {
+  const [value, setValue] = useState("");
+  const [success, setSuccess] = useState<RedeemAppliedGrant[] | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const redeem = useRedeemCode();
+  const history = useMyRedemptionHistory({ page: 1, pageSize: 5 });
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (successTimerRef.current) {
+        clearTimeout(successTimerRef.current);
+      }
+    };
+  }, []);
+
+  const clearSuccessTimer = () => {
+    if (successTimerRef.current) {
+      clearTimeout(successTimerRef.current);
+      successTimerRef.current = null;
+    }
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSuccess(null);
+    setErrorMsg(null);
+    clearSuccessTimer();
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setErrorMsg("Enter a code to redeem.");
+      return;
+    }
+
+    try {
+      const result = await redeem.mutateAsync(trimmed);
+      setSuccess(result.grants);
+      setValue("");
+      successTimerRef.current = setTimeout(() => {
+        setSuccess(null);
+        successTimerRef.current = null;
+      }, SUCCESS_AUTO_CLEAR_MS);
+    } catch (err) {
+      let code: string | undefined;
+      if (err instanceof ApiClientError) {
+        code = err.code;
+      }
+      setErrorMsg(
+        (code && ERROR_MESSAGES[code]) ||
+          (err instanceof Error && err.message
+            ? ERROR_MESSAGES[err.message] ?? DEFAULT_ERROR
+            : DEFAULT_ERROR),
+      );
+    }
+  };
+
+  const dismissSuccess = () => {
+    clearSuccessTimer();
+    setSuccess(null);
+  };
+
+  const showInitialHelp = !success && !errorMsg && !redeem.isPending;
+  const historyItems = history.data?.items ?? [];
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, delay: 0.05 }}
+      className="bg-card rounded border border-accent/20 p-6"
+      aria-labelledby="redeem-code-heading"
+    >
+      <h3
+        id="redeem-code-heading"
+        className="mb-3 font-mono text-[11px] uppercase tracking-[0.16em] text-strong"
+      >
+        Redeem code
+      </h3>
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-3 sm:flex-row">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="ENTER YOUR CODE"
+          aria-label="Redemption code"
+          autoCapitalize="characters"
+          autoCorrect="off"
+          spellCheck={false}
+          maxLength={64}
+          className="flex-1 rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-mono text-sm uppercase tracking-[0.12em] text-strong placeholder:text-meta/70 focus:border-accent focus:bg-card focus:outline-none"
+        />
+        <Button
+          size="md"
+          type="submit"
+          loading={redeem.isPending}
+          disabled={value.trim().length === 0}
+        >
+          Redeem
+        </Button>
+      </form>
+
+      <div className="mt-4">
+        {showInitialHelp && (
+          <p className="font-text text-sm text-meta">
+            Got a code from the team? Enter it here to add quota to your
+            account.
+          </p>
+        )}
+
+        {success && (
+          <div
+            role="status"
+            className="flex items-start justify-between gap-3 rounded border border-success/40 bg-success-soft px-3 py-3"
+          >
+            <div className="font-text text-sm text-body">
+              <p>
+                <span className="font-semibold text-success">Added:</span>{" "}
+                {formatGrantSummary(success)}.
+              </p>
+              <p className="mt-1 text-meta">Active until end of month.</p>
+            </div>
+            <button
+              type="button"
+              onClick={dismissSuccess}
+              aria-label="Dismiss"
+              className="font-mono text-[11px] uppercase tracking-[0.14em] text-meta hover:text-strong"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+
+        {errorMsg && (
+          <p
+            role="alert"
+            className="rounded border border-danger/40 bg-danger-soft px-3 py-2 font-text text-sm text-danger"
+          >
+            {errorMsg}
+          </p>
+        )}
+      </div>
+
+      {historyItems.length > 0 && (
+        <div className="mt-6">
+          <h4 className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+            Recently redeemed
+          </h4>
+          <ul className="space-y-1.5">
+            {historyItems.map((item) => (
+              <HistoryRow key={item.id} item={item} />
+            ))}
+          </ul>
+        </div>
+      )}
+    </motion.section>
+  );
+}

--- a/ornn-web/src/hooks/useRedemptionCodes.ts
+++ b/ornn-web/src/hooks/useRedemptionCodes.ts
@@ -1,0 +1,106 @@
+/**
+ * Redemption-code hooks — admin mint/list/invalidate + caller redeem
+ * and history. Mirrors `hooks/useQuota.ts` so the admin tables and
+ * caller surfaces refresh in lockstep when codes are issued or
+ * consumed.
+ *
+ * `useRedeemCode` invalidates `["me", "quota"]` so a successful redeem
+ * visually refreshes the snapshot (chip / drawer / banner) without a
+ * manual reload. Mint and invalidate flow back into
+ * `["admin", "redemption-codes"]` so the admin table updates without
+ * a refetch click.
+ *
+ * @module hooks/useRedemptionCodes
+ */
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { useIsAuthenticated } from "@/stores/authStore";
+import {
+  getAdminCodeDetail,
+  invalidateCode,
+  listAdminCodes,
+  listMyRedemptionHistory,
+  mintCode,
+  redeemCode,
+  type AdminRedemptionCodeFilters,
+  type MintCodeRequest,
+  type MintCodeResponse,
+  type RedeemCodeResponse,
+  type RedemptionCode,
+  type RedemptionCodeListResponse,
+  type RedemptionHistoryResponse,
+} from "@/services/redemptionCodesApi";
+
+const ADMIN_REDEMPTION_CODES_KEY = ["admin", "redemption-codes"] as const;
+const ME_QUOTA_KEY = ["me", "quota"] as const;
+const ME_REDEMPTION_HISTORY_KEY = ["me", "redemption-codes", "history"] as const;
+
+export function useAdminRedemptionCodes(
+  filters: AdminRedemptionCodeFilters = {},
+): UseQueryResult<RedemptionCodeListResponse> {
+  return useQuery({
+    queryKey: [...ADMIN_REDEMPTION_CODES_KEY, filters] as const,
+    queryFn: () => listAdminCodes(filters),
+    staleTime: 15_000,
+  });
+}
+
+export function useAdminRedemptionCodeDetail(
+  id: string | null,
+): UseQueryResult<RedemptionCode> {
+  return useQuery({
+    queryKey: [...ADMIN_REDEMPTION_CODES_KEY, "detail", id] as const,
+    queryFn: () => getAdminCodeDetail(id!),
+    enabled: Boolean(id),
+    staleTime: 30_000,
+  });
+}
+
+export function useMintCode() {
+  const qc = useQueryClient();
+  return useMutation<MintCodeResponse, Error, MintCodeRequest>({
+    mutationFn: mintCode,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ADMIN_REDEMPTION_CODES_KEY });
+    },
+  });
+}
+
+export function useInvalidateCode() {
+  const qc = useQueryClient();
+  return useMutation<RedemptionCode, Error, string>({
+    mutationFn: invalidateCode,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ADMIN_REDEMPTION_CODES_KEY });
+    },
+  });
+}
+
+export function useRedeemCode() {
+  const qc = useQueryClient();
+  return useMutation<RedeemCodeResponse, Error, string>({
+    mutationFn: redeemCode,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ME_QUOTA_KEY });
+      qc.invalidateQueries({ queryKey: ME_REDEMPTION_HISTORY_KEY });
+    },
+  });
+}
+
+export function useMyRedemptionHistory(params: {
+  page?: number;
+  pageSize?: number;
+} = {}): UseQueryResult<RedemptionHistoryResponse> {
+  const isAuthed = useIsAuthenticated();
+  return useQuery({
+    queryKey: [...ME_REDEMPTION_HISTORY_KEY, params] as const,
+    queryFn: () => listMyRedemptionHistory(params),
+    enabled: isAuthed,
+    staleTime: 30_000,
+  });
+}

--- a/ornn-web/src/pages/SettingsPage.tsx
+++ b/ornn-web/src/pages/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/Button";
 import { PageTransition } from "@/components/layout/PageTransition";
+import { RedeemCodeSection } from "@/components/settings/RedeemCodeSection";
 import { useAuthStore } from "@/stores/authStore";
 import { config } from "@/config";
 
@@ -103,6 +104,9 @@ export function SettingsPage() {
             </div>
           </div>
         </motion.div>
+
+        {/* Redeem code — accept admin-issued codes that grant quota. */}
+        <RedeemCodeSection />
 
         {/* NyxID Settings Link */}
         {NYXID_SETTINGS_URL && (

--- a/ornn-web/src/pages/admin/RedemptionCodesPage.tsx
+++ b/ornn-web/src/pages/admin/RedemptionCodesPage.tsx
@@ -1,0 +1,193 @@
+/**
+ * RedemptionCodesPage — admin lever for minted single-use redemption
+ * codes (issue #306).
+ *
+ * Layout:
+ *   - Page header + "Mint code" CTA
+ *   - Status filter chips (all / active / redeemed / invalidated)
+ *   - Search input (debounced) — code prefix or note substring
+ *   - Paginated RedemptionCodesTable with row click → detail drawer
+ *   - Per-row Invalidate button on active rows
+ *
+ * @module pages/admin/RedemptionCodesPage
+ */
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Pagination } from "@/components/ui/Pagination";
+import { useDebounce } from "@/hooks/useDebounce";
+import { useToastStore } from "@/stores/toastStore";
+import {
+  useAdminRedemptionCodes,
+  useInvalidateCode,
+} from "@/hooks/useRedemptionCodes";
+import { MintRedemptionCodeModal } from "@/components/admin/redemption-codes/MintRedemptionCodeModal";
+import { RedemptionCodeDetailDrawer } from "@/components/admin/redemption-codes/RedemptionCodeDetailDrawer";
+import { RedemptionCodesTable } from "@/components/admin/redemption-codes/RedemptionCodesTable";
+import type {
+  RedemptionCode,
+  RedemptionCodeStatus,
+} from "@/services/redemptionCodesApi";
+
+const PAGE_SIZE = 20;
+
+const STATUS_TABS: Array<{ id: RedemptionCodeStatus | "all"; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "active", label: "Active" },
+  { id: "redeemed", label: "Redeemed" },
+  { id: "invalidated", label: "Invalidated" },
+];
+
+export function RedemptionCodesPage() {
+  const [statusFilter, setStatusFilter] = useState<
+    RedemptionCodeStatus | "all"
+  >("all");
+  const [page, setPage] = useState(1);
+  const [query, setQuery] = useState("");
+  const debounced = useDebounce(query, 300);
+
+  const [mintOpen, setMintOpen] = useState(false);
+  const [drawerCode, setDrawerCode] = useState<RedemptionCode | null>(null);
+  const [pendingInvalidateId, setPendingInvalidateId] = useState<string | null>(
+    null,
+  );
+
+  const addToast = useToastStore((s) => s.addToast);
+  const invalidateCode = useInvalidateCode();
+
+  const codesQuery = useAdminRedemptionCodes({
+    status: statusFilter === "all" ? undefined : statusFilter,
+    search: debounced || undefined,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const items = codesQuery.data?.items ?? [];
+  const totalPages = codesQuery.data?.totalPages ?? 1;
+
+  const onTabChange = (next: RedemptionCodeStatus | "all") => {
+    setStatusFilter(next);
+    setPage(1);
+  };
+
+  const onInvalidate = async (code: RedemptionCode) => {
+    const ok = window.confirm(
+      `Invalidate code ${code.code}? It will no longer be redeemable.`,
+    );
+    if (!ok) return;
+    setPendingInvalidateId(code.id);
+    try {
+      await invalidateCode.mutateAsync(code.id);
+      addToast({
+        type: "success",
+        message: `Code ${code.code} invalidated.`,
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error ? err.message : "Failed to invalidate code.",
+      });
+    } finally {
+      setPendingInvalidateId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-2xl font-bold uppercase tracking-tight text-strong">
+            Redemption codes
+          </h1>
+          <p className="mt-1 font-text text-meta">
+            Mint single-use codes that bundle one or more current-month quota
+            grants. Codes can be invalidated before redemption.
+          </p>
+        </div>
+        <Button size="sm" onClick={() => setMintOpen(true)}>
+          Mint code
+        </Button>
+      </header>
+
+      <nav
+        role="tablist"
+        aria-label="Status"
+        className="flex border-b border-subtle"
+      >
+        {STATUS_TABS.map((t) => {
+          const active = t.id === statusFilter;
+          return (
+            <button
+              key={t.id}
+              role="tab"
+              aria-selected={active}
+              onClick={() => onTabChange(t.id)}
+              className={`-mb-px border-b-2 px-4 py-2 font-mono text-[11px] font-semibold uppercase tracking-[0.18em] transition-colors ${
+                active
+                  ? "border-accent text-accent"
+                  : "border-transparent text-meta hover:text-strong"
+              }`}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(1);
+          }}
+          placeholder="Filter by code prefix or note…"
+          aria-label="Filter redemption codes"
+          className="w-full max-w-sm rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-mono text-xs text-strong placeholder:text-meta/70 focus:border-accent focus:bg-card focus:outline-none"
+        />
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <Card>
+          <RedemptionCodesTable
+            rows={items}
+            isLoading={codesQuery.isLoading}
+            errorMessage={
+              codesQuery.error
+                ? codesQuery.error instanceof Error
+                  ? codesQuery.error.message
+                  : "Failed to load redemption codes"
+                : null
+            }
+            invalidatingId={pendingInvalidateId}
+            onRowClick={(code) => setDrawerCode(code)}
+            onInvalidateClick={onInvalidate}
+          />
+        </Card>
+      </motion.div>
+
+      {totalPages > 1 && (
+        <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+      )}
+
+      <MintRedemptionCodeModal
+        isOpen={mintOpen}
+        onClose={() => setMintOpen(false)}
+      />
+
+      <RedemptionCodeDetailDrawer
+        isOpen={drawerCode !== null}
+        onClose={() => setDrawerCode(null)}
+        code={drawerCode}
+      />
+    </div>
+  );
+}

--- a/ornn-web/src/pages/admin/index.ts
+++ b/ornn-web/src/pages/admin/index.ts
@@ -10,3 +10,4 @@ export { AdminSkillsPage } from "./AdminSkillsPage";
 export { PlatformSettingsPage } from "./PlatformSettingsPage";
 export { MirrorPage } from "./MirrorPage";
 export { QuotaManagementPage } from "./QuotaManagementPage";
+export { RedemptionCodesPage } from "./RedemptionCodesPage";

--- a/ornn-web/src/services/redemptionCodesApi.schema.ts
+++ b/ornn-web/src/services/redemptionCodesApi.schema.ts
@@ -1,0 +1,147 @@
+/**
+ * Standalone Zod schemas for redemption-code payloads. Mirrors the
+ * backend types in `ornn-api/src/domains/redemption-codes/types.ts`
+ * but with ISO string dates as the wire format.
+ *
+ * Kept separate from `redemptionCodesApi.ts` so unit tests can import
+ * the schemas without dragging the apiClient → authStore → zustand
+ * persist chain.
+ *
+ * @module services/redemptionCodesApi.schema
+ */
+
+import { z } from "zod";
+
+export const SURFACE_VALUES = ["playground", "skillGen"] as const;
+export const SurfaceSchema = z.enum(SURFACE_VALUES);
+export type Surface = z.infer<typeof SurfaceSchema>;
+
+export const REDEMPTION_CODE_STATUSES = [
+  "active",
+  "redeemed",
+  "invalidated",
+] as const;
+export const RedemptionCodeStatusSchema = z.enum(REDEMPTION_CODE_STATUSES);
+export type RedemptionCodeStatus = z.infer<typeof RedemptionCodeStatusSchema>;
+
+export const RedemptionGrantEntrySchema = z
+  .object({
+    surface: SurfaceSchema,
+    amount: z.number().int().positive(),
+  })
+  .strict();
+export type RedemptionGrantEntry = z.infer<typeof RedemptionGrantEntrySchema>;
+
+export const ActorMetaSchema = z
+  .object({
+    userId: z.string(),
+    email: z.string(),
+    displayName: z.string(),
+  })
+  .strict();
+export type ActorMeta = z.infer<typeof ActorMetaSchema>;
+
+/**
+ * Wire shape emitted by the admin serializer in
+ * `ornn-api/src/domains/admin/redemption-codes/routes.ts`. Optional
+ * fields are emitted as `null` (not omitted) so the schema accepts
+ * `null`.
+ */
+export const RedemptionCodeSchema = z
+  .object({
+    id: z.string(),
+    code: z.string(),
+    grants: z.array(RedemptionGrantEntrySchema).min(1),
+    note: z.string().nullable(),
+    status: RedemptionCodeStatusSchema,
+    createdAt: z.string(),
+    createdBy: ActorMetaSchema,
+    expiresAt: z.string(),
+    redeemedAt: z.string().nullable(),
+    redeemedBy: ActorMetaSchema.nullable(),
+    invalidatedAt: z.string().nullable(),
+    invalidatedBy: ActorMetaSchema.nullable(),
+  })
+  .strict();
+export type RedemptionCode = z.infer<typeof RedemptionCodeSchema>;
+
+export const MintCodeRequestSchema = z
+  .object({
+    grants: z.array(RedemptionGrantEntrySchema).min(1).max(SURFACE_VALUES.length),
+    note: z.string().max(500).optional(),
+    expiresAt: z.string(),
+  })
+  .strict();
+export type MintCodeRequest = z.infer<typeof MintCodeRequestSchema>;
+
+export const MintCodeResponseSchema = z
+  .object({
+    code: RedemptionCodeSchema,
+  })
+  .strict();
+export type MintCodeResponse = z.infer<typeof MintCodeResponseSchema>;
+
+export const RedemptionCodeListResponseSchema = z
+  .object({
+    items: z.array(RedemptionCodeSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    pageSize: z.number().int().positive(),
+    totalPages: z.number().int().positive(),
+  })
+  .strict();
+export type RedemptionCodeListResponse = z.infer<
+  typeof RedemptionCodeListResponseSchema
+>;
+
+export const RedeemCodeRequestSchema = z
+  .object({
+    code: z.string().min(1),
+  })
+  .strict();
+export type RedeemCodeRequest = z.infer<typeof RedeemCodeRequestSchema>;
+
+export const RedeemAppliedGrantSchema = z
+  .object({
+    surface: SurfaceSchema,
+    amount: z.number().int().nonnegative(),
+    monthMarker: z.string(),
+    newAdminGrant: z.number().int().nonnegative(),
+  })
+  .strict();
+export type RedeemAppliedGrant = z.infer<typeof RedeemAppliedGrantSchema>;
+
+export const RedeemCodeResponseSchema = z
+  .object({
+    codeId: z.string(),
+    redeemedAt: z.string(),
+    grants: z.array(RedeemAppliedGrantSchema).min(1),
+  })
+  .strict();
+export type RedeemCodeResponse = z.infer<typeof RedeemCodeResponseSchema>;
+
+export const RedemptionHistoryItemSchema = z
+  .object({
+    id: z.string(),
+    code: z.string(),
+    grants: z.array(RedemptionGrantEntrySchema),
+    note: z.string().nullable(),
+    redeemedAt: z.string().nullable(),
+    expiresAt: z.string(),
+    createdAt: z.string(),
+  })
+  .strict();
+export type RedemptionHistoryItem = z.infer<typeof RedemptionHistoryItemSchema>;
+
+export const RedemptionHistoryResponseSchema = z
+  .object({
+    items: z.array(RedemptionHistoryItemSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    pageSize: z.number().int().positive(),
+    totalPages: z.number().int().positive(),
+  })
+  .strict();
+export type RedemptionHistoryResponse = z.infer<
+  typeof RedemptionHistoryResponseSchema
+>;

--- a/ornn-web/src/services/redemptionCodesApi.ts
+++ b/ornn-web/src/services/redemptionCodesApi.ts
@@ -1,0 +1,156 @@
+/**
+ * Redemption-code HTTP client — wraps the admin
+ * `/api/v1/admin/redemption-codes/*` mint/list/invalidate endpoints
+ * and the caller-scoped `/api/v1/me/redemption-codes/*` redeem and
+ * history endpoints.
+ *
+ * Mirrors the backend shapes in
+ * `ornn-api/src/domains/redemption-codes/types.ts` and the route
+ * serializers; payloads are validated through the Zod schemas in
+ * `redemptionCodesApi.schema.ts` so a backend regression is surfaced
+ * loudly on the client.
+ *
+ * @module services/redemptionCodesApi
+ */
+
+import { apiGet, apiPost } from "./apiClient";
+import {
+  MintCodeResponseSchema,
+  RedeemCodeResponseSchema,
+  RedemptionCodeListResponseSchema,
+  RedemptionCodeSchema,
+  RedemptionHistoryResponseSchema,
+  type MintCodeRequest,
+  type MintCodeResponse,
+  type RedeemCodeResponse,
+  type RedemptionCode,
+  type RedemptionCodeListResponse,
+  type RedemptionCodeStatus,
+  type RedemptionHistoryResponse,
+} from "./redemptionCodesApi.schema";
+
+export type {
+  ActorMeta,
+  MintCodeRequest,
+  MintCodeResponse,
+  RedeemAppliedGrant,
+  RedeemCodeRequest,
+  RedeemCodeResponse,
+  RedemptionCode,
+  RedemptionCodeListResponse,
+  RedemptionCodeStatus,
+  RedemptionGrantEntry,
+  RedemptionHistoryItem,
+  RedemptionHistoryResponse,
+  Surface,
+} from "./redemptionCodesApi.schema";
+
+export interface AdminRedemptionCodeFilters {
+  status?: RedemptionCodeStatus;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export async function mintCode(req: MintCodeRequest): Promise<MintCodeResponse> {
+  const res = await apiPost<unknown>("/api/v1/admin/redemption-codes", req);
+  if (!res.data) {
+    throw new Error("Mint response missing");
+  }
+  const parsed = MintCodeResponseSchema.safeParse(res.data);
+  if (!parsed.success) {
+    throw new Error(`Mint response shape invalid: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+export async function listAdminCodes(
+  filters: AdminRedemptionCodeFilters = {},
+): Promise<RedemptionCodeListResponse> {
+  const res = await apiGet<unknown>("/api/v1/admin/redemption-codes", {
+    status: filters.status,
+    search: filters.search,
+    page: filters.page,
+    pageSize: filters.pageSize,
+  });
+  if (!res.data) {
+    throw new Error("Admin redemption-code list missing");
+  }
+  const parsed = RedemptionCodeListResponseSchema.safeParse(res.data);
+  if (!parsed.success) {
+    throw new Error(
+      `Admin redemption-code list shape invalid: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+export async function getAdminCodeDetail(id: string): Promise<RedemptionCode> {
+  const res = await apiGet<{ code: unknown }>(
+    `/api/v1/admin/redemption-codes/${encodeURIComponent(id)}`,
+  );
+  if (!res.data?.code) {
+    throw new Error("Redemption code detail missing");
+  }
+  const parsed = RedemptionCodeSchema.safeParse(res.data.code);
+  if (!parsed.success) {
+    throw new Error(`Redemption code shape invalid: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+export async function invalidateCode(id: string): Promise<RedemptionCode> {
+  const res = await apiPost<{ code: unknown }>(
+    `/api/v1/admin/redemption-codes/${encodeURIComponent(id)}/invalidate`,
+    {},
+  );
+  if (!res.data?.code) {
+    throw new Error("Invalidate response missing");
+  }
+  const parsed = RedemptionCodeSchema.safeParse(res.data.code);
+  if (!parsed.success) {
+    throw new Error(`Invalidate response shape invalid: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+export async function redeemCode(code: string): Promise<RedeemCodeResponse> {
+  const res = await apiPost<unknown>("/api/v1/me/redemption-codes/redeem", {
+    code,
+  });
+  if (!res.data) {
+    throw new Error("Redeem response missing");
+  }
+  const parsed = RedeemCodeResponseSchema.safeParse(res.data);
+  if (!parsed.success) {
+    throw new Error(`Redeem response shape invalid: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+export async function listMyRedemptionHistory(params: {
+  page?: number;
+  pageSize?: number;
+} = {}): Promise<RedemptionHistoryResponse> {
+  const res = await apiGet<unknown>("/api/v1/me/redemption-codes/history", {
+    page: params.page,
+    pageSize: params.pageSize,
+  });
+  if (!res.data) {
+    throw new Error("Redemption history missing");
+  }
+  const parsed = RedemptionHistoryResponseSchema.safeParse(res.data);
+  if (!parsed.success) {
+    throw new Error(`Redemption history shape invalid: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+// Test-only export — Zod parsers surfaced for unit tests.
+export const __test__ = {
+  MintCodeResponseSchema,
+  RedeemCodeResponseSchema,
+  RedemptionCodeListResponseSchema,
+  RedemptionCodeSchema,
+  RedemptionHistoryResponseSchema,
+};


### PR DESCRIPTION
## Summary

- Admin can mint single-use, time-bounded **redemption codes** carrying a multi-surface (`playground` / `skillGen`) quota grant; user redeems from Settings → Redeem code; grant lands on the caller's current-month bucket via existing `QuotaService.grant()` so audit + notification fanout is reused (no parallel ledger).
- Lifecycle `active → redeemed | invalidated` with race-safe atomic pivot — concurrent redemptions of the same code resolve to exactly one winner. Admin can invalidate `active` codes; redeemed / already-invalidated codes return 409.
- Code shape: 16 chars from a confusable-stripped alphabet (`0/O/1/I/L` excluded), server-generated, normalised to upper-case at the API boundary so the user-facing form accepts any case.

## Surfaces

**Backend** — `ornn-api/src/domains/redemption-codes/` (types, repo, service, me-routes, tests) + `domains/admin/redemption-codes/routes.ts`. Wired in `bootstrap.ts`.

**Frontend** — admin page at `/admin/redemption-codes` (mint modal with copy-on-success, list + filter + search, invalidate, detail drawer); user form on Settings page with per-error-code messages (`NOT_FOUND` / `EXPIRED` / `INVALIDATED` / `ALREADY_REDEEMED`). API client + TanStack Query hooks in `services/redemptionCodesApi*` and `hooks/useRedemptionCodes.ts`.

## Test plan

- [x] Backend unit + integration: 29 new tests covering happy path, every error-code mapping, parallel-redeem race
- [x] Frontend: redeem-form per-error-code message mapping; mint-modal client-side guards (no zero grants, no duplicate surface, expiresAt > now)
- [x] Full suite: **507 api / 63 web / 17 sdk = 587 passing, 0 failing**
- [x] Typecheck: api + web + sdk all clean
- [ ] Local docker round-trip — recommended before merge: rebuild both images, hit `/admin/redemption-codes` and Settings end-to-end against a real Mongo

Closes #306.