### PR TITLE
feat: landing-page announcement popup (admin-managed)

### DIFF
--- a/.changeset/landing-announcement-popup.md
+++ b/.changeset/landing-announcement-popup.md
@@ -1,0 +1,12 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+Landing-page announcement popup with admin management. Admins can curate news / changelog blurbs from a new `/admin/announcements` page; the most recent enabled record currently within its `[startsAt, endsAt]` window is shown to every visitor (anonymous + signed-in) on the landing page, dismissible per-id via `localStorage`.
+
+- **API.** New `announcements` Mongo domain. Public `GET /api/v1/announcements/active` (anonymous-friendly) returns the single live record or `null`. Admin CRUD lives under `/api/v1/admin/announcements` gated on `ornn:admin:skill`.
+- **Admin UI.** Top-level `/admin/announcements` next to Skills and Quota — list table with LIVE / SCHEDULED / EXPIRED / DISABLED status, per-row enable / edit / delete, and a 560px right-edge drawer for create / edit with a markdown body preview, optional CTA pair, and optional schedule window.
+- **Landing.** New `AnnouncementPopup` mounted on `/`. One-shot per id: `localStorage` key `ornn:announcement:dismissed:<id>` keeps the same browser from being re-prompted. CTA links open in a new tab and also mark dismissed on click.
+
+Closes #307.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -62,6 +62,11 @@ import { NotificationRepository } from "./domains/notifications/repository";
 import { NotificationService } from "./domains/notifications/service";
 import { createNotificationRoutes } from "./domains/notifications/routes";
 
+// Domain: Announcements (landing-page popup)
+import { AnnouncementRepository } from "./domains/announcements/repository";
+import { AnnouncementService } from "./domains/announcements/service";
+import { createAnnouncementRoutes } from "./domains/announcements/routes";
+
 // Domain: Analytics
 import { AnalyticsRepository } from "./domains/analytics/repository";
 import { AnalyticsService } from "./domains/analytics/service";
@@ -420,6 +425,14 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   );
   const notificationService = new NotificationService({ notificationRepo });
   const notificationRoutes = createNotificationRoutes({ notificationService });
+
+  // ---- Domain: Announcements (landing-page popup, issue #307) ----
+  const announcementRepo = new AnnouncementRepository(db);
+  void announcementRepo.ensureIndexes().catch((err) =>
+    logger.warn({ err }, "announcements indexes ensureIndexes failed — proceeding anyway"),
+  );
+  const announcementService = new AnnouncementService({ repo: announcementRepo });
+  const announcementRoutes = createAnnouncementRoutes({ announcementService });
 
   // ---- NyxID Orgs Client — built early so the audit fan-out can expand
   //   sharedWithOrgs into member rosters when sending consumer notifications.
@@ -813,6 +826,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   apiApp.route("/", mirrorRoutes);
   apiApp.route("/", auditRoutes);
   apiApp.route("/", notificationRoutes);
+  apiApp.route("/", announcementRoutes);
   apiApp.route("/", analyticsRoutes);
   apiApp.route("/", searchRoutes);
   apiApp.route("/", generationRoutes);

--- a/ornn-api/src/domains/announcements/repository.ts
+++ b/ornn-api/src/domains/announcements/repository.ts
@@ -1,0 +1,149 @@
+/**
+ * Announcement repository — one Mongo collection, `announcements`.
+ *
+ * Reads:
+ *   - listAll(): admin table (newest first, every record).
+ *   - findActive(now): public popup — single enabled record currently
+ *     within its [startsAt, endsAt] window, picked by most-recent
+ *     createdAt so admins can supersede a live one by simply creating
+ *     a new enabled record.
+ *
+ * Writes are admin-driven CRUD. No fan-out, no batch jobs.
+ *
+ * @module domains/announcements/repository
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Collection, Db, Document } from "mongodb";
+import pino from "pino";
+import type { AnnouncementDocument } from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "announcementRepository" });
+
+export interface CreateAnnouncementInput {
+  title: string;
+  bodyMarkdown: string;
+  ctaLabel?: string | null;
+  ctaUrl?: string | null;
+  enabled: boolean;
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+  createdBy: string;
+}
+
+export interface UpdateAnnouncementInput {
+  title?: string;
+  bodyMarkdown?: string;
+  ctaLabel?: string | null;
+  ctaUrl?: string | null;
+  enabled?: boolean;
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+}
+
+export class AnnouncementRepository {
+  private readonly collection: Collection;
+
+  constructor(db: Db) {
+    this.collection = db.collection("announcements");
+  }
+
+  async ensureIndexes(): Promise<void> {
+    try {
+      // The "active" lookup filters on enabled + window bounds and orders
+      // by createdAt; a single compound covers both the predicate selection
+      // and the ordering well enough for the cardinality we expect (<<1k).
+      await this.collection.createIndex({ enabled: 1, createdAt: -1 });
+    } catch (err) {
+      logger.error({ err }, "Failed to create announcements indexes");
+    }
+  }
+
+  async create(input: CreateAnnouncementInput): Promise<AnnouncementDocument> {
+    const now = new Date();
+    const doc: Document = {
+      _id: randomUUID() as unknown as Document["_id"],
+      title: input.title,
+      bodyMarkdown: input.bodyMarkdown,
+      ctaLabel: input.ctaLabel ?? null,
+      ctaUrl: input.ctaUrl ?? null,
+      enabled: input.enabled,
+      startsAt: input.startsAt ?? null,
+      endsAt: input.endsAt ?? null,
+      createdBy: input.createdBy,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.collection.insertOne(doc);
+    return mapDoc(doc)!;
+  }
+
+  async listAll(): Promise<AnnouncementDocument[]> {
+    const docs = await this.collection.find({}).sort({ createdAt: -1 }).toArray();
+    return docs.map((d) => mapDoc(d)!);
+  }
+
+  async findById(id: string): Promise<AnnouncementDocument | null> {
+    const doc = await this.collection.findOne({ _id: id as unknown as Document["_id"] });
+    return mapDoc(doc);
+  }
+
+  async findActive(now: Date): Promise<AnnouncementDocument | null> {
+    const doc = await this.collection
+      .find({
+        enabled: true,
+        $and: [
+          { $or: [{ startsAt: null }, { startsAt: { $lte: now } }] },
+          { $or: [{ endsAt: null }, { endsAt: { $gt: now } }] },
+        ],
+      })
+      .sort({ createdAt: -1 })
+      .limit(1)
+      .next();
+    return mapDoc(doc);
+  }
+
+  async update(id: string, patch: UpdateAnnouncementInput): Promise<AnnouncementDocument | null> {
+    const $set: Record<string, unknown> = { updatedAt: new Date() };
+    if (patch.title !== undefined) $set.title = patch.title;
+    if (patch.bodyMarkdown !== undefined) $set.bodyMarkdown = patch.bodyMarkdown;
+    if (patch.ctaLabel !== undefined) $set.ctaLabel = patch.ctaLabel;
+    if (patch.ctaUrl !== undefined) $set.ctaUrl = patch.ctaUrl;
+    if (patch.enabled !== undefined) $set.enabled = patch.enabled;
+    if (patch.startsAt !== undefined) $set.startsAt = patch.startsAt;
+    if (patch.endsAt !== undefined) $set.endsAt = patch.endsAt;
+    await this.collection.updateOne({ _id: id as unknown as Document["_id"] }, { $set });
+    return this.findById(id);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const res = await this.collection.deleteOne({ _id: id as unknown as Document["_id"] });
+    return (res.deletedCount ?? 0) > 0;
+  }
+}
+
+function mapDoc(doc: Document | null): AnnouncementDocument | null {
+  if (!doc) return null;
+  return {
+    _id: String(doc._id),
+    title: String(doc.title ?? ""),
+    bodyMarkdown: String(doc.bodyMarkdown ?? ""),
+    ctaLabel: doc.ctaLabel == null ? null : String(doc.ctaLabel),
+    ctaUrl: doc.ctaUrl == null ? null : String(doc.ctaUrl),
+    enabled: Boolean(doc.enabled),
+    startsAt: toNullableDate(doc.startsAt),
+    endsAt: toNullableDate(doc.endsAt),
+    createdBy: String(doc.createdBy ?? ""),
+    createdAt: toDate(doc.createdAt),
+    updatedAt: toDate(doc.updatedAt ?? doc.createdAt),
+  };
+}
+
+function toDate(v: unknown): Date {
+  return v instanceof Date ? v : new Date(v as string | number);
+}
+
+function toNullableDate(v: unknown): Date | null {
+  if (v == null) return null;
+  return v instanceof Date ? v : new Date(v as string | number);
+}

--- a/ornn-api/src/domains/announcements/routes.ts
+++ b/ornn-api/src/domains/announcements/routes.ts
@@ -1,0 +1,157 @@
+/**
+ * Announcement HTTP routes.
+ *
+ *   GET    /api/v1/announcements/active            — public, anonymous
+ *   GET    /api/v1/admin/announcements             — admin list
+ *   POST   /api/v1/admin/announcements             — admin create
+ *   PATCH  /api/v1/admin/announcements/:id         — admin update
+ *   DELETE /api/v1/admin/announcements/:id         — admin delete
+ *
+ * The public endpoint never sees `createdBy` or scheduling internals — it
+ * only returns the rendering shape used by the landing-page popup.
+ *
+ * @module domains/announcements/routes
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  type AuthVariables,
+  getAuth,
+  nyxidAuthMiddleware,
+  requirePermission,
+} from "../../middleware/nyxidAuth";
+import { AppError } from "../../shared/types/index";
+import type { AnnouncementService } from "./service";
+import type { AnnouncementDocument } from "./types";
+
+const ADMIN_PERMISSION = "ornn:admin:skill";
+
+const isoDateNullable = z
+  .union([z.string().datetime({ offset: true }), z.null()])
+  .transform((v) => (v === null ? null : new Date(v)));
+
+const optionalString = (max: number) => z.string().trim().min(1).max(max);
+
+const createSchema = z.object({
+  title: optionalString(200),
+  bodyMarkdown: z.string().min(1).max(20_000),
+  ctaLabel: z.union([z.string().trim().min(1).max(80), z.null()]).optional(),
+  ctaUrl: z.union([z.string().trim().url().max(2048), z.null()]).optional(),
+  enabled: z.boolean(),
+  startsAt: isoDateNullable.optional(),
+  endsAt: isoDateNullable.optional(),
+});
+
+const updateSchema = z.object({
+  title: optionalString(200).optional(),
+  bodyMarkdown: z.string().min(1).max(20_000).optional(),
+  ctaLabel: z.union([z.string().trim().min(1).max(80), z.null()]).optional(),
+  ctaUrl: z.union([z.string().trim().url().max(2048), z.null()]).optional(),
+  enabled: z.boolean().optional(),
+  startsAt: isoDateNullable.optional(),
+  endsAt: isoDateNullable.optional(),
+});
+
+export interface AnnouncementRoutesConfig {
+  readonly announcementService: AnnouncementService;
+}
+
+export function createAnnouncementRoutes(
+  config: AnnouncementRoutesConfig,
+): Hono<{ Variables: AuthVariables }> {
+  const { announcementService } = config;
+  const app = new Hono<{ Variables: AuthVariables }>();
+  const auth = nyxidAuthMiddleware();
+  const adminGuard = requirePermission(ADMIN_PERMISSION);
+
+  // ---- Public ----
+  app.get("/announcements/active", async (c) => {
+    const active = await announcementService.getActive();
+    return c.json({ data: { active }, error: null });
+  });
+
+  // ---- Admin ----
+  app.get("/admin/announcements", auth, adminGuard, async (c) => {
+    const items = await announcementService.listAll();
+    return c.json({ data: { items: items.map(toAdminDto) }, error: null });
+  });
+
+  app.post("/admin/announcements", auth, adminGuard, async (c) => {
+    const authCtx = getAuth(c);
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = createSchema.safeParse(body);
+    if (!parsed.success) {
+      throw AppError.badRequest(
+        "INVALID_ANNOUNCEMENT_INPUT",
+        parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+      );
+    }
+    const created = await announcementService.create({
+      title: parsed.data.title,
+      bodyMarkdown: parsed.data.bodyMarkdown,
+      ctaLabel: parsed.data.ctaLabel ?? null,
+      ctaUrl: parsed.data.ctaUrl ?? null,
+      enabled: parsed.data.enabled,
+      startsAt: parsed.data.startsAt ?? null,
+      endsAt: parsed.data.endsAt ?? null,
+      createdBy: authCtx.userId,
+    });
+    return c.json({ data: toAdminDto(created), error: null }, 201);
+  });
+
+  app.patch("/admin/announcements/:id", auth, adminGuard, async (c) => {
+    const id = c.req.param("id");
+    const body = await c.req.json().catch(() => ({}));
+    const parsed = updateSchema.safeParse(body);
+    if (!parsed.success) {
+      throw AppError.badRequest(
+        "INVALID_ANNOUNCEMENT_INPUT",
+        parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+      );
+    }
+    if (Object.keys(parsed.data).length === 0) {
+      throw AppError.badRequest("INVALID_ANNOUNCEMENT_INPUT", "No fields to update");
+    }
+    const updated = await announcementService.update(id, parsed.data);
+    return c.json({ data: toAdminDto(updated), error: null });
+  });
+
+  app.delete("/admin/announcements/:id", auth, adminGuard, async (c) => {
+    const id = c.req.param("id");
+    await announcementService.delete(id);
+    return c.json({ data: { id }, error: null });
+  });
+
+  return app;
+}
+
+interface AdminAnnouncementDto {
+  id: string;
+  title: string;
+  bodyMarkdown: string;
+  ctaLabel: string | null;
+  ctaUrl: string | null;
+  enabled: boolean;
+  startsAt: string | null;
+  endsAt: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function toAdminDto(doc: AnnouncementDocument): AdminAnnouncementDto {
+  return {
+    id: doc._id,
+    title: doc.title,
+    bodyMarkdown: doc.bodyMarkdown,
+    ctaLabel: doc.ctaLabel,
+    ctaUrl: doc.ctaUrl,
+    enabled: doc.enabled,
+    startsAt: doc.startsAt ? doc.startsAt.toISOString() : null,
+    endsAt: doc.endsAt ? doc.endsAt.toISOString() : null,
+    createdBy: doc.createdBy,
+    createdAt: doc.createdAt.toISOString(),
+    updatedAt: doc.updatedAt.toISOString(),
+  };
+}

--- a/ornn-api/src/domains/announcements/service.test.ts
+++ b/ornn-api/src/domains/announcements/service.test.ts
@@ -1,0 +1,215 @@
+/**
+ * AnnouncementService unit tests against an in-memory repository fake.
+ *
+ * Covers:
+ *   - getActive() picks the most recent record matching enabled + window.
+ *   - Disabled records and out-of-window records are filtered out.
+ *   - create/update reject inverted [startsAt, endsAt] windows.
+ *   - update on a missing id surfaces a 404 AppError.
+ *
+ * @module domains/announcements/service.test
+ */
+
+import { describe, expect, it } from "bun:test";
+import { AnnouncementService } from "./service";
+import type {
+  AnnouncementRepository,
+  CreateAnnouncementInput,
+  UpdateAnnouncementInput,
+} from "./repository";
+import type { AnnouncementDocument } from "./types";
+
+class FakeRepo {
+  private rows = new Map<string, AnnouncementDocument>();
+  private nextId = 0;
+
+  async ensureIndexes(): Promise<void> {}
+
+  async create(input: CreateAnnouncementInput): Promise<AnnouncementDocument> {
+    const now = new Date();
+    const id = `a-${++this.nextId}`;
+    const doc: AnnouncementDocument = {
+      _id: id,
+      title: input.title,
+      bodyMarkdown: input.bodyMarkdown,
+      ctaLabel: input.ctaLabel ?? null,
+      ctaUrl: input.ctaUrl ?? null,
+      enabled: input.enabled,
+      startsAt: input.startsAt ?? null,
+      endsAt: input.endsAt ?? null,
+      createdBy: input.createdBy,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.rows.set(id, doc);
+    return doc;
+  }
+
+  async listAll(): Promise<AnnouncementDocument[]> {
+    return [...this.rows.values()].sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+    );
+  }
+
+  async findById(id: string): Promise<AnnouncementDocument | null> {
+    return this.rows.get(id) ?? null;
+  }
+
+  async findActive(now: Date): Promise<AnnouncementDocument | null> {
+    const matches = [...this.rows.values()]
+      .filter(
+        (d) =>
+          d.enabled &&
+          (d.startsAt === null || d.startsAt.getTime() <= now.getTime()) &&
+          (d.endsAt === null || d.endsAt.getTime() > now.getTime()),
+      )
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return matches[0] ?? null;
+  }
+
+  async update(
+    id: string,
+    patch: UpdateAnnouncementInput,
+  ): Promise<AnnouncementDocument | null> {
+    const existing = this.rows.get(id);
+    if (!existing) return null;
+    const next: AnnouncementDocument = {
+      ...existing,
+      title: patch.title !== undefined ? patch.title : existing.title,
+      bodyMarkdown:
+        patch.bodyMarkdown !== undefined ? patch.bodyMarkdown : existing.bodyMarkdown,
+      ctaLabel: patch.ctaLabel !== undefined ? patch.ctaLabel : existing.ctaLabel,
+      ctaUrl: patch.ctaUrl !== undefined ? patch.ctaUrl : existing.ctaUrl,
+      enabled: patch.enabled !== undefined ? patch.enabled : existing.enabled,
+      startsAt: patch.startsAt !== undefined ? patch.startsAt : existing.startsAt,
+      endsAt: patch.endsAt !== undefined ? patch.endsAt : existing.endsAt,
+      updatedAt: new Date(),
+    };
+    this.rows.set(id, next);
+    return next;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.rows.delete(id);
+  }
+
+  // The fake force-overrides createdAt for ordering tests.
+  setCreatedAt(id: string, when: Date): void {
+    const row = this.rows.get(id);
+    if (row) this.rows.set(id, { ...row, createdAt: when });
+  }
+}
+
+function makeService(now: Date = new Date("2026-05-08T12:00:00Z")) {
+  const repo = new FakeRepo();
+  const svc = new AnnouncementService({
+    repo: repo as unknown as AnnouncementRepository,
+    clock: () => now,
+  });
+  return { svc, repo };
+}
+
+const baseInput = {
+  title: "Hello",
+  bodyMarkdown: "World",
+  enabled: true,
+  createdBy: "u-admin",
+} as const;
+
+describe("AnnouncementService", () => {
+  it("getActive returns null when no records exist", async () => {
+    const { svc } = makeService();
+    expect(await svc.getActive()).toBeNull();
+  });
+
+  it("getActive picks the most recent enabled in-window record", async () => {
+    const now = new Date("2026-05-08T12:00:00Z");
+    const { svc, repo } = makeService(now);
+    const older = await svc.create({ ...baseInput, title: "older" });
+    const newer = await svc.create({ ...baseInput, title: "newer" });
+    repo.setCreatedAt(older._id, new Date("2026-05-01T00:00:00Z"));
+    repo.setCreatedAt(newer._id, new Date("2026-05-07T00:00:00Z"));
+    const active = await svc.getActive();
+    expect(active?.id).toBe(newer._id);
+    expect(active?.title).toBe("newer");
+  });
+
+  it("getActive ignores disabled records", async () => {
+    const { svc } = makeService();
+    await svc.create({ ...baseInput, enabled: false });
+    expect(await svc.getActive()).toBeNull();
+  });
+
+  it("getActive respects startsAt lower bound", async () => {
+    const now = new Date("2026-05-08T12:00:00Z");
+    const { svc } = makeService(now);
+    await svc.create({
+      ...baseInput,
+      startsAt: new Date("2026-06-01T00:00:00Z"),
+    });
+    expect(await svc.getActive()).toBeNull();
+  });
+
+  it("getActive respects endsAt upper bound (exclusive)", async () => {
+    const now = new Date("2026-05-08T12:00:00Z");
+    const { svc } = makeService(now);
+    await svc.create({
+      ...baseInput,
+      endsAt: new Date("2026-05-08T12:00:00Z"),
+    });
+    expect(await svc.getActive()).toBeNull();
+  });
+
+  it("getActive returns the public projection (no createdBy / dates)", async () => {
+    const { svc } = makeService();
+    await svc.create({
+      ...baseInput,
+      ctaLabel: "Read more",
+      ctaUrl: "https://ornn.dev/news",
+    });
+    const active = await svc.getActive();
+    expect(active).toEqual({
+      id: expect.any(String),
+      title: "Hello",
+      bodyMarkdown: "World",
+      ctaLabel: "Read more",
+      ctaUrl: "https://ornn.dev/news",
+    });
+  });
+
+  it("create rejects inverted [startsAt, endsAt] windows", async () => {
+    const { svc } = makeService();
+    await expect(
+      svc.create({
+        ...baseInput,
+        startsAt: new Date("2026-06-01T00:00:00Z"),
+        endsAt: new Date("2026-05-01T00:00:00Z"),
+      }),
+    ).rejects.toThrow(/endsAt must be strictly after startsAt/);
+  });
+
+  it("update merges window bounds before validating order", async () => {
+    const { svc } = makeService();
+    const created = await svc.create({
+      ...baseInput,
+      startsAt: new Date("2026-05-01T00:00:00Z"),
+      endsAt: new Date("2026-06-01T00:00:00Z"),
+    });
+    // Patching only endsAt to before existing startsAt must fail.
+    await expect(
+      svc.update(created._id, { endsAt: new Date("2026-04-15T00:00:00Z") }),
+    ).rejects.toThrow(/endsAt must be strictly after startsAt/);
+  });
+
+  it("update on missing id throws ANNOUNCEMENT_NOT_FOUND", async () => {
+    const { svc } = makeService();
+    await expect(svc.update("does-not-exist", { enabled: false })).rejects.toThrow(
+      /Announcement not found/,
+    );
+  });
+
+  it("delete on missing id throws ANNOUNCEMENT_NOT_FOUND", async () => {
+    const { svc } = makeService();
+    await expect(svc.delete("does-not-exist")).rejects.toThrow(/Announcement not found/);
+  });
+});

--- a/ornn-api/src/domains/announcements/service.ts
+++ b/ornn-api/src/domains/announcements/service.ts
@@ -1,0 +1,119 @@
+/**
+ * Announcement service — thin wrapper around the repo, plus the
+ * `getActive()` rule used by the public landing-page endpoint.
+ *
+ * Validation lives in the route layer (Zod). Business rules here are
+ * limited to:
+ *   - "Active = enabled + within window, newest first."
+ *   - "endsAt must be strictly after startsAt when both are set."
+ *
+ * @module domains/announcements/service
+ */
+
+import pino from "pino";
+import { AppError } from "../../shared/types/index";
+import type {
+  AnnouncementRepository,
+  CreateAnnouncementInput,
+  UpdateAnnouncementInput,
+} from "./repository";
+import type { AnnouncementDocument, PublicAnnouncement } from "./types";
+
+const logger = pino({ level: "info" }).child({ module: "announcementService" });
+
+export interface AnnouncementServiceDeps {
+  readonly repo: AnnouncementRepository;
+  /** Override for tests; defaults to `() => new Date()` in production. */
+  readonly clock?: () => Date;
+}
+
+export class AnnouncementService {
+  private readonly repo: AnnouncementRepository;
+  private readonly clock: () => Date;
+
+  constructor(deps: AnnouncementServiceDeps) {
+    this.repo = deps.repo;
+    this.clock = deps.clock ?? (() => new Date());
+  }
+
+  // ---- Public surface ----------------------------------------------------
+
+  /**
+   * Returns the announcement to show to landing-page visitors right now,
+   * or `null` if none qualifies. Anonymous users hit this endpoint —
+   * never include audit fields (`createdBy`, raw timestamps) in the
+   * response shape.
+   */
+  async getActive(): Promise<PublicAnnouncement | null> {
+    const doc = await this.repo.findActive(this.clock());
+    return doc ? toPublic(doc) : null;
+  }
+
+  // ---- Admin surface -----------------------------------------------------
+
+  async listAll(): Promise<AnnouncementDocument[]> {
+    return this.repo.listAll();
+  }
+
+  async getById(id: string): Promise<AnnouncementDocument> {
+    const doc = await this.repo.findById(id);
+    if (!doc) {
+      throw AppError.notFound("ANNOUNCEMENT_NOT_FOUND", "Announcement not found");
+    }
+    return doc;
+  }
+
+  async create(input: CreateAnnouncementInput): Promise<AnnouncementDocument> {
+    this.assertWindowOrder(input.startsAt ?? null, input.endsAt ?? null);
+    const doc = await this.repo.create(input);
+    logger.info(
+      { announcementId: doc._id, enabled: doc.enabled, by: input.createdBy },
+      "Announcement created",
+    );
+    return doc;
+  }
+
+  async update(id: string, patch: UpdateAnnouncementInput): Promise<AnnouncementDocument> {
+    // When either bound is in the patch, validate against the resulting
+    // pair (existing value preserved on the side that wasn't sent).
+    if (patch.startsAt !== undefined || patch.endsAt !== undefined) {
+      const existing = await this.getById(id);
+      const startsAt = patch.startsAt !== undefined ? patch.startsAt : existing.startsAt;
+      const endsAt = patch.endsAt !== undefined ? patch.endsAt : existing.endsAt;
+      this.assertWindowOrder(startsAt, endsAt);
+    }
+    const updated = await this.repo.update(id, patch);
+    if (!updated) {
+      throw AppError.notFound("ANNOUNCEMENT_NOT_FOUND", "Announcement not found");
+    }
+    logger.info({ announcementId: id, enabled: updated.enabled }, "Announcement updated");
+    return updated;
+  }
+
+  async delete(id: string): Promise<void> {
+    const removed = await this.repo.delete(id);
+    if (!removed) {
+      throw AppError.notFound("ANNOUNCEMENT_NOT_FOUND", "Announcement not found");
+    }
+    logger.info({ announcementId: id }, "Announcement deleted");
+  }
+
+  private assertWindowOrder(startsAt: Date | null, endsAt: Date | null): void {
+    if (startsAt && endsAt && endsAt.getTime() <= startsAt.getTime()) {
+      throw AppError.badRequest(
+        "INVALID_ANNOUNCEMENT_WINDOW",
+        "endsAt must be strictly after startsAt",
+      );
+    }
+  }
+}
+
+function toPublic(doc: AnnouncementDocument): PublicAnnouncement {
+  return {
+    id: doc._id,
+    title: doc.title,
+    bodyMarkdown: doc.bodyMarkdown,
+    ctaLabel: doc.ctaLabel,
+    ctaUrl: doc.ctaUrl,
+  };
+}

--- a/ornn-api/src/domains/announcements/types.ts
+++ b/ornn-api/src/domains/announcements/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Announcement (landing-page popup) domain types.
+ *
+ * Single-active model: at most one announcement is shown to visitors at
+ * a time. Admin curates the list; the public surface picks the most
+ * recently-created enabled record currently within its `[startsAt, endsAt]`
+ * window. A null bound means open-ended on that side.
+ *
+ * @module domains/announcements/types
+ */
+
+export interface AnnouncementDocument {
+  readonly _id: string;
+  readonly title: string;
+  readonly bodyMarkdown: string;
+  readonly ctaLabel: string | null;
+  readonly ctaUrl: string | null;
+  readonly enabled: boolean;
+  /** Optional start of the visibility window. `null` = no lower bound. */
+  readonly startsAt: Date | null;
+  /** Optional end of the visibility window (exclusive). `null` = no upper bound. */
+  readonly endsAt: Date | null;
+  /** NyxID user_id of the admin who created the announcement. */
+  readonly createdBy: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/**
+ * Shape returned to anonymous landing-page visitors. Strips internal
+ * scheduling + audit fields — the SPA only needs what it renders.
+ */
+export interface PublicAnnouncement {
+  readonly id: string;
+  readonly title: string;
+  readonly bodyMarkdown: string;
+  readonly ctaLabel: string | null;
+  readonly ctaUrl: string | null;
+}

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -126,6 +126,9 @@ const AdminSkillsPage = lazy(() =>
 const AdminQuotaManagementPage = lazy(() =>
   import("@/pages/admin").then((m) => ({ default: m.QuotaManagementPage })),
 );
+const AdminAnnouncementsPage = lazy(() =>
+  import("@/pages/admin").then((m) => ({ default: m.AnnouncementsPage })),
+);
 
 // Settings layout + section components live under pages/admin/settings.
 const SettingsLayout = lazy(() =>
@@ -245,6 +248,7 @@ const router = createBrowserRouter(
             <Route path="/admin/users-legacy" element={<AdminUsersLegacyPage />} />
             <Route path="/admin/skills" element={<AdminSkillsPage />} />
             <Route path="/admin/quota" element={<AdminQuotaManagementPage />} />
+            <Route path="/admin/announcements" element={<AdminAnnouncementsPage />} />
 
             {/* /admin/mirror keeps working but redirects to the new
                 settings/mirror section so existing deep-links + bookmarks

--- a/ornn-web/src/components/admin/announcements/AnnouncementEditDrawer.tsx
+++ b/ornn-web/src/components/admin/announcements/AnnouncementEditDrawer.tsx
@@ -1,0 +1,416 @@
+/**
+ * AnnouncementEditDrawer — create or edit a single landing-popup
+ * announcement. Right-edge slide-in following the QuotaUserDetailDrawer
+ * pattern. Fields: title, markdown body (with live preview), CTA
+ * label/URL, enabled toggle, optional [startsAt, endsAt] window
+ * (datetime-local inputs, persisted as ISO).
+ *
+ * @module components/admin/announcements/AnnouncementEditDrawer
+ */
+
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { z } from "zod";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { ReadmeViewer } from "@/components/skill/ReadmeViewer";
+import { useToastStore } from "@/stores/toastStore";
+import {
+  useCreateAnnouncement,
+  useUpdateAnnouncement,
+} from "@/hooks/useAnnouncements";
+import type {
+  AdminAnnouncement,
+  CreateAnnouncementInput,
+} from "@/services/announcementsApi";
+
+interface DrawerForm {
+  title: string;
+  bodyMarkdown: string;
+  ctaLabel: string;
+  ctaUrl: string;
+  enabled: boolean;
+  /** Empty string ⇒ unset. `<input type="datetime-local">` value, naive local. */
+  startsAtLocal: string;
+  endsAtLocal: string;
+}
+
+const SCHEMA = z
+  .object({
+    title: z.string().trim().min(1, "Title is required").max(200),
+    bodyMarkdown: z.string().trim().min(1, "Body is required").max(20_000),
+    ctaLabel: z.string().trim().max(80),
+    ctaUrl: z.string().trim(),
+    enabled: z.boolean(),
+    startsAtLocal: z.string(),
+    endsAtLocal: z.string(),
+  })
+  .superRefine((v, ctx) => {
+    // CTA pair must be both-or-neither.
+    const hasLabel = v.ctaLabel.length > 0;
+    const hasUrl = v.ctaUrl.length > 0;
+    if (hasLabel !== hasUrl) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [hasUrl ? "ctaLabel" : "ctaUrl"],
+        message: "CTA label and URL must both be set, or both be empty",
+      });
+    }
+    if (hasUrl) {
+      try {
+        const u = new URL(v.ctaUrl);
+        if (u.protocol !== "http:" && u.protocol !== "https:") {
+          throw new Error("non-http");
+        }
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["ctaUrl"],
+          message: "CTA URL must be a valid http(s) URL",
+        });
+      }
+    }
+    // Window order: only validate when both are set.
+    if (v.startsAtLocal && v.endsAtLocal) {
+      const start = Date.parse(v.startsAtLocal);
+      const end = Date.parse(v.endsAtLocal);
+      if (Number.isFinite(start) && Number.isFinite(end) && end <= start) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["endsAtLocal"],
+          message: "End must be strictly after start",
+        });
+      }
+    }
+  });
+
+function emptyForm(): DrawerForm {
+  return {
+    title: "",
+    bodyMarkdown: "",
+    ctaLabel: "",
+    ctaUrl: "",
+    enabled: true,
+    startsAtLocal: "",
+    endsAtLocal: "",
+  };
+}
+
+function isoToLocalInputValue(iso: string | null): string {
+  if (!iso) return "";
+  // Strip the seconds + tz suffix so the value matches `<input
+  // type="datetime-local">`'s expected format ("YYYY-MM-DDTHH:mm").
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const tzOffsetMs = d.getTimezoneOffset() * 60_000;
+  const local = new Date(d.getTime() - tzOffsetMs);
+  return local.toISOString().slice(0, 16);
+}
+
+function localInputValueToIso(value: string): string | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function fromAnnouncement(a: AdminAnnouncement): DrawerForm {
+  return {
+    title: a.title,
+    bodyMarkdown: a.bodyMarkdown,
+    ctaLabel: a.ctaLabel ?? "",
+    ctaUrl: a.ctaUrl ?? "",
+    enabled: a.enabled,
+    startsAtLocal: isoToLocalInputValue(a.startsAt),
+    endsAtLocal: isoToLocalInputValue(a.endsAt),
+  };
+}
+
+function toInput(form: DrawerForm): CreateAnnouncementInput {
+  const ctaLabel = form.ctaLabel.trim();
+  const ctaUrl = form.ctaUrl.trim();
+  return {
+    title: form.title.trim(),
+    bodyMarkdown: form.bodyMarkdown.trim(),
+    ctaLabel: ctaLabel ? ctaLabel : null,
+    ctaUrl: ctaUrl ? ctaUrl : null,
+    enabled: form.enabled,
+    startsAt: localInputValueToIso(form.startsAtLocal),
+    endsAt: localInputValueToIso(form.endsAtLocal),
+  };
+}
+
+export interface AnnouncementEditDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** When set, drawer is in edit mode. */
+  announcement: AdminAnnouncement | null;
+}
+
+export function AnnouncementEditDrawer({
+  isOpen,
+  onClose,
+  announcement,
+}: AnnouncementEditDrawerProps) {
+  const isEdit = announcement !== null;
+  const addToast = useToastStore((s) => s.addToast);
+  const createMut = useCreateAnnouncement();
+  const updateMut = useUpdateAnnouncement();
+  const saving = createMut.isPending || updateMut.isPending;
+
+  const [form, setForm] = useState<DrawerForm>(() => emptyForm());
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [showPreview, setShowPreview] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setForm(announcement ? fromAnnouncement(announcement) : emptyForm());
+    setErrors({});
+    setShowPreview(false);
+  }, [isOpen, announcement]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = SCHEMA.safeParse(form);
+    if (!parsed.success) {
+      const next: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const k = issue.path.join(".");
+        if (!next[k]) next[k] = issue.message;
+      }
+      setErrors(next);
+      return;
+    }
+    setErrors({});
+    const input = toInput(form);
+    if (isEdit && announcement) {
+      updateMut.mutate(
+        { id: announcement.id, patch: input },
+        {
+          onSuccess: () => {
+            addToast({ type: "success", message: "Announcement updated" });
+            onClose();
+          },
+          onError: (err) =>
+            addToast({
+              type: "error",
+              message: err instanceof Error ? err.message : "Save failed",
+            }),
+        },
+      );
+    } else {
+      createMut.mutate(input, {
+        onSuccess: () => {
+          addToast({ type: "success", message: "Announcement created" });
+          onClose();
+        },
+        onError: (err) =>
+          addToast({
+            type: "error",
+            message: err instanceof Error ? err.message : "Save failed",
+          }),
+      });
+    }
+  };
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-50">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="absolute inset-0 bg-black/55 backdrop-blur-[2px]"
+            onClick={onClose}
+          />
+          <motion.aside
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ type: "spring", stiffness: 240, damping: 28, mass: 0.9 }}
+            role="dialog"
+            aria-label={isEdit ? "Edit announcement" : "New announcement"}
+            className="card-impression absolute right-0 top-0 flex h-full w-full max-w-[560px] flex-col gap-5 overflow-y-auto border-l border-subtle bg-page p-6 sm:p-8"
+          >
+            <header className="flex items-baseline justify-between">
+              <div>
+                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                  [§ {isEdit ? "EDIT" : "NEW"} — ANNOUNCEMENT]
+                </p>
+                <h2 className="mt-1 font-display text-xl font-semibold tracking-tight text-strong">
+                  {isEdit ? announcement?.title : "New announcement"}
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className="-mr-2 -mt-2 inline-flex h-8 w-8 items-center justify-center rounded-sm text-meta transition-colors hover:bg-elevated hover:text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  className="h-5 w-5"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </header>
+
+            <form onSubmit={onSubmit} className="flex flex-col gap-4">
+              <Input
+                label="Title"
+                value={form.title}
+                onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+                error={errors.title}
+                maxLength={200}
+              />
+
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between">
+                  <label className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
+                    Body (markdown)
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => setShowPreview((v) => !v)}
+                    className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta hover:text-accent"
+                  >
+                    {showPreview ? "Edit" : "Preview"}
+                  </button>
+                </div>
+                {showPreview ? (
+                  <div className="min-h-[180px] rounded-sm border border-subtle bg-elevated/40 px-3 py-2">
+                    {form.bodyMarkdown.trim() ? (
+                      <ReadmeViewer content={form.bodyMarkdown} />
+                    ) : (
+                      <p className="font-text text-sm text-meta">Nothing to preview.</p>
+                    )}
+                  </div>
+                ) : (
+                  <textarea
+                    value={form.bodyMarkdown}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, bodyMarkdown: e.target.value }))
+                    }
+                    rows={8}
+                    maxLength={20_000}
+                    className={`
+                      w-full rounded-sm border border-subtle bg-elevated/40 px-3 py-2
+                      font-mono text-sm text-strong placeholder:text-meta/70
+                      transition-colors duration-150
+                      focus:border-accent focus:outline-none focus:bg-card
+                      ${errors.bodyMarkdown ? "border-danger! focus:border-danger!" : ""}
+                    `}
+                  />
+                )}
+                {errors.bodyMarkdown && (
+                  <span className="font-mono text-[11px] text-danger">
+                    {errors.bodyMarkdown}
+                  </span>
+                )}
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Input
+                  label="CTA label (optional)"
+                  value={form.ctaLabel}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, ctaLabel: e.target.value }))
+                  }
+                  error={errors.ctaLabel}
+                  placeholder="Read the changelog"
+                  maxLength={80}
+                />
+                <Input
+                  label="CTA URL (optional)"
+                  value={form.ctaUrl}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, ctaUrl: e.target.value }))
+                  }
+                  error={errors.ctaUrl}
+                  placeholder="https://ornn.dev/changelog"
+                  inputMode="url"
+                />
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="flex flex-col gap-1.5">
+                  <label className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
+                    Starts at (optional, local time)
+                  </label>
+                  <input
+                    type="datetime-local"
+                    value={form.startsAtLocal}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, startsAtLocal: e.target.value }))
+                    }
+                    className="w-full rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-text text-sm text-strong focus:border-accent focus:bg-card focus:outline-none"
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <label className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
+                    Ends at (optional, local time)
+                  </label>
+                  <input
+                    type="datetime-local"
+                    value={form.endsAtLocal}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, endsAtLocal: e.target.value }))
+                    }
+                    className={`
+                      w-full rounded-sm border border-subtle bg-elevated/40 px-3 py-2
+                      font-text text-sm text-strong
+                      focus:border-accent focus:bg-card focus:outline-none
+                      ${errors.endsAtLocal ? "border-danger! focus:border-danger!" : ""}
+                    `}
+                  />
+                  {errors.endsAtLocal && (
+                    <span className="font-mono text-[11px] text-danger">
+                      {errors.endsAtLocal}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <label className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.14em] text-meta">
+                <input
+                  type="checkbox"
+                  checked={form.enabled}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, enabled: e.target.checked }))
+                  }
+                  className="h-3.5 w-3.5 accent-accent"
+                />
+                Enabled
+              </label>
+
+              <div className="mt-2 flex items-center justify-end gap-2">
+                <Button variant="secondary" onClick={onClose} type="button">
+                  Cancel
+                </Button>
+                <Button variant="primary" type="submit" loading={saving}>
+                  {isEdit ? "Save changes" : "Create announcement"}
+                </Button>
+              </div>
+            </form>
+          </motion.aside>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/ornn-web/src/components/layout/AdminLayout.tsx
+++ b/ornn-web/src/components/layout/AdminLayout.tsx
@@ -54,6 +54,15 @@ const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    path: "/admin/announcements",
+    label: "Announcements",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5.882V19.24a1.76 1.76 0 01-3.417.586l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+      </svg>
+    ),
+  },
+  {
     path: "/admin/settings",
     label: "Settings",
     icon: (
@@ -78,6 +87,8 @@ function getBreadcrumbs(pathname: string): Array<{ label: string; path?: string 
     breadcrumbs.push({ label: "Quota" });
   } else if (pathname.startsWith("/admin/skills")) {
     breadcrumbs.push({ label: "Skills" });
+  } else if (pathname.startsWith("/admin/announcements")) {
+    breadcrumbs.push({ label: "Announcements" });
   } else if (pathname.startsWith("/admin/settings")) {
     breadcrumbs.push({ label: "Settings", path: "/admin/settings" });
     const tail = pathname.replace(/^\/admin\/settings\/?/, "");

--- a/ornn-web/src/hooks/useAnnouncements.ts
+++ b/ornn-web/src/hooks/useAnnouncements.ts
@@ -1,0 +1,77 @@
+/**
+ * React Query hooks for announcements.
+ *
+ *   - `useActiveAnnouncement` — public, anonymous-safe; landing-page popup.
+ *   - `useAdminAnnouncements` — admin list (gated by AdminGuard).
+ *   - `useCreate / useUpdate / useDelete` — admin mutations that
+ *     invalidate both the admin list and the public active query so a
+ *     just-saved announcement appears for visitors immediately.
+ *
+ * @module hooks/useAnnouncements
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createAnnouncement,
+  deleteAnnouncement,
+  fetchActiveAnnouncement,
+  fetchAdminAnnouncements,
+  updateAnnouncement,
+  type AdminAnnouncement,
+  type CreateAnnouncementInput,
+  type PublicAnnouncement,
+  type UpdateAnnouncementInput,
+} from "@/services/announcementsApi";
+
+const ACTIVE_KEY = ["announcements", "active"] as const;
+const ADMIN_KEY = ["announcements", "admin"] as const;
+
+export function useActiveAnnouncement(opts: { enabled?: boolean } = {}) {
+  return useQuery<PublicAnnouncement | null>({
+    queryKey: ACTIVE_KEY,
+    queryFn: fetchActiveAnnouncement,
+    // 5min — content rarely changes; admin mutations invalidate explicitly.
+    staleTime: 5 * 60_000,
+    enabled: opts.enabled ?? true,
+  });
+}
+
+export function useAdminAnnouncements() {
+  return useQuery<AdminAnnouncement[]>({
+    queryKey: ADMIN_KEY,
+    queryFn: fetchAdminAnnouncements,
+    staleTime: 30_000,
+  });
+}
+
+function useInvalidateAll() {
+  const qc = useQueryClient();
+  return () => {
+    void qc.invalidateQueries({ queryKey: ADMIN_KEY });
+    void qc.invalidateQueries({ queryKey: ACTIVE_KEY });
+  };
+}
+
+export function useCreateAnnouncement() {
+  const invalidate = useInvalidateAll();
+  return useMutation<AdminAnnouncement, Error, CreateAnnouncementInput>({
+    mutationFn: createAnnouncement,
+    onSuccess: invalidate,
+  });
+}
+
+export function useUpdateAnnouncement() {
+  const invalidate = useInvalidateAll();
+  return useMutation<AdminAnnouncement, Error, { id: string; patch: UpdateAnnouncementInput }>({
+    mutationFn: ({ id, patch }) => updateAnnouncement(id, patch),
+    onSuccess: invalidate,
+  });
+}
+
+export function useDeleteAnnouncement() {
+  const invalidate = useInvalidateAll();
+  return useMutation<void, Error, string>({
+    mutationFn: deleteAnnouncement,
+    onSuccess: invalidate,
+  });
+}

--- a/ornn-web/src/pages/LandingPage.tsx
+++ b/ornn-web/src/pages/LandingPage.tsx
@@ -18,6 +18,7 @@ import { PublishSection } from "@/pages/landing/PublishSection";
 import { LandingFooter } from "@/pages/landing/LandingFooter";
 import { SectionRule } from "@/pages/landing/HammeredDivider";
 import { LandingChrome } from "@/pages/landing/LandingChrome";
+import { AnnouncementPopup } from "@/pages/landing/AnnouncementPopup";
 
 export function LandingPage() {
   return (
@@ -43,6 +44,7 @@ export function LandingPage() {
         <PublishSection />
       </main>
       <LandingFooter />
+      <AnnouncementPopup />
     </div>
   );
 }

--- a/ornn-web/src/pages/admin/AnnouncementsPage.tsx
+++ b/ornn-web/src/pages/admin/AnnouncementsPage.tsx
@@ -1,0 +1,248 @@
+/**
+ * AnnouncementsPage — admin surface for landing-page popup announcements.
+ *
+ * Single-active model: at most one announcement renders to visitors at
+ * a time (most recent enabled record currently within its
+ * [startsAt, endsAt] window). The list shows everything so an admin
+ * can see history, supersede live records by creating a new one, or
+ * disable / delete stale ones.
+ *
+ * @module pages/admin/AnnouncementsPage
+ */
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToastStore } from "@/stores/toastStore";
+import { AnnouncementEditDrawer } from "@/components/admin/announcements/AnnouncementEditDrawer";
+import {
+  useAdminAnnouncements,
+  useDeleteAnnouncement,
+  useUpdateAnnouncement,
+} from "@/hooks/useAnnouncements";
+import type { AdminAnnouncement } from "@/services/announcementsApi";
+
+const ROW_DATE_FMT: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+function formatRange(a: AdminAnnouncement): string {
+  const fmt = (iso: string | null): string =>
+    iso ? new Date(iso).toLocaleString(undefined, ROW_DATE_FMT) : "—";
+  if (!a.startsAt && !a.endsAt) return "Always (no schedule)";
+  return `${fmt(a.startsAt)}  →  ${fmt(a.endsAt)}`;
+}
+
+function statusLabel(a: AdminAnnouncement, now: Date): {
+  label: string;
+  tone: "live" | "scheduled" | "expired" | "disabled";
+} {
+  if (!a.enabled) return { label: "DISABLED", tone: "disabled" };
+  if (a.startsAt && new Date(a.startsAt).getTime() > now.getTime()) {
+    return { label: "SCHEDULED", tone: "scheduled" };
+  }
+  if (a.endsAt && new Date(a.endsAt).getTime() <= now.getTime()) {
+    return { label: "EXPIRED", tone: "expired" };
+  }
+  return { label: "LIVE", tone: "live" };
+}
+
+const TONE_STYLE: Record<
+  ReturnType<typeof statusLabel>["tone"],
+  string
+> = {
+  live: "border-accent/40 text-accent bg-accent/10",
+  scheduled: "border-subtle text-meta bg-elevated/50",
+  expired: "border-subtle text-meta bg-elevated/30",
+  disabled: "border-subtle text-meta bg-elevated/30",
+};
+
+export function AnnouncementsPage() {
+  const addToast = useToastStore((s) => s.addToast);
+  const announcementsQuery = useAdminAnnouncements();
+  const deleteMut = useDeleteAnnouncement();
+  const updateMut = useUpdateAnnouncement();
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editing, setEditing] = useState<AdminAnnouncement | null>(null);
+
+  const openCreate = () => {
+    setEditing(null);
+    setDrawerOpen(true);
+  };
+  const openEdit = (a: AdminAnnouncement) => {
+    setEditing(a);
+    setDrawerOpen(true);
+  };
+
+  const onToggleEnabled = (a: AdminAnnouncement) => {
+    updateMut.mutate(
+      { id: a.id, patch: { enabled: !a.enabled } },
+      {
+        onSuccess: () =>
+          addToast({
+            type: "success",
+            message: a.enabled ? "Announcement disabled" : "Announcement enabled",
+          }),
+        onError: (err) =>
+          addToast({
+            type: "error",
+            message: err instanceof Error ? err.message : "Update failed",
+          }),
+      },
+    );
+  };
+
+  const onDelete = (a: AdminAnnouncement) => {
+    if (!confirm(`Delete announcement "${a.title}"?`)) return;
+    deleteMut.mutate(a.id, {
+      onSuccess: () =>
+        addToast({ type: "success", message: "Announcement deleted" }),
+      onError: (err) =>
+        addToast({
+          type: "error",
+          message: err instanceof Error ? err.message : "Delete failed",
+        }),
+    });
+  };
+
+  const now = new Date();
+  const items = announcementsQuery.data ?? [];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25 }}
+      className="flex flex-col gap-6 p-6 sm:p-8"
+    >
+      <header className="flex items-end justify-between gap-4 flex-wrap">
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+            [§ ADMIN — ANNOUNCEMENTS]
+          </p>
+          <h1 className="mt-1 font-display text-2xl font-semibold tracking-tight text-strong">
+            Landing page popup
+          </h1>
+          <p className="mt-2 max-w-2xl font-text text-sm text-meta">
+            One announcement is shown at a time on the marketing page —
+            the most recently created enabled record currently inside its
+            schedule window. Disabled and out-of-window records stay
+            here for history.
+          </p>
+        </div>
+        <Button variant="primary" onClick={openCreate}>
+          New announcement
+        </Button>
+      </header>
+
+      <Card className="overflow-hidden">
+        {announcementsQuery.isLoading ? (
+          <div className="flex flex-col gap-2 p-6">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 p-12 text-center">
+            <p className="font-display text-lg text-strong">No announcements yet</p>
+            <p className="max-w-md font-text text-sm text-meta">
+              Create the first announcement and visitors will see it on
+              their next landing-page load.
+            </p>
+            <Button variant="secondary" onClick={openCreate} className="mt-2">
+              Create announcement
+            </Button>
+          </div>
+        ) : (
+          <table className="w-full text-left text-sm">
+            <thead className="bg-elevated/40">
+              <tr className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                <th className="px-4 py-3">Title</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Window</th>
+                <th className="px-4 py-3">Created</th>
+                <th className="px-4 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((a) => {
+                const status = statusLabel(a, now);
+                return (
+                  <tr key={a.id} className="border-t border-subtle">
+                    <td className="px-4 py-3 align-top">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(a)}
+                        className="text-left font-display text-base font-semibold text-strong hover:text-accent"
+                      >
+                        {a.title}
+                      </button>
+                      {a.ctaUrl && (
+                        <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                          CTA → {a.ctaLabel || a.ctaUrl}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 align-top">
+                      <span
+                        className={`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] ${TONE_STYLE[status.tone]}`}
+                      >
+                        {status.label}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 align-top font-mono text-[11px] text-meta">
+                      {formatRange(a)}
+                    </td>
+                    <td className="px-4 py-3 align-top font-mono text-[11px] text-meta">
+                      {new Date(a.createdAt).toLocaleString(undefined, ROW_DATE_FMT)}
+                    </td>
+                    <td className="px-4 py-3 align-top">
+                      <div className="flex items-center justify-end gap-2">
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => onToggleEnabled(a)}
+                          disabled={updateMut.isPending}
+                        >
+                          {a.enabled ? "Disable" : "Enable"}
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => openEdit(a)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={() => onDelete(a)}
+                          disabled={deleteMut.isPending}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      <AnnouncementEditDrawer
+        isOpen={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        announcement={editing}
+      />
+    </motion.div>
+  );
+}

--- a/ornn-web/src/pages/admin/index.ts
+++ b/ornn-web/src/pages/admin/index.ts
@@ -10,3 +10,4 @@ export { AdminSkillsPage } from "./AdminSkillsPage";
 export { PlatformSettingsPage } from "./PlatformSettingsPage";
 export { MirrorPage } from "./MirrorPage";
 export { QuotaManagementPage } from "./QuotaManagementPage";
+export { AnnouncementsPage } from "./AnnouncementsPage";

--- a/ornn-web/src/pages/landing/AnnouncementPopup.test.tsx
+++ b/ornn-web/src/pages/landing/AnnouncementPopup.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * AnnouncementPopup tests.
+ *
+ * Covers:
+ *   - Renders the modal when an active announcement exists and the
+ *     user hasn't dismissed that id.
+ *   - Does NOT render when the active id has already been dismissed
+ *     (localStorage flag from a prior visit).
+ *   - Dismiss writes the per-id flag so a re-mount stays closed.
+ *   - Returns null when there is no active announcement.
+ *
+ * Mocks `useActiveAnnouncement` directly so the test never pulls in
+ * the api client / auth store auto-init chain.
+ *
+ * @module pages/landing/AnnouncementPopup.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import type { PublicAnnouncement } from "@/services/announcementsApi";
+
+// jsdom in this project does not ship a working localStorage. Inject
+// a minimal in-memory replacement before any test code touches it.
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  const fake: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: fake,
+    configurable: true,
+  });
+}
+installFakeLocalStorage();
+
+const mockActive = vi.fn<() => { data: PublicAnnouncement | null }>();
+
+vi.mock("@/hooks/useAnnouncements", () => ({
+  useActiveAnnouncement: () => mockActive(),
+}));
+
+import { AnnouncementPopup } from "./AnnouncementPopup";
+
+describe("AnnouncementPopup", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockActive.mockReset();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when there is no active announcement", () => {
+    mockActive.mockReturnValue({ data: null });
+    render(<AnnouncementPopup />);
+    expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
+  });
+
+  it("renders the announcement modal when active and not dismissed", async () => {
+    mockActive.mockReturnValue({
+      data: {
+        id: "a-1",
+        title: "Ornn 1.2 is live",
+        bodyMarkdown: "**Now with** chained skills.",
+        ctaLabel: "See changelog",
+        ctaUrl: "https://ornn.dev/changelog",
+      },
+    });
+    render(<AnnouncementPopup />);
+    expect(
+      await screen.findByRole("heading", { name: /Ornn 1\.2 is live/i }),
+    ).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: /See changelog/i });
+    expect(cta).toHaveAttribute("href", "https://ornn.dev/changelog");
+    expect(cta).toHaveAttribute("target", "_blank");
+  });
+
+  it("does not render when the active id has been dismissed", () => {
+    localStorage.setItem("ornn:announcement:dismissed:a-1", "1");
+    mockActive.mockReturnValue({
+      data: {
+        id: "a-1",
+        title: "Already-seen news",
+        bodyMarkdown: "Body",
+        ctaLabel: null,
+        ctaUrl: null,
+      },
+    });
+    render(<AnnouncementPopup />);
+    expect(screen.queryByRole("heading", { name: /Already-seen news/i })).toBeNull();
+  });
+
+  it("dismiss button closes and persists the flag", async () => {
+    mockActive.mockReturnValue({
+      data: {
+        id: "a-2",
+        title: "Hello there",
+        bodyMarkdown: "Body",
+        ctaLabel: null,
+        ctaUrl: null,
+      },
+    });
+    render(<AnnouncementPopup />);
+    expect(
+      await screen.findByRole("heading", { name: /Hello there/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss/i }));
+    expect(localStorage.getItem("ornn:announcement:dismissed:a-2")).toBe("1");
+  });
+});

--- a/ornn-web/src/pages/landing/AnnouncementPopup.tsx
+++ b/ornn-web/src/pages/landing/AnnouncementPopup.tsx
@@ -1,0 +1,98 @@
+/**
+ * AnnouncementPopup — landing-page modal that surfaces the currently
+ * active announcement to every visitor (anonymous + signed-in).
+ *
+ * Industry-standard "what's new" pattern (Linear / Vercel / GitHub):
+ *   - One-shot per announcement id. Once dismissed, that id never
+ *     reappears for the same browser; admins force a re-show by
+ *     creating a new announcement.
+ *   - localStorage-keyed dismissal (`ornn:announcement:dismissed:<id>`).
+ *     No server-side write — keeps the endpoint stateless and
+ *     anonymous-friendly.
+ *   - Renders nothing on the server-side until the React Query has
+ *     resolved, so we don't briefly flash an empty modal frame.
+ *
+ * @module pages/landing/AnnouncementPopup
+ */
+
+import { useEffect, useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { ReadmeViewer } from "@/components/skill/ReadmeViewer";
+import { useActiveAnnouncement } from "@/hooks/useAnnouncements";
+
+const DISMISS_KEY_PREFIX = "ornn:announcement:dismissed:";
+
+function isDismissed(id: string): boolean {
+  try {
+    return localStorage.getItem(DISMISS_KEY_PREFIX + id) === "1";
+  } catch {
+    // Private mode / disabled storage → fall through and let the modal
+    // re-render. Better to nag than to break.
+    return false;
+  }
+}
+
+function markDismissed(id: string): void {
+  try {
+    localStorage.setItem(DISMISS_KEY_PREFIX + id, "1");
+  } catch {
+    // No-op; see above.
+  }
+}
+
+export function AnnouncementPopup() {
+  const { data: announcement } = useActiveAnnouncement();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!announcement) {
+      setOpen(false);
+      return;
+    }
+    if (!isDismissed(announcement.id)) {
+      setOpen(true);
+    }
+  }, [announcement]);
+
+  const close = () => {
+    if (announcement) markDismissed(announcement.id);
+    setOpen(false);
+  };
+
+  if (!announcement) return null;
+
+  const ctaHref = announcement.ctaUrl ?? null;
+  const ctaLabel = announcement.ctaLabel ?? null;
+  const isExternalCta = ctaHref ? /^https?:\/\//i.test(ctaHref) : false;
+
+  return (
+    <Modal isOpen={open} onClose={close} title={announcement.title}>
+      <div className="flex flex-col gap-5">
+        <div className="markdown-body text-body">
+          <ReadmeViewer content={announcement.bodyMarkdown} />
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Button variant="secondary" onClick={close} type="button">
+            Dismiss
+          </Button>
+          {ctaHref && ctaLabel && (
+            <a
+              href={ctaHref}
+              target={isExternalCta ? "_blank" : undefined}
+              rel={isExternalCta ? "noopener noreferrer" : undefined}
+              onClick={() => {
+                // Mark dismissed on CTA click so a returning user who
+                // followed the link isn't asked again on next visit.
+                if (announcement) markDismissed(announcement.id);
+              }}
+              className="inline-flex items-center justify-center rounded-sm border border-accent-muted bg-accent px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.1em] text-page transition-colors hover:bg-accent-muted"
+            >
+              {ctaLabel}
+            </a>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/ornn-web/src/services/announcementsApi.ts
+++ b/ornn-web/src/services/announcementsApi.ts
@@ -1,0 +1,79 @@
+/**
+ * Announcement API client — both the public popup endpoint and the
+ * admin CRUD endpoints.
+ *
+ * @module services/announcementsApi
+ */
+
+import { apiDelete, apiGet, apiPatch, apiPost } from "./apiClient";
+
+export interface PublicAnnouncement {
+  id: string;
+  title: string;
+  bodyMarkdown: string;
+  ctaLabel: string | null;
+  ctaUrl: string | null;
+}
+
+export interface AdminAnnouncement {
+  id: string;
+  title: string;
+  bodyMarkdown: string;
+  ctaLabel: string | null;
+  ctaUrl: string | null;
+  enabled: boolean;
+  /** ISO 8601 string or null. */
+  startsAt: string | null;
+  /** ISO 8601 string or null. */
+  endsAt: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAnnouncementInput {
+  title: string;
+  bodyMarkdown: string;
+  ctaLabel?: string | null;
+  ctaUrl?: string | null;
+  enabled: boolean;
+  startsAt?: string | null;
+  endsAt?: string | null;
+}
+
+export type UpdateAnnouncementInput = Partial<CreateAnnouncementInput>;
+
+/** Public — anonymous-friendly. Returns null when no record qualifies. */
+export async function fetchActiveAnnouncement(): Promise<PublicAnnouncement | null> {
+  const res = await apiGet<{ active: PublicAnnouncement | null }>(
+    "/api/v1/announcements/active",
+  );
+  return res.data?.active ?? null;
+}
+
+export async function fetchAdminAnnouncements(): Promise<AdminAnnouncement[]> {
+  const res = await apiGet<{ items: AdminAnnouncement[] }>("/api/v1/admin/announcements");
+  return res.data?.items ?? [];
+}
+
+export async function createAnnouncement(
+  input: CreateAnnouncementInput,
+): Promise<AdminAnnouncement> {
+  const res = await apiPost<AdminAnnouncement>("/api/v1/admin/announcements", input);
+  return res.data!;
+}
+
+export async function updateAnnouncement(
+  id: string,
+  patch: UpdateAnnouncementInput,
+): Promise<AdminAnnouncement> {
+  const res = await apiPatch<AdminAnnouncement>(
+    `/api/v1/admin/announcements/${encodeURIComponent(id)}`,
+    patch,
+  );
+  return res.data!;
+}
+
+export async function deleteAnnouncement(id: string): Promise<void> {
+  await apiDelete(`/api/v1/admin/announcements/${encodeURIComponent(id)}`);
+}


### PR DESCRIPTION
## Summary
- New `announcements` backend domain — public `GET /api/v1/announcements/active` (anonymous-friendly) + admin CRUD under `/api/v1/admin/announcements` gated on `ornn:admin:skill`.
- New top-level admin page `/admin/announcements` (next to Skills / Quota) — list with LIVE / SCHEDULED / EXPIRED / DISABLED status, per-row enable / edit / delete, and a 560px right-edge drawer for create / edit with markdown body preview, optional CTA pair, and optional `[startsAt, endsAt]` window.
- New `AnnouncementPopup` mounted on `/` — single-active model. Renders the most recent enabled record currently in window; one-shot per id via `ornn:announcement:dismissed:<id>` in `localStorage`. CTA links open in a new tab and also mark dismissed on click.

Industry-standard "what's new" pattern (Linear / Vercel / GitHub).

## Test plan
- [x] `bun run test` in `ornn-api` — 488 pass / 0 fail (10 new for `AnnouncementService`)
- [x] `bun run test` in `ornn-web` — 54 pass / 0 fail (4 new for `AnnouncementPopup`)
- [x] `bun tsc --noEmit` clean for both packages
- [ ] Smoke test in dev: create an announcement in admin, verify it pops on `/`, dismiss, refresh → does not re-pop. Disable → no longer pops in a fresh browser.

Closes #307.