### PR TITLE
fix(web): make redeem-code form reachable from user menu

### DIFF
--- a/.changeset/redeem-code-entry-point.md
+++ b/.changeset/redeem-code-entry-point.md
@@ -1,0 +1,7 @@
+---
+"ornn-web": patch
+---
+
+Mount `/settings` route and add a "Redeem code" entry to the user menu (desktop dropdown between "My Organizations" and "Go to NyxID"; mobile menu after "My Profile"). The redeem form shipped in #306 was previously unreachable because `SettingsPage` had no route. Existing NyxID external links are unchanged.
+
+Closes #310.

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -108,6 +108,9 @@ const ServiceDetailPage = lazy(() =>
 const NotificationsPage = lazy(() =>
   import("@/pages/NotificationsPage").then((m) => ({ default: m.NotificationsPage })),
 );
+const SettingsPage = lazy(() =>
+  import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
+);
 
 // Admin pages — bundled into one chunk by virtue of sharing the barrel
 // import path; only loaded when an /admin route activates.
@@ -240,6 +243,7 @@ const router = createBrowserRouter(
           <Route path="/my-skills" element={<MySkillsPage />} />
           <Route path="/services/:id" element={<ServiceDetailPage />} />
           <Route path="/notifications" element={<NotificationsPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
         </Route>
 
         {/* Admin routes — new IA per Architecture §6.1. */}

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -303,6 +303,9 @@ export function Navbar({ className = "" }: NavbarProps) {
                     <DropdownExternal href={`${getNyxIdUrl()}/orgs`}>
                       {t("nav.myOrgs", "My Organizations")}
                     </DropdownExternal>
+                    <DropdownInternal to="/settings" onClick={() => setUserMenuOpen(false)}>
+                      {t("nav.redeemCode", "Redeem code")}
+                    </DropdownInternal>
                     <DropdownExternal href={getNyxIdUrl()}>
                       {t("nav.goToNyxId")}
                     </DropdownExternal>
@@ -455,6 +458,14 @@ export function Navbar({ className = "" }: NavbarProps) {
                 >
                   {t("nav.myProfile", "My Profile")}
                 </a>
+                <Link
+                  to="/settings"
+                  onClick={closeMenu}
+                  tabIndex={menuOpen ? 0 : -1}
+                  className="border-b border-subtle py-3 font-text text-[16px] text-body transition-colors hover:text-accent"
+                >
+                  {t("nav.redeemCode", "Redeem code")}
+                </Link>
                 {isAdmin(user) && (
                   <Link
                     to="/admin"


### PR DESCRIPTION
## Summary

- Mount `/settings` route under AuthGuard — `SettingsPage` shipped in #306 hosts `RedeemCodeSection` but was never wired into the router after the 297dcad rename, so the form was unreachable.
- Add **Redeem code** entry in the user menu, exactly between **My Organizations** and **Go to NyxID** on desktop, and after **My Profile** on mobile. Both link to `/settings`.
- Existing NyxID external links are unchanged — they manage profile, redeem-code is an Ornn-local action so it gets its own internal entry.

## Test plan

- [x] `bun run typecheck` clean across api / web / sdk
- [x] `bun run --filter ornn-web test` — 67 passing
- [ ] Manual: log in → click avatar → see "Redeem code" between Organizations and Go to NyxID → click → land on `/settings` with the redeem form

Closes #310. Refs #306.