### PR TITLE
[Feature] api.request — capture userAgent / query keys / byte counts

### DIFF
--- a/.changeset/api-request-richer-properties.md
+++ b/.changeset/api-request-richer-properties.md
@@ -1,0 +1,14 @@
+---
+"ornn-api": minor
+---
+
+`api.request` PostHog event now also carries:
+
+- **`userAgent`** — capped at 500 chars (truncate not redact). Distinguishes browser / ornn-sdk / curl / bots.
+- **`queryParamKeys`** — sorted comma-joined list of query-string KEYS only (never values). 20-key cap. PII-safe by construction.
+- **`requestBytes`** — Content-Length on the request body when set.
+- **`responseBytes`** — Content-Length on the response when set (undefined for SSE/chunked).
+
+All four are dropped when undefined rather than emitted with a sentinel — keeps PostHog property graphs clean.
+
+Closes #314.

--- a/ornn-api/src/infra/analytics/index.test.ts
+++ b/ornn-api/src/infra/analytics/index.test.ts
@@ -217,4 +217,57 @@ describe("AnalyticsEmitter", () => {
       requestId: "req-1",
     });
   });
+
+  test("trackApiRequest passes through optional UA / query / size props when set", () => {
+    const tracker = new FakeTracker();
+    const emitter = new AnalyticsEmitter({ tracker, errorSampleRate: 1 });
+
+    emitter.trackApiRequest({
+      userId: "u-2",
+      callerType: "api",
+      method: "GET",
+      path: "/api/v1/skills",
+      status: 200,
+      durationMs: 11,
+      userAgent: "ornn-sdk-ts/0.4.1 node/22",
+      queryParamKeys: "page,pageSize,q",
+      requestBytes: 0,
+      responseBytes: 4096,
+    });
+
+    expect(tracker.calls).toHaveLength(1);
+    expect(tracker.calls[0]!.properties).toEqual({
+      source: "api",
+      callerType: "api",
+      method: "GET",
+      path: "/api/v1/skills",
+      status: 200,
+      durationMs: 11,
+      userAgent: "ornn-sdk-ts/0.4.1 node/22",
+      queryParamKeys: "page,pageSize,q",
+      requestBytes: 0,
+      responseBytes: 4096,
+    });
+  });
+
+  test("trackApiRequest drops the new optional props when undefined", () => {
+    const tracker = new FakeTracker();
+    const emitter = new AnalyticsEmitter({ tracker, errorSampleRate: 1 });
+
+    emitter.trackApiRequest({
+      userId: null,
+      callerType: "system",
+      method: "GET",
+      path: "/api/v1/health",
+      status: 200,
+      durationMs: 1,
+      // userAgent, queryParamKeys, requestBytes, responseBytes all unset
+    });
+
+    const props = tracker.calls[0]!.properties as Record<string, unknown>;
+    expect("userAgent" in props).toBe(false);
+    expect("queryParamKeys" in props).toBe(false);
+    expect("requestBytes" in props).toBe(false);
+    expect("responseBytes" in props).toBe(false);
+  });
 });

--- a/ornn-api/src/infra/analytics/index.ts
+++ b/ornn-api/src/infra/analytics/index.ts
@@ -123,6 +123,14 @@ export class AnalyticsEmitter {
     durationMs: number;
     sourceIp?: string | null;
     requestId?: string | null;
+    /** Capped at 500 chars by the middleware. Distinguishes browser / SDK / CLI / bot. */
+    userAgent?: string;
+    /** Comma-joined sorted list of query-string KEYS (never values). */
+    queryParamKeys?: string;
+    /** Content-Length on the request body when set. */
+    requestBytes?: number;
+    /** Content-Length on the response when set (SSE/chunked → undefined). */
+    responseBytes?: number;
   }): void {
     this.tracker.track(input.userId, "api.request", {
       ...SOURCE_PROPERTY,
@@ -134,6 +142,10 @@ export class AnalyticsEmitter {
       durationMs: input.durationMs,
       ...(input.sourceIp ? { sourceIp: input.sourceIp } : {}),
       ...(input.requestId ? { requestId: input.requestId } : {}),
+      ...(input.userAgent ? { userAgent: input.userAgent } : {}),
+      ...(input.queryParamKeys ? { queryParamKeys: input.queryParamKeys } : {}),
+      ...(input.requestBytes !== undefined ? { requestBytes: input.requestBytes } : {}),
+      ...(input.responseBytes !== undefined ? { responseBytes: input.responseBytes } : {}),
     });
   }
 

--- a/ornn-api/src/middleware/apiRequestTracking.ts
+++ b/ornn-api/src/middleware/apiRequestTracking.ts
@@ -10,6 +10,13 @@
  *   - method, path, routePattern (when available), status, durationMs
  *   - sourceIp (first hop from `X-Forwarded-For`, redacted to /24 / /48)
  *   - requestId for cross-log correlation
+ *   - userAgent (capped at 500 chars) — distinguishes browser / SDK /
+ *     CLI / bot. Truncate not redact: clients self-identify here.
+ *   - queryParamKeys — comma-joined list of query-string KEYS only
+ *     (never values). Lets you slice on "which filter is used" without
+ *     leaking PII through search terms.
+ *   - requestBytes / responseBytes — content-length on each side
+ *     when set. SSE / chunked responses leave responseBytes undefined.
  *
  * Bodies are NOT captured — by design. PostHog event properties are
  * 32 KB capped and bodies don't belong in analytics. If you need
@@ -63,6 +70,12 @@ export function apiRequestTrackingMiddleware(
           durationMs,
           sourceIp,
           requestId,
+          userAgent: capUserAgent(c.req.header("user-agent")),
+          queryParamKeys: extractQueryParamKeys(c),
+          requestBytes: parseContentLength(c.req.header("content-length")),
+          responseBytes: parseContentLength(
+            c.res.headers.get("content-length"),
+          ),
         });
       } catch {
         /* never fail the request because tracking blew up */
@@ -145,4 +158,52 @@ function redactIp(ip: string | null): string | null {
 function extractRoutePattern(c: Context): string | undefined {
   const route = (c.req as unknown as { routePath?: string }).routePath;
   return typeof route === "string" && route.length > 0 ? route : undefined;
+}
+
+/**
+ * Cap user-agent at 500 chars. Real browsers/SDKs are well under
+ * this; a longer string is almost always a bot trying to overflow
+ * something. Truncating preserves the prefix (which carries the
+ * real client signature) and drops the trailing garbage.
+ */
+const USER_AGENT_MAX = 500;
+function capUserAgent(ua: string | undefined): string | undefined {
+  if (!ua) return undefined;
+  return ua.length > USER_AGENT_MAX ? `${ua.slice(0, USER_AGENT_MAX)}…` : ua;
+}
+
+/**
+ * Extract query-string KEYS only — comma-joined, sorted, no values.
+ * Sort ensures the property is comparable across requests (PostHog
+ * filters on equality). Cap to 20 keys so an attacker can't bloat
+ * the event by spamming params.
+ */
+const QUERY_PARAM_KEYS_MAX = 20;
+function extractQueryParamKeys(c: Context): string | undefined {
+  let queries: Record<string, string>;
+  try {
+    queries = c.req.query() as Record<string, string>;
+  } catch {
+    return undefined;
+  }
+  const keys = Object.keys(queries);
+  if (keys.length === 0) return undefined;
+  keys.sort();
+  if (keys.length > QUERY_PARAM_KEYS_MAX) {
+    keys.length = QUERY_PARAM_KEYS_MAX;
+    keys[QUERY_PARAM_KEYS_MAX - 1] = "…";
+  }
+  return keys.join(",");
+}
+
+/**
+ * Parse Content-Length header into a finite non-negative integer.
+ * Anything else (missing, NaN, negative, oversized) returns
+ * undefined — caller drops the property rather than emit garbage.
+ */
+function parseContentLength(value: string | null | undefined): number | undefined {
+  if (value == null || value === "") return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return Math.trunc(n);
 }


### PR DESCRIPTION
Closes #314.

## Summary

- \`api.request\` PostHog event grows four optional properties: \`userAgent\`, \`queryParamKeys\`, \`requestBytes\`, \`responseBytes\`.
- Middleware reads them off the Hono \`Context\`; emitter passes them through and drops them when undefined.
- All four have constraints (UA cap, query-key cap + sort + values stripped, byte parsing rejects negatives/NaN) so the event payload stays bounded and PII-safe.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test\` — 519/519 pass (added 2 new emitter tests)
- [ ] CI green
- [ ] After merge + redeploy: open PostHog → any \`api.request\` event → properties tab shows the new fields populated where appropriate (UA always, queryParamKeys for GETs with query, byte counts for non-streaming endpoints)