### PR TITLE
[Feature] SPA stale-bundle self-recovery — auto-reload on new deploy

### DIFF
--- a/.changeset/spa-version-check-auto-reload.md
+++ b/.changeset/spa-version-check-auto-reload.md
@@ -1,0 +1,11 @@
+---
+"ornn-web": minor
+---
+
+SPA stale-bundle self-recovery. Every build emits `dist/version.json` and bakes the same `<pkg.version>+<git-short-sha>` string into `__APP_VERSION__`. At runtime the SPA polls `/version.json` every 60s + on tab focus / visibility change; when the deployed version differs from the baked one a small ember-stamp banner pinned to the top of the viewport offers a one-click reload. Users on stale tabs / aggressively-cached browsers (Safari) recover without being told to clear cache.
+
+Failure-tolerant: any network / parse / 404 path returns `null` silently — we'd rather under-prompt than spam.
+
+Operator change: `docker build` for ornn-web now needs `--build-arg GIT_COMMIT=$(git rev-parse --short HEAD)` so the deployed bundle has a real commit-pinned identity. CLAUDE.md Step 6 updated to match.
+
+Closes #318.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,9 +254,13 @@ done
 # Backend
 docker build -t "${ORNN_API_IMAGE}" -f ornn-api/Dockerfile .
 
-# Frontend — no build args. All config (nginx upstreams + Vite env)
-# is injected at container startup via the `ornn-web-config` ConfigMap.
-docker build -t "${ORNN_WEB_IMAGE}" -f ornn-web/Dockerfile .
+# Frontend — runtime config (nginx + Vite env) is injected at container
+# startup via the `ornn-web-config` ConfigMap. Pass `GIT_COMMIT` so the
+# stale-bundle auto-reload loop has a fresh build identity baked into
+# both `__APP_VERSION__` and `dist/version.json` (#318).
+docker build \
+  --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) \
+  -t "${ORNN_WEB_IMAGE}" -f ornn-web/Dockerfile .
 ```
 
 ### Step 7: Deploy ornn

--- a/ornn-web/Dockerfile
+++ b/ornn-web/Dockerfile
@@ -27,6 +27,14 @@ RUN bun install
 # Copy frontend source
 COPY ornn-web/ ornn-web/
 
+# Bake the deployed git commit into the bundle (and into dist/version.json).
+# Caller passes `--build-arg GIT_COMMIT=$(git rev-parse --short HEAD)`. The
+# version-check loop in the SPA polls /version.json at runtime and prompts
+# a reload when it differs from the baked __APP_VERSION__ — that's how
+# users on stale Safari sessions auto-recover after a deploy.
+ARG GIT_COMMIT=unknown
+ENV VITE_GIT_COMMIT=$GIT_COMMIT
+
 WORKDIR /app/ornn-web
 RUN bun run build
 

--- a/ornn-web/nginx.conf.template
+++ b/ornn-web/nginx.conf.template
@@ -28,6 +28,17 @@ server {
         try_files $uri =404;
     }
 
+    # ── Build version manifest — MUST be served fresh on every fetch so
+    #    the SPA's version-check loop sees the current deploy. nginx-side
+    #    no-store + the SPA fetches with `cache: "no-store"` for double
+    #    insurance against intermediate caches (Safari, CDNs).
+    location = /version.json {
+        expires -1;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        add_header Pragma "no-cache";
+        try_files $uri =404;
+    }
+
     # ── Static asset caching ──────────────────────────────────────────────
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -29,6 +29,7 @@ import { AuthGuard } from "@/components/auth/AuthGuard";
 import { AdminGuard } from "@/components/auth/AdminGuard";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { HighlighterMarkFilter } from "@/pages/landing/HighlighterMark";
+import { VersionUpdateBanner } from "@/components/layout/VersionUpdateBanner";
 import { PostHogProvider } from "@/components/analytics/PostHogProvider";
 import { CookieConsentBanner } from "@/components/analytics/CookieConsentBanner";
 
@@ -306,6 +307,10 @@ export function App() {
             landing surface and the app-shell nav can use the
             highlighter wash without duplicating filter IDs in the DOM. */}
         <HighlighterMarkFilter />
+        {/* Stale-bundle self-recovery — polls /version.json and prompts
+            a reload when a new ornn-web has been deployed. Renders
+            nothing on the happy path. */}
+        <VersionUpdateBanner />
         <Suspense fallback={<RouteFallback />}>
           <RouterProvider router={router} />
         </Suspense>

--- a/ornn-web/src/components/layout/VersionUpdateBanner.tsx
+++ b/ornn-web/src/components/layout/VersionUpdateBanner.tsx
@@ -1,0 +1,76 @@
+/**
+ * VersionUpdateBanner — surfaces "a new ornn-web is out, reload to get
+ * it" when the runtime version-check loop detects the deployed
+ * `version.json` differs from the baked `__APP_VERSION__`.
+ *
+ * Mounted once at app root; kicks off the monitor on mount, shows a
+ * small ember-stamp banner across the top when triggered, lets the
+ * user reload (or dismiss until next mismatch). Idempotent: monitor
+ * fires once per session.
+ *
+ * @module components/layout/VersionUpdateBanner
+ */
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { startVersionMonitor } from "@/lib/versionCheck";
+
+export function VersionUpdateBanner() {
+  const { t } = useTranslation();
+  const [outdated, setOutdated] = useState(false);
+
+  useEffect(() => {
+    const handle = startVersionMonitor({
+      onOutdated: () => setOutdated(true),
+    });
+    return () => handle.stop();
+  }, []);
+
+  if (!outdated) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="
+        fixed inset-x-0 top-0 z-[100]
+        flex items-center justify-center gap-3
+        border-b border-accent/40 bg-accent/10 px-4 py-2
+        font-mono text-[11px] uppercase tracking-[0.14em] text-accent
+        backdrop-blur-sm
+      "
+    >
+      <span>
+        {t(
+          "versionUpdate.message",
+          "A new version of Ornn is available. Reload to apply.",
+        )}
+      </span>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="
+          rounded-sm border border-accent px-2.5 py-1
+          font-mono text-[10px] uppercase tracking-[0.14em] text-accent
+          transition-colors hover:bg-accent hover:text-page
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+        "
+      >
+        {t("versionUpdate.reload", "Reload")}
+      </button>
+      <button
+        type="button"
+        onClick={() => setOutdated(false)}
+        aria-label={t("versionUpdate.dismiss", "Dismiss")}
+        className="
+          ml-1 rounded-sm border border-transparent px-2 py-1
+          font-mono text-[12px] text-accent/80
+          transition-colors hover:text-accent
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+        "
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/ornn-web/src/lib/versionCheck.test.ts
+++ b/ornn-web/src/lib/versionCheck.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the SPA stale-bundle self-recovery loop.
+ *
+ * @module lib/versionCheck.test
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import {
+  fetchDeployedVersion,
+  getBakedVersion,
+  isOutdated,
+  startVersionMonitor,
+} from "./versionCheck";
+
+describe("isOutdated", () => {
+  it("returns false when deployed === baked", () => {
+    expect(isOutdated("0.7.4+abc1234", "0.7.4+abc1234")).toBe(false);
+  });
+  it("returns true when deployed differs from baked", () => {
+    expect(isOutdated("0.7.5+def5678", "0.7.4+abc1234")).toBe(true);
+  });
+  it("returns false when deployed is null (couldn't fetch)", () => {
+    expect(isOutdated(null, "0.7.4+abc1234")).toBe(false);
+  });
+  it("returns false in dev mode (baked === 'dev')", () => {
+    expect(isOutdated("0.7.4+abc1234", "dev")).toBe(false);
+  });
+});
+
+describe("fetchDeployedVersion", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns version string on 200 with valid JSON", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ version: "0.7.4+abc1234" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    expect(await fetchDeployedVersion()).toBe("0.7.4+abc1234");
+  });
+
+  it("returns null on 404", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("", { status: 404 }),
+    );
+    expect(await fetchDeployedVersion()).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("offline"));
+    expect(await fetchDeployedVersion()).toBeNull();
+  });
+
+  it("returns null on malformed JSON (no version field)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    expect(await fetchDeployedVersion()).toBeNull();
+  });
+
+  it("returns null on empty version field", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ version: "" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    expect(await fetchDeployedVersion()).toBeNull();
+  });
+});
+
+describe("startVersionMonitor", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not fire when /version.json matches the baked version", async () => {
+    // Mock fetch to return the actual baked version from this build.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: getBakedVersion() }), {
+        status: 200,
+      }),
+    );
+    const onOutdated = vi.fn();
+    const handle = startVersionMonitor({ onOutdated, intervalMs: 60_000 });
+    await new Promise((r) => setTimeout(r, 10));
+    handle.stop();
+    expect(onOutdated).not.toHaveBeenCalled();
+  });
+
+  it("fires once when /version.json reports a different version", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "0.0.0+would-never-match" }), {
+        status: 200,
+      }),
+    );
+    const onOutdated = vi.fn();
+    const handle = startVersionMonitor({ onOutdated, intervalMs: 1000 });
+    await new Promise((r) => setTimeout(r, 20));
+    handle.stop();
+    // Skip in dev mode (baked === "dev") — isOutdated short-circuits.
+    if (getBakedVersion() === "dev") {
+      expect(onOutdated).not.toHaveBeenCalled();
+    } else {
+      expect(onOutdated).toHaveBeenCalledWith("0.0.0+would-never-match");
+      expect(onOutdated).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("does not fire on null fetch (network down)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+    const onOutdated = vi.fn();
+    const handle = startVersionMonitor({ onOutdated, intervalMs: 60_000 });
+    await new Promise((r) => setTimeout(r, 10));
+    handle.stop();
+    expect(onOutdated).not.toHaveBeenCalled();
+  });
+
+  it("stop() unsubscribes window/document listeners (no fire after stop)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "dev" }), { status: 200 }),
+    );
+    const onOutdated = vi.fn();
+    const handle = startVersionMonitor({ onOutdated, intervalMs: 60_000 });
+    handle.stop();
+    // Trigger a focus event after stop — must NOT cause a fetch firing.
+    window.dispatchEvent(new Event("focus"));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onOutdated).not.toHaveBeenCalled();
+  });
+});

--- a/ornn-web/src/lib/versionCheck.ts
+++ b/ornn-web/src/lib/versionCheck.ts
@@ -1,0 +1,131 @@
+/**
+ * SPA stale-bundle self-recovery.
+ *
+ * The SPA bakes its build version into `__APP_VERSION__` at compile
+ * time. nginx serves a sister file `/version.json` (written by the
+ * Vite build, never cached) carrying that same version string. At
+ * runtime the SPA polls `/version.json` periodically and on focus;
+ * when the live version drifts from the baked one, a banner offers a
+ * one-click reload. Users on stale tabs / aggressively-cached browsers
+ * (Safari) recover without being told to clear cache.
+ *
+ * Failure-tolerant by design: any network / parse / 404 error is
+ * silent — we'd rather under-prompt than spam the user.
+ *
+ * @module lib/versionCheck
+ */
+
+const VERSION_JSON_PATH = "/version.json";
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * The version baked into the JS bundle at build time. Defined via the
+ * Vite `define` config in `vite.config.ts`. Format: `<pkg.version>+<git-short-sha>`.
+ */
+export function getBakedVersion(): string {
+  // `__APP_VERSION__` is replaced at build time. In dev/test it can
+  // be undefined when the test harness skips Vite — fall back to a
+  // sentinel that never matches the deployed version, so the check
+  // returns "outdated:false" rather than crashing on undefined.
+  if (typeof __APP_VERSION__ === "undefined") return "dev";
+  return __APP_VERSION__;
+}
+
+/**
+ * Fetch the deployed version from `/version.json`. Returns null on
+ * any failure (network, 404, parse, missing field) — caller treats
+ * null as "couldn't check, leave UI alone".
+ */
+export async function fetchDeployedVersion(): Promise<string | null> {
+  try {
+    const res = await fetch(VERSION_JSON_PATH, {
+      cache: "no-store",
+      // Same-origin, no credentials needed; keeps it lean.
+      credentials: "omit",
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { version?: unknown };
+    if (typeof body.version !== "string" || body.version.length === 0) {
+      return null;
+    }
+    return body.version;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true when the deployed version differs from the baked one.
+ * `null` (couldn't fetch) → `false` so the banner stays hidden when
+ * we can't confirm.
+ */
+export function isOutdated(deployed: string | null, baked: string): boolean {
+  if (!deployed) return false;
+  if (baked === "dev") return false;
+  return deployed !== baked;
+}
+
+interface MonitorOptions {
+  /** Called once on first detected mismatch. The monitor stops after this fires. */
+  onOutdated: (deployedVersion: string) => void;
+  /** Override poll interval for tests. */
+  intervalMs?: number;
+}
+
+interface MonitorHandle {
+  stop: () => void;
+}
+
+/**
+ * Start monitoring. Polls `/version.json` on the chosen interval and
+ * additionally whenever the tab regains visibility / focus (so a tab
+ * that was backgrounded for a day surfaces the prompt right away on
+ * return rather than waiting up to a full poll interval).
+ *
+ * Idempotent against multiple invocations of `onOutdated` — fires
+ * exactly once, then the monitor goes quiet. Whoever owns the banner
+ * keeps the version in state and dismisses it on user action.
+ */
+export function startVersionMonitor(opts: MonitorOptions): MonitorHandle {
+  const baked = getBakedVersion();
+  const intervalMs = opts.intervalMs ?? POLL_INTERVAL_MS;
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const fire = (deployed: string) => {
+    if (stopped) return;
+    stopped = true;
+    if (timer) clearInterval(timer);
+    document.removeEventListener("visibilitychange", onVisible);
+    window.removeEventListener("focus", onFocus);
+    opts.onOutdated(deployed);
+  };
+
+  const checkOnce = async () => {
+    if (stopped) return;
+    const deployed = await fetchDeployedVersion();
+    if (deployed && isOutdated(deployed, baked)) fire(deployed);
+  };
+
+  const onVisible = () => {
+    if (document.visibilityState === "visible") void checkOnce();
+  };
+  const onFocus = () => void checkOnce();
+
+  // Initial check is deferred a tick so the function returns a handle
+  // synchronously (lets the caller cancel cleanly in tests).
+  queueMicrotask(checkOnce);
+  timer = setInterval(checkOnce, intervalMs);
+  document.addEventListener("visibilitychange", onVisible);
+  window.addEventListener("focus", onFocus);
+
+  return {
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      if (timer) clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onFocus);
+    },
+  };
+}

--- a/ornn-web/vite.config.ts
+++ b/ornn-web/vite.config.ts
@@ -1,15 +1,72 @@
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "path";
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
 
 const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8"));
 
+/**
+ * Build identity = `<pkg.version>+<git-short-sha>`.
+ *
+ * Inside docker the SHA is passed in as a build-arg → env (the
+ * Dockerfile sets `VITE_GIT_COMMIT`) since the `.git` directory isn't
+ * copied into the image. Locally we fall back to `git rev-parse`. If
+ * neither is available (rare: tarball install, CI without git), we use
+ * a build-time epoch so two builds at different moments still differ.
+ *
+ * Both `__APP_VERSION__` (baked into the JS bundle) and `version.json`
+ * (served as a small static file by nginx) MUST resolve to this exact
+ * string — they're compared at runtime by the version-check loop.
+ */
+function resolveBuildVersion(): string {
+  const sha = (() => {
+    const fromEnv = process.env.VITE_GIT_COMMIT;
+    if (fromEnv && fromEnv.length > 0 && fromEnv !== "unknown") return fromEnv;
+    try {
+      return execSync("git rev-parse --short HEAD", {
+        cwd: __dirname,
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim();
+    } catch {
+      return `t${Date.now()}`;
+    }
+  })();
+  return `${pkg.version}+${sha}`;
+}
+
+const BUILD_VERSION = resolveBuildVersion();
+
+/**
+ * Emit `dist/version.json` after build so the deployed SPA can be
+ * version-checked at runtime. Sister to `__APP_VERSION__` baked into
+ * the JS bundle: the two values together drive the auto-reload-on-
+ * stale-bundle behavior.
+ *
+ * `Cache-Control: no-store` for this path is set in
+ * `nginx.conf.template`.
+ */
+function emitVersionJsonPlugin(version: string): PluginOption {
+  return {
+    name: "ornn-emit-version-json",
+    apply: "build",
+    closeBundle() {
+      const outDir = resolve(__dirname, "dist");
+      writeFileSync(
+        resolve(outDir, "version.json"),
+        `${JSON.stringify({ version })}\n`,
+      );
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), emitVersionJsonPlugin(BUILD_VERSION)],
   define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_VERSION__: JSON.stringify(BUILD_VERSION),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #318.

## Summary

- Every build emits \`dist/version.json\` and bakes the same \`<pkg.version>+<git-short-sha>\` into \`__APP_VERSION__\`.
- New \`lib/versionCheck\` module polls \`/version.json\` (no-store) every 60s + on tab focus / visibility change. Mismatch → banner with one-click reload.
- New \`<VersionUpdateBanner />\` mounted once at app root; renders nothing on the happy path.
- nginx serves \`/version.json\` with \`no-store, no-cache, must-revalidate\` + \`Pragma: no-cache\` (defense-in-depth against intermediate caches).

## Why this matters

Today, when we ship a new ornn-web bundle, users on stale tabs (or browsers like Safari that aggressively cache) keep seeing the old UI until they manually hard-reload. That's not acceptable for a SaaS. After this lands, every future deploy auto-prompts a reload within 60 seconds.

Caveat: this can only help users who are running a build that already includes this code. Anyone currently stuck on a pre-#318 bundle still needs one fresh load to pick up the new logic; from that load forward they're auto-recovering.

## Operator change

\`ornn-web\` \`docker build\` now wants:

\`\`\`bash
docker build \\
  --build-arg GIT_COMMIT=\$(git rev-parse --short HEAD) \\
  -t \"\${ORNN_WEB_IMAGE}\" -f ornn-web/Dockerfile .
\`\`\`

Without the build-arg the bundle gets baked with \`unknown\` and the version-check loop will always think the app is stale (loop fires once on the first run, user dismisses, done — annoying but not broken). CLAUDE.md Step 6 updated.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test\` — 80/80 pass (13 new tests)
- [x] Local \`bun run build\` produces \`dist/version.json\` with correct \`<pkg.version>+<sha>\`
- [ ] CI green
- [ ] Local docker-desktop deploy: confirm \`/version.json\` is served correctly with no-store. Build a v2 image with a synthetic SHA, deploy, watch the existing tab surface the banner within 60s.