### PR TITLE
[Feature] Legal pages — Privacy / ToS / AUP for launch + contact trim

### DIFF
--- a/.changeset/legal-pages-and-contact-trim.md
+++ b/.changeset/legal-pages-and-contact-trim.md
@@ -1,0 +1,15 @@
+---
+"ornn-web": minor
+---
+
+Legal pages for launch — three deep-linkable routes:
+
+- `/legal/privacy` — Privacy Policy (data collected, sub-processors, DSR rights, retention)
+- `/legal/terms` — Terms of Service (eligibility, content license, AS-IS, USD 100 / 12-month liability cap, Singapore governing law)
+- `/legal/acceptable-use` — Acceptable Use Policy (malicious-code rules, AgentSeal disclosure, content rules, takedown / abuse reporting)
+
+All three share a `LegalLayout` shell with cross-doc nav, last-updated stamp, and footer contact. English-only at launch. Cookie consent banner now links into the Privacy Policy. Landing footer carries Privacy / Terms / Acceptable Use links.
+
+Also drops the placeholder Xiaohongshu card and the brand-decorative "WORKSHOP" stamp from the Contact page — both offered no contact value, the stamp wasn't even a link.
+
+Closes #320.

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -69,6 +69,21 @@ const DocsPage = lazy(() =>
 const ContactPage = lazy(() =>
   import("@/pages/ContactPage").then((m) => ({ default: m.ContactPage })),
 );
+const PrivacyPolicyPage = lazy(() =>
+  import("@/pages/legal/PrivacyPolicyPage").then((m) => ({
+    default: m.PrivacyPolicyPage,
+  })),
+);
+const TermsOfServicePage = lazy(() =>
+  import("@/pages/legal/TermsOfServicePage").then((m) => ({
+    default: m.TermsOfServicePage,
+  })),
+);
+const AcceptableUsePage = lazy(() =>
+  import("@/pages/legal/AcceptableUsePage").then((m) => ({
+    default: m.AcceptableUsePage,
+  })),
+);
 
 const ExplorePage = lazy(() =>
   import("@/pages/ExplorePage").then((m) => ({ default: m.ExplorePage })),
@@ -222,6 +237,9 @@ const router = createBrowserRouter(
       <Route element={<RootLayout />}>
         <Route path="/docs" element={<DocsPage />} />
         <Route path="/contact" element={<ContactPage />} />
+        <Route path="/legal/privacy" element={<PrivacyPolicyPage />} />
+        <Route path="/legal/terms" element={<TermsOfServicePage />} />
+        <Route path="/legal/acceptable-use" element={<AcceptableUsePage />} />
         <Route path="/registry" element={<ExplorePage />} />
         <Route path="/skills/:idOrName" element={<SkillDetailPage />} />
         <Route

--- a/ornn-web/src/components/analytics/CookieConsentBanner.tsx
+++ b/ornn-web/src/components/analytics/CookieConsentBanner.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/Button";
 import {
   isUndecided,
@@ -76,8 +77,14 @@ export function CookieConsentBanner() {
                 PostHog (EU)
               </a>{" "}
               to measure feature usage and improve the platform. Session
-              replay is sampled with input fields masked. You can change
-              your choice anytime in settings.
+              replay is sampled with input fields masked. See our{" "}
+              <Link
+                to="/legal/privacy"
+                className="text-accent underline-offset-2 hover:underline"
+              >
+                Privacy Policy
+              </Link>{" "}
+              for details. You can change your choice anytime in settings.
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-3">

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -713,13 +713,6 @@
     "cardEmailHint": "Best for product questions, partnership, and security disclosures. Expect a reply within two business days.",
     "cardGithubLabel": "GITHUB",
     "cardGithubHint": "File bugs, pull requests, and feature requests on the issue tracker.",
-    "cardXhsLabel": "XIAOHONGSHU · 小红书",
-    "cardXhsValue": "Coming soon",
-    "cardXhsHint": "Behind-the-scenes notes from the forge. Handle goes live shortly.",
-    "cardOfficeLabel": "WORKSHOP",
-    "cardOfficeBrand": "Chrono AI",
-    "cardOfficeLocation": "Singapore",
-    "cardOfficeHint": "Built and maintained from the Chrono AI workshop, Singapore.",
     "signoff": "[ END · CONTACT ]"
   }
 }

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -713,13 +713,6 @@
     "cardEmailHint": "适合产品咨询、合作洽谈与安全披露。一般两个工作日内回复。",
     "cardGithubLabel": "GITHUB",
     "cardGithubHint": "在 issue 追踪器上提交 bug、Pull Request 与功能请求。",
-    "cardXhsLabel": "小红书 · XIAOHONGSHU",
-    "cardXhsValue": "即将上线",
-    "cardXhsHint": "工坊幕后日常，账号即将上线。",
-    "cardOfficeLabel": "工坊",
-    "cardOfficeBrand": "Chrono AI",
-    "cardOfficeLocation": "新加坡",
-    "cardOfficeHint": "由位于新加坡的 Chrono AI 工坊打造与维护。",
     "signoff": "[ 完 · 联系 ]"
   }
 }

--- a/ornn-web/src/pages/ContactPage.tsx
+++ b/ornn-web/src/pages/ContactPage.tsx
@@ -1,10 +1,10 @@
 /**
  * Contact Page — Forge Workshop public surface.
  *
- * Lists the channels visitors can reach the team through: support email,
- * GitHub issue tracker, Xiaohongshu (placeholder until handle is published),
- * and a single-line workshop / location stamp. Deliberately backendless —
- * email is a `mailto:` link, GitHub is the existing repo, no contact form.
+ * Two real channels: support email + GitHub issue tracker. The
+ * placeholder Xiaohongshu card and the brand-decorative "WORKSHOP"
+ * stamp were dropped in #320 — both offered no contact value, the
+ * stamp wasn't even a link.
  *
  * Design language follows DESIGN.md "Whole-App Application Guidance →
  * App Shell": cool steel-paper page background (inherited from RootLayout),
@@ -21,8 +21,6 @@ import { HighlighterMark } from "@/pages/landing/HighlighterMark";
 
 const SUPPORT_EMAIL = "support@chrono-ai.fun";
 const GITHUB_REPO_URL = "https://github.com/ChronoAIProject/Ornn";
-// TODO(#278): replace with the real Xiaohongshu URL before merge.
-const XIAOHONGSHU_URL: string | null = null;
 
 function MailIcon({ className }: { className?: string }) {
   return (
@@ -50,42 +48,6 @@ function GitHubIcon({ className }: { className?: string }) {
         clipRule="evenodd"
         d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.847-2.339 4.695-4.566 4.943.359.31.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0022 12.017C22 6.484 17.522 2 12 2z"
       />
-    </svg>
-  );
-}
-
-function BookIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M4 4.5A1.5 1.5 0 0 1 5.5 3H19a1 1 0 0 1 1 1v15a1 1 0 0 1-1 1H6a2 2 0 0 0-2 2V4.5Z" />
-      <path d="M8 7h8M8 11h8M8 15h5" />
-    </svg>
-  );
-}
-
-function PinIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M12 21s7-7.5 7-12a7 7 0 1 0-14 0c0 4.5 7 12 7 12Z" />
-      <circle cx="12" cy="9" r="2.5" />
     </svg>
   );
 }
@@ -188,8 +150,7 @@ export function ContactPage() {
             </p>
           </header>
 
-          {/* Channel grid — 1 col mobile, 2 col sm+. 4 cards stay 2x2 on lg
-              for readability rather than collapsing to a thin 4-up row. */}
+          {/* Channel grid — 1 col mobile, 2 col sm+. */}
           <section
             aria-label={t("contact.channelsLabel")}
             className="grid grid-cols-1 gap-5 sm:grid-cols-2"
@@ -217,36 +178,6 @@ export function ContactPage() {
               helper={t("contact.cardGithubHint")}
               href={GITHUB_REPO_URL}
               external
-            />
-
-            <ChannelCard
-              label={t("contact.cardXhsLabel")}
-              icon={<BookIcon className="h-5 w-5" />}
-              primary={
-                <span className="block font-display text-[20px] font-semibold sm:text-[22px]">
-                  {t("contact.cardXhsValue")}
-                </span>
-              }
-              helper={t("contact.cardXhsHint")}
-              href={XIAOHONGSHU_URL}
-              external
-              disabled={!XIAOHONGSHU_URL}
-            />
-
-            <ChannelCard
-              label={t("contact.cardOfficeLabel")}
-              icon={<PinIcon className="h-5 w-5" />}
-              primary={
-                <span className="block">
-                  <span className="block font-display text-[22px] font-semibold sm:text-[24px]">
-                    {t("contact.cardOfficeBrand")}
-                  </span>
-                  <span className="mt-2 block font-mono text-[12px] font-medium uppercase tracking-[0.22em] text-accent">
-                    {t("contact.cardOfficeLocation")}
-                  </span>
-                </span>
-              }
-              helper={t("contact.cardOfficeHint")}
             />
           </section>
 

--- a/ornn-web/src/pages/landing/LandingFooter.tsx
+++ b/ornn-web/src/pages/landing/LandingFooter.tsx
@@ -43,8 +43,31 @@ export function LandingFooter() {
             </Column>
           </div>
         </div>
-        <div className="mt-10 flex flex-col justify-between gap-2 border-t border-[color:var(--color-border-subtle)] pt-5 font-mono text-[11px] text-meta sm:flex-row">
+        <div className="mt-10 flex flex-col justify-between gap-3 border-t border-[color:var(--color-border-subtle)] pt-5 font-mono text-[11px] text-meta sm:flex-row sm:items-center">
           <div>{t("landing.footer.copyright")}</div>
+          <nav
+            aria-label="Legal"
+            className="flex flex-wrap gap-x-5 gap-y-1"
+          >
+            <Link
+              to="/legal/privacy"
+              className="text-meta no-underline transition-colors hover:text-ember"
+            >
+              {t("landing.footer.legalPrivacy", "Privacy")}
+            </Link>
+            <Link
+              to="/legal/terms"
+              className="text-meta no-underline transition-colors hover:text-ember"
+            >
+              {t("landing.footer.legalTerms", "Terms")}
+            </Link>
+            <Link
+              to="/legal/acceptable-use"
+              className="text-meta no-underline transition-colors hover:text-ember"
+            >
+              {t("landing.footer.legalAup", "Acceptable Use")}
+            </Link>
+          </nav>
           <div>ornn.chrono-ai.fun</div>{/* allow-hardcode brand string in marketing footer */}
         </div>
       </div>

--- a/ornn-web/src/pages/legal/AcceptableUsePage.tsx
+++ b/ornn-web/src/pages/legal/AcceptableUsePage.tsx
@@ -1,0 +1,175 @@
+/**
+ * Acceptable Use Policy.
+ *
+ * Tailored to a skill-marketplace context: user-uploaded code is the
+ * primary risk surface, so the AUP leads with malicious-code rules,
+ * follows with the AgentSeal scan disclosure + takedown process, and
+ * closes with the standard SaaS abuse list.
+ *
+ * @module pages/legal/AcceptableUsePage
+ */
+
+import { LegalLayout } from "./LegalLayout";
+
+export function AcceptableUsePage() {
+  return (
+    <LegalLayout
+      eyebrow="[ § — ACCEPTABLE USE ]"
+      title="Acceptable Use Policy"
+      lastUpdatedIso="2026-05-08"
+    >
+      <p>
+        This Acceptable Use Policy ("AUP") describes activities that are
+        not permitted on Ornn (the "Service"). It applies to everything
+        you upload, publish, run, or transmit through the Service. The
+        AUP supplements our{" "}
+        <a href="/legal/terms">Terms of Service</a> and{" "}
+        <a href="/legal/privacy">Privacy Policy</a>.
+      </p>
+
+      <h2>1. No malicious code</h2>
+      <p>You may not upload, publish, or distribute a skill that:</p>
+      <ul>
+        <li>
+          Contains viruses, worms, ransomware, cryptominers, droppers, or
+          backdoors.
+        </li>
+        <li>
+          Exfiltrates user data, agent prompts, or third-party
+          credentials to an unauthorized destination.
+        </li>
+        <li>
+          Performs network reconnaissance or attack actions (port scans,
+          credential stuffing, denial-of-service, etc.) without a clear
+          authorized purpose.
+        </li>
+        <li>
+          Attempts to break out of the chrono-sandbox or escalate
+          privileges in any execution environment.
+        </li>
+        <li>
+          Uses obfuscation, dynamic-import gymnastics, or runtime code
+          fetching specifically to evade our automated scan.
+        </li>
+      </ul>
+
+      <h2>2. AgentSeal scanning</h2>
+      <p>
+        Every skill version you publish is automatically scanned by{" "}
+        <strong>AgentSeal</strong>, our static analysis runner. The scan
+        produces a verdict (Pass / Caution / Risk) and a numeric score
+        from 0 to 10. Scan results are visible to consumers of your
+        skill so they can decide whether to install it. We may decline
+        to host, deprecate, or remove a skill if the scan surfaces
+        unmitigated risk findings.
+      </p>
+
+      <h2>3. Content rules</h2>
+      <p>You may not publish or transmit content that:</p>
+      <ul>
+        <li>Infringes third-party intellectual property or privacy.</li>
+        <li>
+          Is unlawful, defamatory, harassing, hateful, or directly
+          incites violence.
+        </li>
+        <li>
+          Sexualizes minors or contains other content prohibited by
+          applicable law.
+        </li>
+        <li>Impersonates any person or organization.</li>
+        <li>
+          Is designed to mislead, scam, or fraudulently induce action by
+          another user.
+        </li>
+      </ul>
+
+      <h2>4. Service-integrity rules</h2>
+      <p>You may not:</p>
+      <ul>
+        <li>
+          Probe, scan, or test the vulnerability of the Service except
+          through our coordinated security disclosure channel (
+          <a href="mailto:security@chrono-ai.fun">security@chrono-ai.fun</a>).
+        </li>
+        <li>
+          Circumvent rate limits, quota enforcement, or other usage
+          controls.
+        </li>
+        <li>
+          Use multiple accounts to evade restrictions or amplify quota.
+        </li>
+        <li>
+          Resell, sublicense, or commercially redistribute the Service
+          except as expressly permitted in writing.
+        </li>
+        <li>
+          Scrape the Service in a way that materially burdens our
+          infrastructure.
+        </li>
+      </ul>
+
+      <h2>5. Prompt and model abuse</h2>
+      <p>
+        When using playground, skill generation, or any LLM-backed
+        feature, you may not:
+      </p>
+      <ul>
+        <li>
+          Attempt to extract the underlying model's system prompts,
+          weights, or training data.
+        </li>
+        <li>
+          Use the Service to generate content that violates the model
+          provider's usage policies.
+        </li>
+        <li>
+          Generate sexual content involving minors, biological or chemical
+          weapon instructions, or other categorically prohibited output.
+        </li>
+      </ul>
+
+      <h2>6. Reporting and takedown</h2>
+      <p>
+        To report a skill or content that violates this policy, email{" "}
+        <a href="mailto:abuse@chrono-ai.fun">abuse@chrono-ai.fun</a> with
+        the skill name, version, and a description of the violation. For
+        copyright (DMCA) claims, include all elements required under 17
+        U.S.C. § 512(c)(3) and direct the notice to the same address with
+        subject line "DMCA".
+      </p>
+      <p>
+        We review reports promptly. We may remove or restrict access to
+        offending content while we investigate. We will notify the
+        publisher unless doing so would interfere with an active
+        investigation or is prohibited by law.
+      </p>
+
+      <h2>7. Enforcement</h2>
+      <p>
+        Violations may result in any of: warning, content removal,
+        skill deprecation, account suspension, account termination,
+        and — for unlawful activity — referral to authorities. We choose
+        the response we consider proportionate.
+      </p>
+
+      <h2>8. Updates</h2>
+      <p>
+        We may update this AUP as the Service evolves and new abuse
+        patterns emerge. We will publish material changes here and update
+        the "Last updated" date.
+      </p>
+
+      <h2>9. Contact</h2>
+      <p>
+        Abuse reports:{" "}
+        <a href="mailto:abuse@chrono-ai.fun">abuse@chrono-ai.fun</a>
+        <br />
+        Security disclosures:{" "}
+        <a href="mailto:security@chrono-ai.fun">security@chrono-ai.fun</a>
+        <br />
+        General legal:{" "}
+        <a href="mailto:legal@chrono-ai.fun">legal@chrono-ai.fun</a>
+      </p>
+    </LegalLayout>
+  );
+}

--- a/ornn-web/src/pages/legal/LegalLayout.tsx
+++ b/ornn-web/src/pages/legal/LegalLayout.tsx
@@ -1,0 +1,118 @@
+/**
+ * LegalLayout — shared shell for /legal/* pages (Privacy, Terms, AUP).
+ *
+ * Each legal document gets its own route and lives in this layout so
+ * the visual treatment, typography, and cross-doc nav stay consistent.
+ * Design follows DESIGN.md "Whole-App Application Guidance → App
+ * Shell" — same letterpress + bracketed mono labels we use elsewhere.
+ *
+ * Legal copy is intentionally English-only at launch; translation can
+ * follow once the policies stabilize. The on-page nav stays bilingual
+ * via the i18n keys.
+ *
+ * @module pages/legal/LegalLayout
+ */
+
+import type { ReactNode } from "react";
+import { NavLink } from "react-router-dom";
+import { PageTransition } from "@/components/layout/PageTransition";
+
+interface LegalLayoutProps {
+  /** Mono uppercase eyebrow, e.g. "[ § 02 — PRIVACY POLICY ]". */
+  eyebrow: string;
+  /** Display headline, e.g. "Privacy Policy". */
+  title: string;
+  /** ISO date the doc was last revised. Surfaced under the headline. */
+  lastUpdatedIso: string;
+  /** Doc body — long-form sections. Inherits the prose styles below. */
+  children: ReactNode;
+}
+
+/** Sibling nav targets — kept in sync with App.tsx route paths. */
+const SIBLINGS: Array<{ to: string; label: string }> = [
+  { to: "/legal/privacy", label: "Privacy" },
+  { to: "/legal/terms", label: "Terms of Service" },
+  { to: "/legal/acceptable-use", label: "Acceptable Use" },
+];
+
+export function LegalLayout({
+  eyebrow,
+  title,
+  lastUpdatedIso,
+  children,
+}: LegalLayoutProps) {
+  return (
+    <PageTransition>
+      <div className="h-full overflow-y-auto">
+        <div className="mx-auto max-w-[820px] px-4 py-12 sm:py-16 lg:py-20">
+          <header className="mb-10 sm:mb-12">
+            <p className="mb-5 font-mono text-[11px] uppercase tracking-[0.22em] text-meta">
+              {eyebrow}
+            </p>
+            <h1 className="font-display text-[40px] font-bold leading-[1.05] tracking-tight text-strong sm:text-[52px]">
+              {title}
+            </h1>
+            <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.18em] text-meta">
+              Last updated {formatIsoDate(lastUpdatedIso)}
+            </p>
+          </header>
+
+          {/* Cross-doc nav — small mono row so users can hop between
+              the three policies without going back to the footer. */}
+          <nav
+            aria-label="Legal documents"
+            className="mb-12 flex flex-wrap gap-x-5 gap-y-2 border-y border-subtle py-3"
+          >
+            {SIBLINGS.map((s) => (
+              <NavLink
+                key={s.to}
+                to={s.to}
+                className={({ isActive }) =>
+                  `font-mono text-[11px] uppercase tracking-[0.18em] transition-colors ${
+                    isActive
+                      ? "text-accent"
+                      : "text-meta hover:text-strong"
+                  }`
+                }
+              >
+                {s.label}
+              </NavLink>
+            ))}
+          </nav>
+
+          {/* Long-form prose. Sections + paragraphs use the standard
+              tokens; we apply spacing via children-of selectors so each
+              page can stay heads-down on content. */}
+          <article className="space-y-8 font-text text-[16px] leading-relaxed text-body [&_h2]:mb-3 [&_h2]:mt-10 [&_h2]:font-display [&_h2]:text-[22px] [&_h2]:font-bold [&_h2]:text-strong [&_h3]:mb-2 [&_h3]:mt-6 [&_h3]:font-display [&_h3]:text-[16px] [&_h3]:font-semibold [&_h3]:text-strong [&_li]:mt-2 [&_p]:mt-3 [&_strong]:font-semibold [&_strong]:text-strong [&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-6 [&_a]:text-accent [&_a]:underline [&_a]:underline-offset-4 hover:[&_a]:opacity-80">
+            {children}
+          </article>
+
+          <footer className="mt-16 flex items-center gap-3 border-t border-subtle pt-6">
+            <span className="h-1 w-14 bg-accent" aria-hidden="true" />
+            <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-meta">
+              Questions? Email{" "}
+              <a
+                href="mailto:legal@chrono-ai.fun"
+                className="text-accent underline underline-offset-4 hover:opacity-80"
+              >
+                legal@chrono-ai.fun
+              </a>
+            </span>
+          </footer>
+        </div>
+      </div>
+    </PageTransition>
+  );
+}
+
+function formatIsoDate(iso: string): string {
+  // Stable EN-locale long form: "May 8, 2026". The legal pages are
+  // English-only at launch; once translated, swap to the user's locale.
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}

--- a/ornn-web/src/pages/legal/PrivacyPolicyPage.tsx
+++ b/ornn-web/src/pages/legal/PrivacyPolicyPage.tsx
@@ -1,0 +1,205 @@
+/**
+ * Privacy Policy.
+ *
+ * English-only at launch. Audited by Chrono AI legal before changing
+ * the substance of any section — this is the document users will rely
+ * on when exercising data-subject rights, and it's the disclosure that
+ * keeps PostHog / NyxID / MongoDB in scope as documented sub-processors.
+ *
+ * @module pages/legal/PrivacyPolicyPage
+ */
+
+import { LegalLayout } from "./LegalLayout";
+
+export function PrivacyPolicyPage() {
+  return (
+    <LegalLayout
+      eyebrow="[ § — PRIVACY POLICY ]"
+      title="Privacy Policy"
+      lastUpdatedIso="2026-05-08"
+    >
+      <p>
+        This Privacy Policy explains how <strong>Chrono AI Pte. Ltd.</strong>{" "}
+        ("Chrono AI", "we", "us") collects, uses, and protects information
+        when you use Ornn (the "Service") at{" "}
+        <a href="https://ornn.chrono-ai.fun">ornn.chrono-ai.fun</a> and its{/* allow-hardcode canonical product origin in legal text */}
+        APIs.
+      </p>
+
+      <h2>1. Information we collect</h2>
+
+      <h3>1.1 Account information (via NyxID)</h3>
+      <p>
+        Sign-in is handled by our identity provider, NyxID. When you log
+        in we receive your NyxID user identifier, email address, display
+        name, and the OAuth scopes you grant.
+      </p>
+
+      <h3>1.2 Content you create</h3>
+      <p>
+        Skill packages you upload, skill descriptions, generation prompts
+        you submit, playground messages, and any metadata you attach (tags,
+        categories, version notes) are stored on our servers so the Service
+        can host, version, and audit them on your behalf.
+      </p>
+
+      <h3>1.3 Operational telemetry</h3>
+      <p>
+        We log every API request the Service handles — HTTP method, route,
+        response status, duration, IP-derived country (the source IP itself
+        is redacted to /24 IPv4 / /48 IPv6 before storage), browser
+        user-agent, and a request id used for cross-log correlation. This
+        is used for security, abuse detection, and capacity planning.
+      </p>
+
+      <h3>1.4 Product analytics (PostHog)</h3>
+      <p>
+        With your consent (granted or denied via the cookie banner), we use
+        PostHog Inc. to collect product-analytics events: page views,
+        feature usage (e.g. "skill.created", "playground.run.completed"),
+        and optional session replays. Session replays mask all rendered
+        text, all input values, and all elements marked as sensitive — only
+        layout, click positions, and navigation flow are recorded. We
+        honor the browser's "Do Not Track" signal.
+      </p>
+
+      <h3>1.5 Cookies and similar technologies</h3>
+      <p>
+        We use a small number of first-party cookies and{" "}
+        <code>localStorage</code> entries:
+      </p>
+      <ul>
+        <li>
+          <strong>Authentication state</strong> — your refresh and access
+          tokens, kept locally so you don't have to sign in on every visit.
+        </li>
+        <li>
+          <strong>Cookie consent choice</strong> — your accept/decline
+          decision so we don't re-prompt every visit.
+        </li>
+        <li>
+          <strong>UI preferences</strong> — theme, language.
+        </li>
+        <li>
+          <strong>PostHog SDK</strong> — only when you've consented to
+          analytics. Used by PostHog to assign you a stable analytics id so
+          their funnels work.
+        </li>
+      </ul>
+
+      <h2>2. How we use information</h2>
+      <ul>
+        <li>To provide, secure, and improve the Service.</li>
+        <li>To authenticate your account and authorize your actions.</li>
+        <li>
+          To operate the skill marketplace (host, version, audit, mirror).
+        </li>
+        <li>To detect abuse and enforce our Acceptable Use Policy.</li>
+        <li>To send service-related notifications.</li>
+        <li>
+          To analyze product usage in aggregate (with your analytics
+          consent) so we can prioritize features.
+        </li>
+      </ul>
+
+      <h2>3. Sub-processors and third parties</h2>
+      <p>
+        We share specific data with the following sub-processors only to
+        the extent required to operate the Service:
+      </p>
+      <ul>
+        <li>
+          <strong>NyxID (Chrono AI internal)</strong> — identity, OAuth,
+          API proxy.
+        </li>
+        <li>
+          <strong>MongoDB Atlas / our hosting provider</strong> —
+          application database and infrastructure.
+        </li>
+        <li>
+          <strong>PostHog Inc. (US)</strong> — product analytics + session
+          replay (consent-gated).
+        </li>
+        <li>
+          <strong>chrono-storage / chrono-sandbox (Chrono AI internal)</strong>{" "}
+          — skill package storage and sandboxed execution.
+        </li>
+      </ul>
+      <p>
+        We do not sell personal information. We do not share your data
+        with advertisers.
+      </p>
+
+      <h2>4. Data residency and retention</h2>
+      <p>
+        Application data is stored in our managed-database region (currently
+        Asia-Pacific). PostHog analytics are stored in the PostHog region
+        you see configured in the Service (US or EU). We retain account
+        and content data for as long as your account is active, and for a
+        reasonable period afterward to handle disputes and comply with
+        legal obligations. Operational logs are kept for 30 days; product
+        analytics for up to 12 months.
+      </p>
+
+      <h2>5. Your rights</h2>
+      <p>
+        Subject to applicable law (including the EU GDPR, UK GDPR, US
+        CCPA, and Singapore PDPA), you have the right to:
+      </p>
+      <ul>
+        <li>Access the personal information we hold about you.</li>
+        <li>Correct or update inaccurate information.</li>
+        <li>Delete your account and associated data.</li>
+        <li>Export your content in a portable form.</li>
+        <li>Withdraw analytics consent at any time.</li>
+        <li>
+          Lodge a complaint with your local data-protection authority.
+        </li>
+      </ul>
+      <p>
+        Email <a href="mailto:legal@chrono-ai.fun">legal@chrono-ai.fun</a>{" "}
+        to exercise any of these rights. We respond within 30 days.
+      </p>
+
+      <h2>6. Security</h2>
+      <p>
+        We use TLS for all traffic, encrypted storage at rest for sensitive
+        configuration secrets (e.g. integration credentials), and least-
+        privilege access controls inside Chrono AI. No security model is
+        perfect — please report any vulnerability you find to{" "}
+        <a href="mailto:security@chrono-ai.fun">security@chrono-ai.fun</a>.
+      </p>
+
+      <h2>7. International transfers</h2>
+      <p>
+        We process and store data in jurisdictions where Chrono AI and our
+        sub-processors operate. When we transfer data across borders we
+        use standard contractual safeguards (SCCs or equivalent) where
+        legally required.
+      </p>
+
+      <h2>8. Children</h2>
+      <p>
+        Ornn is not directed at children under 16. We do not knowingly
+        collect personal information from children. If you believe a child
+        has provided us with information, contact us and we will delete it.
+      </p>
+
+      <h2>9. Changes to this policy</h2>
+      <p>
+        We will update the "Last updated" date at the top of this page
+        whenever we revise this policy. For material changes that affect
+        your rights, we will notify you in-product or by email at least 14
+        days before the change takes effect.
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        Privacy questions or requests:{" "}
+        <a href="mailto:legal@chrono-ai.fun">legal@chrono-ai.fun</a>.<br />
+        Security disclosures:{" "}
+        <a href="mailto:security@chrono-ai.fun">security@chrono-ai.fun</a>.
+      </p>
+    </LegalLayout>
+  );
+}

--- a/ornn-web/src/pages/legal/TermsOfServicePage.tsx
+++ b/ornn-web/src/pages/legal/TermsOfServicePage.tsx
@@ -1,0 +1,167 @@
+/**
+ * Terms of Service.
+ *
+ * @module pages/legal/TermsOfServicePage
+ */
+
+import { LegalLayout } from "./LegalLayout";
+
+export function TermsOfServicePage() {
+  return (
+    <LegalLayout
+      eyebrow="[ § — TERMS OF SERVICE ]"
+      title="Terms of Service"
+      lastUpdatedIso="2026-05-08"
+    >
+      <p>
+        These Terms of Service ("Terms") govern your access to and use of
+        Ornn (the "Service") provided by{" "}
+        <strong>Chrono AI Pte. Ltd.</strong> ("Chrono AI", "we", "us"). By
+        creating an account or otherwise using the Service you agree to
+        these Terms.
+      </p>
+
+      <h2>1. Eligibility and account</h2>
+      <p>
+        You must be at least 16 years old to use Ornn. You are responsible
+        for keeping your NyxID credentials secure. You are responsible for
+        everything that happens under your account.
+      </p>
+
+      <h2>2. The Service</h2>
+      <p>
+        Ornn is a skill-lifecycle platform: a registry, runtime, and set
+        of APIs for AI agents to discover, install, run, and publish
+        skills. Features may evolve, and we may add, remove, or change
+        functionality without notice.
+      </p>
+
+      <h2>3. Your content</h2>
+      <p>
+        You retain all ownership of skills, prompts, and other content you
+        upload ("Your Content"). By using the Service, you grant Chrono AI
+        a worldwide, non-exclusive, royalty-free license to host, store,
+        index, transmit, audit, and display Your Content as needed to
+        operate the Service and to make Your Content available to other
+        users in accordance with the visibility settings you choose
+        (private, shared, or public).
+      </p>
+      <p>
+        You represent and warrant that you have the rights necessary to
+        grant the above license, and that Your Content does not violate
+        any third party's rights or applicable law.
+      </p>
+
+      <h2>4. Public skills</h2>
+      <p>
+        When you mark a skill as <strong>public</strong>, you grant other
+        users a perpetual, worldwide, royalty-free license to access,
+        download, install, and run that skill through the Service for
+        their own use. If you later remove or unpublish a skill, copies
+        already installed by other agents may continue to function.
+      </p>
+
+      <h2>5. Acceptable use</h2>
+      <p>
+        Your use of the Service must comply with our{" "}
+        <a href="/legal/acceptable-use">Acceptable Use Policy</a>. We may
+        suspend or terminate access to accounts or content that violates
+        the policy.
+      </p>
+
+      <h2>6. Service availability</h2>
+      <p>
+        We provide the Service on an "as available" basis. We do not
+        guarantee uninterrupted availability. We may perform maintenance
+        with or without notice and may rate-limit, throttle, or suspend
+        usage that materially impacts other users.
+      </p>
+
+      <h2>7. Quotas and fair use</h2>
+      <p>
+        Free-tier accounts are subject to monthly quotas (playground runs,
+        skill-generation runs) administered through the Service. Quota
+        resets, grants, and redemption codes are managed by Chrono AI at
+        our discretion. Abuse of quota mechanisms — including using
+        multiple accounts to circumvent limits — may result in account
+        suspension.
+      </p>
+
+      <h2>8. Third-party integrations</h2>
+      <p>
+        The Service connects to third-party services (LLM providers,
+        chrono-storage, chrono-sandbox, optionally to your own NyxID-bound
+        services). Your use of those third-party services is governed by
+        their own terms. We are not responsible for the availability,
+        accuracy, or pricing of third-party services.
+      </p>
+
+      <h2>9. Fees</h2>
+      <p>
+        Ornn is currently free to use. If we introduce paid tiers, we
+        will give you advance notice and an opportunity to review the
+        applicable terms before any charge.
+      </p>
+
+      <h2>10. Termination</h2>
+      <p>
+        You may stop using the Service at any time. We may suspend or
+        terminate your access immediately, without notice, if we believe
+        you have violated these Terms or our Acceptable Use Policy, or if
+        we are required to do so by law. On termination, sections that by
+        their nature should survive (Sections 3, 11, 12, 13, 14) will
+        survive.
+      </p>
+
+      <h2>11. Disclaimer</h2>
+      <p>
+        THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE", WITHOUT
+        WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING
+        IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+        PURPOSE, AND NON-INFRINGEMENT. CHRONO AI MAKES NO WARRANTY THAT
+        THE SERVICE WILL BE ERROR-FREE OR UNINTERRUPTED. SKILLS PUBLISHED
+        BY OTHER USERS HAVE NOT BEEN VETTED BY US BEYOND OUR AUTOMATED
+        SCAN; YOU INSTALL AND RUN THIRD-PARTY SKILLS AT YOUR OWN RISK.
+      </p>
+
+      <h2>12. Limitation of liability</h2>
+      <p>
+        TO THE FULLEST EXTENT PERMITTED BY LAW, CHRONO AI'S TOTAL LIABILITY
+        FOR ANY CLAIM ARISING OUT OF OR RELATED TO THE SERVICE IS LIMITED
+        TO THE GREATER OF (A) THE AMOUNT YOU PAID US FOR THE SERVICE IN
+        THE 12 MONTHS BEFORE THE CLAIM, OR (B) USD 100. WE WILL NOT BE
+        LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR
+        EXEMPLARY DAMAGES, INCLUDING LOST PROFITS OR DATA, EVEN IF WE
+        WERE ADVISED OF THE POSSIBILITY.
+      </p>
+
+      <h2>13. Indemnification</h2>
+      <p>
+        You agree to defend and indemnify Chrono AI against any claim
+        arising from (a) Your Content, (b) your violation of these Terms,
+        or (c) your violation of any third-party right or applicable law.
+      </p>
+
+      <h2>14. Governing law</h2>
+      <p>
+        These Terms are governed by the laws of Singapore, without regard
+        to its conflict-of-law rules. Any dispute will be resolved in the
+        courts of Singapore, and you consent to their jurisdiction.
+      </p>
+
+      <h2>15. Changes</h2>
+      <p>
+        We may revise these Terms by updating this page. Material changes
+        will be communicated in-product or by email at least 14 days
+        before they take effect. Your continued use of the Service after
+        the effective date constitutes acceptance.
+      </p>
+
+      <h2>16. Contact</h2>
+      <p>
+        Questions about these Terms:{" "}
+        <a href="mailto:legal@chrono-ai.fun">legal@chrono-ai.fun</a>.
+      </p>
+    </LegalLayout>
+  );
+}


### PR DESCRIPTION
Closes #320.

## Summary

Pre-launch legal pages, three deep-linkable routes:

- \`/legal/privacy\`
- \`/legal/terms\`
- \`/legal/acceptable-use\`

All three share a \`LegalLayout\` with cross-doc nav, last-updated stamp, and contact email at footer. English-only at launch. Cookie consent banner + landing footer link in.

Drops the dead Xiaohongshu placeholder card and the WORKSHOP brand-decorative stamp from /contact.

## Reviewer notes

The legal copy is intentionally written so a lawyer can revise prose without engineering touching it again — each page is one component file with text in JSX. Things to flag for the lawyer review: Singapore governing law, USD 100 liability cap floor, 14-day material-change notice, DMCA \`§ 512(c)(3)\` reference, sub-processor list (PostHog, MongoDB Atlas, NyxID, chrono-storage/sandbox).

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test\` — 80/80 pass
- [ ] CI green
- [ ] Browse /legal/privacy, /legal/terms, /legal/acceptable-use after deploy — verify nav, last-updated, contact email, cross-doc links work
- [ ] Verify cookie banner links to /legal/privacy
- [ ] Verify landing footer Privacy / Terms / Acceptable Use links