### PR TITLE
[Chore] Legal pages — consolidate to single support@ inbox

### DIFF
--- a/.changeset/legal-emails-consolidate-support.md
+++ b/.changeset/legal-emails-consolidate-support.md
@@ -1,0 +1,7 @@
+---
+"ornn-web": patch
+---
+
+Collapse all legal-page email contacts (`legal@`, `security@`, `abuse@`) to a single `support@chrono-ai.fun` and tighten the per-page Contact sections that listed the same address two or three times. Matches the inbox we actually staff at launch; separating again later is a one-PR fix.
+
+Closes #322.

--- a/ornn-web/src/pages/legal/AcceptableUsePage.tsx
+++ b/ornn-web/src/pages/legal/AcceptableUsePage.tsx
@@ -89,7 +89,7 @@ export function AcceptableUsePage() {
         <li>
           Probe, scan, or test the vulnerability of the Service except
           through our coordinated security disclosure channel (
-          <a href="mailto:security@chrono-ai.fun">security@chrono-ai.fun</a>).
+          <a href="mailto:support@chrono-ai.fun">support@chrono-ai.fun</a>).
         </li>
         <li>
           Circumvent rate limits, quota enforcement, or other usage
@@ -131,7 +131,7 @@ export function AcceptableUsePage() {
       <h2>6. Reporting and takedown</h2>
       <p>
         To report a skill or content that violates this policy, email{" "}
-        <a href="mailto:abuse@chrono-ai.fun">abuse@chrono-ai.fun</a> with
+        <a href="mailto:support@chrono-ai.fun">support@chrono-ai.fun</a> with
         the skill name, version, and a description of the violation. For
         copyright (DMCA) claims, include all elements required under 17
         U.S.C. § 512(c)(3) and direct the notice to the same address with
@@ -161,14 +161,8 @@ export function AcceptableUsePage() {
 
       <h2>9. Contact</h2>
       <p>
-        Abuse reports:{" "}
-        <a href="mailto:abuse@chrono-ai.fun">abuse@chrono-ai.fun</a>
-        <br />
-        Security disclosures:{" "}
-        <a href="mailto:security@chrono-ai.fun">security@chrono-ai.fun</a>
-        <br />
-        General legal:{" "}
-        <a href="mailto:legal@chrono-ai.fun">legal@chrono-ai.fun</a>
+        Abuse reports, security disclosures, and other policy questions:{" "}
+        <a href="mailto:support@chrono-ai.fun">support@chrono-ai.fun</a>.
       </p>
     </LegalLayout>
   );

--- a/ornn-web/src/pages/legal/LegalLayout.tsx
+++ b/ornn-web/src/pages/legal/LegalLayout.tsx
@@ -92,10 +92,10 @@ export function LegalLayout({
             <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-meta">
               Questions? Email{" "}
               <a
-                href="mailto:legal@chrono-ai.fun"
+                href="mailto:support@chrono-ai.fun"
                 className="text-accent underline underline-offset-4 hover:opacity-80"
               >
-                legal@chrono-ai.fun
+                support@chrono-ai.fun
               </a>
             </span>
           </footer>

--- a/ornn-web/src/pages/legal/PrivacyPolicyPage.tsx
+++ b/ornn-web/src/pages/legal/PrivacyPolicyPage.tsx
@@ -157,7 +157,7 @@ export function PrivacyPolicyPage() {
         </li>
       </ul>
       <p>
-        Email <a href="mailto:legal@chrono-ai.fun">legal@chrono-ai.fun</a>{" "}
+        Email <a href="mailto:support@chrono-ai.fun">support@chrono-ai.fun</a>{" "}
         to exercise any of these rights. We respond within 30 days.
       </p>
 
@@ -167,7 +167,7 @@ export function PrivacyPolicyPage() {
         configuration secrets (e.g. integration credentials), and least-
         privilege access controls inside Chrono AI. No security model is
         perfect — please report any vulnerability you find to{" "}
-        <a href="mailto:security@chrono-ai.fun">security@chrono-ai.fun</a>.
+        <a href="mailto:support@chrono-ai.fun">support@chrono-ai.fun</a>.
       </p>
 
       <h2>7. International transfers</h2>
@@ -195,10 +195,9 @@ export function PrivacyPolicyPage() {
 
       <h2>10. Contact</h2>
       <p>
-        Privacy questions or requests:{" "}
-        <a href="mailto:legal@chrono-ai.fun">legal@chrono-ai.fun</a>.<br />
-        Security disclosures:{" "}
-        <a href="mailto:security@chrono-ai.fun">security@chrono-ai.fun</a>.
+        Privacy questions, data-subject requests, and security
+        disclosures:{" "}
+        <a href="mailto:support@chrono-ai.fun">support@chrono-ai.fun</a>.
       </p>
     </LegalLayout>
   );

--- a/ornn-web/src/pages/legal/TermsOfServicePage.tsx
+++ b/ornn-web/src/pages/legal/TermsOfServicePage.tsx
@@ -160,7 +160,7 @@ export function TermsOfServicePage() {
       <h2>16. Contact</h2>
       <p>
         Questions about these Terms:{" "}
-        <a href="mailto:legal@chrono-ai.fun">legal@chrono-ai.fun</a>.
+        <a href="mailto:support@chrono-ai.fun">support@chrono-ai.fun</a>.
       </p>
     </LegalLayout>
   );


### PR DESCRIPTION
Closes #322.

## Summary

- All \`legal@\` / \`security@\` / \`abuse@\` references on the four legal pages collapsed to \`support@chrono-ai.fun\`.
- The per-page \"Contact\" sections that listed the same address split by topic are now one line.

## Test plan

- [x] \`bun run test\` — 80/80 pass
- [x] \`bunx tsc --noEmit\` clean
- [ ] CI green