### PR TITLE
[Chore] Reposition as end-to-end skill life-cycle manager + footer trim

### DIFF
--- a/.changeset/positioning-skill-lifecycle-manager.md
+++ b/.changeset/positioning-skill-lifecycle-manager.md
@@ -1,0 +1,11 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+"@chronoai/ornn-sdk": patch
+---
+
+Reposition Ornn consistently as **the end-to-end skill life-cycle manager for AI agents** across every public-facing surface — landing footer tagline (EN + ZH), OpenAPI top-level description, repo README, TS + Python SDK package descriptions and READMEs.
+
+Also drops the Product / Developers link columns from the landing footer — every entry was already reachable from the top nav (Registry / Build / Docs / GitHub icon). Footer now carries logo + tagline + (copyright · legal links · brand string).
+
+Closes #326.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 <h1 align="center">Ornn</h1>
 
-<p align="center">The skill platform for AI agents</p>
+<p align="center">The end-to-end skill life-cycle manager for AI agents</p>
 
 ---
 
-Ornn is an AI skill platform where users create, publish, discover, and execute AI skills — packaged prompts and scripts that any agent can use. The ultimate vision is **Skill-as-a-Service**: plug-and-play skill integration for any AI agent.
+Ornn is the end-to-end skill life-cycle manager for AI agents — search, install, run, build, audit, and publish AI skills (packaged prompts and scripts that any agent can use) from one platform. The ultimate vision is **Skill-as-a-Service**: plug-and-play skill integration for any AI agent, across the full life-cycle.
 
 ## What is Ornn
 
-A **skill** is a packaged AI capability — a combination of prompts, scripts, and metadata that an AI agent can discover and execute. Skills are versioned, validated, and stored in the Ornn skill library.
+A **skill** is a packaged AI capability — a combination of prompts, scripts, and metadata that an AI agent can discover and execute. Ornn manages the full skill life-cycle: skills are authored or AI-generated, validated, versioned, audited, published, discovered, installed, executed, and monitored — all through one platform.
 
 The skill library provides multiple discovery methods:
 

--- a/ornn-api/src/openapi/specBuilder.ts
+++ b/ornn-api/src/openapi/specBuilder.ts
@@ -384,7 +384,7 @@ export function buildSpec(): OpenApiSpec {
   return {
     ...baseSpec(
       "ornn API",
-      "API for the ornn skill registry. Provides skill CRUD, search, AI-powered generation, playground, and admin endpoints. All endpoints require NyxID authentication via Bearer token. Responses follow a uniform envelope: { data: T | null, error: { code, message } | null }.",
+      "API for ornn — the end-to-end skill life-cycle manager for AI agents. Covers the full life-cycle: skill CRUD, search, AI-powered generation, playground, audit, and admin endpoints — from spec to ship. All endpoints require NyxID authentication via Bearer token. Responses follow a uniform envelope: { data: T | null, error: { code, message } | null }.",
     ),
     tags: [
       { name: "Skills", description: "Upload, retrieve, update, delete, and inspect AI skill packages." },

--- a/ornn-sdk-python/README.md
+++ b/ornn-sdk-python/README.md
@@ -1,6 +1,6 @@
 # ornn-sdk (Python)
 
-Python client for the [Ornn](https://github.com/ChronoAIProject/Ornn) skill platform.
+Python client for [Ornn](https://github.com/ChronoAIProject/Ornn) — the end-to-end skill life-cycle manager for AI agents.
 
 Wraps the `/api/v1/*` HTTP surface with auth injection, response-envelope unwrapping, and typed errors (`OrnnError`). Mirrors the [TypeScript SDK](../ornn-sdk) so agents written in either language have the same programmatic entry point.
 

--- a/ornn-sdk-python/pyproject.toml
+++ b/ornn-sdk-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "ornn-sdk"
 version = "0.2.0"
-description = "Python client for the Ornn skill platform"
+description = "Python client for Ornn — the end-to-end skill life-cycle manager for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/ornn-sdk/README.md
+++ b/ornn-sdk/README.md
@@ -1,6 +1,6 @@
 # @chronoai/ornn-sdk
 
-TypeScript client for the [Ornn](https://github.com/ChronoAIProject/Ornn) skill platform.
+TypeScript client for [Ornn](https://github.com/ChronoAIProject/Ornn) — the end-to-end skill life-cycle manager for AI agents.
 
 Wraps the `/api/v1/*` HTTP surface with auth injection, response-envelope unwrapping, and typed errors (`OrnnError`).
 

--- a/ornn-sdk/package.json
+++ b/ornn-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@chronoai/ornn-sdk",
   "version": "0.2.0",
   "private": true,
-  "description": "TypeScript client for the Ornn skill platform",
+  "description": "TypeScript client for Ornn — the end-to-end skill life-cycle manager for AI agents",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/ornn-sdk/src/index.ts
+++ b/ornn-sdk/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @chronoai/ornn-sdk — TypeScript client for the Ornn skill platform.
+ * @chronoai/ornn-sdk — TypeScript client for Ornn, the end-to-end skill life-cycle manager for AI agents.
  *
  * Quickstart:
  *

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -650,7 +650,7 @@
       "alsoOnRegistry": "Also on the registry"
     },
     "footer": {
-      "tagline": "The registry for AI agent skills. From the Chrono AI workshop.",
+      "tagline": "The end-to-end skill life-cycle manager for AI agents. From the Chrono AI workshop.",
       "productHeading": "Product",
       "developersHeading": "Developers",
       "productBrowse": "Browse",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -650,7 +650,7 @@
       "alsoOnRegistry": "注册中心其它技能"
     },
     "footer": {
-      "tagline": "AI Agent 技能注册中心。来自 Chrono AI 工作室。",
+      "tagline": "为 AI 代理打造的技能全生命周期管理平台。来自 Chrono AI 工作室。",
       "productHeading": "产品",
       "developersHeading": "开发者",
       "productBrowse": "浏览",

--- a/ornn-web/src/pages/landing/LandingFooter.tsx
+++ b/ornn-web/src/pages/landing/LandingFooter.tsx
@@ -7,41 +7,15 @@ export function LandingFooter() {
   return (
     <footer className="border-t border-[color:var(--color-border-subtle)] bg-graphite px-6 pb-8 pt-14 sm:px-8">
       <div className="mx-auto max-w-[1280px]">
-        <div className="grid gap-10 sm:grid-cols-2 lg:[grid-template-columns:2fr_1fr_1fr]">
-          <div>
-            <Logo className="mb-4 block h-[22px] w-auto text-parchment" />
-            <p className="max-w-[280px] font-ui text-[13px] leading-[1.55] text-meta">
-              {t("landing.footer.tagline")}
-            </p>
-          </div>
-          {/* Mobile: Product + Developers side-by-side via inner 2-col grid.
-              sm+: `display:contents` flattens the wrapper so the columns join
-              the outer grid as direct siblings of the logo block. */}
-          <div className="grid grid-cols-2 gap-10 sm:contents">
-            <Column heading={t("landing.footer.productHeading")}>
-              <FooterLink href="/registry">{t("landing.footer.productBrowse")}</FooterLink>
-              <FooterLink href="/login">{t("landing.footer.productPublish")}</FooterLink>
-              <FooterLink href="/docs?section=cli">{t("landing.footer.productCli")}</FooterLink>
-              <FooterLink
-                external
-                href="https://github.com/ChronoAIProject/Ornn/releases"
-              >
-                {t("landing.footer.productChangelog")}
-              </FooterLink>
-            </Column>
-            <Column heading={t("landing.footer.developersHeading")}>
-              <FooterLink href="/docs">{t("landing.footer.developersDocs")}</FooterLink>
-              <FooterLink href="/docs?section=skill-format">
-                {t("landing.footer.developersSkillFormat")}
-              </FooterLink>
-              <FooterLink
-                external
-                href="https://github.com/ChronoAIProject/Ornn"
-              >
-                {t("landing.footer.developersGitHub")}
-              </FooterLink>
-            </Column>
-          </div>
+        {/* Logo + tagline only — the Product / Developers columns were
+            dropped (#324 follow-up) because every link there is already
+            reachable from the top nav (Registry / Build / Docs / GitHub
+            icon). Footer keeps the brand mark + a one-line tagline. */}
+        <div>
+          <Logo className="mb-4 block h-[22px] w-auto text-parchment" />
+          <p className="max-w-[420px] font-ui text-[13px] leading-[1.55] text-meta">
+            {t("landing.footer.tagline")}
+          </p>
         </div>
         <div className="mt-10 flex flex-col justify-between gap-3 border-t border-[color:var(--color-border-subtle)] pt-5 font-mono text-[11px] text-meta sm:flex-row sm:items-center">
           <div>{t("landing.footer.copyright")}</div>
@@ -72,52 +46,5 @@ export function LandingFooter() {
         </div>
       </div>
     </footer>
-  );
-}
-
-function Column({
-  heading,
-  children,
-}: {
-  heading: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <h4 className="mb-3 font-mono text-[10px] uppercase tracking-[0.25em] text-meta">
-        {heading}
-      </h4>
-      <ul className="m-0 list-none space-y-1.5 p-0">{children}</ul>
-    </div>
-  );
-}
-
-function FooterLink({
-  href,
-  external = false,
-  children,
-}: {
-  href: string;
-  external?: boolean;
-  children: React.ReactNode;
-}) {
-  const cls = "font-ui text-[13px] text-bone no-underline transition-colors duration-150 hover:text-ember";
-  return (
-    <li>
-      {external ? (
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={cls}
-        >
-          {children}
-        </a>
-      ) : (
-        <Link to={href} className={cls}>
-          {children}
-        </Link>
-      )}
-    </li>
   );
 }


### PR DESCRIPTION
Closes #326.

## Summary

- **Reposition**: every public-facing surface (landing footer tagline EN/ZH, OpenAPI top-level description, repo README, TS + Python SDK package + README + module header) now consistently calls Ornn the **end-to-end skill life-cycle manager for AI agents**.
- **Footer trim**: drop the Product / Developers link columns; every link is already in the top nav. Footer now: logo + tagline + (copyright · legal · brand string).

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test\` — 80/80 pass
- [ ] CI green
- [ ] After deploy: landing footer is single-row (no Product/Developers columns); /openapi.json shows new description