### PR TITLE
[Bug] Admin settings Export/Import broken — envelope + dryRun-in-body

### DIFF
--- a/.changeset/admin-settings-export-import-fix.md
+++ b/.changeset/admin-settings-export-import-fix.md
@@ -1,0 +1,10 @@
+---
+"ornn-api": patch
+---
+
+Fix admin Settings → Export / Import (both directions broken):
+
+- **Export**: backend now wraps the export envelope in the standard `{ data, error }` shape so the SPA's `apiGet` can parse it. Previously returned a raw envelope, which made the SPA throw "Export missing" on every click.
+- **Import**: backend now accepts the `dryRun` flag from the request body (where the SPA sends it) in addition to the query string. Previously query-only — the "Run dry-run preview" button silently committed the import every time.
+
+Closes #330.

--- a/ornn-api/src/domains/settings/exportImport/routes.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/routes.test.ts
@@ -194,6 +194,53 @@ describe("settings export/import routes", () => {
     expect(playground.status).toBe("applied");
   });
 
+  it("G3: dryRun=true in BODY is honored — response audit reports dryRun=true (#330)", async () => {
+    const recordImport = mock(async () => {});
+    const audit: SettingsAuditLogger = {
+      recordExport: async () => {},
+      recordImport,
+    };
+    const { app } = makeApp({ audit });
+    const res = await app.request("/api/v1/admin/settings/import", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        schemaVersion: SETTINGS_SCHEMA_VERSION,
+        sections: {
+          playground: {
+            defaultProviderId: null,
+            defaultModelId: null,
+            sseKeepAliveMs: 15_000,
+            defaultMonthlyQuota: 99,
+          },
+        },
+        dryRun: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 5));
+    const args = (recordImport.mock.calls as unknown as Array<
+      [{ dryRun: boolean }]
+    >)[0]![0];
+    expect(args.dryRun).toBe(true);
+  });
+
+  it("G3: GET /export returns standard { data, error } envelope (#330)", async () => {
+    const { app } = makeApp();
+    const res = await app.request("/api/v1/admin/settings/export", {
+      method: "GET",
+      headers: {},
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data?: { schemaVersion: number };
+      error: unknown;
+    };
+    expect(json.error).toBeNull();
+    expect(json.data).toBeDefined();
+    expect(json.data!.schemaVersion).toBe(SETTINGS_SCHEMA_VERSION);
+  });
+
   it("G3: audit emission failure does not break the response", async () => {
     const recordExport = mock(async () => {
       throw new Error("audit-broken");

--- a/ornn-api/src/domains/settings/exportImport/routes.ts
+++ b/ornn-api/src/domains/settings/exportImport/routes.ts
@@ -85,7 +85,8 @@ export function createSettingsExportImportRoutes(
   app.get("/admin/settings/export", auth, adminGuard, async (c) => {
     const envelope = await exporter.export();
     const filename = exporter.filenameFor(envName);
-    c.header("Content-Type", "application/json; charset=utf-8");
+    // Surface the suggested filename for clients that want it; the
+    // browser SPA serializes the JSON itself for the download blob.
     c.header("Content-Disposition", `attachment; filename="${filename}"`);
     // Fire-and-forget audit emission; never blocks the download.
     void audit
@@ -96,7 +97,10 @@ export function createSettingsExportImportRoutes(
       .catch((err) =>
         logger.warn({ err }, "settings.export audit emit failed — ignoring"),
       );
-    return c.body(JSON.stringify(envelope, null, 2));
+    // Wrap in the standard `{ data, error }` envelope so apiGet on the
+    // SPA side can parse it like every other endpoint. Was returning
+    // raw JSON before — that broke the SPA's downloader (#330).
+    return c.json({ data: envelope, error: null });
   });
 
   app.post(
@@ -122,7 +126,14 @@ export function createSettingsExportImportRoutes(
       if (!body || typeof body !== "object") {
         throw AppError.badRequest("INVALID_BODY", "JSON body required");
       }
-      const dryRun = c.req.query("dryRun") === "1" || c.req.query("dryRun") === "true";
+      // Accept dryRun from either the body (the SPA path) OR the
+      // query string (curl / scripts). Body takes precedence. Was
+      // query-only before — that silently mutated on the SPA's
+      // "preview" button (#330).
+      const dryRun =
+        (body as { dryRun?: unknown }).dryRun === true ||
+        c.req.query("dryRun") === "1" ||
+        c.req.query("dryRun") === "true";
       const actor = currentActor(c);
       const result = await importer.import(body, actor, { dryRun });
       void audit


### PR DESCRIPTION
Closes #330.

## Summary

- Export endpoint now returns the standard \`{ data, error }\` envelope so the SPA's \`apiGet\` can parse it. Was returning raw — SPA threw \"Export missing\" and the file never downloaded.
- Import endpoint now accepts \`dryRun\` from the JSON body (where the SPA sends it) in addition to the query string. Was query-only — the \"Run dry-run preview\" button silently committed the import every click.

Two new route-test cases pin both fixes.

## Test plan

- [x] \`bun test\` — 521/521 pass (added 2 new tests)
- [x] \`bunx tsc --noEmit\` clean
- [ ] CI green
- [ ] After deploy: admin Settings → Export downloads a file; \"Run dry-run preview\" surfaces the diff without writing