### PR TITLE
[Chore] Settings export — trim LLM model catalog, keep operator flags

### DIFF
--- a/.changeset/export-trim-llm-model-catalog.md
+++ b/.changeset/export-trim-llm-model-catalog.md
@@ -1,0 +1,7 @@
+---
+"ornn-api": patch
+---
+
+Settings export trims each LLM provider's `models` array to operator-state fields only. The synced catalog fields (`displayName`, `firstSeenAt`, `lastSyncedAt`) — which are derived data refilled by hitting the upstream gateway via `/admin/settings/llm-providers` Sync — are no longer in the export. Operator flags (`enabledForPlayground`, `enabledForSkillGen`, `defaultForPlayground`, `defaultForSkillGen`, `removed`) stay so the export still captures the choices an admin made about which models to expose.
+
+Closes part of #330 — keeps the export portable without dragging stale upstream catalog snapshots along.

--- a/ornn-api/src/domains/settings/exportImport/exporter.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/exporter.test.ts
@@ -52,7 +52,19 @@ function fakeSettingsService(): SettingsService {
       modelListUrl: "https://api.openai.com/v1/models",
       apiFormat: "chat-completion",
       auth: { kind: "apiKey", apiKey: "sk-real" },
-      models: [],
+      models: [
+        {
+          id: "gpt-4o",
+          displayName: "GPT-4o",
+          enabledForPlayground: true,
+          enabledForSkillGen: true,
+          defaultForPlayground: true,
+          defaultForSkillGen: false,
+          removed: false,
+          firstSeenAt: new Date("2026-01-01"),
+          lastSyncedAt: new Date("2026-04-01"),
+        },
+      ],
       maxOutputTokens: 8192,
       defaultTemperature: 0.7,
       createdAt: new Date("2026-01-01"),
@@ -131,6 +143,27 @@ describe("SettingsExporter", () => {
     expect(mirror.enabled).toBe(true);
     const playground = env.sections.playground as Record<string, unknown>;
     expect(playground.defaultProviderId).toBe("openai");
+  });
+
+  it("UT-EXPORT-005: provider models keep operator flags but drop synced catalog fields (#330)", async () => {
+    const exporter = new SettingsExporter({ settingsService: fakeSettingsService() });
+    const env = await exporter.export();
+    const providers = env.sections.llmProviders as Array<Record<string, unknown>>;
+    const models = providers[0]!.models as Array<Record<string, unknown>>;
+    expect(models).toHaveLength(1);
+    const m = models[0]!;
+    // Operator flags survive the export.
+    expect(m.id).toBe("gpt-4o");
+    expect(m.enabledForPlayground).toBe(true);
+    expect(m.enabledForSkillGen).toBe(true);
+    expect(m.defaultForPlayground).toBe(true);
+    expect(m.defaultForSkillGen).toBe(false);
+    expect(m.removed).toBe(false);
+    // Synced catalog noise is gone — refilled by /sync against the
+    // upstream gateway.
+    expect("displayName" in m).toBe(false);
+    expect("firstSeenAt" in m).toBe(false);
+    expect("lastSyncedAt" in m).toBe(false);
   });
 
   it("UT-EXPORT-006: exportedAt is ISO-8601 UTC", async () => {

--- a/ornn-api/src/domains/settings/exportImport/exporter.ts
+++ b/ornn-api/src/domains/settings/exportImport/exporter.ts
@@ -93,6 +93,20 @@ function redactProviderSecrets(p: LlmProvider): Record<string, unknown> {
       auth[field] = redactSentinel(field);
     }
   }
+  // Trim each model entry to operator-set state only. The synced
+  // catalog fields (displayName, firstSeenAt, lastSyncedAt) are
+  // derived data — refilled by the next /sync against the upstream
+  // gateway — and don't belong in a portable export. The flags
+  // (enabledFor*, defaultFor*, removed) ARE operator state and stay.
+  // See #330.
+  const models = p.models.map((m) => ({
+    id: m.id,
+    enabledForPlayground: m.enabledForPlayground,
+    enabledForSkillGen: m.enabledForSkillGen,
+    defaultForPlayground: m.defaultForPlayground,
+    defaultForSkillGen: m.defaultForSkillGen,
+    removed: m.removed,
+  }));
   return {
     _id: p._id,
     name: p.name,
@@ -100,7 +114,7 @@ function redactProviderSecrets(p: LlmProvider): Record<string, unknown> {
     modelListUrl: p.modelListUrl,
     apiFormat: p.apiFormat,
     auth,
-    models: p.models,
+    models,
     maxOutputTokens: p.maxOutputTokens,
     defaultTemperature: p.defaultTemperature,
   };


### PR DESCRIPTION
Refs #330.

## What

Each LLM provider's \`models\` array in the export is now trimmed to operator-state fields only. The synced catalog noise (\`displayName\`, \`firstSeenAt\`, \`lastSyncedAt\`) — refilled on demand by Sync against the upstream gateway — is no longer in the export.

Per-model operator flags (\`enabledForPlayground\`, \`enabledForSkillGen\`, \`defaultForPlayground\`, \`defaultForSkillGen\`, \`removed\`) stay. Provider container fields (gateway URL, auth, defaults) stay.

## Why

Per the conversation in #330: model list is derived data — operator clicks Sync to refresh from upstream. Carrying it through export bloats the file and drags a stale snapshot that the next-env importer (when implemented) would have to reconcile against the live catalog.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test\` — 522/522 pass (1 new test pinning the trim shape)
- [ ] CI green