### PR TITLE
[Bug] Settings export — drop provider 'models' field entirely

### DIFF
--- a/.changeset/export-drop-models-entirely.md
+++ b/.changeset/export-drop-models-entirely.md
@@ -1,0 +1,9 @@
+---
+"ornn-api": patch
+---
+
+Settings export now drops the `models` array from each LLM provider entry entirely. Previously trimmed to operator flags (#332); now removed. Model catalog is derived data — refreshed by Sync against the upstream gateway via /admin/settings/llm-providers — and doesn't belong in a portable settings export. Per-model flags ride out of band; re-set after Sync.
+
+Provider container fields (gateway URL, auth, defaults) stay in the export.
+
+Closes #335.

--- a/ornn-api/src/domains/settings/exportImport/exporter.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/exporter.test.ts
@@ -145,25 +145,18 @@ describe("SettingsExporter", () => {
     expect(playground.defaultProviderId).toBe("openai");
   });
 
-  it("UT-EXPORT-005: provider models keep operator flags but drop synced catalog fields (#330)", async () => {
+  it("UT-EXPORT-005: provider `models` field is NOT in the export (#330)", async () => {
     const exporter = new SettingsExporter({ settingsService: fakeSettingsService() });
     const env = await exporter.export();
     const providers = env.sections.llmProviders as Array<Record<string, unknown>>;
-    const models = providers[0]!.models as Array<Record<string, unknown>>;
-    expect(models).toHaveLength(1);
-    const m = models[0]!;
-    // Operator flags survive the export.
-    expect(m.id).toBe("gpt-4o");
-    expect(m.enabledForPlayground).toBe(true);
-    expect(m.enabledForSkillGen).toBe(true);
-    expect(m.defaultForPlayground).toBe(true);
-    expect(m.defaultForSkillGen).toBe(false);
-    expect(m.removed).toBe(false);
-    // Synced catalog noise is gone — refilled by /sync against the
-    // upstream gateway.
-    expect("displayName" in m).toBe(false);
-    expect("firstSeenAt" in m).toBe(false);
-    expect("lastSyncedAt" in m).toBe(false);
+    expect(providers).toHaveLength(1);
+    // Provider container stays — gateway URL, auth, defaults are
+    // operator-set config worth replicating across envs.
+    expect(providers[0]!.name).toBe("openai");
+    expect(providers[0]!.gatewayUrl).toBe("https://api.openai.com");
+    // Model catalog is derived data, refilled by Sync; entirely
+    // absent from the export.
+    expect("models" in providers[0]!).toBe(false);
   });
 
   it("UT-EXPORT-006: exportedAt is ISO-8601 UTC", async () => {

--- a/ornn-api/src/domains/settings/exportImport/exporter.ts
+++ b/ornn-api/src/domains/settings/exportImport/exporter.ts
@@ -93,20 +93,10 @@ function redactProviderSecrets(p: LlmProvider): Record<string, unknown> {
       auth[field] = redactSentinel(field);
     }
   }
-  // Trim each model entry to operator-set state only. The synced
-  // catalog fields (displayName, firstSeenAt, lastSyncedAt) are
-  // derived data — refilled by the next /sync against the upstream
-  // gateway — and don't belong in a portable export. The flags
-  // (enabledFor*, defaultFor*, removed) ARE operator state and stay.
+  // Models are NOT exported — the catalog is derived data, refreshed
+  // on demand by clicking Sync in /admin/settings/llm-providers.
+  // Per-model flags ride out of band — set them again after sync.
   // See #330.
-  const models = p.models.map((m) => ({
-    id: m.id,
-    enabledForPlayground: m.enabledForPlayground,
-    enabledForSkillGen: m.enabledForSkillGen,
-    defaultForPlayground: m.defaultForPlayground,
-    defaultForSkillGen: m.defaultForSkillGen,
-    removed: m.removed,
-  }));
   return {
     _id: p._id,
     name: p.name,
@@ -114,7 +104,6 @@ function redactProviderSecrets(p: LlmProvider): Record<string, unknown> {
     modelListUrl: p.modelListUrl,
     apiFormat: p.apiFormat,
     auth,
-    models,
     maxOutputTokens: p.maxOutputTokens,
     defaultTemperature: p.defaultTemperature,
   };


### PR DESCRIPTION
Closes #335.

## Summary

Drops the \`models\` array from each LLM provider's export entry entirely. #332 had trimmed it to operator flags; per #335 the intent is no models in the export at all — the catalog is derived data, refreshed by Sync. Provider container fields (gateway URL, auth, defaults) stay.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test\` — 522/522 pass (UT-EXPORT-005 retargeted)
- [ ] CI green