### PR TITLE
[Chore] i18n cleanup — drop forge/workshop voice + t()-ify ServiceDetail/AnnouncementsPage

### DIFF
--- a/.changeset/i18n-cleanup-pre-v060.md
+++ b/.changeset/i18n-cleanup-pre-v060.md
@@ -1,0 +1,15 @@
+---
+"ornn-web": patch
+---
+
+Pre-v0.6.0 i18n cleanup:
+
+- Drop workshop / forge / 工坊 brand voice from four keys still using it after the recent positioning change. New copy aligns with "the end-to-end skill life-cycle manager for AI agents":
+  - `login.tagline` — "Skill life-cycle for AI agents" / "面向 AI 代理的技能生命周期平台"
+  - `notFound.goHome` — "Return to home" / "返回首页"
+  - `landing.footer.tagline` — drops the "From the Chrono AI workshop" tail
+  - `contact.headlineHighlight` — "team" / "我们"
+- t()-ify `ServiceDetailPage` end-to-end. New `serviceDetail` i18n section covers status badges, action button, error/empty states, back nav, and all card headings.
+- t()-ify the three hardcoded strings in `AnnouncementsPage` empty state.
+
+Closes #339.

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -485,7 +485,7 @@
   },
   "login": {
     "eyebrow": "[ § ENTRY — NYXID ]",
-    "tagline": "The Forge for AI Capabilities",
+    "tagline": "Skill life-cycle for AI agents",
     "desc": "Sign in with your NyxID account to access the platform.",
     "loginBtn": "Login with NyxID",
     "terms": "By continuing, you agree to our Terms of Service and Privacy Policy."
@@ -494,7 +494,7 @@
     "eyebrow": "[ § 404 — NOT FOUND ]",
     "code": "404",
     "message": "This sector of the grid does not exist.",
-    "goHome": "Return to Forge"
+    "goHome": "Return to home"
   },
   "docs": {
     "onThisPage": "On this page",
@@ -649,7 +649,7 @@
       "alsoOnRegistry": "Also on the registry"
     },
     "footer": {
-      "tagline": "The end-to-end skill life-cycle manager for AI agents. From the Chrono AI workshop.",
+      "tagline": "The end-to-end skill life-cycle manager for AI agents.",
       "productHeading": "Product",
       "developersHeading": "Developers",
       "productBrowse": "Browse",
@@ -704,7 +704,7 @@
   "contact": {
     "eyebrow": "[ § 01 — CONTACT ]",
     "headlineStart": "Talk to the",
-    "headlineHighlight": "workshop",
+    "headlineHighlight": "team",
     "headlineEnd": ".",
     "subhead": "Questions, partnerships, or a skill you want to publish? Reach us through any of the channels below — we read everything.",
     "channelsLabel": "Contact channels",
@@ -713,5 +713,26 @@
     "cardGithubLabel": "GITHUB",
     "cardGithubHint": "File bugs, pull requests, and feature requests on the issue tracker.",
     "signoff": "[ END · CONTACT ]"
+  },
+  "serviceDetail": {
+    "failedToLoad": "Failed to load service: {{error}}",
+    "notFound": "Not found",
+    "back": "Back",
+    "backToMy": "Back to My Services",
+    "backToAdmin": "Back to Admin Services",
+    "statusActive": "active",
+    "statusInactive": "inactive",
+    "generateSkillBtn": "Generate Skill",
+    "proxyUrlHeading": "NyxID Proxy URL",
+    "openapiHeading": "OpenAPI Spec URL",
+    "openapiNotConfigured": "No OpenAPI spec configured",
+    "sourceCodeHeading": "Source Code",
+    "homepageHeading": "Homepage",
+    "notConfigured": "Not configured"
+  },
+  "announcementsAdmin": {
+    "noAnnouncements": "No announcements yet",
+    "emptyHint": "Create the first announcement and visitors will see it on their next landing-page load.",
+    "createBtn": "Create announcement"
   }
 }

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -485,7 +485,7 @@
   },
   "login": {
     "eyebrow": "[ § 入口 — NYXID ]",
-    "tagline": "锻造 AI 能力的工坊",
+    "tagline": "面向 AI 代理的技能生命周期平台",
     "desc": "使用 NyxID 账号登录以访问平台。",
     "loginBtn": "使用 NyxID 登录",
     "terms": "继续即表示你同意我们的服务条款和隐私政策。"
@@ -494,7 +494,7 @@
     "eyebrow": "[ § 404 — 未找到 ]",
     "code": "404",
     "message": "这片网格区域不存在。",
-    "goHome": "返回工坊"
+    "goHome": "返回首页"
   },
   "docs": {
     "onThisPage": "本页目录",
@@ -649,7 +649,7 @@
       "alsoOnRegistry": "注册中心其它技能"
     },
     "footer": {
-      "tagline": "为 AI 代理打造的技能全生命周期管理平台。来自 Chrono AI 工作室。",
+      "tagline": "为 AI 代理打造的技能全生命周期管理平台。",
       "productHeading": "产品",
       "developersHeading": "开发者",
       "productBrowse": "浏览",
@@ -704,7 +704,7 @@
   "contact": {
     "eyebrow": "[ § 01 — 联系 ]",
     "headlineStart": "联系",
-    "headlineHighlight": "工坊",
+    "headlineHighlight": "我们",
     "headlineEnd": "。",
     "subhead": "有问题、想合作，或想发布技能？通过下方任意一个渠道联系我们 —— 每一封都会读到。",
     "channelsLabel": "联系渠道",
@@ -713,5 +713,26 @@
     "cardGithubLabel": "GITHUB",
     "cardGithubHint": "在 issue 追踪器上提交 bug、Pull Request 与功能请求。",
     "signoff": "[ 完 · 联系 ]"
+  },
+  "serviceDetail": {
+    "failedToLoad": "加载服务失败: {{error}}",
+    "notFound": "未找到",
+    "back": "返回",
+    "backToMy": "返回我的服务",
+    "backToAdmin": "返回平台服务",
+    "statusActive": "活跃",
+    "statusInactive": "未启用",
+    "generateSkillBtn": "生成技能",
+    "proxyUrlHeading": "NyxID 代理 URL",
+    "openapiHeading": "OpenAPI 规范 URL",
+    "openapiNotConfigured": "未配置 OpenAPI 规范",
+    "sourceCodeHeading": "源代码",
+    "homepageHeading": "主页",
+    "notConfigured": "未配置"
+  },
+  "announcementsAdmin": {
+    "noAnnouncements": "暂无公告",
+    "emptyHint": "创建第一条公告后，访客下次加载落地页时就会看到。",
+    "createBtn": "创建公告"
   }
 }

--- a/ornn-web/src/pages/ServiceDetailPage.tsx
+++ b/ornn-web/src/pages/ServiceDetailPage.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useEffect } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
@@ -30,6 +31,7 @@ interface ServiceDetail {
 }
 
 export function ServiceDetailPage() {
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -91,8 +93,8 @@ export function ServiceDetailPage() {
     return (
       <PageTransition>
         <div className="py-4">
-          <p className="font-text text-sm text-danger">Failed to load service: {error ?? "Not found"}</p>
-          <Button variant="secondary" className="mt-4" onClick={() => navigate(-1)}>Back</Button>
+          <p className="font-text text-sm text-danger">{t("serviceDetail.failedToLoad", { error: error ?? t("serviceDetail.notFound") })}</p>
+          <Button variant="secondary" className="mt-4" onClick={() => navigate(-1)}>{t("serviceDetail.back")}</Button>
         </div>
       </PageTransition>
     );
@@ -108,7 +110,7 @@ export function ServiceDetailPage() {
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
           </svg>
-          Back to {source === "my" ? "My Services" : "Admin Services"}
+          {source === "my" ? t("serviceDetail.backToMy") : t("serviceDetail.backToAdmin")}
         </button>
 
         <div className="mb-6">
@@ -116,13 +118,13 @@ export function ServiceDetailPage() {
             <div className="flex items-center gap-3">
               <h1 className="font-display text-2xl tracking-wider text-strong">{service.name}</h1>
               <Badge color={service.isActive ? "green" : "muted"}>
-                {service.isActive ? "active" : "inactive"}
+                {service.isActive ? t("serviceDetail.statusActive") : t("serviceDetail.statusInactive")}
               </Badge>
               <Badge color="yellow">{service.serviceCategory}</Badge>
             </div>
             {isAdminUser && (
               <Button onClick={() => setShowGenerateModal(true)}>
-                Generate Skill
+                {t("serviceDetail.generateSkillBtn")}
               </Button>
             )}
           </div>
@@ -133,40 +135,40 @@ export function ServiceDetailPage() {
 
         <div className="space-y-4">
           <Card>
-            <h3 className="font-display text-[10px] font-700 tracking-widest uppercase text-meta mb-2">NyxID Proxy URL</h3>
+            <h3 className="font-display text-[10px] font-700 tracking-widest uppercase text-meta mb-2">{t("serviceDetail.proxyUrlHeading")}</h3>
             <p className="font-mono text-xs text-accent break-all">{service.proxyUrl}</p>
           </Card>
 
           <Card>
-            <h3 className="font-display text-[10px] font-700 tracking-widest uppercase text-meta mb-2">OpenAPI Spec URL</h3>
+            <h3 className="font-display text-[10px] font-700 tracking-widest uppercase text-meta mb-2">{t("serviceDetail.openapiHeading")}</h3>
             {service.openapiProxyUrl ? (
               <a href={service.openapiProxyUrl} target="_blank" rel="noopener noreferrer" className="font-mono text-xs text-accent hover:underline break-all">
                 {service.openapiProxyUrl}
               </a>
             ) : (
-              <p className="font-text text-xs text-meta italic">No OpenAPI spec configured</p>
+              <p className="font-text text-xs text-meta italic">{t("serviceDetail.openapiNotConfigured")}</p>
             )}
           </Card>
 
           <Card>
-            <h3 className="font-display text-[10px] font-700 tracking-widest uppercase text-meta mb-2">Source Code</h3>
+            <h3 className="font-display text-[10px] font-700 tracking-widest uppercase text-meta mb-2">{t("serviceDetail.sourceCodeHeading")}</h3>
             {service.repositoryUrl ? (
               <a href={service.repositoryUrl} target="_blank" rel="noopener noreferrer" className="font-mono text-xs text-accent hover:underline break-all">
                 {service.repositoryUrl}
               </a>
             ) : (
-              <p className="font-text text-xs text-meta italic">Not configured</p>
+              <p className="font-text text-xs text-meta italic">{t("serviceDetail.notConfigured")}</p>
             )}
           </Card>
 
           <Card>
-            <h3 className="font-display text-[10px] font-700 tracking-widest uppercase text-meta mb-2">Homepage</h3>
+            <h3 className="font-display text-[10px] font-700 tracking-widest uppercase text-meta mb-2">{t("serviceDetail.homepageHeading")}</h3>
             {service.homepageUrl ? (
               <a href={service.homepageUrl} target="_blank" rel="noopener noreferrer" className="font-mono text-xs text-accent hover:underline break-all">
                 {service.homepageUrl}
               </a>
             ) : (
-              <p className="font-text text-xs text-meta italic">Not configured</p>
+              <p className="font-text text-xs text-meta italic">{t("serviceDetail.notConfigured")}</p>
             )}
           </Card>
         </div>

--- a/ornn-web/src/pages/admin/AnnouncementsPage.tsx
+++ b/ornn-web/src/pages/admin/AnnouncementsPage.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
@@ -64,6 +65,7 @@ const TONE_STYLE: Record<
 };
 
 export function AnnouncementsPage() {
+  const { t } = useTranslation();
   const addToast = useToastStore((s) => s.addToast);
   const announcementsQuery = useAdminAnnouncements();
   const deleteMut = useDeleteAnnouncement();
@@ -151,13 +153,12 @@ export function AnnouncementsPage() {
           </div>
         ) : items.length === 0 ? (
           <div className="flex flex-col items-center gap-2 p-12 text-center">
-            <p className="font-display text-lg text-strong">No announcements yet</p>
+            <p className="font-display text-lg text-strong">{t("announcementsAdmin.noAnnouncements")}</p>
             <p className="max-w-md font-text text-sm text-meta">
-              Create the first announcement and visitors will see it on
-              their next landing-page load.
+              {t("announcementsAdmin.emptyHint")}
             </p>
             <Button variant="secondary" onClick={openCreate} className="mt-2">
-              Create announcement
+              {t("announcementsAdmin.createBtn")}
             </Button>
           </div>
         ) : (


### PR DESCRIPTION
Closes #339.

## Summary

Pre-v0.6.0 i18n review:

1. **Drop workshop / forge / 工坊 voice** from 4 user-facing keys that didn't migrate when we repositioned to \"end-to-end skill life-cycle manager\":
   - login.tagline · notFound.goHome · landing.footer.tagline · contact.headlineHighlight
2. **t()-ify ServiceDetailPage** — entire page was English-hardcoded; full pass with new \`serviceDetail\` i18n section.
3. **t()-ify AnnouncementsPage** empty-state — three strings.

## Out of scope (kept English)

- Legal pages — intentional, agreed English-only at launch.
- \`MirrorSetupHelp.tsx\` — multi-paragraph admin walkthrough about GitHub App registration. Real translation is a separate task; admin-only surface.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test\` — 80/80 pass
- [ ] CI green
- [ ] After deploy + hard reload: contact H1 reads \"Talk to the team.\", login subtitle drops \"Forge\", 404 button says \"Return to home\", footer tagline ends at \"...for AI agents.\", flipping to zh on ServiceDetailPage renders Chinese.