### PR TITLE
feat(web): replace browser-native confirm() with Ornn ConfirmDialog (#359)

### DIFF
--- a/.changeset/confirm-dialog-replace-native-confirm.md
+++ b/.changeset/confirm-dialog-replace-native-confirm.md
@@ -1,0 +1,12 @@
+---
+"ornn-web": patch
+---
+
+Replace browser-native `window.confirm()` prompts with the new `ConfirmDialog` Ornn primitive so destructive-action confirmations stay inside the Forge Workshop vocabulary (card-impression surface, hairline border, Space Grotesk title, spring entry, ESC + backdrop dismissal). Two admin callsites updated:
+
+- `/admin/announcements` delete announcement
+- `/admin/redemption-codes` invalidate redemption code
+
+`ConfirmDialog` lives at `components/ui/ConfirmDialog.tsx`, layered on top of the existing `Modal`. Declarative props (`isOpen` / `onClose` / `onConfirm` / `title` / `description` / `confirmLabel` / `cancelLabel` / `variant` / `isLoading`); the mutation lives outside, the dialog only orchestrates the UI. Also adds ESC-key dismissal to the underlying `Modal` primitive so every modal in the app — not just confirms — closes on ESC for parity with the native dialog it replaced.
+
+Closes #359.

--- a/ornn-web/src/components/ui/ConfirmDialog.tsx
+++ b/ornn-web/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,96 @@
+/**
+ * ConfirmDialog — Forge Workshop replacement for `window.confirm()`.
+ *
+ * Drop-in for any "are you sure?" gating. Built on top of the `Modal`
+ * primitive so it inherits the backdrop fade, spring entry,
+ * `card-impression` letterpress surface, hairline border, ESC + backdrop
+ * dismissal, and Space Grotesk display title — i.e., the same popup
+ * vocabulary the rest of the app uses. The browser-native confirm
+ * dialog ("…says…" + OS-rendered buttons) is explicitly NOT used
+ * anywhere in the platform.
+ *
+ * Declarative, not imperative: callers track a `pendingX` state for the
+ * row awaiting confirmation, render the dialog with `isOpen={pending !==
+ * null}`, and clear that state on confirm / cancel. The mutation runs
+ * inside `onConfirm`; pass `isLoading` while it's in flight to disable
+ * Cancel and put a spinner on the Confirm button. The dialog itself
+ * never owns the mutation — keeping it stateless means it nests cleanly
+ * inside whatever loading / error orchestration the page already has
+ * (toast store, React Query, etc.).
+ *
+ * @module components/ui/ConfirmDialog
+ */
+
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+
+export interface ConfirmDialogProps {
+  isOpen: boolean;
+  /** Fires on Cancel button, backdrop click, and ESC. */
+  onClose: () => void;
+  /** Fires on the Confirm button. Cleared by the caller. */
+  onConfirm: () => void;
+  /** Display heading — short noun phrase ("Delete announcement?"). */
+  title: string;
+  /** Body text under the title. Plain string or rich node. */
+  description?: ReactNode;
+  /** Override the Confirm button label. Defaults to `common.confirm`. */
+  confirmLabel?: string;
+  /** Override the Cancel button label. Defaults to `common.cancel`. */
+  cancelLabel?: string;
+  /**
+   * Confirm-button color. `"danger"` paints the danger token (destructive
+   * actions: delete, invalidate). `"primary"` paints ember accent
+   * (constructive: publish, send).
+   */
+  variant?: "primary" | "danger";
+  /**
+   * When `true`, Confirm shows a spinner and Cancel is disabled. The
+   * dialog can still be dismissed via ESC / backdrop — the in-flight
+   * mutation continues independently and the calling page surfaces the
+   * outcome via toast.
+   */
+  isLoading?: boolean;
+}
+
+export function ConfirmDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  variant = "primary",
+  isLoading = false,
+}: ConfirmDialogProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      {description !== undefined && description !== null && (
+        <div className="font-text text-[15px] leading-relaxed text-body">
+          {description}
+        </div>
+      )}
+      <div className="mt-6 flex flex-wrap items-center justify-end gap-3">
+        <Button
+          variant="secondary"
+          onClick={onClose}
+          disabled={isLoading}
+        >
+          {cancelLabel ?? t("common.cancel")}
+        </Button>
+        <Button
+          variant={variant}
+          onClick={onConfirm}
+          loading={isLoading}
+        >
+          {confirmLabel ?? t("common.confirm")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/ornn-web/src/components/ui/Modal.tsx
+++ b/ornn-web/src/components/ui/Modal.tsx
@@ -5,12 +5,16 @@
  * with a hairline border and a hard-offset letterpress impression
  * (no soft drop shadow per DESIGN.md). Title uses Space Grotesk display.
  *
+ * Closes on backdrop click + ESC key. Modal callers all expect onClose
+ * to fire on either dismissal vector, so wiring ESC at the primitive
+ * level fixes the parity gap with native dialogs once and for free.
+ *
  * @module components/ui/Modal
  */
 
 import { motion, AnimatePresence } from "framer-motion";
 import { createPortal } from "react-dom";
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 
 export interface ModalProps {
   isOpen: boolean;
@@ -21,6 +25,15 @@ export interface ModalProps {
 }
 
 export function Modal({ isOpen, onClose, title, children, className = "" }: ModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
   return createPortal(
     <AnimatePresence>
       {isOpen && (

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -2,6 +2,7 @@
   "common": {
     "save": "Save",
     "cancel": "Cancel",
+    "confirm": "Confirm",
     "delete": "Delete",
     "edit": "Edit",
     "back": "Back",
@@ -871,7 +872,8 @@
         "always": "Always (no schedule)"
       },
       "confirm": {
-        "delete": "Delete announcement \"{{title}}\"?"
+        "deleteTitle": "Delete announcement?",
+        "delete": "\"{{title}}\" will be removed permanently."
       },
       "toast": {
         "disabled": "Announcement disabled",
@@ -946,7 +948,9 @@
         "status": "Status"
       },
       "confirm": {
-        "invalidate": "Invalidate code {{code}}? It will no longer be redeemable."
+        "invalidateTitle": "Invalidate redemption code?",
+        "invalidate": "{{code}} will no longer be redeemable.",
+        "invalidateAction": "Invalidate"
       },
       "toast": {
         "invalidated": "Code {{code}} invalidated.",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -2,6 +2,7 @@
   "common": {
     "save": "保存",
     "cancel": "取消",
+    "confirm": "确认",
     "delete": "删除",
     "edit": "编辑",
     "back": "返回",
@@ -871,7 +872,8 @@
         "always": "始终（未设置排期）"
       },
       "confirm": {
-        "delete": "删除公告\"{{title}}\"？"
+        "deleteTitle": "删除公告？",
+        "delete": "\"{{title}}\" 将被永久移除。"
       },
       "toast": {
         "disabled": "公告已停用",
@@ -946,7 +948,9 @@
         "status": "状态"
       },
       "confirm": {
-        "invalidate": "作废兑换码 {{code}}？作废后将无法再被兑换。"
+        "invalidateTitle": "作废兑换码？",
+        "invalidate": "{{code}} 作废后将无法再被兑换。",
+        "invalidateAction": "作废"
       },
       "toast": {
         "invalidated": "兑换码 {{code}} 已作废。",

--- a/ornn-web/src/pages/admin/AnnouncementsPage.tsx
+++ b/ornn-web/src/pages/admin/AnnouncementsPage.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useToastStore } from "@/stores/toastStore";
 import { AnnouncementEditDrawer } from "@/components/admin/announcements/AnnouncementEditDrawer";
@@ -81,6 +82,7 @@ export function AnnouncementsPage() {
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editing, setEditing] = useState<AdminAnnouncement | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<AdminAnnouncement | null>(null);
 
   const openCreate = () => {
     setEditing(null);
@@ -114,19 +116,23 @@ export function AnnouncementsPage() {
     );
   };
 
-  const onDelete = (a: AdminAnnouncement) => {
-    if (!confirm(t("adminPages.announcements.confirm.delete", { title: a.title }))) return;
-    deleteMut.mutate(a.id, {
-      onSuccess: () =>
-        addToast({ type: "success", message: t("adminPages.announcements.toast.deleted") }),
-      onError: (err) =>
+  const onConfirmDelete = () => {
+    if (!pendingDelete) return;
+    deleteMut.mutate(pendingDelete.id, {
+      onSuccess: () => {
+        addToast({ type: "success", message: t("adminPages.announcements.toast.deleted") });
+        setPendingDelete(null);
+      },
+      onError: (err) => {
         addToast({
           type: "error",
           message: translateError(
             err,
             t("adminPages.announcements.toast.deleteFailed"),
           ),
-        }),
+        });
+        setPendingDelete(null);
+      },
     });
   };
 
@@ -244,7 +250,7 @@ export function AnnouncementsPage() {
                         <Button
                           variant="danger"
                           size="sm"
-                          onClick={() => onDelete(a)}
+                          onClick={() => setPendingDelete(a)}
                           disabled={deleteMut.isPending}
                         >
                           {t("common.delete")}
@@ -263,6 +269,19 @@ export function AnnouncementsPage() {
         isOpen={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         announcement={editing}
+      />
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== null}
+        onClose={() => setPendingDelete(null)}
+        onConfirm={onConfirmDelete}
+        title={t("adminPages.announcements.confirm.deleteTitle")}
+        description={t("adminPages.announcements.confirm.delete", {
+          title: pendingDelete?.title ?? "",
+        })}
+        confirmLabel={t("common.delete")}
+        variant="danger"
+        isLoading={deleteMut.isPending}
       />
     </motion.div>
   );

--- a/ornn-web/src/pages/admin/RedemptionCodesPage.tsx
+++ b/ornn-web/src/pages/admin/RedemptionCodesPage.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Pagination } from "@/components/ui/Pagination";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useToastStore } from "@/stores/toastStore";
@@ -53,6 +54,9 @@ export function RedemptionCodesPage() {
 
   const [mintOpen, setMintOpen] = useState(false);
   const [drawerCode, setDrawerCode] = useState<RedemptionCode | null>(null);
+  const [pendingInvalidate, setPendingInvalidate] = useState<RedemptionCode | null>(
+    null,
+  );
   const [pendingInvalidateId, setPendingInvalidateId] = useState<string | null>(
     null,
   );
@@ -75,11 +79,13 @@ export function RedemptionCodesPage() {
     setPage(1);
   };
 
-  const onInvalidate = async (code: RedemptionCode) => {
-    const ok = window.confirm(
-      t("adminPages.redemption.confirm.invalidate", { code: code.code }),
-    );
-    if (!ok) return;
+  const onInvalidate = (code: RedemptionCode) => {
+    setPendingInvalidate(code);
+  };
+
+  const onConfirmInvalidate = async () => {
+    const code = pendingInvalidate;
+    if (!code) return;
     setPendingInvalidateId(code.id);
     try {
       await invalidateCode.mutateAsync(code.id);
@@ -97,6 +103,7 @@ export function RedemptionCodesPage() {
       });
     } finally {
       setPendingInvalidateId(null);
+      setPendingInvalidate(null);
     }
   };
 
@@ -189,6 +196,19 @@ export function RedemptionCodesPage() {
         isOpen={drawerCode !== null}
         onClose={() => setDrawerCode(null)}
         code={drawerCode}
+      />
+
+      <ConfirmDialog
+        isOpen={pendingInvalidate !== null}
+        onClose={() => setPendingInvalidate(null)}
+        onConfirm={onConfirmInvalidate}
+        title={t("adminPages.redemption.confirm.invalidateTitle")}
+        description={t("adminPages.redemption.confirm.invalidate", {
+          code: pendingInvalidate?.code ?? "",
+        })}
+        confirmLabel={t("adminPages.redemption.confirm.invalidateAction")}
+        variant="danger"
+        isLoading={pendingInvalidateId !== null}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Two admin actions today fall through to `window.confirm()` — the browser-native prompt that reads "ornn.ornn-cluster.local says…" with stock OS buttons — instead of using Ornn's own popup vocabulary. This PR introduces a `ConfirmDialog` primitive and migrates both callsites onto it so destructive confirmations stay inside the Forge Workshop design language.

**Before** (`/admin/announcements` → Delete):
> ornn.ornn-cluster.local says
> 删除公告"Testtesttest"?
> [Cancel] [OK]

**After:** card-impression dialog with hairline border, Space Grotesk Bold title, spring entry, danger-variant Confirm button, ESC + backdrop + Cancel dismissal — same vocabulary the rest of the app already uses.

## Audit recap

Full `confirm()` / `alert()` / `prompt()` sweep across `ornn-web/src`:

| File | Line | Call | Fate |
|---|---|---|---|
| `pages/admin/AnnouncementsPage.tsx` | 118 | `confirm(...)` (delete) | migrated |
| `pages/admin/RedemptionCodesPage.tsx` | 79 | `window.confirm(...)` (invalidate) | migrated |
| `components/skill/DownloadButton.tsx` | 13 | `window.open(...)` (file download) | legit, untouched |

No `<dialog>` HTML elements, no `Notification` API, no custom `show*()` wrappers. Post-merge, zero browser-native modal entry points remain.

## Surfaces

**New `ConfirmDialog`** at `ornn-web/src/components/ui/ConfirmDialog.tsx`, layered on top of the existing `Modal`. Declarative:
```tsx
<ConfirmDialog
  isOpen={pending !== null}
  onClose={() => setPending(null)}
  onConfirm={onConfirmDelete}
  title="Delete announcement?"
  description="\"Foo\" will be removed permanently."
  confirmLabel="Delete"
  variant="danger"
  isLoading={mutation.isPending}
/>
```

**`Modal` ESC support** added at the same time — the parity gap with `window.confirm` (ESC = cancel) was the same gap every existing Modal consumer hit, so wiring ESC at the primitive level fixes it once across the board. Existing consumers already expect `onClose` to fire on dismissal; no behavior change for them, they just get ESC for free.

**i18n** — split the existing question strings in `en.json` + `zh.json` into a `*.confirm.*Title` (display heading) + `*.confirm.<verb>` (description body) pair. Added `common.confirm` for the generic Confirm button label.

## Commits (stacked in dependency order)

1. `feat(web): add ConfirmDialog primitive + ESC support on Modal`
2. `feat(web): swap window.confirm for ConfirmDialog in admin pages`
3. `docs: changeset for ConfirmDialog migration`

## Test plan

- [x] `rg 'confirm\(' ornn-web/src` returns only the new docstring reference — zero callsites
- [x] `bunx eslint <touched files>` clean
- [x] `bunx tsc --noEmit -p ornn-web/tsconfig.json` clean
- [x] `bun run test:web` — 80/80 pass
- [x] `bun run build:web` — production bundle builds
- [ ] CI `lint` / `typecheck` / `test` / `build` / `docker-build` / `check-changeset` all green
- [ ] Manual smoke (post-merge): admin → `/admin/announcements` → Delete → confirm dialog renders in Forge vocabulary; ESC dismisses; Confirm with `variant="danger"` runs the mutation and toast shows on settle. Same for `/admin/redemption-codes` → Invalidate.

Closes #359.