### PR TITLE
fix(web): close i18n + nav coverage gaps (Redeem code, Dashboard, LandingNav News) (#361)

### DIFF
--- a/.changeset/i18n-and-nav-coverage.md
+++ b/.changeset/i18n-and-nav-coverage.md
@@ -1,0 +1,11 @@
+---
+"ornn-web": patch
+---
+
+Close three i18n / nav coverage gaps that landed under the radar:
+
+- **`nav.redeemCode` key was missing in both `en.json` and `zh.json`** — Navbar dropdown used `t("nav.redeemCode", "Redeem code")` with a fallback, so the English string was rendered to every locale. Added the key in both languages (`Redeem code` / `兑换码`).
+- **Admin Dashboard was 100% hardcoded English.** `pages/admin/DashboardPage.tsx` + `components/admin/RecentActivities.tsx` had zero `useTranslation` calls. Both now wire to a new `adminPages.dashboard.*` i18n block covering heading, subtitle, the two section headings, all six tile labels + helpers, aria labels, the PostHog body / not-configured warning, and the Activity feed + Insights link labels. Skill-visibility code identifiers (`isSystemSkill: true`, `!isPrivate ∧ !isSystemSkill`, `isPrivate: true`) stay verbatim across locales — they're code, not natural language.
+- **LandingNav had no `/news` entry.** PR #358 only added News to the app-shell `Navbar` (RootLayout), so anonymous visitors landing on `/` saw only Registry / Build / Docs / Contact. Added News between Docs and Contact in both the desktop nav row and the mobile hamburger panel, reusing the existing `nav.news` i18n key.
+
+Closes #361.

--- a/ornn-web/src/components/admin/RecentActivities.tsx
+++ b/ornn-web/src/components/admin/RecentActivities.tsx
@@ -11,6 +11,7 @@
  */
 
 import { motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
 import { Card } from "@/components/ui/Card";
 import {
   isPostHogConfigured,
@@ -19,6 +20,7 @@ import {
 } from "@/lib/postHogLinks";
 
 export function RecentActivities() {
+  const { t } = useTranslation();
   const configured = isPostHogConfigured();
   const activityUrl = postHogActivityUrl();
   const insightsUrl = postHogInsightsUrl();
@@ -32,21 +34,17 @@ export function RecentActivities() {
       <Card>
         <header className="mb-4 flex items-center justify-between">
           <h2 className="font-display text-lg font-semibold uppercase tracking-tight text-strong">
-            Recent activity
+            {t("adminPages.dashboard.recentActivity.heading")}
           </h2>
         </header>
 
         <p className="font-text text-sm leading-relaxed text-body">
-          Audit + activity events live in PostHog. Every API request,
-          login, skill mutation, and admin action is captured there as
-          a typed event with caller, source IP, status, and timing —
-          searchable, filterable, and pivotable into funnels.
+          {t("adminPages.dashboard.recentActivity.body")}
         </p>
 
         {!configured && (
           <p className="mt-3 font-mono text-[11px] text-meta">
-            PostHog isn't configured yet — set it up under Settings →
-            Telemetry.
+            {t("adminPages.dashboard.recentActivity.notConfigured")}
           </p>
         )}
 
@@ -57,7 +55,7 @@ export function RecentActivities() {
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-sm border border-strong-edge bg-card px-3 py-1.5 font-mono text-[11px] font-semibold uppercase tracking-[0.12em] text-strong hover:border-accent"
           >
-            Activity feed ↗
+            {t("adminPages.dashboard.recentActivity.activityFeed")} ↗
           </a>
           <a
             href={insightsUrl}
@@ -65,7 +63,7 @@ export function RecentActivities() {
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-sm border border-strong-edge bg-card px-3 py-1.5 font-mono text-[11px] font-semibold uppercase tracking-[0.12em] text-strong hover:border-accent"
           >
-            Insights ↗
+            {t("adminPages.dashboard.recentActivity.insights")} ↗
           </a>
         </div>
       </Card>

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -41,6 +41,7 @@
     "signOut": "Sign Out",
     "settings": "Settings",
     "adminPanel": "Admin Panel",
+    "redeemCode": "Redeem code",
     "goToNyxId": "Go to NyxID",
     "createSkill": "Create Skill",
     "lightMode": "Light Mode",
@@ -846,6 +847,33 @@
     "startTyping": "Start typing..."
   },
   "adminPages": {
+    "dashboard": {
+      "heading": "Dashboard",
+      "subtitle": "Platform snapshot — user breakdown, skill visibility partition, and the latest 10 activities.",
+      "loadFailed": "Failed to load stats",
+      "users": {
+        "heading": "Users",
+        "ariaLabel": "Users overview",
+        "total": "Total users",
+        "admin": "Admin users",
+        "normal": "Normal users",
+        "bypassQuota": "Bypass quota"
+      },
+      "skills": {
+        "heading": "Skills",
+        "ariaLabel": "Skills overview",
+        "system": "System skills",
+        "public": "Public skills",
+        "private": "Private skills"
+      },
+      "recentActivity": {
+        "heading": "Recent activity",
+        "body": "Audit + activity events live in PostHog. Every API request, login, skill mutation, and admin action is captured there as a typed event with caller, source IP, status, and timing — searchable, filterable, and pivotable into funnels.",
+        "notConfigured": "PostHog isn't configured yet — set it up under Settings → Telemetry.",
+        "activityFeed": "Activity feed",
+        "insights": "Insights"
+      }
+    },
     "announcements": {
       "eyebrow": "[§ ADMIN — ANNOUNCEMENTS]",
       "title": "Landing page popup",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -41,6 +41,7 @@
     "signOut": "退出",
     "settings": "设置",
     "adminPanel": "管理面板",
+    "redeemCode": "兑换码",
     "goToNyxId": "前往 NyxID",
     "createSkill": "创建技能",
     "lightMode": "浅色模式",
@@ -846,6 +847,33 @@
     "startTyping": "开始输入..."
   },
   "adminPages": {
+    "dashboard": {
+      "heading": "仪表盘",
+      "subtitle": "平台快照 —— 用户分布、技能可见性划分,以及最近 10 条活动。",
+      "loadFailed": "加载统计失败",
+      "users": {
+        "heading": "用户",
+        "ariaLabel": "用户概览",
+        "total": "用户总数",
+        "admin": "管理员",
+        "normal": "普通用户",
+        "bypassQuota": "不计配额"
+      },
+      "skills": {
+        "heading": "技能",
+        "ariaLabel": "技能概览",
+        "system": "系统技能",
+        "public": "公开技能",
+        "private": "私有技能"
+      },
+      "recentActivity": {
+        "heading": "近期活动",
+        "body": "审计与活动事件统一记录在 PostHog。每一次 API 调用、登录、技能变更和管理员操作都会被记录为带有调用者、来源 IP、状态与耗时的结构化事件,可搜索、可筛选、可聚合成漏斗分析。",
+        "notConfigured": "PostHog 尚未配置 —— 请在「设置 → 遥测」中完成配置。",
+        "activityFeed": "活动信息流",
+        "insights": "洞察"
+      }
+    },
     "announcements": {
       "eyebrow": "[§ 管理 — 公告]",
       "title": "落地页弹窗",

--- a/ornn-web/src/pages/admin/DashboardPage.tsx
+++ b/ornn-web/src/pages/admin/DashboardPage.tsx
@@ -11,12 +11,14 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { DashboardTile } from "@/components/admin/DashboardTile";
 import { RecentActivities } from "@/components/admin/RecentActivities";
 import { fetchDashboardStats } from "@/services/adminDashboardApi";
 import { translateError } from "@/utils/translateError";
 
 export function DashboardPage() {
+  const { t } = useTranslation();
   const stats = useQuery({
     queryKey: ["admin", "dashboard", "stats"] as const,
     queryFn: fetchDashboardStats,
@@ -24,33 +26,38 @@ export function DashboardPage() {
   });
 
   const errorMsg = stats.error
-    ? translateError(stats.error, "Failed to load stats")
+    ? translateError(stats.error, t("adminPages.dashboard.loadFailed"))
     : null;
 
   const data = stats.data;
+
+  // Skill-visibility helper labels are code identifiers, not natural
+  // language — kept verbatim across locales on purpose.
+  const SKILL_PREDICATE_SYSTEM = "isSystemSkill: true";
+  const SKILL_PREDICATE_PUBLIC = "!isPrivate ∧ !isSystemSkill";
+  const SKILL_PREDICATE_PRIVATE = "isPrivate: true";
 
   return (
     <div className="space-y-8">
       <header>
         <h1 className="font-display text-2xl font-bold uppercase tracking-tight text-strong">
-          Dashboard
+          {t("adminPages.dashboard.heading")}
         </h1>
         <p className="mt-1 font-text text-meta">
-          Platform snapshot — user breakdown, skill visibility partition,
-          and the latest 10 activities.
+          {t("adminPages.dashboard.subtitle")}
         </p>
       </header>
 
       <section
-        aria-label="Users overview"
+        aria-label={t("adminPages.dashboard.users.ariaLabel")}
         className="space-y-3"
       >
         <h2 className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
-          Users
+          {t("adminPages.dashboard.users.heading")}
         </h2>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <DashboardTile
-            label="Total users"
+            label={t("adminPages.dashboard.users.total")}
             value={data?.users.total}
             tone="accent"
             isLoading={stats.isLoading}
@@ -58,16 +65,16 @@ export function DashboardPage() {
             delay={0}
           />
           <DashboardTile
-            label="Admin users"
+            label={t("adminPages.dashboard.users.admin")}
             value={data?.users.admin}
             tone="support"
-            helper="Bypass quota"
+            helper={t("adminPages.dashboard.users.bypassQuota")}
             isLoading={stats.isLoading}
             errorMessage={errorMsg}
             delay={0.05}
           />
           <DashboardTile
-            label="Normal users"
+            label={t("adminPages.dashboard.users.normal")}
             value={data?.users.normal}
             tone="neutral"
             isLoading={stats.isLoading}
@@ -78,36 +85,36 @@ export function DashboardPage() {
       </section>
 
       <section
-        aria-label="Skills overview"
+        aria-label={t("adminPages.dashboard.skills.ariaLabel")}
         className="space-y-3"
       >
         <h2 className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
-          Skills
+          {t("adminPages.dashboard.skills.heading")}
         </h2>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <DashboardTile
-            label="System skills"
+            label={t("adminPages.dashboard.skills.system")}
             value={data?.skills.system}
             tone="accent"
-            helper="isSystemSkill: true"
+            helper={SKILL_PREDICATE_SYSTEM}
             isLoading={stats.isLoading}
             errorMessage={errorMsg}
             delay={0.15}
           />
           <DashboardTile
-            label="Public skills"
+            label={t("adminPages.dashboard.skills.public")}
             value={data?.skills.public}
             tone="support"
-            helper="!isPrivate ∧ !isSystemSkill"
+            helper={SKILL_PREDICATE_PUBLIC}
             isLoading={stats.isLoading}
             errorMessage={errorMsg}
             delay={0.2}
           />
           <DashboardTile
-            label="Private skills"
+            label={t("adminPages.dashboard.skills.private")}
             value={data?.skills.private}
             tone="neutral"
-            helper="isPrivate: true"
+            helper={SKILL_PREDICATE_PRIVATE}
             isLoading={stats.isLoading}
             errorMessage={errorMsg}
             delay={0.25}

--- a/ornn-web/src/pages/landing/LandingNav.tsx
+++ b/ornn-web/src/pages/landing/LandingNav.tsx
@@ -196,6 +196,21 @@ export function LandingNav() {
             )}
           </Link>
           <Link
+            to="/news"
+            aria-current={isNavActive("/news") ? "page" : undefined}
+            className={`focus-ring-ember transition-colors duration-150 ${
+              isNavActive("/news")
+                ? "font-semibold text-parchment"
+                : "hover:text-ember"
+            }`}
+          >
+            {isNavActive("/news") ? (
+              <HighlighterMark className="highlighter-mark--loose">{t("nav.news")}</HighlighterMark>
+            ) : (
+              t("nav.news")
+            )}
+          </Link>
+          <Link
             to="/contact"
             aria-current={isNavActive("/contact") ? "page" : undefined}
             className={`focus-ring-ember transition-colors duration-150 ${
@@ -506,6 +521,23 @@ export function LandingNav() {
                 <HighlighterMark className="highlighter-mark--loose">{t("nav.docs")}</HighlighterMark>
               ) : (
                 t("nav.docs")
+              )}
+            </Link>
+            <Link
+              to="/news"
+              onClick={closeMenu}
+              tabIndex={menuOpen ? 0 : -1}
+              aria-current={isNavActive("/news") ? "page" : undefined}
+              className={`focus-ring-ember border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] transition-colors ${
+                isNavActive("/news")
+                  ? "font-semibold text-parchment"
+                  : "text-bone hover:text-ember"
+              }`}
+            >
+              {isNavActive("/news") ? (
+                <HighlighterMark className="highlighter-mark--loose">{t("nav.news")}</HighlighterMark>
+              ) : (
+                t("nav.news")
               )}
             </Link>
             <Link


### PR DESCRIPTION
## Summary

Three small but visible coverage gaps surfaced after PR #358 / #360:

1. **Redeem code dropdown item never localized** — `nav.redeemCode` key was missing from both `en.json` + `zh.json`; the Navbar fallback string ("Redeem code") shipped to every locale.
2. **Admin Dashboard had zero i18n** — `pages/admin/DashboardPage.tsx` + `components/admin/RecentActivities.tsx` had no `useTranslation` calls. Result: `zh` users saw English chrome on a Chinese-localized navbar (the screenshot in #361).
3. **LandingNav lacked /news** — PR #358 only added News to the app-shell `Navbar`; anonymous visitors on `/` saw Registry / Build / Docs / Contact, with no path to the announcement archive.

## Commits

Stacked so each compiles + tests pass independently:

1. `fix(web): add missing nav.redeemCode i18n + adminPages.dashboard.* keys` — pure i18n adds in en.json + zh.json so the next two commits have keys to land on
2. `feat(web): localize admin Dashboard + RecentActivities` — wire `useTranslation()`; every visible string now reads through the new `adminPages.dashboard.*` block. Skill-visibility code identifiers (`isSystemSkill: true`, `!isPrivate ∧ !isSystemSkill`, `isPrivate: true`) extracted to module-scope constants and left verbatim across locales — they're code, not natural language.
3. `feat(web): add /news entry to LandingNav desktop + mobile` — adds Link blocks in both the desktop md+ row and the mobile hamburger panel between Docs and Contact, mirroring the app-shell Navbar ordering. Reuses the existing `nav.news` key from #358.
4. `docs: changeset`

## Test plan

- [x] No hardcoded English residue in `DashboardPage.tsx` / `RecentActivities.tsx` (regex sweep clean)
- [x] `bunx tsc --noEmit -p ornn-web/tsconfig.json` clean
- [x] `bunx eslint <touched files>` — 0 errors
- [x] `bun run test:web` — 80/80 pass
- [x] `bun run build:web` — production bundle builds
- [x] `en.json` + `zh.json` both valid JSON
- [ ] CI all green
- [ ] Manual smoke (post-merge):
  - Switch to `zh` → user dropdown shows **兑换码** between 管理面板 and 退出
  - `/admin/dashboard` renders 100% in active locale (English ↔ Chinese) except the three code identifiers
  - `/` landing nav shows **5** entries: Registry / Build / Docs / News / Contact; mobile hamburger shows the same

Closes #361.