### PR TITLE
refactor(web): extract shared lib/userMenu so Navbar + LandingNav can't drift (#363)

### DIFF
--- a/.changeset/shared-user-menu.md
+++ b/.changeset/shared-user-menu.md
@@ -1,0 +1,11 @@
+---
+"ornn-web": patch
+---
+
+Extract the signed-in avatar-dropdown content into a shared `lib/userMenu` module so the app-shell `Navbar` and landing `LandingNav` can't drift apart again.
+
+Both navs used to hand-maintain identical item lists (profile / services / orgs / redeem code / NyxID / admin section / signout). Over time LandingNav fell behind: it was missing **Redeem code** and **Admin services** on desktop, and its mobile hamburger was even sparser (profile + admin + signout only). The shape mirrored the previous `/news` drift fixed in #361 — two surfaces, two hand-maintained copies, divergence by drift.
+
+`lib/userMenu.ts` now exports `getNyxIdUrl()` (was duplicated verbatim in both navs) plus a `useUserMenuGroups(user)` hook returning a typed, i18n-resolved, admin-gated list of grouped items. Each surface renders the items with its own wrapper components — `Navbar` keeps `text-body` / `hover:bg-elevated` / `hover:text-accent`, `LandingNav` keeps `text-bone` / `hover:bg-surface-elevated` / `hover:text-ember` — but the **content** lives in one place. Renaming, reordering, or gating an item is now a single-file edit that lands on both surfaces in the same commit; divergence becomes a TS error instead of a visual one. Both desktop dropdowns AND mobile hamburger menus now render the full item list on every surface.
+
+Closes #363.

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -19,26 +19,13 @@
 import { useState, useRef, useEffect } from "react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useAuthStore, useIsAuthenticated, useCurrentUser, isAdmin } from "@/stores/authStore";
+import { useAuthStore, useIsAuthenticated, useCurrentUser } from "@/stores/authStore";
 import { useThemeStore } from "@/stores/themeStore";
 import { logActivity } from "@/services/activityApi";
 import { Logo } from "@/components/brand/Logo";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { HighlighterMark } from "@/pages/landing/HighlighterMark";
-import { config } from "@/config";
-
-function getNyxIdUrl(): string {
-  try {
-    const authorizeUrl = config.nyxidOauthAuthorizeUrl;
-    if (authorizeUrl) {
-      const url = new URL(authorizeUrl);
-      return url.origin;
-    }
-  } catch {
-    /* ignore */
-  }
-  return "https://nyx.chrono-ai.fun"; // allow-hardcode legacy fallback; runtime config supplies the real value
-}
+import { useUserMenuGroups, type UserMenuItem } from "@/lib/userMenu";
 
 function GitHubIcon({ className }: { className?: string }) {
   return (
@@ -127,10 +114,102 @@ export function Navbar({ className = "" }: NavbarProps) {
   const { theme, toggle: toggleTheme } = useThemeStore();
   const isAuthenticated = useIsAuthenticated();
   const user = useCurrentUser();
+  const userMenuGroups = useUserMenuGroups(user);
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Render one dropdown row in the desktop avatar menu. Each kind maps
+   * to its surface-styled wrapper (DropdownExternal / DropdownInternal)
+   * or to the inline ember-toned logout button. The item descriptors
+   * come from `useUserMenuGroups` — see lib/userMenu.ts for the
+   * single-source-of-truth rationale.
+   */
+  function renderDesktopItem(
+    item: UserMenuItem,
+    closeMenu: () => void,
+    onLogout: () => void | Promise<void>,
+  ) {
+    if (item.kind === "external" && item.href) {
+      return (
+        <DropdownExternal key={item.key} href={item.href}>
+          {item.label}
+        </DropdownExternal>
+      );
+    }
+    if (item.kind === "internal" && item.to) {
+      return (
+        <DropdownInternal key={item.key} to={item.to} onClick={closeMenu}>
+          {item.label}
+        </DropdownInternal>
+      );
+    }
+    // logout
+    return (
+      <button
+        key={item.key}
+        type="button"
+        onClick={onLogout}
+        className="flex w-full items-center px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.14em] text-accent transition-colors hover:bg-elevated"
+      >
+        {item.label}
+      </button>
+    );
+  }
+
+  /**
+   * Render one row inside the mobile hamburger panel. Same items as
+   * the desktop dropdown, different styling: border-b separators
+   * between rows, larger Inter body type, no group-level borders.
+   * The logout row uses the same ember mono treatment as in desktop
+   * but without the border-b (it's the last item).
+   */
+  function renderMobileItem(item: UserMenuItem, closeMenu: () => void) {
+    const itemRowClass =
+      "border-b border-subtle py-3 font-text text-[16px] text-body transition-colors hover:text-accent";
+    if (item.kind === "external" && item.href) {
+      return (
+        <a
+          key={item.key}
+          href={item.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={closeMenu}
+          tabIndex={menuOpen ? 0 : -1}
+          className={itemRowClass}
+        >
+          {item.label}
+        </a>
+      );
+    }
+    if (item.kind === "internal" && item.to) {
+      return (
+        <Link
+          key={item.key}
+          to={item.to}
+          onClick={closeMenu}
+          tabIndex={menuOpen ? 0 : -1}
+          className={itemRowClass}
+        >
+          {item.label}
+        </Link>
+      );
+    }
+    // logout
+    return (
+      <button
+        key={item.key}
+        type="button"
+        onClick={handleLogout}
+        tabIndex={menuOpen ? 0 : -1}
+        className="py-3 text-left font-mono text-[12px] uppercase tracking-[0.14em] text-accent transition-colors hover:text-accent-muted"
+      >
+        {item.label}
+      </button>
+    );
+  }
 
   // Close avatar dropdown on outside click + ESC
   useEffect(() => {
@@ -294,44 +373,16 @@ export function Navbar({ className = "" }: NavbarProps) {
                     <p className="truncate font-mono text-[11px] text-meta">{user.email}</p>
                   </div>
 
-                  <div className="py-1">
-                    <DropdownExternal href={`${getNyxIdUrl()}/settings`}>
-                      {t("nav.myProfile", "My Profile")}
-                    </DropdownExternal>
-                    <DropdownExternal href={`${getNyxIdUrl()}/services`}>
-                      {t("nav.myServices", "My NyxID Services")}
-                    </DropdownExternal>
-                    <DropdownExternal href={`${getNyxIdUrl()}/orgs`}>
-                      {t("nav.myOrgs", "My Organizations")}
-                    </DropdownExternal>
-                    <DropdownInternal to="/settings" onClick={() => setUserMenuOpen(false)}>
-                      {t("nav.redeemCode", "Redeem code")}
-                    </DropdownInternal>
-                    <DropdownExternal href={getNyxIdUrl()}>
-                      {t("nav.goToNyxId")}
-                    </DropdownExternal>
-                  </div>
-
-                  {isAdmin(user) && (
-                    <div className="border-t border-subtle py-1">
-                      <DropdownInternal to="/admin" onClick={() => setUserMenuOpen(false)}>
-                        {t("nav.adminPanel")}
-                      </DropdownInternal>
-                      <DropdownExternal href={`${getNyxIdUrl()}/admin/services`}>
-                        {t("nav.adminServices", "Admin NyxID Services")}
-                      </DropdownExternal>
-                    </div>
-                  )}
-
-                  <div className="border-t border-subtle py-1">
-                    <button
-                      type="button"
-                      onClick={handleLogout}
-                      className="flex w-full items-center px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.14em] text-accent transition-colors hover:bg-elevated"
+                  {userMenuGroups.map((group, i) => (
+                    <div
+                      key={group.id}
+                      className={`py-1 ${i > 0 ? "border-t border-subtle" : ""}`}
                     >
-                      {t("nav.signOut")}
-                    </button>
-                  </div>
+                      {group.items.map((item) =>
+                        renderDesktopItem(item, () => setUserMenuOpen(false), handleLogout),
+                      )}
+                    </div>
+                  ))}
                 </div>
               )}
             </div>
@@ -449,42 +500,9 @@ export function Navbar({ className = "" }: NavbarProps) {
                     <p className="truncate font-mono text-[11px] text-meta">{user.email}</p>
                   </div>
                 </div>
-                <a
-                  href={`${getNyxIdUrl()}/settings`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={closeMenu}
-                  tabIndex={menuOpen ? 0 : -1}
-                  className="border-b border-subtle py-3 font-text text-[16px] text-body transition-colors hover:text-accent"
-                >
-                  {t("nav.myProfile", "My Profile")}
-                </a>
-                <Link
-                  to="/settings"
-                  onClick={closeMenu}
-                  tabIndex={menuOpen ? 0 : -1}
-                  className="border-b border-subtle py-3 font-text text-[16px] text-body transition-colors hover:text-accent"
-                >
-                  {t("nav.redeemCode", "Redeem code")}
-                </Link>
-                {isAdmin(user) && (
-                  <Link
-                    to="/admin"
-                    onClick={closeMenu}
-                    tabIndex={menuOpen ? 0 : -1}
-                    className="border-b border-subtle py-3 font-text text-[16px] text-body transition-colors hover:text-accent"
-                  >
-                    {t("nav.adminPanel")}
-                  </Link>
-                )}
-                <button
-                  type="button"
-                  onClick={handleLogout}
-                  tabIndex={menuOpen ? 0 : -1}
-                  className="py-3 text-left font-mono text-[12px] uppercase tracking-[0.14em] text-accent transition-colors hover:text-accent-muted"
-                >
-                  {t("nav.signOut")}
-                </button>
+                {userMenuGroups
+                  .flatMap((g) => g.items)
+                  .map((item) => renderMobileItem(item, closeMenu))}
               </>
             ) : (
               <Link

--- a/ornn-web/src/lib/userMenu.ts
+++ b/ornn-web/src/lib/userMenu.ts
@@ -1,0 +1,149 @@
+/**
+ * Single source of truth for the signed-in avatar dropdown content.
+ *
+ * The dropdown ships on two surfaces — the app-shell `Navbar` (used in
+ * RootLayout) and the landing-page `LandingNav` (used only on `/`).
+ * Historically each surface hand-maintained its own item list, which
+ * drifted: LandingNav was missing `Redeem code` and `Admin services`;
+ * both surfaces' mobile menus were sparser than their own desktop
+ * dropdowns. See #363 (and #361 for the i18n drift that surfaced first).
+ *
+ * This module flips the data-flow: the *items* live here, typed and
+ * i18n-resolved and admin-gated; each surface renders them with its
+ * own wrapper components so the per-surface design tokens
+ * (`text-bone`/`hover:text-ember` for landing; `text-body`/
+ * `hover:text-accent` for app-shell) stay intact. Adding or renaming
+ * an item now touches a single file and lands on both surfaces in the
+ * same commit; divergence becomes a TS error rather than a visual one.
+ *
+ * `getNyxIdUrl()` is also exported from here because both navs were
+ * carrying verbatim copies.
+ *
+ * @module lib/userMenu
+ */
+
+import { useTranslation } from "react-i18next";
+import { config } from "@/config";
+import { isAdmin } from "@/stores/authStore";
+import type { AuthUser } from "@/types/auth";
+
+/** Derive the NyxID portal origin from the runtime authorize URL. */
+export function getNyxIdUrl(): string {
+  try {
+    const authorizeUrl = config.nyxidOauthAuthorizeUrl;
+    if (authorizeUrl) {
+      return new URL(authorizeUrl).origin;
+    }
+  } catch {
+    /* ignore — fall through to the legacy default below */
+  }
+  return "https://nyx.chrono-ai.fun"; // allow-hardcode legacy fallback; runtime config supplies the real value
+}
+
+export type UserMenuItemKind = "external" | "internal" | "logout";
+
+export interface UserMenuItem {
+  /** Stable React key. */
+  readonly key: string;
+  readonly kind: UserMenuItemKind;
+  /** Already-localized label. */
+  readonly label: string;
+  /** Set when `kind === "external"`. Opens via target=_blank. */
+  readonly href?: string;
+  /** Set when `kind === "internal"`. In-app router path. */
+  readonly to?: string;
+}
+
+export type UserMenuGroupId = "main" | "admin" | "logout";
+
+export interface UserMenuGroup {
+  readonly id: UserMenuGroupId;
+  readonly items: readonly UserMenuItem[];
+}
+
+/**
+ * Returns the dropdown content for the currently signed-in user, or
+ * an empty array when anonymous. Groups carry an `id` so the consumer
+ * can draw separators between them (the first group has no top border;
+ * each subsequent group is rendered with a hairline divider above).
+ *
+ * The hook is intentionally tiny — pure derivation on top of
+ * `useTranslation` and the passed-in user. No side effects, no
+ * subscriptions; safe to call in any nav component.
+ */
+export function useUserMenuGroups(user: AuthUser | null): UserMenuGroup[] {
+  const { t } = useTranslation();
+  if (!user) return [];
+  const nyxid = getNyxIdUrl();
+
+  const main: UserMenuGroup = {
+    id: "main",
+    items: [
+      {
+        key: "profile",
+        kind: "external",
+        href: `${nyxid}/settings`,
+        label: t("nav.myProfile"),
+      },
+      {
+        key: "services",
+        kind: "external",
+        href: `${nyxid}/services`,
+        label: t("nav.myServices"),
+      },
+      {
+        key: "orgs",
+        kind: "external",
+        href: `${nyxid}/orgs`,
+        label: t("nav.myOrgs"),
+      },
+      {
+        key: "redeem",
+        kind: "internal",
+        to: "/settings",
+        label: t("nav.redeemCode"),
+      },
+      {
+        key: "nyxid",
+        kind: "external",
+        href: nyxid,
+        label: t("nav.goToNyxId"),
+      },
+    ],
+  };
+
+  const groups: UserMenuGroup[] = [main];
+
+  if (isAdmin(user)) {
+    groups.push({
+      id: "admin",
+      items: [
+        {
+          key: "admin-panel",
+          kind: "internal",
+          to: "/admin",
+          label: t("nav.adminPanel"),
+        },
+        {
+          key: "admin-services",
+          kind: "external",
+          href: `${nyxid}/admin/services`,
+          label: t("nav.adminServices"),
+        },
+      ],
+    });
+  }
+
+  groups.push({
+    id: "logout",
+    items: [
+      {
+        key: "logout",
+        kind: "logout",
+        label: t("nav.signOut"),
+      },
+    ],
+  });
+
+  return groups;
+}

--- a/ornn-web/src/pages/landing/LandingNav.tsx
+++ b/ornn-web/src/pages/landing/LandingNav.tsx
@@ -3,27 +3,13 @@ import { Link, useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { useThemeStore } from "@/stores/themeStore";
-import { useAuthStore, useIsAuthenticated, useCurrentUser, isAdmin } from "@/stores/authStore";
+import { useAuthStore, useIsAuthenticated, useCurrentUser } from "@/stores/authStore";
 import { logActivity } from "@/services/activityApi";
-import { config } from "@/config";
+import { useUserMenuGroups, type UserMenuItem } from "@/lib/userMenu";
 import { Logo } from "@/components/brand/Logo";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { EmberLink } from "./EmberButton";
 import { HighlighterMark } from "./HighlighterMark";
-
-/** Derive NyxID home URL from the authorize URL env var. */
-function getNyxIdUrl(): string {
-  try {
-    const authorizeUrl = config.nyxidOauthAuthorizeUrl;
-    if (authorizeUrl) {
-      const url = new URL(authorizeUrl);
-      return url.origin;
-    }
-  } catch {
-    /* ignore */
-  }
-  return "https://nyx.chrono-ai.fun"; // allow-hardcode legacy fallback; runtime config supplies the real value
-}
 
 /**
  * One row inside the desktop avatar dropdown — opens an external URL
@@ -102,6 +88,7 @@ export function LandingNav() {
 
   const isAuthenticated = useIsAuthenticated();
   const user = useCurrentUser();
+  const userMenuGroups = useUserMenuGroups(user);
 
   // Avatar dropdown — mirrors `Navbar.tsx`'s desktop user-menu but
   // restyled in landing tokens. Closes on outside click + ESC.
@@ -133,6 +120,93 @@ export function LandingNav() {
   };
 
   const initial = (user?.displayName || user?.email || "?").charAt(0).toUpperCase();
+
+  /**
+   * Render one row of the desktop avatar dropdown. Each kind maps to
+   * its landing-styled wrapper (DropdownExternal / DropdownInternal
+   * bind to bone/ember/surface-elevated tokens for the dark landing
+   * surface), or to the ember-toned logout button. Items come from
+   * `useUserMenuGroups` — see lib/userMenu.ts.
+   */
+  function renderDesktopItem(item: UserMenuItem) {
+    if (item.kind === "external" && item.href) {
+      return (
+        <DropdownExternal key={item.key} href={item.href}>
+          {item.label}
+        </DropdownExternal>
+      );
+    }
+    if (item.kind === "internal" && item.to) {
+      return (
+        <DropdownInternal key={item.key} to={item.to} onClick={() => setUserMenuOpen(false)}>
+          {item.label}
+        </DropdownInternal>
+      );
+    }
+    // logout
+    return (
+      <button
+        key={item.key}
+        type="button"
+        onClick={handleLogout}
+        className="flex w-full items-center px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.14em] text-ember transition-colors hover:bg-[color:var(--surface-elevated)]"
+      >
+        {item.label}
+      </button>
+    );
+  }
+
+  /**
+   * Render one row inside the mobile hamburger panel. Larger Inter
+   * body type, border-b separators, bone fill / ember hover — same
+   * Landing tokens as the desktop dropdown's wrappers, just at mobile
+   * scale. Logout uses the same ember mono treatment minus the
+   * border-b (it's the trailing row).
+   */
+  function renderMobileItem(item: UserMenuItem) {
+    const itemRowClass =
+      "border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] text-bone transition-colors hover:text-ember";
+    if (item.kind === "external" && item.href) {
+      return (
+        <a
+          key={item.key}
+          href={item.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={closeMenu}
+          tabIndex={menuOpen ? 0 : -1}
+          className={itemRowClass}
+        >
+          {item.label}
+        </a>
+      );
+    }
+    if (item.kind === "internal" && item.to) {
+      return (
+        <Link
+          key={item.key}
+          to={item.to}
+          onClick={closeMenu}
+          tabIndex={menuOpen ? 0 : -1}
+          className={itemRowClass}
+        >
+          {item.label}
+        </Link>
+      );
+    }
+    // logout
+    return (
+      <button
+        key={item.key}
+        type="button"
+        onClick={handleLogout}
+        tabIndex={menuOpen ? 0 : -1}
+        className="flex items-center justify-start py-3 font-mono text-[12px] uppercase tracking-[0.14em] text-ember transition-colors hover:text-parchment"
+      >
+        {item.label}
+      </button>
+    );
+  }
 
   return (
     <nav className="sticky top-0 z-50 border-b border-[color:var(--color-border-subtle)] [background-color:var(--surface-nav)] backdrop-blur-md">
@@ -354,41 +428,14 @@ export function LandingNav() {
                       <p className="truncate font-mono text-[11px] text-bone">{user.email}</p>
                     </div>
 
-                    {/* Per-user external links — open the user's NyxID
-                        portal in a new tab so the landing surface stays
-                        focused on Ornn. */}
-                    <div className="py-1">
-                      <DropdownExternal href={`${getNyxIdUrl()}/settings`}>
-                        {t("nav.myProfile", "My Profile")}
-                      </DropdownExternal>
-                      <DropdownExternal href={`${getNyxIdUrl()}/services`}>
-                        {t("nav.myServices", "My NyxID Services")}
-                      </DropdownExternal>
-                      <DropdownExternal href={`${getNyxIdUrl()}/orgs`}>
-                        {t("nav.myOrgs", "My Organizations")}
-                      </DropdownExternal>
-                      <DropdownExternal href={getNyxIdUrl()}>
-                        {t("nav.goToNyxId")}
-                      </DropdownExternal>
-                    </div>
-
-                    {isAdmin(user) && (
-                      <div className="border-t border-[color:var(--color-border-subtle)] py-1">
-                        <DropdownInternal to="/admin" onClick={() => setUserMenuOpen(false)}>
-                          {t("nav.adminPanel")}
-                        </DropdownInternal>
-                      </div>
-                    )}
-
-                    <div className="border-t border-[color:var(--color-border-subtle)] py-1">
-                      <button
-                        type="button"
-                        onClick={handleLogout}
-                        className="flex w-full items-center px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.14em] text-ember transition-colors hover:bg-[color:var(--surface-elevated)]"
+                    {userMenuGroups.map((group, i) => (
+                      <div
+                        key={group.id}
+                        className={`py-1 ${i > 0 ? "border-t border-[color:var(--color-border-subtle)]" : ""}`}
                       >
-                        {t("nav.signOut")}
-                      </button>
-                    </div>
+                        {group.items.map((item) => renderDesktopItem(item))}
+                      </div>
+                    ))}
                   </motion.div>
                 )}
               </AnimatePresence>
@@ -621,34 +668,9 @@ export function LandingNav() {
                     <p className="truncate font-mono text-[11px] text-bone">{user.email}</p>
                   </div>
                 </div>
-                <a
-                  href={`${getNyxIdUrl()}/settings`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={closeMenu}
-                  tabIndex={menuOpen ? 0 : -1}
-                  className="border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] text-bone transition-colors hover:text-ember"
-                >
-                  {t("nav.myProfile", "My Profile")}
-                </a>
-                {isAdmin(user) && (
-                  <Link
-                    to="/admin"
-                    onClick={closeMenu}
-                    tabIndex={menuOpen ? 0 : -1}
-                    className="border-b border-[color:var(--color-border-subtle)] py-3 font-text text-[16px] text-bone transition-colors hover:text-ember"
-                  >
-                    {t("nav.adminPanel")}
-                  </Link>
-                )}
-                <button
-                  type="button"
-                  onClick={handleLogout}
-                  tabIndex={menuOpen ? 0 : -1}
-                  className="flex items-center justify-start py-3 font-mono text-[12px] uppercase tracking-[0.14em] text-ember transition-colors hover:text-parchment"
-                >
-                  {t("nav.signOut")}
-                </button>
+                {userMenuGroups
+                  .flatMap((g) => g.items)
+                  .map((item) => renderMobileItem(item))}
               </>
             ) : (
               <>


### PR DESCRIPTION
## Summary

The signed-in avatar dropdown was implemented twice — once in `components/layout/Navbar.tsx` (app-shell) and once in `pages/landing/LandingNav.tsx` (landing). Both surfaces hand-maintained identical item lists and a verbatim copy of `getNyxIdUrl`, which drifted over time:

| Item | Gate | Navbar | LandingNav (before) | LandingNav (after) |
|---|---|---|---|---|
| Profile / Services / Orgs / NyxID | signed in | ✅ | ✅ | ✅ |
| **Redeem code** | signed in | ✅ | ❌ | ✅ |
| Admin Panel | isAdmin | ✅ | ✅ | ✅ |
| **Admin services** | isAdmin | ✅ | ❌ | ✅ |
| Sign out | signed in | ✅ | ✅ | ✅ |

Plus both navs' mobile hamburgers were sparser than their own desktop dropdowns — Navbar mobile only had Profile + Redeem code + Admin Panel + Sign out; LandingNav mobile had Profile + Admin Panel + Sign out. Mobile drift on top of cross-surface drift.

Same drift class as the `/news` entry fix in #361. Patching the items by hand each time doesn't address the root cause: two surfaces own two copies of the same data.

## Fix

Flip the data-flow. The **items** live in `lib/userMenu.ts` now; each surface renders them with its own surface-styled wrappers.

- **`lib/userMenu.ts`** exports `getNyxIdUrl()`, the `UserMenuItem` / `UserMenuGroup` types, and a `useUserMenuGroups(user)` hook. Pure derivation on top of `useTranslation` + the passed-in user; returns a typed, i18n-resolved, admin-gated, grouped list. No subscriptions, no side effects.
- **`Navbar.tsx`** drops its inline `getNyxIdUrl` + item lists. Two small per-file renderer helpers (`renderDesktopItem` / `renderMobileItem`) switch on `item.kind` and apply the workshop-surface tokens (`text-body` / `hover:bg-elevated` / `hover:text-accent`). The existing `DropdownExternal` / `DropdownInternal` wrappers stay — they encode the desktop styling.
- **`LandingNav.tsx`** does the same with landing tokens (`text-bone` / `hover:bg-surface-elevated` / `hover:text-ember`). Mobile hamburger gets the full item list it was missing.

The visual difference between the landing dark surface and the app-shell workshop surface is **intentional and preserved** — only the *content* is shared, not the styling.

## Commits (stacked in dependency order)

1. `feat(web): add shared lib/userMenu hook + getNyxIdUrl`
2. `refactor(web): consume useUserMenuGroups in app-shell Navbar`
3. `refactor(web): consume useUserMenuGroups in LandingNav`
4. `docs: changeset`

## Test plan

- [x] `bunx tsc --noEmit -p ornn-web/tsconfig.json` clean
- [x] `bunx eslint <touched files>` — 0 errors (one pre-existing warning in Navbar:235 setState-in-effect, unchanged)
- [x] `bun run test:web` — 80/80 pass (incl. RT-HARDCODE-SWEEP-WEB regression test, which required the `// allow-hardcode` opt-out to remain on the same line as the legacy fallback URL)
- [x] `bun run build:web` — production bundle builds
- [ ] CI: lint / typecheck / test / build / docker-build / check-changeset / gitleaks / python-sdk-test / check-approval — all green
- [ ] Manual smoke (post-merge):
  - On `/` (landing): user dropdown shows the full 8-item list (Profile / Services / Orgs / Redeem code / NyxID / Admin Panel / Admin services / Sign out) — was 6 before
  - On `/registry` (app-shell): same dropdown structure (cross-surface parity)
  - Mobile hamburger on both surfaces: same full item list as desktop
  - Per-surface styling preserved: landing renders against dark bg-page with bone/ember hover; app-shell renders against workshop card with body/accent hover

Closes #363.