### PR TITLE
docs: rewrite README around agent-developer onboarding (#369)

### DIFF
--- a/.changeset/readme-agent-onboarding.md
+++ b/.changeset/readme-agent-onboarding.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs-only — rewrite the README around the agent-developer onboarding flow: trim hero logo, drop the redundant `<h1>`, prune the contributor-facing Packages / Tech Stack / Architecture sections, and add a three-step **How to use Ornn** section explaining how any agent runtime plugs in via the ChronoAI core service skill + `nyxid` CLI. No package version bump.
+
+Closes #369.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Closest analog: **npm registry + npm CLI fused, model-agnostic** — works for C
 
 `ornn-web` is a secondary surface for skill owners and platform admins; it is not the primary product.
 
+## How to use Ornn
+
+Ornn is model-agnostic — any AI agent runtime (Claude, GPT, Gemini, or a custom in-house stack) can connect and consume the full skill-lifecycle API. Three steps to bring an agent online:
+
+1. **Install the ChronoAI core service skill into the agent.** This is the bootstrap skill — it introduces Ornn to the agent and drives the rest of the setup.
+2. **Let the agent provision the NyxID CLI.** On first run, the core skill instructs the agent to install `nyxid` — the CLI that brokers every Ornn request and response with proper authentication and authorization. The agent follows the skill's setup procedure end-to-end; no manual operator steps required.
+3. **Start the conversation.** Once `nyxid` is configured in the agent's environment, ask it to search, install, run, build, or publish Ornn skills. The agent learns the end-to-end lifecycle — `search → pull → install → execute → build → upload → share` — through the same API it just connected to.
+
 ## Documentation
 
 Full documentation lives at [ornn.chrono-ai.fun/docs](https://ornn.chrono-ai.fun/docs).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="ornn-web/public/logo-dark.svg">
-    <img src="ornn-web/public/logo-light.svg" width="320" alt="Ornn" />
+    <img src="ornn-web/public/logo-light.svg" width="200" alt="Ornn" />
   </picture>
 </p>
-
-<h1 align="center">Ornn</h1>
 
 <p align="center">
   <a href="https://github.com/ChronoAIProject/Ornn/actions/workflows/ci.yml"><img src="https://github.com/ChronoAIProject/Ornn/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>

--- a/README.md
+++ b/README.md
@@ -29,31 +29,6 @@ Closest analog: **npm registry + npm CLI fused, model-agnostic** — works for C
 
 `ornn-web` is a secondary surface for skill owners and platform admins; it is not the primary product.
 
-## Packages
-
-| Package | Path | Description |
-|---------|------|-------------|
-| `ornn-api` | [`ornn-api/`](ornn-api/) | Backend API (Bun + Hono + MongoDB) |
-| `ornn-web` | [`ornn-web/`](ornn-web/) | React SPA (Vite + React 19 + Zustand + TanStack Query) |
-| `@chronoai/ornn-sdk` | [`sdk/typescript/`](sdk/typescript/) | TypeScript client for `/api/v1/*` |
-| `ornn-sdk` (Python) | [`sdk/python/`](sdk/python/) | Python client for `/api/v1/*` (httpx) — separate release cadence |
-
-## Tech Stack
-
-- **Language / runtime:** TypeScript on Bun (workspace monorepo); Vite for the frontend dev / build.
-- **Backend:** Hono on Bun.
-- **Frontend:** React 19, Zustand, TanStack Query, Tailwind CSS 4, Framer Motion, React Router 7.
-- **Database:** MongoDB 7.
-- **Validation:** Zod.
-- **Logging:** Pino.
-- **Tests:** Bun test (backend); Vitest + Testing Library + jsdom (frontend + TS SDK); pytest + respx (Python SDK).
-
-## Architecture
-
-Two packages — `ornn-api` (backend) and `ornn-web` (web UI). All configurable values come from environment variables; no hardcoded config.
-
-See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for external services, skill format, and the observability pipeline.
-
 ## Documentation
 
 Full documentation lives at [ornn.chrono-ai.fun/docs](https://ornn.chrono-ai.fun/docs).


### PR DESCRIPTION
## Summary

Reshape the README from a contributor / repo-explorer doc to an agent-developer onboarding doc. The previous structure led with a 320px logo + duplicate `<h1>Ornn</h1>` and then dove into Packages / Tech Stack / Architecture — all of which serve someone setting up the repo, not someone plugging their AI agent into Ornn. The actual three-step setup ("install the core skill, provision nyxid, start the conversation") was missing entirely.

## Changes

- **Hero trim** — logo `width="320"` → `width="200"`, dropped the redundant `<h1>Ornn</h1>` (the wordmark already says it).
- **Pruned contributor sections** — removed Packages, Tech Stack, Architecture. All three are already covered: `docs/ARCHITECTURE.md` for architecture; per-package `package.json` for stack details; `CLAUDE.md` for repo navigation.
- **New `How to use Ornn`** section between `What is Ornn` and `Documentation`. Three numbered steps in the same declarative em-dash tone as the intro:
  1. Install the ChronoAI core service skill into the agent
  2. Let the agent provision the `nyxid` CLI (the auth/authz broker; the core skill walks the agent through install end-to-end)
  3. Start the conversation — ask the agent to search / install / run / build / publish; it learns the lifecycle through the same API it just connected to

Net README is now: hero → tagline → What is Ornn → How to use Ornn → Documentation → License. Same reading flow an agent developer needs in order.

## Commits

1. `docs: shrink README hero logo to 200px + drop redundant H1 title`
2. `docs: prune Packages / Tech Stack / Architecture from README`
3. `docs: add How to use Ornn agent-onboarding section`
4. `docs: empty changeset for README rewrite`

## Test plan

- [x] `head -40 README.md` reads cleanly — hero, badges, tagline, intro, onboarding all in order
- [x] Light + dark logo variants still resolve correctly (no path change from #365)
- [ ] CI all green (lint / typecheck / test / build / docker-build / **check-changeset** / gitleaks / python-sdk-test / check-approval). check-changeset is the one this PR is most likely to interact with — an empty changeset is the documented form for docs-only PRs.
- [ ] Manual smoke: view the PR diff on GitHub web in both light and dark mode → README renders the new structure without theme regression.

Closes #369.