### PR TITLE
feat(web): i18n the PostHog cookie-consent banner

### DIFF
--- a/.changeset/posthog-consent-banner-i18n.md
+++ b/.changeset/posthog-consent-banner-i18n.md
@@ -1,0 +1,7 @@
+---
+"ornn-web": patch
+---
+
+frontend: i18n the PostHog cookie-consent banner.
+
+The GDPR analytics-consent banner (`CookieConsentBanner`) was hardcoded in English. Pulled every visible string — the `[ § ANALYTICS — CONSENT ]` stamp, the title, the body (with inline PostHog + Privacy Policy links), and the Accept / Decline buttons — out into a new `cookieConsent.*` block in `i18n/en.json` and `i18n/zh.json`. The body uses `<Trans>` with named `postHogLink` / `privacyLink` component slots so the link anchors stay translation-friendly without splitting the sentence into glued fragments. zh visitors now see the banner in Chinese; switching language via the existing `ornn-lang` toggle re-renders it live.

--- a/ornn-web/src/components/analytics/CookieConsentBanner.tsx
+++ b/ornn-web/src/components/analytics/CookieConsentBanner.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { Trans, useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/Button";
 import {
   isUndecided,
@@ -26,6 +27,7 @@ import {
 } from "@/lib/cookieConsent";
 
 export function CookieConsentBanner() {
+  const { t } = useTranslation();
   // Hydrate from localStorage on mount so SSR-style snapshots don't
   // briefly flash the banner for users who already decided.
   const [visible, setVisible] = useState<boolean>(false);
@@ -58,33 +60,34 @@ export function CookieConsentBanner() {
         <div className="flex flex-col gap-4">
           <div className="min-w-0">
             <p className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-meta">
-              [ § ANALYTICS — CONSENT ]
+              {t("cookieConsent.stamp")}
             </p>
             <h2
               id="cookie-consent-title"
               className="mb-1 font-display text-base font-semibold tracking-tight text-strong"
             >
-              We use cookies for product analytics.
+              {t("cookieConsent.title")}
             </h2>
             <p className="font-text text-sm leading-relaxed text-body">
-              Ornn uses{" "}
-              <a
-                href="https://posthog.com/eu"
-                target="_blank"
-                rel="noreferrer noopener"
-                className="text-accent underline-offset-2 hover:underline"
-              >
-                PostHog (EU)
-              </a>{" "}
-              to measure feature usage and improve the platform. Session
-              replay is sampled with input fields masked. See our{" "}
-              <Link
-                to="/legal/privacy"
-                className="text-accent underline-offset-2 hover:underline"
-              >
-                Privacy Policy
-              </Link>{" "}
-              for details. You can change your choice anytime in settings.
+              <Trans
+                i18nKey="cookieConsent.body"
+                components={{
+                  postHogLink: (
+                    <a
+                      href="https://posthog.com/eu"
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="text-accent underline-offset-2 hover:underline"
+                    />
+                  ),
+                  privacyLink: (
+                    <Link
+                      to="/legal/privacy"
+                      className="text-accent underline-offset-2 hover:underline"
+                    />
+                  ),
+                }}
+              />
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-3">
@@ -94,7 +97,7 @@ export function CookieConsentBanner() {
               onClick={decline}
               className="min-w-[96px]"
             >
-              Decline
+              {t("cookieConsent.decline")}
             </Button>
             <Button
               variant="primary"
@@ -102,7 +105,7 @@ export function CookieConsentBanner() {
               onClick={accept}
               className="min-w-[96px]"
             >
-              Accept
+              {t("cookieConsent.accept")}
             </Button>
           </div>
         </div>

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -273,6 +273,13 @@
     "totalPulls": "Total",
     "noUsage": "No usage in this range."
   },
+  "cookieConsent": {
+    "stamp": "[ § ANALYTICS — CONSENT ]",
+    "title": "We use cookies for product analytics.",
+    "body": "Ornn uses <postHogLink>PostHog (EU)</postHogLink> to measure feature usage and improve the platform. Session replay is sampled with input fields masked. See our <privacyLink>Privacy Policy</privacyLink> for details. You can change your choice anytime in settings.",
+    "decline": "Decline",
+    "accept": "Accept"
+  },
   "versionDiff": {
     "openButton": "Compare versions",
     "title": "Compare versions",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -273,6 +273,13 @@
     "totalPulls": "总计",
     "noUsage": "此区间内没有使用记录。"
   },
+  "cookieConsent": {
+    "stamp": "[ § 产品分析 — 同意 ]",
+    "title": "我们使用 Cookie 进行产品分析。",
+    "body": "Ornn 使用 <postHogLink>PostHog（欧盟）</postHogLink> 来衡量功能使用情况并改进平台。会话回放会按比例采样，且输入字段会被遮盖。详情请见我们的<privacyLink>隐私政策</privacyLink>。你可以随时在设置中更改你的选择。",
+    "decline": "拒绝",
+    "accept": "接受"
+  },
   "versionDiff": {
     "openButton": "对比版本",
     "title": "对比版本",


### PR DESCRIPTION
Closes #373.

## Summary

The GDPR analytics-consent banner (`CookieConsentBanner`) was the last user-facing surface in `ornn-web` still hardcoded in English, so zh visitors got a Chinese app with one English banner pinned to the bottom-right. Pulled every visible string out into a new `cookieConsent.*` block in `i18n/en.json` + `zh.json`, and routed the component through `useTranslation` / `<Trans>`.

## Changes

- `ornn-web/src/i18n/en.json` + `zh.json` — new `cookieConsent` block: `stamp`, `title`, `body`, `decline`, `accept`. Full parity, zh covers the mono stamp too (`[ § 产品分析 — 同意 ]`).
- `ornn-web/src/components/analytics/CookieConsentBanner.tsx` — uses `useTranslation()` for the stamp / title / buttons. The body, which has two inline anchors (`https://posthog.com/eu` and the `/legal/privacy` `Link`), uses `<Trans i18nKey="cookieConsent.body" components={{ postHogLink, privacyLink }} />` so the sentence stays one cohesive block per locale instead of being glued from fragments.
- `.changeset/posthog-consent-banner-i18n.md` — patch bump for `ornn-web`.

## Test plan

- [x] `bun run lint` (tsc --noEmit) — clean.
- [x] `bun run test` — 80/80 passing across both packages.
- [ ] Manual: load app in zh, banner reads in Chinese; switch to en via toggle, banner re-renders to English live; both anchors still navigate (PostHog opens in a new tab, Privacy Policy routes in-app).

## Out of scope

- Translating legal pages (Privacy / ToS / AUP) — English-only at launch per #320.
- Adding locales beyond en / zh.


---
_Generated by [Claude Code](https://claude.ai/code/session_013JbmYq6rPqwkHnXu5JHNhK)_