### PR TITLE
chore(repo): OSS repo-health setup — community files, issue/PR templates, expanded README

### DIFF
--- a/.changeset/oss-repo-health-setup.md
+++ b/.changeset/oss-repo-health-setup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Repo-health setup: SECURITY, CODE_OF_CONDUCT, CONTRIBUTING, SUPPORT, issue forms, PR template, expanded README. No code changes; no version bump.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report something that is broken in Ornn.
+title: "[Bug] "
+labels: ["bug"]
+assignees: ["chronoai-shining"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the sections below so we can reproduce and triage quickly.
+
+        If this might be a security issue, **stop** and use [Private Vulnerability Reporting](https://github.com/ChronoAIProject/Ornn/security/advisories/new) instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: "When I call POST /api/v1/skills/foo, the response is 500 instead of 200."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, copy-pasteable steps. Include the request payload if relevant.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit SHA
+      description: The release tag (e.g. v0.9.3) or commit SHA where you observed this.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface?
+      multiple: true
+      options:
+        - ornn-api (backend)
+        - ornn-web (frontend)
+        - deployment / infra
+        - documentation
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Paste any relevant logs. Redact secrets.
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Environment details, related issues, anything else useful.

--- a/.github/ISSUE_TEMPLATE/cicd.yml
+++ b/.github/ISSUE_TEMPLATE/cicd.yml
@@ -1,0 +1,33 @@
+name: CI / CD task
+description: Changes to CI workflows, release automation, branch policy, or build infrastructure.
+title: "[CI/CD] "
+labels: ["infra"]
+assignees: ["chronoai-shining"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to change in CI/CD?
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why now?
+      description: What problem does this fix or prevent? Link to any failing run / incident.
+    validations:
+      required: true
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: Implementation plan
+      description: Which workflow files / configs change, and how.
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Rollback plan
+      description: If this breaks CI, how do we revert quickly?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question about using Ornn
+    url: https://github.com/ChronoAIProject/Ornn/discussions/categories/q-a
+    about: Usage questions belong in Discussions Q&A, not Issues. Issues are for bugs and tracked work.
+  - name: Idea, proposal, or RFC
+    url: https://github.com/ChronoAIProject/Ornn/discussions/categories/ideas
+    about: Open-ended ideas and design discussion start in Discussions Ideas. File a Feature issue once the scope is concrete.
+  - name: Security vulnerability
+    url: https://github.com/ChronoAIProject/Ornn/security/advisories/new
+    about: Do not file a public issue. Use Private Vulnerability Reporting.
+  - name: Documentation
+    url: https://ornn.chrono-ai.fun/docs
+    about: Product documentation lives on the docs site.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,38 @@
+name: Documentation task
+description: Improve, add, or fix documentation (README, docs/, in-code, public site).
+title: "[Docs] "
+labels: ["documentation"]
+assignees: ["chronoai-shining"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs to change?
+      description: Which doc, which section, and what is wrong or missing.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where does this doc live?
+      options:
+        - README.md
+        - docs/ in this repo
+        - in-code comments / JSDoc
+        - public docs site (ornn.chrono-ai.fun/docs)
+        - CONTRIBUTING / SECURITY / SUPPORT
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Sketch the new content, or describe what you want explained.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose a new feature or enhancement to an existing one.
+title: "[Feature] "
+labels: ["enhancement"]
+assignees: ["chronoai-shining"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature. If your idea is still exploratory or open-ended, consider starting a thread in [Discussions → Ideas](https://github.com/ChronoAIProject/Ornn/discussions/categories/ideas) first — issues are for tracked, scoped work.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the user / agent-developer pain point. Avoid jumping straight to a solution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should change? API shape, UX flow, deployment behaviour, etc.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface?
+      multiple: true
+      options:
+        - ornn-api (backend)
+        - ornn-web (frontend)
+        - deployment / infra
+        - documentation
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you weigh? Why this one?
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / non-goals
+      description: What is explicitly out of scope for this issue?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related issues, prior discussions, screenshots, mockups.

--- a/.github/ISSUE_TEMPLATE/misc.yml
+++ b/.github/ISSUE_TEMPLATE/misc.yml
@@ -1,0 +1,26 @@
+name: Misc task
+description: Anything that does not fit Bug / Feature / CI-CD / Docs — e.g. chores, refactors, tracking issues, governance.
+title: "[Misc] "
+labels: ["dx"]
+assignees: ["chronoai-shining"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why does this need to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / checklist
+      description: A checkbox list of concrete steps, if known.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,61 @@
+<!--
+  Thanks for opening a PR! Fill out the sections below so the reviewer has
+  what they need. PRs missing an issue link or a changeset will be held until
+  both are added. See CONTRIBUTING.md for the full guide.
+-->
+
+## Summary
+
+<!-- 1–3 sentences: what changes and why. The body explains, the title doesn't. -->
+
+## Linked issue
+
+<!--
+  Required. Use one of: Closes #N, Fixes #N, Resolves #N.
+  Prose like "this addresses #N" does NOT auto-close the issue.
+  If no issue exists yet, stop and open one first — every PR must link one.
+-->
+
+Closes #
+
+## Type of change
+
+<!-- Tick all that apply. -->
+
+- [ ] Bug fix (`fix:`)
+- [ ] New feature (`feat:`)
+- [ ] Refactor (`refactor:`) — no behaviour change
+- [ ] Docs (`docs:`)
+- [ ] CI / build / infra (`chore(ci):`, `chore(infra):`)
+- [ ] Breaking change
+
+## Commit decomposition
+
+<!--
+  Multiple small self-contained commits > one big combined commit. See
+  CONTRIBUTING.md → "Commit standards".
+-->
+
+- [ ] Each commit is self-contained (a reviewer can understand it from the diff + message alone).
+- [ ] Each commit is small (one logical change).
+- [ ] Refactors are separated from behaviour changes.
+- [ ] No `Co-Authored-By` trailers.
+
+## Changeset
+
+<!-- CI blocks PRs without a changeset file under .changeset/. -->
+
+- [ ] Added a changeset (`bun changeset`) — describe the user-facing impact.
+- [ ] Or this PR is docs-only / CI-only and uses an empty changeset (`bun changeset --empty`).
+
+## Testing
+
+<!-- How was this verified? Unit tests, integration tests, manual QA, screenshots? -->
+
+## Screenshots / recordings
+
+<!-- For visual / UI changes. Remove this section otherwise. -->
+
+## Notes for the reviewer
+
+<!-- Anything non-obvious: tradeoffs considered, deferred follow-ups, related PRs. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its Code of Conduct.
+
+By participating in this project — issues, pull requests, discussions, or any other community space — you agree to follow the standards described there.
+
+## Reporting
+
+To report conduct concerns, open a confidential channel by filing a [Private Vulnerability Report](https://github.com/ChronoAIProject/Ornn/security/advisories/new) with the title prefixed `Conduct:` (we reuse the same private inbox so reports stay maintainer-only).
+
+Maintainers will follow the enforcement guidelines from the Contributor Covenant and respond within a reasonable time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,162 @@
+# Contributing to Ornn
+
+Thanks for your interest in Ornn. This guide covers everything an external contributor needs: how to set up the repo, how we branch, how we shape commits, how we wire PRs to issues, and how releases are cut.
+
+If you only read one section, read **[Issue-first workflow](#issue-first-workflow)** — every PR must link a GitHub issue, no exceptions.
+
+---
+
+## Table of contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting set up](#getting-set-up)
+- [Issue-first workflow](#issue-first-workflow)
+- [Branching strategy](#branching-strategy)
+- [Commit standards](#commit-standards)
+- [Changesets (required on every PR)](#changesets-required-on-every-pr)
+- [Pull requests](#pull-requests)
+- [Code standards](#code-standards)
+- [Tests](#tests)
+- [Releases](#releases)
+- [Where to ask questions](#where-to-ask-questions)
+
+---
+
+## Code of Conduct
+
+By participating you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md) (Contributor Covenant 2.1).
+
+## Getting set up
+
+Prerequisites: [Bun](https://bun.sh), Docker, a local Kubernetes cluster for full integration runs.
+
+```bash
+git clone https://github.com/ChronoAIProject/Ornn.git
+cd Ornn
+bun install
+bun run test       # backend (Bun) + frontend (Vitest)
+bun run lint
+bun run typecheck
+bun run build:web
+```
+
+Full local-cluster setup (MongoDB, MinIO, OpenSandbox, NyxID, Ornn services) is documented in the project `CLAUDE.md` under "Local Deployment". You do not need the full cluster to land code changes — unit tests alone are sufficient for most PRs.
+
+## Issue-first workflow
+
+**Every PR must link to at least one GitHub issue.** This is load-bearing — it lets us track work, attribute changes, and auto-close issues on merge.
+
+1. **Before opening a PR, find or create a matching issue.**
+2. If no issue exists, create one using an [issue template](https://github.com/ChronoAIProject/Ornn/issues/new/choose). The template prefills:
+   - Title prefix — one of `[Bug]`, `[Feature]`, `[CI/CD]`, `[Docs]`, `[Misc]`
+   - Default assignee
+   - At least one topic label
+3. Link the issue in your PR body using `Closes #N`, `Fixes #N`, or `Resolves #N` — these keywords auto-close the issue on merge. Prose like "this addresses #N" does **not** auto-close and will be rejected at review.
+
+A PR without an issue link will be held until one is added.
+
+### When to use Discussions instead
+
+- Open-ended ideas, RFCs, brainstorming → [Discussions → Ideas](https://github.com/ChronoAIProject/Ornn/discussions/categories/ideas)
+- Usage questions → [Discussions → Q&A](https://github.com/ChronoAIProject/Ornn/discussions/categories/q-a)
+
+Question-shaped issues will be converted to discussions.
+
+## Branching strategy
+
+- **`main`** — production. Protected. PRs only from `develop`. No direct pushes, no force pushes.
+- **`develop`** — default branch, active development. Protected. PRs accepted from any feature branch.
+- **`feature/<short-name>`** — your branch. Must be created from the latest `origin/develop`.
+
+```bash
+git fetch origin
+git checkout develop
+git pull
+git checkout -b feature/short-name
+```
+
+Never branch off a stale local `develop` or another feature branch.
+
+## Commit standards
+
+Multiple small, self-contained commits are always better than one big combined commit. This is non-negotiable.
+
+Rules:
+
+1. **Each commit is self-contained.** A reviewer reading just that commit's diff and message can understand what changed and why.
+2. **Each commit is small.** One logical change per commit. Schema migration is one commit. New endpoint is another. Frontend drawer is another. Old-page deletion is another.
+3. **Each commit's message is detailed.** Subject line ≤ 72 chars, in conventional-commit style (`feat(api):`, `fix(web):`, `chore(repo):`, `docs:`). Body explains *why*, the constraints, and any non-obvious decisions. Reference the linked issue.
+4. **Order matters.** Stack commits in dependency order so each intermediate commit compiles and tests pass.
+5. **Refactors go in their own commit.** Pure refactor first, behaviour change on top. Never bury a fix inside a "drive-by cleanup."
+6. **No `Co-Authored-By` trailers.** Single-author commits only.
+
+Example for a feature that touches schema + API + frontend:
+
+```
+feat(api): extend Foo schema with bar flag (#NNN)
+feat(api): migration — populate Foo.bar from legacy table (#NNN)
+feat(api): PATCH /admin/foo/:id/bar endpoint (#NNN)
+feat(web): FooDrawer wires the new bar toggle (#NNN)
+chore(web): drop deprecated foo-bar select (#NNN)
+docs: changeset for #NNN
+```
+
+Six commits is fine. One commit covering all of the above is **not fine** — it forecloses bisection and forces the reviewer to re-do the decomposition.
+
+## Changesets (required on every PR)
+
+This project uses [Changesets](https://github.com/changesets/changesets) to manage versions. `ornn-api` and `ornn-web` share a unified version (fixed-linked mode).
+
+Every PR targeting `develop` must include a changeset. CI blocks PRs without one.
+
+```bash
+bun changeset
+```
+
+Select the affected package(s), pick a semver bump level (`patch`, `minor`, `major`), and write a short user-facing description. Commit the generated `.changeset/*.md` file with your PR.
+
+For docs-only, CI-only, or config-only PRs that should not bump the version, use:
+
+```bash
+bun changeset --empty
+```
+
+## Pull requests
+
+- Target branch: `develop` (or `main` only when promoting a release).
+- PR title follows the same conventional-commit style as commits.
+- PR body must use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) — it includes the `Closes #N` field and the commit-decomposition checklist.
+- Required checks: CI (lint, typecheck, tests, Docker build), changeset presence, branch policy.
+- A maintainer review is required before merge; CODEOWNERS gates trust-critical paths (workflows, Dockerfiles, deployment, package manifests).
+- Branches auto-delete on merge.
+
+## Code standards
+
+- TypeScript + Bun on the backend; React 19 + Vite + Tailwind on the frontend.
+- Use `Result` patterns and Zod validation. No bare `try/catch` in routes — use error middleware.
+- Read all configurable values from environment variables. No hardcoded config.
+- No hardcoded secrets, credentials, API keys, or tokens — ever.
+- Include sufficient logging (Pino). `info` for lifecycle events, `debug` for detailed flow, `error` for failures with context. Never log plaintext secrets.
+- Fewer lines > more abstractions. Keep code simple.
+- Project domain knowledge: see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
+- Visual / UI changes: see [`docs/DESIGN.md`](docs/DESIGN.md) before deviating from the design system.
+
+## Tests
+
+- Unit tests are colocated with source files.
+- Integration tests live in `tests/`.
+- Run everything locally with `bun run test`.
+- All checks run in CI on every PR.
+
+## Releases
+
+Releases are fully automated via Changesets. Maintainer-driven; contributors don't need to do anything beyond including a changeset on each PR. The flow is documented in [`CLAUDE.md`](CLAUDE.md#versioning--releases).
+
+## Where to ask questions
+
+- Usage / how-to → [Discussions → Q&A](https://github.com/ChronoAIProject/Ornn/discussions/categories/q-a)
+- Design / RFC discussion → [Discussions → Ideas](https://github.com/ChronoAIProject/Ornn/discussions/categories/ideas)
+- Bug? Feature? → file an [issue](https://github.com/ChronoAIProject/Ornn/issues/new/choose)
+- Security report → [Private Vulnerability Reporting](https://github.com/ChronoAIProject/Ornn/security/advisories/new) — see [SECURITY.md](SECURITY.md)
+
+Thanks for contributing.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,28 @@
   <a href="https://github.com/ChronoAIProject/Ornn/actions/workflows/ci.yml"><img src="https://github.com/ChronoAIProject/Ornn/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://github.com/ChronoAIProject/Ornn/releases"><img src="https://img.shields.io/github/v/release/ChronoAIProject/Ornn" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/ChronoAIProject/Ornn" alt="License" /></a>
+  <a href="https://github.com/ChronoAIProject/Ornn/commits/develop"><img src="https://img.shields.io/github/last-commit/ChronoAIProject/Ornn/develop" alt="Last commit" /></a>
+  <a href="https://github.com/ChronoAIProject/Ornn/discussions"><img src="https://img.shields.io/github/discussions/ChronoAIProject/Ornn" alt="Discussions" /></a>
+  <a href="https://github.com/ChronoAIProject/Ornn/stargazers"><img src="https://img.shields.io/github/stars/ChronoAIProject/Ornn?style=flat" alt="Stars" /></a>
 </p>
 
-<p align="center">The agent-facing skill-lifecycle API for AI agents.</p>
+<p align="center">
+  <img src="https://img.shields.io/badge/status-alpha-orange" alt="Project status: alpha" />
+  <img src="https://img.shields.io/badge/model-agnostic-blue" alt="Model-agnostic" />
+  <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20MCP-blueviolet" alt="HTTP and MCP" />
+</p>
+
+<p align="center"><strong>The agent-facing skill-lifecycle API for AI agents.</strong></p>
+
+<p align="center">
+  <a href="#what-is-ornn">What is Ornn</a> ·
+  <a href="#how-it-works">How it works</a> ·
+  <a href="#quickstart">Quickstart</a> ·
+  <a href="#documentation">Docs</a> ·
+  <a href="#roadmap">Roadmap</a> ·
+  <a href="#community">Community</a> ·
+  <a href="#contributing">Contributing</a>
+</p>
 
 ---
 
@@ -29,17 +48,74 @@ Closest analog: **npm registry + npm CLI fused, model-agnostic** — works for C
 
 `ornn-web` is a secondary surface for skill owners and platform admins; it is not the primary product.
 
-## How to use Ornn
+## How it works
 
-Ornn is model-agnostic — any AI agent runtime (Claude, GPT, Gemini, or a custom in-house stack) can connect and consume the full skill-lifecycle API. Three steps to bring an agent online:
+```
+┌──────────────┐    HTTP / MCP    ┌──────────────┐    auth     ┌──────────┐
+│   AI agent   │ ───────────────▶ │   ornn-api   │ ──────────▶ │  NyxID   │
+│ (any model)  │                  │              │             └──────────┘
+└──────────────┘                  │              │   storage   ┌──────────┐
+       │                          │              │ ──────────▶ │ MongoDB  │
+       │                          │              │             └──────────┘
+       │                          │              │   sandbox   ┌──────────┐
+       │ pull / execute           │              │ ──────────▶ │ OpenSbox │
+       ▼                          └──────────────┘             └──────────┘
+┌──────────────┐
+│ Local skill  │
+│   runtime    │
+└──────────────┘
+```
 
-1. **Install the ChronoAI core service skill into the agent.** This is the bootstrap skill — it introduces Ornn to the agent and drives the rest of the setup.
-2. **Let the agent provision the NyxID CLI.** On first run, the core skill instructs the agent to install `nyxid` — the CLI that brokers every Ornn request and response with proper authentication and authorization. The agent follows the skill's setup procedure end-to-end; no manual operator steps required.
-3. **Start the conversation.** Once `nyxid` is configured in the agent's environment, ask it to search, install, run, build, or publish Ornn skills. The agent learns the end-to-end lifecycle — `search → pull → install → execute → build → upload → share` — through the same API it just connected to.
+The agent talks to `ornn-api` through `nyxid`, which brokers authentication and authorization on the agent's behalf. Skills are versioned artifacts that the agent pulls, runs in a sandbox, and (optionally) publishes back.
+
+For a deeper view, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+## Quickstart
+
+> **Status:** alpha. Surfaces and schemas can change before v1. Pin a release tag.
+
+The shortest path to bringing an agent online with Ornn — no manual operator steps inside the agent loop:
+
+1. **Install the ChronoAI core service skill into your agent.** This is the bootstrap skill — it introduces Ornn to the agent and drives the rest of setup.
+2. **Let the agent provision the NyxID CLI.** On first run, the core skill instructs the agent to install `nyxid`. The agent follows the skill end-to-end.
+3. **Talk to the agent.** Ask it to search, install, run, build, or publish skills. The agent learns the lifecycle through the same API it just connected to.
+
+Once connected, an agent can hit the API directly. A minimal request shape (after `nyxid` is configured):
+
+```bash
+nyxid proxy request ornn-api GET /api/v1/skills?q=summarize
+```
+
+Full per-endpoint reference: [ornn.chrono-ai.fun/docs](https://ornn.chrono-ai.fun/docs).
 
 ## Documentation
 
-Full documentation lives at [ornn.chrono-ai.fun/docs](https://ornn.chrono-ai.fun/docs).
+- **Product docs** — [ornn.chrono-ai.fun/docs](https://ornn.chrono-ai.fun/docs)
+- **Architecture** — [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+- **Conventions** — [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md)
+- **Design system** — [`docs/DESIGN.md`](docs/DESIGN.md)
+
+## Roadmap
+
+Tracked publicly on GitHub:
+
+- **Open issues & milestones** — [Issues](https://github.com/ChronoAIProject/Ornn/issues) · [Milestones](https://github.com/ChronoAIProject/Ornn/milestones)
+- **What shipped** — [Releases](https://github.com/ChronoAIProject/Ornn/releases) · per-package changelogs in [`ornn-api/CHANGELOG.md`](ornn-api/CHANGELOG.md) and [`ornn-web/CHANGELOG.md`](ornn-web/CHANGELOG.md)
+
+## Community
+
+- **Questions / how-to** → [Discussions → Q&A](https://github.com/ChronoAIProject/Ornn/discussions/categories/q-a)
+- **Ideas / RFCs** → [Discussions → Ideas](https://github.com/ChronoAIProject/Ornn/discussions/categories/ideas)
+- **Show off your agent integration** → [Discussions → Show & Tell](https://github.com/ChronoAIProject/Ornn/discussions/categories/show-and-tell)
+- **Bug or feature** → [open an issue](https://github.com/ChronoAIProject/Ornn/issues/new/choose)
+- **Security report** → [Private Vulnerability Reporting](https://github.com/ChronoAIProject/Ornn/security/advisories/new) — see [SECURITY.md](SECURITY.md)
+- **Support guide** → [SUPPORT.md](SUPPORT.md)
+
+## Contributing
+
+Pull requests are welcome. Before opening one, read [CONTRIBUTING.md](CONTRIBUTING.md) — it covers the issue-first workflow, branching, commit decomposition, and the changeset rule (CI blocks PRs without one).
+
+By participating you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+Ornn is an agent-facing API. A vulnerability in Ornn can affect every agent connected to it, so we take disclosure seriously and aim to acknowledge reports quickly.
+
+## Supported Versions
+
+Only the latest release on the [`main`](https://github.com/ChronoAIProject/Ornn/tree/main) branch receives security updates. We do not backport fixes to older versions.
+
+| Version       | Supported          |
+| ------------- | ------------------ |
+| Latest `main` | :white_check_mark: |
+| Anything else | :x:                |
+
+## Reporting a Vulnerability
+
+**Do not file a public GitHub issue for security vulnerabilities.** Public issues are indexed and visible before a fix can ship.
+
+Use GitHub's **[Private Vulnerability Reporting](https://github.com/ChronoAIProject/Ornn/security/advisories/new)** instead. It creates a private advisory thread visible only to maintainers and you.
+
+Please include, at minimum:
+
+- A clear description of the vulnerability and its impact.
+- Reproduction steps or a proof-of-concept.
+- The commit SHA, release tag, or deployment URL where you observed it.
+- Your assessment of severity (e.g. CVSS vector, or a plain-English worst case).
+
+If you cannot use GitHub's reporting flow, open an empty issue titled "Security contact request" and a maintainer will reach out through a private channel — **do not include any vulnerability details in that issue**.
+
+## What to Expect
+
+- **Acknowledgement:** within 3 business days.
+- **Initial assessment:** within 7 business days, including a severity rating and a rough remediation timeline.
+- **Fix and disclosure:** coordinated with you. We aim to ship a fix within 30 days for high/critical findings; lower-severity findings may be batched into the next release.
+- **Credit:** if you'd like, we'll credit you in the published GitHub Security Advisory and the release notes. Anonymous reports are fine too.
+
+## Scope
+
+In scope:
+
+- This repository's source code (`ornn-api`, `ornn-web`, SDKs, deployment manifests).
+- The hosted instance at `https://ornn.chrono-ai.fun`.
+
+Out of scope:
+
+- Dependencies — please report upstream first; we'll follow when a CVE is published.
+- Social engineering, physical attacks, or denial-of-service against the hosted instance.
+- Findings on third-party services Ornn integrates with (NyxID, MinIO, OpenSandbox, MongoDB) — report those to the respective project.
+
+## Safe Harbour
+
+Good-faith security research conducted within the scope above is welcome. We will not pursue legal action against researchers who:
+
+- Make a good-faith effort to avoid privacy violations, data destruction, and service degradation.
+- Give us reasonable time to remediate before any public disclosure.
+- Do not exploit the vulnerability beyond what is necessary to demonstrate it.
+
+Thank you for helping keep Ornn and the agents that depend on it safe.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,35 @@
+# Getting Support
+
+Welcome — here is where to take different kinds of questions so they reach the right place.
+
+## I have a question about using Ornn
+
+Use **[GitHub Discussions → Q&A](https://github.com/ChronoAIProject/Ornn/discussions/categories/q-a)**.
+
+Discussions are the canonical Q&A surface. Issues are reserved for bugs, features, and tracked work — questions filed as issues will be converted to discussions.
+
+## I want to share something I built with Ornn
+
+Post it in **[Discussions → Show & Tell](https://github.com/ChronoAIProject/Ornn/discussions/categories/show-and-tell)**.
+
+## I think I found a bug
+
+File a [bug report](https://github.com/ChronoAIProject/Ornn/issues/new?template=bug_report.yml). Please include reproduction steps and the commit SHA or release version.
+
+## I have a feature idea
+
+- Small, well-scoped requests: file a [feature request](https://github.com/ChronoAIProject/Ornn/issues/new?template=feature_request.yml).
+- Larger or open-ended ideas: start a thread in **[Discussions → Ideas](https://github.com/ChronoAIProject/Ornn/discussions/categories/ideas)** first.
+
+## I found a security issue
+
+**Do not file a public issue.** Use [GitHub Private Vulnerability Reporting](https://github.com/ChronoAIProject/Ornn/security/advisories/new). Details: [SECURITY.md](SECURITY.md).
+
+## I want to contribute code
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) — it covers branching, commit standards, changesets, and the issue-first PR rule.
+
+## Documentation
+
+Full product docs: [ornn.chrono-ai.fun/docs](https://ornn.chrono-ai.fun/docs).
+Architecture, conventions, and design system: [`docs/`](docs/).


### PR DESCRIPTION
## Summary

Brings the repository up to industry-standard OSS health for external agent developers. Adds the community-health files GitHub's checker grades on, mechanizes the project's issue/PR rules through templates, and expands the README from a 47-line landing card into a proper on-ramp.

Closes #377.

## What changes

| Area | File(s) |
|------|---------|
| Vulnerability disclosure | `SECURITY.md` |
| Conduct | `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, by reference) |
| Contributor guide | `CONTRIBUTING.md` (public-facing subset of `CLAUDE.md`) |
| Support routing | `SUPPORT.md` |
| Issue forms | `.github/ISSUE_TEMPLATE/{bug_report,feature_request,cicd,docs,misc}.yml` + `config.yml` |
| PR template | `.github/PULL_REQUEST_TEMPLATE.md` |
| README | Status row, nav, "How it works" diagram, Quickstart, Roadmap, Community, Contributing |

Each file is its own commit so the decomposition matches `CLAUDE.md`'s commit-size rule.

## Out of scope (deliberate)

- **SDK install / version badges.** `@chronoai/ornn-sdk` and `ornn-sdk` (Python) are not yet released; will land alongside the release decision.
- **Email-based security inbox.** Disclosure is via GitHub Private Vulnerability Reporting only.
- **Real-time channel (Discord/Slack).** None exists yet; community routes through GitHub Discussions + Issues only.

## Remote settings — needs your token

`gh repo edit` failed with `HTTP 403: Resource not accessible by personal access token` during execution. The PAT in this environment lacks admin scope on the repo. The following still need to be applied manually with a token that has it:

```bash
gh repo edit ChronoAIProject/Ornn \
  --description "Agent-facing skill-lifecycle API. The npm registry + CLI for AI agents — model-agnostic (Claude, GPT, Gemini, or custom)." \
  --homepage "https://ornn.chrono-ai.fun" \
  --enable-discussions \
  --add-topic ai-agents --add-topic llm --add-topic mcp \
  --add-topic agent-skills --add-topic agent-tools \
  --add-topic skill-registry --add-topic model-context-protocol \
  --add-topic claude --add-topic gpt --add-topic gemini \
  --add-topic typescript --add-topic bun
```

After enabling Discussions, create categories `Announcements`, `Q&A`, `Ideas`, `Show & Tell`, `RFCs` in the GitHub UI — the links in `SUPPORT.md`, `README.md`, and `.github/ISSUE_TEMPLATE/config.yml` already point at `categories/q-a`, `categories/ideas`, and `categories/show-and-tell`, so seeding those category slugs makes everything resolve in one step.

## Test plan

- [x] All eight commits applied cleanly on top of `develop` (1f2699e).
- [ ] `Changeset check` CI passes — empty changeset is included.
- [ ] `CI` workflow passes (no source code changed; should be green).
- [ ] Issue forms render correctly on `New issue` page after merge.
- [ ] PR template renders correctly when opening this PR.
- [ ] Render-check `README.md` on GitHub web after merge — confirm the logo + ASCII diagram + section anchors look right.
- [ ] (Manual) Apply the `gh repo edit` command above with an admin-scoped token.
- [ ] (Manual) Create the five Discussions categories with the slugs `q-a`, `ideas`, `show-and-tell`, `announcements`, `rfcs`.