### PR TITLE
fix(web): point NyxID 'My Services' to /keys and 'Admin Services' to /services

### DIFF
--- a/.changeset/fix-nyxid-menu-urls.md
+++ b/.changeset/fix-nyxid-menu-urls.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Fix NyxID portal links in the signed-in user menu — "My Services" now opens `/keys` and "Admin Services" now opens `/services`. Previously both pointed to non-existent or wrong portal paths.

--- a/ornn-web/src/lib/userMenu.ts
+++ b/ornn-web/src/lib/userMenu.ts
@@ -81,7 +81,7 @@ export function useUserMenuGroups(user: AuthUser | null): UserMenuGroup[] {
       {
         key: "services",
         kind: "external",
-        href: `${nyxid}/services`,
+        href: `${nyxid}/keys`,
         label: t("nav.myServices"),
       },
       {
@@ -120,7 +120,7 @@ export function useUserMenuGroups(user: AuthUser | null): UserMenuGroup[] {
         {
           key: "admin-services",
           kind: "external",
-          href: `${nyxid}/admin/services`,
+          href: `${nyxid}/services`,
           label: t("nav.adminServices"),
         },
       ],


### PR DESCRIPTION
## Summary

Both NyxID-bound entries in the signed-in user menu were targeting the wrong portal path:

| Menu item | Before | After |
|---|---|---|
| My Services | `${nyxid}/services` | `${nyxid}/keys` |
| Admin Services | `${nyxid}/admin/services` | `${nyxid}/services` |

On the NyxID portal, `/services` is the platform-wide service registry (admin-only there); a regular user's per-service credentials live at `/keys`. The previous `/admin/services` path doesn't exist, so the admin entry was effectively dead.

Closes #379.

## Visibility (already correct)

The admin-only gate on the Admin Services entry was already in place — the entry sits inside the `if (isAdmin(user)) { groups.push({ id: "admin", ... }) }` block in `useUserMenuGroups`, so non-admin users have never seen it. No visibility change needed in this PR.

## Test plan

- [x] `bun run lint` / `typecheck` pass
- [ ] CI green
- [ ] Manual: as a regular user, click "My Services" → lands on `${nyxid}/keys`
- [ ] Manual: as an admin, click "Admin Services" → lands on `${nyxid}/services`
- [ ] Manual: as a regular user, confirm no "Admin Services" entry is visible

## Notes

Labels stay as-is in both locales (`nav.myServices` / `nav.adminServices`) — they describe what the destination page is *about*, not the URL slug. If we later decide "My Services" should read "My API Keys" to match the URL, that's a separate UX call.