### PR TITLE
chore(ci): add Dependabot config for supply-chain baseline

### DIFF
--- a/.changeset/dependabot-supply-chain-baseline.md
+++ b/.changeset/dependabot-supply-chain-baseline.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Dependabot for weekly grouped dependency PRs (bun / pip / github-actions / docker). Documents the upcoming `bun audit` CI gate in CONTRIBUTING.md.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,92 @@
+# Dependabot keeps our supply chain current. Three groupings to minimise
+# PR churn: minor/patch bundled per-ecosystem, security-only PRs come through
+# uncapped (one per CVE), majors stay un-grouped so they're easy to triage.
+#
+# See SECURITY.md for the public vuln disclosure path; CI's `audit` job
+# (CI workflow → audit) is the runtime gate that blocks high/critical
+# regressions from landing.
+
+version: 2
+updates:
+  # ---- Bun workspace (root + ornn-api + ornn-web) -------------------------
+  # Dependabot walks the workspace from /, so a single entry covers every
+  # package.json in the tree.
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "infra"]
+    groups:
+      bun-minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+
+  # ---- Python SDK ---------------------------------------------------------
+  - package-ecosystem: pip
+    directory: /sdk/python
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "infra"]
+    groups:
+      pip-minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+
+  # ---- GitHub Actions -----------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "infra"]
+    groups:
+      actions-all:
+        applies-to: version-updates
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(ci)"
+      include: scope
+
+  # ---- Docker base images -------------------------------------------------
+  - package-ecosystem: docker
+    directory: /ornn-api
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "infra"]
+    commit-message:
+      prefix: "chore(docker)"
+      include: scope
+
+  - package-ecosystem: docker
+    directory: /ornn-web
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "infra"]
+    commit-message:
+      prefix: "chore(docker)"
+      include: scope

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,12 @@ bun changeset --empty
 - Project domain knowledge: see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
 - Visual / UI changes: see [`docs/DESIGN.md`](docs/DESIGN.md) before deviating from the design system.
 
+### Supply-chain hygiene
+
+- **Dependabot** (configured in [`.github/dependabot.yml`](.github/dependabot.yml)) opens grouped weekly PRs for npm/bun, pip, GitHub Actions, and Docker base images. Treat its PRs as first-class — review on the same cadence as feature work.
+- **`bun audit`** is the local-and-CI vulnerability gate. The CI `audit` job blocks any PR that introduces a **high** or **critical** advisory; moderate+ advisories show up in the PR step summary but don't block. Before opening a PR, run `bun audit --audit-level=high` locally to catch regressions.
+- **Security disclosure** never goes through public issues or PRs — use the Private Vulnerability Reporting flow in [`SECURITY.md`](SECURITY.md).
+
 ## Tests
 
 - Unit tests are colocated with source files.


### PR DESCRIPTION
## Summary

First half of the supply-chain baseline tracked in #383. Adds Dependabot so new CVEs in transitive deps surface as weekly PRs instead of sitting unnoticed.

The second half — the CI `bun audit --audit-level=high` gate that blocks high/critical regressions — lands in the follow-up PR alongside the cleanup of the 34 vulns currently in the lockfile, so the gate doesn't immediately self-block on day one.

Related to #383 (will be closed by the follow-up PR that lands the audit gate).

## Coverage

| Ecosystem | Directory | Cadence | Grouping |
|---|---|---|---|
| bun | `/` | Weekly Mon 08:00 Asia/Shanghai | minor+patch grouped, majors separate |
| pip | `/sdk/python` | Weekly | minor+patch grouped |
| github-actions | `/` | Weekly | all grouped |
| docker | `/ornn-api`, `/ornn-web` | Weekly | per-Dockerfile |

PR limit: 10 (bun), 5 (pip, gh-actions), 3 (docker each). Labels: `dependencies`, `infra`.

## Why this comes first

A public launch without supply-chain alerting means a new transitive CVE can sit unnoticed for months. Dependabot is free and built-in — no excuse for not having it before going public. Pairs with the upcoming `bun audit` CI gate to give us:

- **Dependabot** = "tell us when something becomes vulnerable" (weekly cadence)
- **CI audit gate** = "stop new high/critical from landing" (per-PR gate, coming next)

## Test plan

- [x] `bun run lint` / `typecheck` (no code changed but lockfile-affected paths verified)
- [ ] CI green
- [ ] Manual: visit Dependabot tab post-merge, confirm config parses and version PRs start opening