### PR TITLE
chore(ci): add bun audit --audit-level=high gate to block supply-chain regressions

### DIFF
--- a/.changeset/empty-ci-audit-gate.md
+++ b/.changeset/empty-ci-audit-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add CI `bun audit` gate. CI-only — no version bump.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,35 @@ jobs:
       - name: Scan for secrets
         run: gitleaks detect --source . --log-opts="origin/${{ github.base_ref }}..HEAD" --verbose
 
+  audit:
+    # Fails on any high or critical advisory in the Bun workspace. Moderate
+    # and below print to the PR step summary but don't block — Dependabot
+    # picks them up on the weekly cadence (.github/dependabot.yml).
+    #
+    # Ignored advisories — accepted residual risk documented in #385:
+    #   GHSA-r5fr-rjxr-66jc  lodash-es high   (via mermaid)
+    #   GHSA-f23m-r3pf-42rh  lodash-es moderate (via mermaid)
+    # lodash-es is archived at 4.17.21 with no upstream fix; the vulnerable
+    # APIs (_.template / _.unset / _.omit) are not reachable through
+    # mermaid's surface under our usage.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - name: Audit (high+critical block PR)
+        run: bun audit --audit-level=high --ignore=GHSA-r5fr-rjxr-66jc --ignore=GHSA-f23m-r3pf-42rh
+      - name: Audit summary (moderate+ — informational)
+        if: ${{ !cancelled() }}
+        run: |
+          {
+            echo "### bun audit — full report (moderate and above)"
+            echo ""
+            echo '```'
+            bun audit --audit-level=moderate || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   docker-build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Follow-up to #385 that was deferred when the original PAT lacked \`Workflows: Read and write\` scope. Adds the runtime CI gate that blocks any PR introducing a high or critical advisory in the Bun workspace.

Pairs with:
- #384 (Dependabot weekly cadence — surveillance)
- #385 (lockfile cleanup — baseline)

to complete the supply-chain hygiene baseline ahead of public launch.

Closes #387.

## How the gate behaves

| Severity | Behaviour |
|---|---|
| Critical / High (not on ignore list) | **Blocks the PR** |
| Moderate | Prints to PR step summary (markdown block, with the full audit output) — does **not** block |
| Low / informational | Not surfaced |

## Ignored advisories

| GHSA | Package | Path | Reason |
|---|---|---|---|
| GHSA-r5fr-rjxr-66jc | lodash-es (high) | mermaid → lodash-es | Archived upstream at 4.17.21; \`_.template\` not exposed by mermaid's API under our usage |
| GHSA-f23m-r3pf-42rh | lodash-es (moderate) | mermaid → lodash-es | Same root cause |

Both ignored with explicit \`--ignore=GHSA-...\` flags so a future maintainer can see they were deliberately accepted. The comment block above the job in \`ci.yml\` documents the rationale at the point of use.

## Test plan

- [x] Local: \`bun audit --audit-level=high --ignore=GHSA-r5fr-rjxr-66jc --ignore=GHSA-f23m-r3pf-42rh\` → No vulnerabilities found, exit 0.
- [ ] CI: this PR's own \`audit\` job runs and passes (gate validates itself).
- [ ] All other CI jobs remain green.