### PR TITLE
feat(api): drop legacy share.* notifications on boot

### DIFF
--- a/.changeset/drop-legacy-share-notifications.md
+++ b/.changeset/drop-legacy-share-notifications.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Drop legacy `share.*` notifications on boot. PR #198 removed the share/audit-gate workflow but pre-#198 notification rows still surfaced via `GET /api/v1/notifications` with dead deep-links into the removed `/shares/*` route tree. A new idempotent boot migration deletes any notification whose category is not in the current allowed set.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -61,6 +61,7 @@ import { createAuditRoutes } from "./domains/skills/audit/routes";
 import { NotificationRepository } from "./domains/notifications/repository";
 import { NotificationService } from "./domains/notifications/service";
 import { createNotificationRoutes } from "./domains/notifications/routes";
+import { dropLegacyNotificationCategories } from "./domains/notifications/migration";
 
 // Domain: Announcements (landing-page popup)
 import { AnnouncementRepository } from "./domains/announcements/repository";
@@ -428,6 +429,16 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const notificationRepo = new NotificationRepository(db);
   void notificationRepo.ensureIndexes().catch((err) =>
     logger.warn({ err }, "notifications indexes ensureIndexes failed — proceeding anyway"),
+  );
+  // One-time boot migration (#218) — drop legacy `share.*` rows left over
+  // from the pre-#198 share/audit-gate workflow. Idempotent; no-op after
+  // first run. Failure is non-fatal — old rows surface as ugly UI but
+  // never block the boot.
+  await dropLegacyNotificationCategories(db).catch((err) =>
+    logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "dropLegacyNotificationCategories failed — legacy notification rows may still surface in /notifications until the next deploy",
+    ),
   );
   const notificationService = new NotificationService({ notificationRepo });
   const notificationRoutes = createNotificationRoutes({ notificationService });

--- a/ornn-api/src/domains/notifications/migration.ts
+++ b/ornn-api/src/domains/notifications/migration.ts
@@ -1,0 +1,72 @@
+/**
+ * One-time boot migration for #218 — drop legacy `share.*` and any other
+ * out-of-vocabulary notifications.
+ *
+ * PR #198 removed the share/audit-gate workflow. The `NotificationCategory`
+ * type was tightened at the same time:
+ *
+ *   audit.completed | audit.risky_for_consumer | quota.credits_granted
+ *
+ * but pre-#198 rows in the `notifications` collection still carry dead
+ * categories like `share.needs_justification` and dead deep-links into
+ * the removed `/shares/*` route tree (which now 404). They surface from
+ * `GET /api/v1/notifications` and look broken to the user.
+ *
+ * This migration deletes any row whose `category` is not in the current
+ * allowed set. Idempotent: subsequent runs find zero matching rows and
+ * short-circuit.
+ *
+ * @module domains/notifications/migration
+ */
+
+import type { Db } from "mongodb";
+import pino from "pino";
+
+const logger = pino({ level: "info" }).child({
+  module: "notificationsMigration",
+});
+
+const ALLOWED_CATEGORIES = [
+  "audit.completed",
+  "audit.risky_for_consumer",
+  "quota.credits_granted",
+] as const;
+
+export async function dropLegacyNotificationCategories(db: Db): Promise<void> {
+  const collection = db.collection("notifications");
+
+  // Count first so the log line is informative even when nothing matches —
+  // makes it obvious when re-running on a clean DB that the migration is
+  // a no-op vs. silently doing nothing.
+  const filter = { category: { $nin: ALLOWED_CATEGORIES } };
+  const candidateCount = await collection.countDocuments(filter);
+  if (candidateCount === 0) {
+    logger.info(
+      { allowedCategories: ALLOWED_CATEGORIES },
+      "dropLegacyNotificationCategories: no out-of-vocabulary rows — nothing to migrate",
+    );
+    return;
+  }
+
+  // Surface a sample of which categories we're about to delete so an
+  // operator reviewing logs can audit the change before the next deploy.
+  const sample = await collection
+    .aggregate<{ _id: unknown; count: number }>([
+      { $match: filter },
+      { $group: { _id: "$category", count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 20 },
+    ])
+    .toArray();
+
+  logger.info(
+    { candidateCount, sample, allowedCategories: ALLOWED_CATEGORIES },
+    "dropLegacyNotificationCategories: deleting out-of-vocabulary rows",
+  );
+
+  const result = await collection.deleteMany(filter);
+  logger.info(
+    { deletedCount: result.deletedCount ?? 0 },
+    "dropLegacyNotificationCategories: done",
+  );
+}


### PR DESCRIPTION
## Summary

Adds a one-time, idempotent boot migration that deletes notification rows whose \`category\` is not in the current allowed set. Cleans up pre-PR-#198 \`share.*\` rows that still surface from \`GET /api/v1/notifications\` with dead deep-links into the removed \`/shares/*\` route tree.

Closes #218.

## What the migration does

\`\`\`
allowed = { audit.completed, audit.risky_for_consumer, quota.credits_granted }

  count = db.notifications.countDocuments({ category: { \$nin: allowed } })
  if count == 0:  return  // idempotent
  log per-category breakdown for operator audit
  db.notifications.deleteMany({ category: { \$nin: allowed } })
\`\`\`

Follows the #270 \`migrateModelCatalogIntoProviders\` precedent exactly:
- Module at \`ornn-api/src/domains/notifications/migration.ts\`.
- Wired in \`bootstrap.ts\` after \`notificationRepo.ensureIndexes()\`.
- Failure is non-fatal (caught + logged); legacy rows would still be ugly UI but never block boot.

## Scope clarifications vs. issue body

| Issue mentions | Status in this PR |
|---|---|
| \`share.*\` notifications with dead /shares/ deep-links | **Fixed** by this migration |
| \`/admin/activities\` returning \`waiverCount\` | **Moot** — endpoint was removed in #271 (PostHog dashboard replaced it). The activity rows are no longer surfaced, so cleaning storage gives no user-visible benefit. |
| \`audit.completed\` body text references waivers/reviewers | **Separate concern** — the current \`NotificationService\` still emits that wording (\`ornn-api/src/domains/notifications/service.ts:78\`), not just old rows. A pure copy update belongs in its own PR. |

## Test plan

- [x] \`bun run typecheck\` → 0 errors
- [x] \`bun run lint\` → 78 warnings, 0 errors (develop baseline)
- [x] \`bun run test\` → 528 pass, 0 fail, 5 todo across 50 files
- [x] \`bun audit\` → No vulnerabilities found
- [ ] CI green
- [ ] Manual post-deploy: \`GET /api/v1/notifications\` no longer returns any row with \`category: "share.*"\`
- [ ] Manual post-deploy: ornn-api log shows one-time line \`dropLegacyNotificationCategories: done\` with a non-zero deletedCount; subsequent boots log \`nothing to migrate\`