### PR TITLE
chore(ci): trust dependabot in approval gate + exempt from changeset-check

### DIFF
--- a/.changeset/dependabot-gate-relaxation.md
+++ b/.changeset/dependabot-gate-relaxation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Trust dependabot[bot] in the require-review approval gate, and exempt Dependabot PRs from the changeset-check requirement. CI-only — no version bump.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -8,6 +8,13 @@ on:
 jobs:
   check-changeset:
     runs-on: ubuntu-latest
+    # Dependabot PRs are pure dependency bumps that don't produce
+    # user-facing changelog entries; requiring an empty changeset on
+    # every weekly batch is friction-only. The full lint / typecheck /
+    # test / build / docker-build / audit gate stack still runs on every
+    # Dependabot PR, so behaviour and security regressions are caught
+    # downstream. Tracked in #402.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/require-review.yml
+++ b/.github/workflows/require-review.yml
@@ -29,10 +29,16 @@ jobs:
             //   - chronoai-shining (maintainer)
             //   - github-actions[bot] (release-bump + sync PRs opened by
             //     the changeset-release workflow state machine)
+            //   - dependabot[bot] (weekly dep update PRs from the
+            //     supply-chain baseline in #383 — kept defence-in-depth
+            //     by the audit / lint / typecheck / test / docker-build
+            //     gates that still run on every PR)
             const TRUSTED_AUTHORS = new Set([
               'chronoai-shining',
               'github-actions[bot]',
               'app/github-actions',
+              'dependabot[bot]',
+              'app/dependabot',
             ]);
             if (TRUSTED_AUTHORS.has(author)) {
               console.log(`PR author is ${author} — no approval required`);


### PR DESCRIPTION
## Summary

The supply-chain baseline (#384 / #385 / #390) had Dependabot open its first weekly batch of 10 PRs (#386–#397). Every one of them fails two gates that have no business blocking a bot:

| Gate | Why it fails for Dependabot |
|---|---|
| \`require-review\` (\`check-approval\`) | \`TRUSTED_AUTHORS\` whitelists \`chronoai-shining\` and \`github-actions[bot]\` only — \`dependabot[bot]\` was never added. |
| \`changeset-check\` | Dependabot doesn't author changeset files; pure dep bumps don't have user-facing changelog entries anyway. |

This PR fixes both. Future Dependabot PRs sail through both gates and just need to pass the actual quality stack (lint / typecheck / test / build / docker-build / **audit** / gitleaks).

Closes #402.

## Defence-in-depth still intact

Auto-trusting Dependabot is not blind — the full per-PR check stack still runs:

| Check | What it catches |
|---|---|
| \`audit\` (\`--audit-level=high\`) | New high/critical CVEs introduced by the bump |
| \`lint\`, \`typecheck\` | Type / static-analysis regressions |
| \`test\` | Behaviour regressions (533 tests) |
| \`build\`, \`docker-build\` | Production-image breakage |
| \`gitleaks\` | Smuggled secrets |

A hostile or compromised dep bump can't get past those. The two gates being relaxed here add friction without adding real security on top.

## Out of scope

Whether to additionally enable Dependabot's GitHub-native auto-merge (so patch + minor PRs land automatically the moment CI is green) is a separate UX decision. Tracked at the bottom of #402.

## Test plan

- [ ] This PR is opened by \`chronoai-shining\` so \`check-approval\` should still pass via the existing whitelist.
- [ ] An empty changeset is included so \`check-changeset\` still passes (the exemption is keyed on \`github.actor\`, not the PR author of changes to the workflow file).
- [ ] All other CI jobs remain green.
- [ ] **Validation**: after this lands, retrigger CI on #386 (GH Actions group). \`check-approval\` and \`check-changeset\` should now pass without manual intervention.