### PR TITLE
fix(ci): check changeset-check skip against PR author, not last pusher

### DIFF
--- a/.changeset/changeset-check-author-skip.md
+++ b/.changeset/changeset-check-author-skip.md
@@ -1,0 +1,4 @@
+---
+---
+
+Hot-fix CI: the Dependabot exemption in `changeset-check` now keys on PR author instead of last pusher, so maintainer-driven branch syncs no longer re-arm the gate.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -14,7 +14,12 @@ jobs:
     # test / build / docker-build / audit gate stack still runs on every
     # Dependabot PR, so behaviour and security regressions are caught
     # downstream. Tracked in #402.
-    if: github.actor != 'dependabot[bot]'
+    #
+    # `github.event.pull_request.user.login` (PR author) instead of
+    # `github.actor` (last pusher) — otherwise a maintainer running
+    # `gh pr update-branch` to sync a Dependabot PR with develop
+    # reverts the actor to themselves and re-arms this gate.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Hot-fix for #404. The Dependabot exemption added in that PR keyed the skip on `github.actor` (the user who pushed the latest commit), so a maintainer running `gh pr update-branch` to sync a Dependabot PR with develop reverted the actor to themselves and re-armed the gate.

Caught immediately on #386: `check-approval` passed (the require-review fix worked), but `check-changeset` re-failed after my `gh pr update-branch` sync.

Fix: read the PR author from `github.event.pull_request.user.login`, which is stable across syncs.

Related to #402.