### PR TITLE
chore(deps): upgrade @hookform/resolvers 3 → 5 (supersedes Dependabot #391)

### DIFF
--- a/.changeset/upgrade-hookform-resolvers-5.md
+++ b/.changeset/upgrade-hookform-resolvers-5.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Upgrade `@hookform/resolvers` 3 → 5. v5 changed the Resolver to reference the Zod output shape; form components are updated to use the `z.input` / `z.output` split so the form-state types and the submit-handler types are both correctly narrowed. Pure type refactor — no behaviour change.

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
       "name": "ornn-web",
       "version": "0.5.0",
       "dependencies": {
-        "@hookform/resolvers": "^3.9.0",
+        "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.62.0",
         "diff": "^9.0.0",
         "framer-motion": "^11.15.0",
@@ -230,7 +230,7 @@
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
-    "@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
+    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 

--- a/ornn-web/package.json
+++ b/ornn-web/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.9.0",
+    "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.62.0",
     "diff": "^9.0.0",
     "framer-motion": "^11.15.0",

--- a/ornn-web/src/components/form/SkillForm.tsx
+++ b/ornn-web/src/components/form/SkillForm.tsx
@@ -33,12 +33,19 @@ const skillFormSchema = z.object({
   readmeMd: z.string().max(50000).optional(),
 });
 
-type SkillFormData = z.infer<typeof skillFormSchema>;
+// `z.input` is the pre-validation shape (optional fields where the
+// schema has `.default(...)`); `z.output` is post-validation (defaults
+// applied, so those fields are required). @hookform/resolvers 5 typed
+// the Resolver against the output, so useForm has to be parameterised
+// with both — pre-validation form state and post-validation submit
+// payload — for the SubmitHandler to typecheck.
+type SkillFormInput = z.input<typeof skillFormSchema>;
+type SkillFormData = z.output<typeof skillFormSchema>;
 
 export interface SkillFormProps {
   /** "create" shows all fields; "edit" hides name, version, file */
   mode: "create" | "edit";
-  defaultValues?: Partial<SkillFormData>;
+  defaultValues?: Partial<SkillFormInput>;
   onSubmit: (data: SkillFormData, file?: File) => void;
   isSubmitting?: boolean;
   className?: string;
@@ -63,7 +70,7 @@ export function SkillForm({
     control,
     watch,
     formState: { errors },
-  } = useForm<SkillFormData>({
+  } = useForm<SkillFormInput, unknown, SkillFormData>({
     resolver: zodResolver(skillFormSchema),
     defaultValues: {
       name: "",
@@ -144,7 +151,7 @@ export function SkillForm({
         control={control}
         render={({ field }) => (
           <TagInput
-            tags={field.value}
+            tags={field.value ?? []}
             onChange={field.onChange}
             error={errors.tags?.message}
           />

--- a/ornn-web/src/components/skill/guided/StepBasicInfo.tsx
+++ b/ornn-web/src/components/skill/guided/StepBasicInfo.tsx
@@ -18,7 +18,7 @@ import { RuntimeSelect } from "@/components/form/RuntimeSelect";
 import { MultiValueInput } from "@/components/form/MultiValueInput";
 import { SKILL_CATEGORY_INFO } from "@/utils/constants";
 import { OUTPUT_TYPES } from "@/utils/skillFrontmatterSchema";
-import type { BasicInfoData } from "@/utils/skillCreateSchemas";
+import type { BasicInfoData, BasicInfoInput } from "@/utils/skillCreateSchemas";
 import { useTranslation } from "react-i18next";
 import { translateError } from "@/utils/translateError";
 
@@ -29,7 +29,7 @@ function fieldError(msg: string | undefined): string | undefined {
 }
 
 export interface StepBasicInfoProps {
-  form: UseFormReturn<BasicInfoData>;
+  form: UseFormReturn<BasicInfoInput, unknown, BasicInfoData>;
   showTools: boolean;
   showRuntimes: boolean;
 }
@@ -156,7 +156,7 @@ export function StepBasicInfo({
             control={form.control}
             render={({ field }) => (
               <ToolsInput
-                tools={field.value}
+                tools={field.value ?? []}
                 onChange={field.onChange}
                 error={fieldError(
                   form.formState.errors.metadata?.toolList?.message,
@@ -173,7 +173,7 @@ export function StepBasicInfo({
             control={form.control}
             render={({ field }) => (
               <RuntimeSelect
-                selected={field.value}
+                selected={field.value ?? []}
                 onChange={field.onChange}
                 error={fieldError(
                   form.formState.errors.metadata?.runtime?.message,
@@ -191,7 +191,7 @@ export function StepBasicInfo({
             render={({ field }) => (
               <MultiValueInput
                 label={t("guided.runtimeDeps")}
-                values={field.value}
+                values={field.value ?? []}
                 onChange={field.onChange}
                 placeholder={t("guided.runtimeDepsPlaceholder")}
                 helperText={t("guided.runtimeDepsHelper")}
@@ -209,7 +209,7 @@ export function StepBasicInfo({
             render={({ field }) => (
               <MultiValueInput
                 label={t("guided.envVars")}
-                values={field.value}
+                values={field.value ?? []}
                 onChange={field.onChange}
                 placeholder={t("guided.envVarsPlaceholder")}
                 helperText={t("guided.envVarsHelper")}
@@ -230,7 +230,7 @@ export function StepBasicInfo({
           control={form.control}
           render={({ field }) => (
             <TagInput
-              tags={field.value}
+              tags={field.value ?? []}
               onChange={field.onChange}
               error={fieldError(form.formState.errors.metadata?.tag?.message)}
             />
@@ -333,7 +333,7 @@ export function StepBasicInfo({
                     render={({ field }) => (
                       <MultiValueInput
                         label={t("guided.allowedTools")}
-                        values={field.value}
+                        values={field.value ?? []}
                         onChange={field.onChange}
                         placeholder={t("guided.allowedToolsPlaceholder")}
                         helperText={t("guided.allowedToolsHelper")}
@@ -356,7 +356,7 @@ export function StepBasicInfo({
                     render={({ field }) => (
                       <MultiValueInput
                         label={t("guided.contextPaths")}
-                        values={field.value}
+                        values={field.value ?? []}
                         onChange={field.onChange}
                         placeholder={t("guided.contextPathsPlaceholder")}
                         helperText={t("guided.contextPathsHelper")}

--- a/ornn-web/src/components/skill/guided/StepContent.tsx
+++ b/ornn-web/src/components/skill/guided/StepContent.tsx
@@ -7,11 +7,11 @@
 import { Controller, type UseFormReturn } from "react-hook-form";
 import { motion } from "framer-motion";
 import { MarkdownEditor } from "@/components/form/MarkdownEditor";
-import type { ContentData } from "@/utils/skillCreateSchemas";
+import type { ContentData, ContentInput } from "@/utils/skillCreateSchemas";
 import { useTranslation } from "react-i18next";
 
 export interface StepContentProps {
-  form: UseFormReturn<ContentData>;
+  form: UseFormReturn<ContentInput, unknown, ContentData>;
 }
 
 export function StepContent({ form }: StepContentProps) {

--- a/ornn-web/src/pages/skill/CreateSkillGuidedPage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGuidedPage.tsx
@@ -26,7 +26,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { track } from "@/lib/analytics";
 import { buildSkillMd } from "@/utils/frontmatterBuilder";
 import { buildFileTreeFromFolders, readUploadedFileContents } from "@/utils/fileTreeBuilder";
-import { basicInfoSchema, contentSchema, type BasicInfoData, type ContentData } from "@/utils/skillCreateSchemas";
+import { basicInfoSchema, contentSchema, type BasicInfoData, type BasicInfoInput, type ContentData, type ContentInput } from "@/utils/skillCreateSchemas";
 import type { FileNode } from "@/components/editor/FileTree";
 import type { SkillMetadata, SkillMetadataBlock, UploadableFolder } from "@/types/skillPackage";
 import { createDefaultSkillMetadata } from "@/types/skillPackage";
@@ -121,7 +121,7 @@ export function CreateSkillGuidedPage() {
   );
 
   // Basic info form (nested metadata)
-  const basicInfoForm = useForm<BasicInfoData>({
+  const basicInfoForm = useForm<BasicInfoInput, unknown, BasicInfoData>({
     resolver: zodResolver(basicInfoSchema),
     defaultValues: {
       name: formData.name,
@@ -140,7 +140,7 @@ export function CreateSkillGuidedPage() {
   });
 
   // Content form
-  const contentForm = useForm<ContentData>({
+  const contentForm = useForm<ContentInput, unknown, ContentData>({
     resolver: zodResolver(contentSchema),
     defaultValues: {
       readmeMd: formData.readmeMd,
@@ -204,7 +204,12 @@ export function CreateSkillGuidedPage() {
     if (currentStep === 0) {
       const isValid = await basicInfoForm.trigger();
       if (isValid) {
-        const data = basicInfoForm.getValues();
+        // `getValues()` returns the pre-validation (input) shape — fields
+        // with `.default(...)` show up as optional even though `trigger()`
+        // just succeeded. Cast to the post-validation type so the
+        // downstream `FormState` merge picks up the now-populated values
+        // without each one needing its own `?? defaultLiteral`.
+        const data = basicInfoForm.getValues() as BasicInfoData;
         setFormData((prev) => ({
           ...prev,
           name: data.name,
@@ -225,7 +230,7 @@ export function CreateSkillGuidedPage() {
     } else if (currentStep === 1) {
       const isValid = await contentForm.trigger();
       if (isValid) {
-        const data = contentForm.getValues();
+        const data = contentForm.getValues() as ContentData;
         setFormData((prev) => ({ ...prev, ...data }));
         setCurrentStep(2);
       }

--- a/ornn-web/src/utils/skillCreateSchemas.ts
+++ b/ornn-web/src/utils/skillCreateSchemas.ts
@@ -55,5 +55,12 @@ export const contentSchema = z.object({
   readmeMd: z.string().min(50, "Content must be at least 50 characters"),
 });
 
-export type BasicInfoData = z.infer<typeof basicInfoSchema>;
-export type ContentData = z.infer<typeof contentSchema>;
+// `Input` is the pre-validation shape (fields with `.default(...)` are
+// optional); `Data` is the post-validation shape (defaults applied, so
+// those fields are required). @hookform/resolvers 5 typed the Resolver
+// against the output, so consumers of these forms need both variants
+// (input for `useForm` / `UseFormReturn`, output for the submit handler).
+export type BasicInfoInput = z.input<typeof basicInfoSchema>;
+export type BasicInfoData = z.output<typeof basicInfoSchema>;
+export type ContentInput = z.input<typeof contentSchema>;
+export type ContentData = z.output<typeof contentSchema>;


### PR DESCRIPTION
Supersedes Dependabot #391 — the bump crossed two majors and needed coupled type refactoring at consumers, so the bot's auto-PR couldn't merge.

## Why this had to be a takeover

@hookform/resolvers v5 typed the `Resolver` against the Zod *output* shape rather than the input. With `useForm<T>` parameterised the old way, the form values (input shape, with `.default(…)` fields optional) get erroneously narrowed to the post-validation output (defaults applied, required). v5 caught this with the three-arg `useForm<InputShape, TContext, OutputShape>` generic, and the matching three-arg `UseFormReturn` for components that receive a form prop.

## Changes

| File | Change |
|---|---|
| `ornn-web/package.json` + `bun.lock` | `@hookform/resolvers` 3.10.0 → 5.2.2 |
| `ornn-web/src/utils/skillCreateSchemas.ts` | Export both `BasicInfoInput` / `BasicInfoData` and `ContentInput` / `ContentData` (z.input / z.output respectively) |
| `ornn-web/src/components/form/SkillForm.tsx` | Three-arg `useForm`, `SkillFormProps.defaultValues` typed as Input, submit handler signature unchanged (still Output) |
| `ornn-web/src/components/skill/guided/StepBasicInfo.tsx` | `UseFormReturn\<…\>` prop uses the three-arg form; field.value passed to MultiValueInput/TagInput/RuntimeSelect/ToolsInput uses `?? []` |
| `ornn-web/src/components/skill/guided/StepContent.tsx` | Same prop-type adjustment |
| `ornn-web/src/pages/skill/CreateSkillGuidedPage.tsx` | `useForm` three-arg; `getValues()` post-trigger cast to the output type (one cast replaces six per-field `?? defaultLiteral` patches) |

Pure refactor — no behaviour change at runtime, only the type model narrows correctly. Follow the comment block in `skillCreateSchemas.ts` if you add another form on top of this pattern.

## Verification

| Check | Result |
|---|---|
| `bun audit` | No vulnerabilities found |
| `bun run lint` | 78 warnings, 0 errors (develop baseline) |
| `bun run typecheck` | 0 errors |
| `bun run test` | 528 + 15 + 1 pass, 0 fail across 50 files |
| `bun run build:web` | built in 334ms |

After this lands, close Dependabot #391 as superseded.