### PR TITLE
chore(deps): upgrade zod 3 → 4 (supersedes Dependabot #397)

### DIFF
--- a/.changeset/upgrade-zod-4.md
+++ b/.changeset/upgrade-zod-4.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Upgrade `zod` 3 → 4 across the workspace. Three mechanical breaking-change fixes: `z.record(X)` → `z.record(z.string(), X)`, `invalid_type_error` constructor option → `error` callback, and a one-line type bridge for `zod-to-json-schema` while the upstream package catches up to v4. No runtime behaviour change.

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "pino-pretty": "^13.1.3",
         "posthog-node": "^5.33.2",
         "yaml": "^2.9.0",
-        "zod": "^3.24.0",
+        "zod": "^4.4.3",
         "zod-to-json-schema": "^3.25.1",
       },
       "devDependencies": {
@@ -60,7 +60,7 @@
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.0",
         "yaml": "^2.9.0",
-        "zod": "^3.24.0",
+        "zod": "^4.4.3",
         "zustand": "^5.0.0",
       },
       "devDependencies": {
@@ -1534,7 +1534,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
@@ -1605,6 +1605,8 @@
     "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "eslint-plugin-react-hooks/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/ornn-api/package.json
+++ b/ornn-api/package.json
@@ -20,7 +20,7 @@
     "pino-pretty": "^13.1.3",
     "posthog-node": "^5.33.2",
     "yaml": "^2.9.0",
-    "zod": "^3.24.0",
+    "zod": "^4.4.3",
     "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -32,7 +32,7 @@ const playgroundMessageSchema = z.object({
   toolCalls: z.array(z.object({
     id: z.string(),
     name: z.string(),
-    args: z.record(z.unknown()),
+    args: z.record(z.string(), z.unknown()),
   })).optional(),
   toolCallId: z.string().optional(),
 });
@@ -40,7 +40,7 @@ const playgroundMessageSchema = z.object({
 const chatRequestSchema = z.object({
   messages: z.array(playgroundMessageSchema).min(1).max(100),
   skillId: z.string().optional(),
-  envVars: z.record(z.string()).optional(),
+  envVars: z.record(z.string(), z.string()).optional(),
   /**
    * Optional admin-curated model id. When omitted, falls back to the
    * surface default (or 503 if no models are enabled). When provided,

--- a/ornn-api/src/openapi/schemas.ts
+++ b/ornn-api/src/openapi/schemas.ts
@@ -63,7 +63,7 @@ export const skillDetailResponseSchema = z.object({
   description: z.string().describe("Brief description of what the skill does and when to use it"),
   license: z.string().nullable().describe("SPDX license identifier (e.g. 'MIT', 'Apache-2.0'), or null if not specified"),
   compatibility: z.string().nullable().describe("Compatible AI model or platform (e.g. 'claude', 'gpt-4'), or null if model-agnostic"),
-  metadata: z.record(z.unknown()).describe("Structured skill metadata including category, outputType, runtimes, tools, and tags. See skill format spec for full schema"),
+  metadata: z.record(z.string(), z.unknown()).describe("Structured skill metadata including category, outputType, runtimes, tools, and tags. See skill format spec for full schema"),
   tags: z.array(z.string()).describe("List of tag names for categorization and search filtering"),
   skillHash: z.string().describe("SHA-256 hash of the skill package contents. Changes when the skill is updated"),
   presignedPackageUrl: z.string().describe("Temporary pre-signed URL to download the skill package ZIP file. Expires after a short period"),
@@ -78,8 +78,8 @@ export const skillDetailApiResponse = apiResponse(skillDetailResponseSchema);
 export const skillJsonResponseSchema = z.object({
   name: z.string().describe("Skill name"),
   description: z.string().describe("Skill description"),
-  metadata: z.record(z.unknown()).describe("Structured skill metadata (category, outputType, runtimes, tools, tags)"),
-  files: z.record(z.string()).describe("Map of relative file path to file content string. Keys are paths like 'skill.md', 'scripts/run.py'. Values are the full text content of each file. Binary files are excluded"),
+  metadata: z.record(z.string(), z.unknown()).describe("Structured skill metadata (category, outputType, runtimes, tools, tags)"),
+  files: z.record(z.string(), z.string()).describe("Map of relative file path to file content string. Keys are paths like 'skill.md', 'scripts/run.py'. Values are the full text content of each file. Binary files are excluded"),
 });
 
 export const skillJsonApiResponse = apiResponse(skillJsonResponseSchema);
@@ -167,17 +167,17 @@ export const chatRequestBodySchema = z.object({
     toolCalls: z.array(z.object({
       id: z.string(),
       name: z.string(),
-      args: z.record(z.unknown()),
+      args: z.record(z.string(), z.unknown()),
     })).optional(),
     toolCallId: z.string().optional(),
   })).min(1).max(100),
   skillId: z.string().optional(),
-  envVars: z.record(z.string()).optional(),
+  envVars: z.record(z.string(), z.string()).optional(),
 });
 
 export const playgroundChatEventSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("text-delta"), delta: z.string() }),
-  z.object({ type: z.literal("tool-call"), toolCall: z.object({ id: z.string(), name: z.string(), args: z.record(z.unknown()) }) }),
+  z.object({ type: z.literal("tool-call"), toolCall: z.object({ id: z.string(), name: z.string(), args: z.record(z.string(), z.unknown()) }) }),
   z.object({ type: z.literal("tool-result"), toolCallId: z.string(), result: z.string() }),
   z.object({ type: z.literal("error"), message: z.string() }),
   z.object({ type: z.literal("finish"), finishReason: z.string() }),

--- a/ornn-api/src/openapi/specBuilder.ts
+++ b/ornn-api/src/openapi/specBuilder.ts
@@ -16,7 +16,11 @@ type PathItem = Record<string, unknown>;
 type OpenApiSpec = Record<string, unknown>;
 
 function toSchema(zodSchema: ZodTypeAny): JsonSchema {
-  const result = zodToJsonSchema(zodSchema, { target: "openApi3", $refStrategy: "none" }) as JsonSchema;
+  // Zod 4 changed the public ZodType signature; zod-to-json-schema's
+  // type guards still target the v3 shape. Cast through `any` at the
+  // boundary — the runtime shape is unchanged, this is purely the
+  // type bridge.
+  const result = zodToJsonSchema(zodSchema as unknown as Parameters<typeof zodToJsonSchema>[0], { target: "openApi3", $refStrategy: "none" }) as JsonSchema;
   // Remove top-level $schema key (not valid in OpenAPI component schemas)
   delete result.$schema;
   return result;

--- a/ornn-api/src/shared/schemas/skillFrontmatter.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.ts
@@ -121,8 +121,16 @@ export const skillFrontmatterSchema = z.object({
   // lossless. A clear message points them at the fix.
   version: z
     .string({
-      invalid_type_error:
-        "version must be a quoted string — write `version: \"0.1\"` in SKILL.md, not `version: 0.1` (YAML parses the unquoted form as a number and loses the trailing zero).",
+      // Zod 4 replaced the per-issue keys (`invalid_type_error`,
+      // `required_error`, …) with a single `error` callback that
+      // receives the issue and decides what to surface. The intent
+      // here is unchanged: only override the message when the parsed
+      // value isn't a string (i.e. YAML parsed `version: 0.1` as a
+      // number).
+      error: (issue) =>
+        issue.code === "invalid_type"
+          ? 'version must be a quoted string — write `version: "0.1"` in SKILL.md, not `version: 0.1` (YAML parses the unquoted form as a number and loses the trailing zero).'
+          : undefined,
     })
     .regex(
       SKILL_VERSION_REGEX,
@@ -139,7 +147,7 @@ export const skillFrontmatterSchema = z.object({
   context: z.array(z.string()).optional(),
   agent: z.string().max(100).optional(),
   "argument-hint": z.string().max(500).optional(),
-  hooks: z.record(z.unknown()).optional(),
+  hooks: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type SkillFrontmatterInput = z.input<typeof skillFrontmatterSchema>;

--- a/ornn-web/package.json
+++ b/ornn-web/package.json
@@ -33,7 +33,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",
     "yaml": "^2.9.0",
-    "zod": "^3.24.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/ornn-web/src/utils/skillCreateSchemas.ts
+++ b/ornn-web/src/utils/skillCreateSchemas.ts
@@ -45,7 +45,7 @@ export const basicInfoSchema = z.object({
   context: z.array(z.string()).default([]),
   agent: z.string().max(100).optional(),
   argumentHint: z.string().max(500).optional(),
-  hooks: z.record(z.unknown()).optional(),
+  hooks: z.record(z.string(), z.unknown()).optional(),
 });
 
 /**

--- a/ornn-web/src/utils/skillFrontmatterSchema.ts
+++ b/ornn-web/src/utils/skillFrontmatterSchema.ts
@@ -209,7 +209,7 @@ export const skillFrontmatterSchema = z.object({
   model: z.string().max(100).optional(),
   context: z.array(z.string()).optional(),
   agent: z.string().max(100).optional(),
-  hooks: z.record(z.unknown()).optional(),
+  hooks: z.record(z.string(), z.unknown()).optional(),
   argumentHint: z.string().max(500).optional(),
 
   // Ornn platform extensions (top-level)


### PR DESCRIPTION
Supersedes Dependabot #397. Zod 4 has real breaking changes; this PR makes them mechanically.

| Breaking change | Sites | Fix |
|---|---|---|
| `z.record(X)` removed in favour of `z.record(K, V)` | 11 across api + web | Explicit `z.record(z.string(), …)` — semantic-preserving |
| `invalid_type_error` constructor option removed | 1 (`skillFrontmatter.version`) | Switch to the new `error: (issue) => …` callback, gated on `issue.code === "invalid_type"` so behaviour stays identical |
| `zod-to-json-schema`'s type guards target v3 `ZodType` | 1 (`openapi/specBuilder.toSchema`) | One-line cast at the boundary. Runtime unchanged; drop the cast when the upstream package ships v4 support |

No runtime behaviour change. All gates clean (lint / typecheck / 533 tests / build:web 314ms / audit). After this lands, close Dependabot #397.