### PR TITLE
fix(ci): release workflow uses GitHub App token so bot-opened PRs trigger downstream workflows

### DIFF
--- a/.changeset/release-bot-app-token.md
+++ b/.changeset/release-bot-app-token.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI: `changeset-release` workflow now authenticates as the `ornn-release-bot` GitHub App so its bot-opened PRs trigger downstream required workflows. No application code change.

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -20,10 +20,17 @@ name: Changeset release
 #   C) No pending changesets and the tag already exists — a normal
 #      hotfix / docs / CI push that shouldn't release anything. No-op.
 #
-# The bot needs `contents: write` + `pull-requests: write` so it can
-# push branches and open PRs. The org-level "Allow GitHub Actions to
-# create and approve pull requests" must be enabled for the PR-create
-# step to succeed (confirmed April 2026).
+# The bot authenticates as the `ornn-release-bot` GitHub App (issue #237)
+# rather than the default GITHUB_TOKEN. GITHUB_TOKEN-driven pushes do
+# not trigger downstream workflows (GitHub's recursive-run safeguard),
+# which leaves required status checks on bot-opened PRs stuck in
+# "Expected — waiting" forever. App tokens are a separate identity, so
+# the safeguard does not apply.
+#
+# The app needs `contents: write` + `pull-requests: write` on the repo
+# (granted at install time). Org-level "Allow GitHub Actions to create
+# and approve pull requests" must stay enabled regardless of the token
+# in use.
 
 on:
   push:
@@ -36,13 +43,44 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # The `permissions:` block governs the default GITHUB_TOKEN; this
+    # workflow doesn't rely on it for any writes (those go through the
+    # app token minted in the first step) but `contents: read` is
+    # needed by the checkout that runs before the app token exists.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Discover app bot user id (for git commit email)
+        id: bot-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SLUG="${{ steps.app-token.outputs.app-slug }}"
+          # GitHub App bot accounts have a numeric user id used in the
+          # noreply email pattern:
+          #   <user-id>+<slug>[bot]@users.noreply.github.com
+          # The id is stable for the lifetime of the app. Look it up
+          # rather than hardcoding so the workflow keeps working if
+          # the app is ever recreated with the same slug.
+          USER_ID=$(gh api "/users/${SLUG}%5Bbot%5D" --jq .id)
+          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
+          echo "user-id=${USER_ID}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${SLUG}[bot] → user id ${USER_ID}"
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Make git push, gh CLI, and downstream `pull_request` event
+          # fan-out all run under the app identity — this is the whole
+          # point of #237.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect state
         id: state
@@ -78,12 +116,12 @@ jobs:
       - name: Create release-bump PR (A)
         if: steps.state.outputs.pending != '0'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_AUTHOR_NAME: ${{ steps.bot-id.outputs.slug }}[bot]
+          GIT_AUTHOR_EMAIL: ${{ steps.bot-id.outputs.user-id }}+${{ steps.bot-id.outputs.slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.bot-id.outputs.slug }}[bot]
+          GIT_COMMITTER_EMAIL: ${{ steps.bot-id.outputs.user-id }}+${{ steps.bot-id.outputs.slug }}[bot]@users.noreply.github.com
         run: |
           bun run version-packages
           NEW_VERSION=$(node -p "require('./ornn-api/package.json').version")
@@ -112,11 +150,11 @@ jobs:
       - name: Create tag + GitHub Release (B)
         if: steps.state.outputs.pending == '0' && steps.state.outputs.tag_exists == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_AUTHOR_NAME: ${{ steps.bot-id.outputs.slug }}[bot]
+          GIT_AUTHOR_EMAIL: ${{ steps.bot-id.outputs.user-id }}+${{ steps.bot-id.outputs.slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.bot-id.outputs.slug }}[bot]
+          GIT_COMMITTER_EMAIL: ${{ steps.bot-id.outputs.user-id }}+${{ steps.bot-id.outputs.slug }}[bot]@users.noreply.github.com
         run: |
           VERSION="${{ steps.state.outputs.version }}"
           TAG="${{ steps.state.outputs.tag }}"
@@ -148,12 +186,12 @@ jobs:
       - name: Open sync PR main → develop (B)
         if: steps.state.outputs.pending == '0' && steps.state.outputs.tag_exists == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_AUTHOR_NAME: ${{ steps.bot-id.outputs.slug }}[bot]
+          GIT_AUTHOR_EMAIL: ${{ steps.bot-id.outputs.user-id }}+${{ steps.bot-id.outputs.slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.bot-id.outputs.slug }}[bot]
+          GIT_COMMITTER_EMAIL: ${{ steps.bot-id.outputs.user-id }}+${{ steps.bot-id.outputs.slug }}[bot]@users.noreply.github.com
         run: |
           VERSION="${{ steps.state.outputs.version }}"
           SYNC_BRANCH="sync/post-release-v${VERSION}"
@@ -213,10 +251,16 @@ jobs:
               echo "::error::refusing to auto-merge: base '$PR_BASE' is not 'develop'"
               exit 1
             fi
+            # Allow the previous github-actions identity (kept for old
+            # in-flight runs that started before the #237 cutover) and
+            # the new release-bot app identity. Anything else is
+            # refused so a hostile actor can't make this safety rail
+            # auto-merge an arbitrary PR.
             case "$PR_AUTHOR" in
               github-actions|app/github-actions|github-actions\[bot\]) ;;
+              ornn-release-bot|app/ornn-release-bot|ornn-release-bot\[bot\]) ;;
               *)
-                echo "::error::refusing to auto-merge: author '$PR_AUTHOR' is not the github-actions bot"
+                echo "::error::refusing to auto-merge: author '$PR_AUTHOR' is not a trusted release bot"
                 exit 1
                 ;;
             esac

--- a/.github/workflows/require-review.yml
+++ b/.github/workflows/require-review.yml
@@ -27,8 +27,14 @@ jobs:
 
             // Trusted authors can self-merge without external approval:
             //   - chronoai-shining (maintainer)
-            //   - github-actions[bot] (release-bump + sync PRs opened by
-            //     the changeset-release workflow state machine)
+            //   - github-actions[bot] (legacy — release-bump + sync PRs
+            //     opened by changeset-release before #237 cut over to
+            //     the GitHub App identity; kept so any in-flight bot PRs
+            //     from before that PR landed still pass this gate)
+            //   - ornn-release-bot[bot] (current changeset-release
+            //     identity per #237 — release-bump + sync PRs now come
+            //     from the GitHub App so downstream `pull_request`
+            //     workflows actually fire on its PRs)
             //   - dependabot[bot] (weekly dep update PRs from the
             //     supply-chain baseline in #383 — kept defence-in-depth
             //     by the audit / lint / typecheck / test / docker-build
@@ -37,6 +43,8 @@ jobs:
               'chronoai-shining',
               'github-actions[bot]',
               'app/github-actions',
+              'ornn-release-bot[bot]',
+              'app/ornn-release-bot',
               'dependabot[bot]',
               'app/dependabot',
             ]);


### PR DESCRIPTION
## Summary

Fixes the long-standing release-workflow stall described in #237. The \`changeset-release.yml\` state machine now authenticates as the \`ornn-release-bot\` GitHub App rather than the default \`GITHUB_TOKEN\`, so the \`release/v<next> → main\` and \`sync/post-release-v<v> → develop\` PRs it opens fan out their \`pull_request\` events into downstream workflows the way they're supposed to.

Closes #237.

## Why

GitHub's recursive-run safeguard explicitly does not trigger downstream workflows for \`pull_request\` events authored by the default \`GITHUB_TOKEN\`. That left every release-bump / sync PR sitting with required status checks (\`check-approval\`, \`check-source-branch\`) stuck in **"Expected — waiting for status to be reported"** until someone pushed a manual empty commit. Hit on v0.5.0 (#235). About to hit again on v0.6.0 (#337 is open right now) — this PR ships ahead of it.

App tokens are a separate identity, exempt from that safeguard. Drop in the app, swap the token reference, done.

## Changes

### \`.github/workflows/changeset-release.yml\`
| Step | Change |
|---|---|
| (new) \`Mint app token\` | \`actions/create-github-app-token@v2\` reads \`RELEASE_BOT_APP_ID\` + \`RELEASE_BOT_PRIVATE_KEY\` secrets |
| (new) \`Discover app bot user id\` | Looks up \`/users/<slug>[bot]\` at runtime so the \`<id>+<slug>[bot]@users.noreply.github.com\` commit-email is correct without hardcoding (resilient to app re-creation with same slug) |
| \`actions/checkout\` | Now uses the app token so \`git push\` operations run under the app identity |
| All State-A / State-B run steps | \`GITHUB_TOKEN\` + \`GH_TOKEN\` env vars now reference the minted app token; \`GIT_AUTHOR\` / \`GIT_COMMITTER\` derived dynamically from the bot slug + user-id |
| Auto-merge safety rail | Author whitelist gains the new bot identity case (plus the legacy \`github-actions[bot]\` case stays for in-flight runs) |
| Job-level \`permissions:\` | Tightened from \`contents: write, pull-requests: write\` → \`contents: read\` — those grants belonged to the default GITHUB_TOKEN, which is no longer used for writes (app token carries its own grants from the installation) |

### \`.github/workflows/require-review.yml\`
\`TRUSTED_AUTHORS\` gains \`ornn-release-bot[bot]\` + \`app/ornn-release-bot\`, so the bot's PRs auto-pass \`check-approval\`. Existing entries (\`chronoai-shining\`, \`github-actions[bot]\`, \`dependabot[bot]\`, …) unchanged.

## Setup (done by user before this PR)

- Created \`ornn-release-bot\` GitHub App under the \`ChronoAIProject\` org
- Repository permissions: \`Contents: Read & write\`, \`Pull requests: Read & write\`
- Installed on \`ChronoAIProject/Ornn\` (selected repository: only Ornn)
- Generated private key, stored in repo secrets:
  - \`RELEASE_BOT_APP_ID\` = 3685384
  - \`RELEASE_BOT_PRIVATE_KEY\` = (the .pem contents)

## Test plan

- [ ] CI green on this PR (lint / typecheck / test / build / docker-build / audit / gitleaks / check-changeset / check-approval — the existing gates run normally because this PR's author is \`chronoai-shining\`, on the existing whitelist).
- [ ] **Real validation** comes on next release: merge a develop → main PR with pending changesets, then watch:
  - The bot-opened \`release/v<next> → main\` PR shows \`check-approval\` + \`check-source-branch\` running automatically (no manual nudge).
  - After merging that, the auto-created \`sync/post-release-v<v> → develop\` PR completes its auto-merge step without stalling.
- [ ] If anything goes sideways with the app identity on the first run, the legacy \`github-actions[bot]\` whitelist entries are still there as a quick rollback target.