### PR TITLE
fix(web): install card visibility + size polish (#413, #414)

### DIFF
--- a/.changeset/install-card-visibility-and-size.md
+++ b/.changeset/install-card-visibility-and-size.md
@@ -1,0 +1,8 @@
+---
+"ornn-web": patch
+---
+
+Two install-card polish fixes:
+
+- Install card visibility now follows the skill itself — anyone who can see the skill can see the install card, including unauthenticated viewers on public skills. The prior `canTryWithCli` gate from #411 was an unnecessary second wall on top of the page-level access control.
+- Install card height is stable when switching tabs. The Via-prompt code block is now a fixed 160px scrollable preview (was 288px max, which dwarfed the npx tab); both tabpanels reserve the same 224px envelope so the card outline doesn't jump.

--- a/ornn-web/src/components/skill/SkillInstallCard.tsx
+++ b/ornn-web/src/components/skill/SkillInstallCard.tsx
@@ -131,10 +131,13 @@ function CopyBlock({
 
   return (
     <div className="flex items-stretch overflow-hidden rounded border border-strong-edge bg-elevated/40">
+      {/* Fixed-height code area on both variants so switching tabs
+          doesn't change the card height (#414). The prompt is meant to
+          be copied, not read inline — internal scroll for the rest. */}
       <code
         className={
           multiline
-            ? "flex-1 max-h-72 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs text-strong"
+            ? "flex-1 h-40 overflow-y-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs leading-relaxed text-strong"
             : "flex-1 overflow-x-auto px-3 py-2 font-mono text-sm text-strong"
         }
       >
@@ -230,8 +233,13 @@ export function SkillInstallCard({ skill, className }: SkillInstallCardProps) {
         </TabButton>
       </div>
 
+      {/* Both tabpanels share `min-h-[14rem]` (224px) so the card height
+          stays put as the user switches between them (#414). Picked to
+          accommodate the npx tab's natural content (helper text +
+          command + footer); the prompt tab's fixed-height code block
+          (160px) plus its helper text fits within the same envelope. */}
       {tab === "prompt" && (
-        <div role="tabpanel" className="mt-3 space-y-3">
+        <div role="tabpanel" className="mt-3 min-h-[14rem] space-y-3">
           <p className="font-text text-xs text-meta">
             {t(
               "skillInstallCard.promptHelper",
@@ -247,7 +255,7 @@ export function SkillInstallCard({ skill, className }: SkillInstallCardProps) {
       )}
 
       {tab === "npx" && (
-        <div role="tabpanel" className="mt-3 space-y-3">
+        <div role="tabpanel" className="mt-3 min-h-[14rem] space-y-3">
           {npxAvailable ? (
             <>
               <p className="font-text text-xs text-meta">

--- a/ornn-web/src/components/skill/SkillInstallCard.tsx
+++ b/ornn-web/src/components/skill/SkillInstallCard.tsx
@@ -10,11 +10,11 @@
  *                   renders an "unavailable" placeholder when those conditions
  *                   don't hold instead of hiding the whole tab.
  *
- * Hidden entirely when the caller is not authenticated, or for non-public
- * skills viewed by a non-owner — i.e. when the caller can't try the skill
- * at all (canTryWithCli is false). Otherwise the card always shows so the
- * prompt path is reachable for private-skill owners and for deployments
- * without the GitHub mirror configured.
+ * Visibility follows the skill itself (#413). The component renders
+ * whenever the skill detail page does — the page-level auth + ACL
+ * guards already enforce "can this person see this skill at all", and
+ * both tabs (prompt + npx) only emit public metadata, so no second
+ * gate is needed here.
  *
  * Replaces the older MirrorInstallCard + the "Install skill to my agent"
  * three-dots menu item (#411).

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -125,7 +125,6 @@ export function SkillDetailPage() {
   const isOwner = !!(isAuthenticated && user?.id && skill?.createdBy === user.id);
   const isAdminUser = isAdmin(user);
   const canManageVersions = isOwner || isAdminUser;
-  const canTryWithCli = !!skill && (!skill.isPrivate || isOwner);
 
   const latestVersion = versionList[0]?.version;
   const viewingLatest = !versionParam || (latestVersion && versionParam === latestVersion);
@@ -426,12 +425,12 @@ export function SkillDetailPage() {
         )}
 
         {/* ── Install card (#411) ── */}
-        {/* Folded the old MirrorInstallCard + the "Install skill to my agent"
-            three-dots menu item into one tabbed card. Gate on canTryWithCli
-            so private-skill owners still see the prompt path (they used to
-            reach it via the now-deleted three-dots menu); strangers viewing
-            a private skill see nothing, same as before. */}
-        {canTryWithCli && <SkillInstallCard className="shrink-0" skill={skill} />}
+        {/* Visibility follows the skill (#413): if the viewer can see this
+            skill detail page they can see the install card. The page-level
+            auth + ACL guards already enforce "can this person see this
+            skill at all". Both tabs (prompt + npx) only emit public
+            metadata so there's no reason to gate further. */}
+        <SkillInstallCard className="shrink-0" skill={skill} />
 
         {/* ── Hero strip ── */}
         <SkillHeroStrip


### PR DESCRIPTION
Two follow-up fixes for the install-card refactor (#411).

| Issue | Fix |
|---|---|
| #413 — install card hidden for anonymous viewers / non-auth on public skills | Drop the `canTryWithCli` gate at the call site. Both tabs only emit public metadata; the page-level auth + ACL guards already enforce skill access. |
| #414 — Via-prompt too tall + card height jumps between tabs | Via-prompt code block changes from `max-h-72` (288px max) → fixed `h-40` (160px) with internal scroll. Both tabpanels reserve `min-h-[14rem]` (224px) so the card outline stays put when switching tabs. |

Closes #413, closes #414.

Three commits:

1. `fix(web): install card visibility follows skill (#413)`
2. `fix(web): install card — unify Via-prompt + Via-npx height (#414)`
3. `docs: changeset`

Locally clean: typecheck / lint / tests / build all green.