### PR TITLE
feat(web): install card — center npx command + i18n the skillInstallCard namespace

### DIFF
--- a/.changeset/install-card-i18n-and-centered.md
+++ b/.changeset/install-card-i18n-and-centered.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Install card — center the Via-npx command on both axes inside its code box. Also fills in the missing `skillInstallCard` i18n namespace for both en and zh (previously all strings only had inline English fallbacks).

--- a/ornn-web/src/components/skill/SkillInstallCard.tsx
+++ b/ornn-web/src/components/skill/SkillInstallCard.tsx
@@ -153,7 +153,11 @@ function CopyBlock({
             // pr-20 reserves a clear gutter so prompt text never slides
             // under the floating COPY button.
             ? "block h-full overflow-y-auto whitespace-pre-wrap break-words px-3 py-2 pr-20 font-mono text-xs leading-relaxed text-strong"
-            : "h-full flex items-center overflow-x-auto px-3 pr-20 font-mono text-sm text-strong"
+            // Single-line command centred both axes inside the h-32
+            // box. Symmetric `px-20` mirrors the COPY-button gutter on
+            // the left so the centred text is visually centred, not
+            // offset by the right-only padding.
+            : "h-full flex items-center justify-center overflow-x-auto px-20 font-mono text-sm text-strong"
         }
       >
         {content}

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -93,6 +93,27 @@
     "deleteSuccess": "Skill deleted successfully",
     "deleteFailed": "Failed to delete skill"
   },
+  "skillInstallCard": {
+    "title": "Install",
+    "subtitle": "Drop this skill into your own agent with one of the two flows below.",
+    "tablistAria": "Install method",
+    "tabPrompt": "Via prompt",
+    "tabNpx": "Via npx",
+    "promptHelper": "Copy the block below and paste it into your agent — it instructs the agent to fetch and install this skill from Ornn.",
+    "npxHelper": "Mirrored to GitHub for one-line installation in any agent harness.",
+    "npxNotAvailablePrivate": "Not available — private skills are never mirrored to GitHub. Use the prompt flow instead.",
+    "npxNotAvailableMirrorOff": "Not available — this deployment doesn't have the GitHub mirror configured. Use the prompt flow instead.",
+    "copy": "Copy",
+    "copied": "Copied",
+    "copyPromptAria": "Copy install prompt",
+    "copyNpxAria": "Copy install command",
+    "viewOnGithub": "View on GitHub",
+    "synced": "Synced",
+    "lagging": "Lagging",
+    "pending": "Pending first sync",
+    "lastSync": "Last sync",
+    "commit": "Commit"
+  },
   "skillDetail": {
     "packageContents": "Package Contents",
     "description": "Description",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -93,6 +93,27 @@
     "deleteSuccess": "技能删除成功",
     "deleteFailed": "删除技能失败"
   },
+  "skillInstallCard": {
+    "title": "安装",
+    "subtitle": "通过下面任一方式把这个技能装到你自己的 agent 里。",
+    "tablistAria": "安装方式",
+    "tabPrompt": "提示词",
+    "tabNpx": "Npx 命令",
+    "promptHelper": "复制下面这段内容粘贴到你的 agent —— 它会指引 agent 从 Ornn 拉取并安装该技能。",
+    "npxHelper": "已镜像到 GitHub，可在任何 agent 环境中一行命令安装。",
+    "npxNotAvailablePrivate": "不可用 —— 私有技能不会镜像到 GitHub。请改用 Via prompt。",
+    "npxNotAvailableMirrorOff": "不可用 —— 当前部署未配置 GitHub 镜像。请改用 Via prompt。",
+    "copy": "复制",
+    "copied": "已复制",
+    "copyPromptAria": "复制安装提示词",
+    "copyNpxAria": "复制安装命令",
+    "viewOnGithub": "在 GitHub 上查看",
+    "synced": "已同步",
+    "lagging": "落后",
+    "pending": "等待首次同步",
+    "lastSync": "最近同步",
+    "commit": "Commit"
+  },
   "skillDetail": {
     "packageContents": "技能内容",
     "description": "描述",


### PR DESCRIPTION
Two coupled tweaks:

1. **Center the npx command** both vertically and horizontally inside the h-32 code box. Symmetric `px-20` padding mirrors the COPY-button gutter on the left so the centered text is visually centered, not offset.
2. **Add the skillInstallCard i18n namespace** to en.json + zh.json. The component already had inline English fallbacks at every t() call site, but zh users were silently seeing English — now both catalogues have the full set of keys (title, subtitle, tab labels, helpers, copy states, sync chip labels, etc.).