### PR TITLE
feat(ci): release body from curated .github/release-notes-next.md file

### DIFF
--- a/.changeset/release-notes-from-repo-file.md
+++ b/.changeset/release-notes-from-repo-file.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI: release workflow now reads `.github/release-notes-next.md` as the GitHub Release body, with a fall-back to a short link-to-CHANGELOG body when the file isn't curated. Replaces the raw-CHANGELOG dump that blew past GitHub's 125 000-char limit on v0.6.0.

--- a/.github/release-notes-next.md
+++ b/.github/release-notes-next.md
@@ -1,0 +1,55 @@
+<!--
+@claude / future-me, before opening the next develop → main release PR:
+
+  1. Read every file under `.changeset/*.md` (these get consumed at
+     release time). Also skim the bits of `ornn-api/CHANGELOG.md` and
+     `ornn-web/CHANGELOG.md` that landed since the previous tag if you
+     want extra context.
+  2. Replace each `(write here)` block below with a brief, user-facing
+     summary. Drop an entire section if there's nothing for it.
+
+Style rules:
+
+  - One bullet = one product-level fact a user / agent developer
+    actually cares about. 6–12 words. Plain prose.
+  - Cluster purely-technical items (refactors, dep bumps, infra / CI,
+    type fixes, internal renames) into a single trailing bullet per
+    section:
+      Fixed       → "Few technical bugs fixed"
+      New Feature → "Technical enhancement"
+      Changed     → "Technical enhancement"
+    Don't expand the technical bucket into individual bullets.
+  - No PR / issue refs, no version numbers, no author thanks, no
+    "see #N" links. The CHANGELOG link at the bottom of the
+    auto-generated release body already covers all of that.
+  - English only. Tight.
+  - If a section ends up with only the technical-bucket bullet, that's
+    fine — keep it. If a section ends up with zero bullets (genuinely
+    nothing happened in that bucket), delete the whole section
+    including its heading.
+
+How this file is used by the release workflow:
+
+  - `.github/workflows/changeset-release.yml` State B reads this file.
+  - If the file is missing OR still contains the literal string
+    `(write here)`, the workflow falls back to a short body that
+    links to the in-repo CHANGELOGs (release still publishes, just
+    without custom prose).
+  - Otherwise the file's content below this comment block is used as
+    the GitHub Release body, with the CHANGELOG-link footer appended.
+
+After release, leave this file's content as-is or replace it ahead of
+the next release. The workflow doesn't care about post-release state.
+-->
+
+## Fixed
+
+- (write here)
+
+## New Feature
+
+- (write here)
+
+## Changed
+
+- (write here)

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -161,50 +161,70 @@ jobs:
           git tag -a "${TAG}" -m "Release ${TAG}"
           git push origin "${TAG}"
 
-          extract_section() {
-            awk -v v="$1" '
-              /^## / {
-                if (found) { exit }
-                if ($0 ~ "^## " v "$") { found=1; next }
-              }
-              found { print }
-            ' "$2"
-          }
-          API_NOTES=$(extract_section "${VERSION}" ornn-api/CHANGELOG.md)
-          WEB_NOTES=$(extract_section "${VERSION}" ornn-web/CHANGELOG.md)
+          # Release-body resolution, in priority order (#431):
+          #
+          #   1. `.github/release-notes-next.md` — if the file exists
+          #      and the author has filled it in (placeholder string
+          #      `(write here)` removed), strip its HTML comment block
+          #      and use the remaining prose as the release body.
+          #      Footer with CHANGELOG links is always appended.
+          #
+          #   2. Short body that just links to the per-package
+          #      CHANGELOG sections on the tag. Used when (1) wasn't
+          #      filled in, or when the full inline notes would
+          #      exceed GitHub's 125 000-char body cap (#429 / #430).
+          #
+          # Inline-CHANGELOG body was retired — even when it fits, the
+          # raw consumed changesets are engineer-speak that doesn't
+          # belong on a public release page. Authors curate the
+          # user-facing summary into release-notes-next.md before
+          # opening their develop → main PR.
+          REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
+          CHANGELOG_FOOTER=$(cat <<EOF
 
-          BODY_FULL=$(cat <<EOF
-          ## \`ornn-api\` ${VERSION}
-          ${API_NOTES}
-          ## \`ornn-web\` ${VERSION}
-          ${WEB_NOTES}
+          ---
+
+          Full per-PR detail: [\`ornn-api\` CHANGELOG](${REPO_URL}/blob/${TAG}/ornn-api/CHANGELOG.md#${VERSION//./}) · [\`ornn-web\` CHANGELOG](${REPO_URL}/blob/${TAG}/ornn-web/CHANGELOG.md#${VERSION//./})
           EOF
           )
 
-          # GitHub's create-release API rejects bodies > 125 000 chars
-          # (platform-wide hard limit, not a repo setting — can't be
-          # raised). Big releases — v0.6.0 hit this at #429 — exceed
-          # the cap easily once 50+ changesets stack up. Fall back to
-          # a short body linking to the in-repo CHANGELOG on the tag,
-          # which renders the same content without duplicating it
-          # into the release-create call. 120 000 leaves headroom for
-          # the framing text we wrap around the notes.
-          BODY_LEN=${#BODY_FULL}
-          MAX_LEN=120000
-          if [ "$BODY_LEN" -gt "$MAX_LEN" ]; then
-            echo "Body is ${BODY_LEN} chars (cap ${MAX_LEN}) — using short-body fallback with CHANGELOG links."
-            REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
-            BODY=$(cat <<EOF
-          The combined per-package CHANGELOG section for v${VERSION} exceeds GitHub Releases' 125 000-char body limit, so the release notes themselves live in the in-repo CHANGELOGs on the v${VERSION} tag:
+          RELEASE_NOTES_FILE=".github/release-notes-next.md"
+          USE_CURATED=false
+          if [ -f "$RELEASE_NOTES_FILE" ] && ! grep -qF '(write here)' "$RELEASE_NOTES_FILE"; then
+            USE_CURATED=true
+          fi
 
-          - **\`ornn-api\` ${VERSION}**: ${REPO_URL}/blob/${TAG}/ornn-api/CHANGELOG.md
-          - **\`ornn-web\` ${VERSION}**: ${REPO_URL}/blob/${TAG}/ornn-web/CHANGELOG.md
-
-          Compare commits: ${REPO_URL}/compare/v\$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "main")...${TAG}
-          EOF
-          )
+          if $USE_CURATED; then
+            echo "Using curated release notes from $RELEASE_NOTES_FILE"
+            # Strip the leading HTML comment block (instructions to the
+            # author). Everything between `<!--` and the matching `-->`
+            # on its own line is dropped.
+            CURATED=$(awk '
+              BEGIN { in_comment = 0 }
+              /^<!--/ { in_comment = 1; next }
+              /-->$/ { if (in_comment) { in_comment = 0; next } }
+              !in_comment { print }
+            ' "$RELEASE_NOTES_FILE")
+            BODY="${CURATED}${CHANGELOG_FOOTER}"
           else
-            BODY="$BODY_FULL"
+            echo "release-notes-next.md is missing or unedited — using short-body fallback."
+            BODY=$(cat <<EOF
+          Release notes weren't curated for v${VERSION}. The full per-PR detail is in the in-repo CHANGELOGs on the \`${TAG}\` tag:
+          ${CHANGELOG_FOOTER}
+          EOF
+          )
+          fi
+
+          # Final length safety check — even a curated body shouldn't
+          # exceed the cap, but guard against an author pasting in a
+          # 100k-char block of prose by accident.
+          if [ ${#BODY} -gt 120000 ]; then
+            echo "::warning::Resolved body is ${#BODY} chars (cap 120 000). Falling back to short link body."
+            BODY=$(cat <<EOF
+          Release notes body exceeded the size cap. Full per-PR detail is in the in-repo CHANGELOGs:
+          ${CHANGELOG_FOOTER}
+          EOF
+          )
           fi
 
           gh release create "${TAG}" --title "${TAG}" --notes "${BODY}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,20 @@ bun changeset --empty
 
 Releases are fully automated via Changesets. Maintainer-driven; contributors don't need to do anything beyond including a changeset on each PR. The flow is documented in [`CLAUDE.md`](CLAUDE.md#versioning--releases).
 
+### Release notes — maintainer task per release
+
+The auto-generated `CHANGELOG.md` is engineer-speak (PR refs, author thanks, paragraph-long rationales). The public **GitHub Releases page** uses a curated, user-facing summary instead.
+
+Before opening a `develop → main` release PR, the maintainer (or their local Claude) edits **[`.github/release-notes-next.md`](.github/release-notes-next.md)** into a brief three-section summary:
+
+- **Fixed** — bug fixes the user notices. Cluster technical-only fixes into a single trailing `Few technical bugs fixed` bullet.
+- **New Feature** — new features the user notices. Cluster technical-only work into a single trailing `Technical enhancement` bullet.
+- **Changed** — changes to existing features. Same `Technical enhancement` cluster for the technical-only bucket.
+
+One bullet = 6–12 words. Plain prose. No PR / issue refs. The full per-PR detail is linked at the bottom of every release body automatically.
+
+The release workflow (`changeset-release.yml`) reads this file at release time. If it's missing or still contains the placeholder string `(write here)`, the workflow falls back to a short body that links to the in-repo `CHANGELOG.md` files — release still publishes, just without curated prose.
+
 ## Where to ask questions
 
 - Usage / how-to → [Discussions → Q&A](https://github.com/ChronoAIProject/Ornn/discussions/categories/q-a)


### PR DESCRIPTION
Replaces the auto-CHANGELOG-dump release body (which blew past GitHub's 125 000-char API limit on v0.6.0, see #429) with a maintainer-curated three-section summary read from `.github/release-notes-next.md` (Fixed / New Feature / Changed). Closes #431.

Falls back to a short link-to-CHANGELOG body when the file is missing or still has the `(write here)` placeholder — release always publishes.

v0.6.0 release body has already been hand-rewritten on the GH Releases page using this format as a reference for what good looks like.

## Maintainer workflow

Before opening a develop → main release PR:
1. Read every `.changeset/*.md` (and the CHANGELOG diff since the last tag if you want more context).
2. Edit `.github/release-notes-next.md` to fill in the three sections with brief 6-12 word user-facing bullets. Cluster technical-only items into a single trailing `Few technical bugs fixed` / `Technical enhancement` bullet per section.
3. Drop sections that are genuinely empty.

The HTML comment block at the top of the file has the full instructions targeted at the author (or their local Claude).