### PR TITLE
feat(ci): gate PRs to main on a properly-filled release-notes-next.md

### DIFF
--- a/.changeset/gate-release-notes.md
+++ b/.changeset/gate-release-notes.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI: gate PRs targeting main on a properly-filled release-notes-next.md file.

--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -1,0 +1,72 @@
+name: Check release notes
+
+# Gates every PR targeting `main` on a properly-filled
+# `.github/release-notes-next.md`. The release workflow falls back to a
+# short link-to-CHANGELOG body when the file isn't curated — that
+# fallback is fine for emergencies but a poor default. This gate forces
+# the maintainer to fill in the three-section summary BEFORE the
+# release-bump train starts, so v<X.Y.Z> always ships with curated
+# release notes on the GitHub Releases page. Tracked in #433.
+#
+# Required-status check binding (one-time, in the repo Settings UI):
+# add `Check release notes` to main's branch-protection list so the
+# gate is actually load-bearing.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  check-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate .github/release-notes-next.md
+        run: |
+          set -u
+          FILE=".github/release-notes-next.md"
+
+          # ── 1. File exists ─────────────────────────────────────────
+          if [ ! -f "$FILE" ]; then
+            echo "::error file=$FILE::Release notes file does not exist. Create $FILE with Fixed / New Feature / Changed sections before merging to main."
+            exit 1
+          fi
+
+          FAILED=0
+
+          # ── 2. All three section headings present ──────────────────
+          # `grep -F` so the literal `## ` doesn't get interpreted as
+          # a regex. One section per required heading.
+          for section in "## Fixed" "## New Feature" "## Changed"; do
+            if ! grep -qF "$section" "$FILE"; then
+              echo "::error file=$FILE::Missing required heading: \`$section\`. Release notes must contain Fixed / New Feature / Changed sections — leave an empty section with the technical-bucket bullet (\"Few technical bugs fixed\" / \"Technical enhancement\") if nothing notable happened in that bucket this release."
+              FAILED=1
+            fi
+          done
+
+          # ── 3. Placeholder `(write here)` removed ──────────────────
+          # The seeded template at .github/release-notes-next.md uses
+          # `(write here)` for each bullet slot. Any remaining
+          # occurrence means at least one section hasn't been filled
+          # in — the workflow would fall back to the short link body
+          # at release time, but better to catch it at PR-open time.
+          if grep -qF '(write here)' "$FILE"; then
+            echo "::error file=$FILE::Release notes still contain the \`(write here)\` placeholder. Replace each placeholder with brief user-facing bullets (6-12 words each). Cluster technical-only items into a single \`Few technical bugs fixed\` / \`Technical enhancement\` trailing bullet."
+            FAILED=1
+          fi
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo ""
+            echo "Release-notes flow reminder:"
+            echo "  - Read the comment block at the top of $FILE for the formatting rules."
+            echo "  - Run \`bun changeset status\` to see what's pending for this release."
+            echo "  - One bullet = one product-level fact, 6-12 words."
+            echo "  - Drop a section entirely if there's genuinely nothing for it."
+            exit 1
+          fi
+
+          echo "✓ Release notes valid — all three sections present, no placeholders."


### PR DESCRIPTION
Gates every PR targeting `main` on `.github/release-notes-next.md` being properly filled in.

Fails the PR check if:
- The file is missing.
- Any of `## Fixed`, `## New Feature`, `## Changed` headings is absent.
- The `(write here)` placeholder string is still present.

Forces the maintainer to curate user-facing release notes before the release-bump train starts.

Closes #433.

## Maintainer follow-up after merge

This workflow file alone isn't gating — until `Check release notes` is added to `main`'s branch-protection **required status checks** list (Repo Settings → Branches → `main` → Branch protection rule → Require status checks to pass before merging), the check is advisory and PRs could still merge red. Add it via the Settings UI once the workflow has run successfully on a sample PR.

## Coverage

- This workflow only triggers on `pull_request` events targeting `main`. PRs to `develop` (like this one) don't fire it.
- The next `develop → main` PR will be the first to actually exercise the gate.
