### PR TITLE
feat: surface last-run status of the scheduled mirror reconcile

### DIFF
--- a/.changeset/mirror-scheduled-run-status.md
+++ b/.changeset/mirror-scheduled-run-status.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+Surface last-run status of the scheduled mirror reconcile (#475). Both the GitHub mirror settings page and the legacy mirror dashboard now show whether the most recent *scheduled* fire succeeded, failed (with the error message), is currently running, or hasn't happened yet — sourced from Agenda's persisted recurring-job doc so the view is consistent across pods and survives restarts. The previous in-process `lastReconcile` block on `GET /admin/mirror/status` is replaced with a new `scheduledRun` block. Manual `Reconcile now` clicks from the dashboard still work but do not appear in this widget; the 409 "already running" guard on the manual reconcile endpoint is unchanged.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -648,16 +648,12 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     ornnPublicOrigin: config.ornnPublicOrigin,
     settingsService,
   });
-  const mirrorRoutes = createMirrorRoutes({
-    mirrorService,
-    settingsService,
-    skillRepo,
-  });
   // In-process mirror reconcile scheduler. Multi-pod-safe (Agenda's
   // per-fire row lock on `agendaJobs`); schedule is driven by
   // `settings.mirror.reconcileSchedule` and updated dynamically by the
   // scheduler's own 1-minute sync tick. Replaces the legacy k8s
-  // CronJob (#437).
+  // CronJob (#437). Constructed before `createMirrorRoutes` so the
+  // status endpoint can read scheduled-run history through it (#475).
   let mirrorScheduler: MirrorScheduler | null = null;
   try {
     mirrorScheduler = createMirrorScheduler({
@@ -674,6 +670,12 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     );
     mirrorScheduler = null;
   }
+  const mirrorRoutes = createMirrorRoutes({
+    mirrorService,
+    settingsService,
+    skillRepo,
+    mirrorScheduler,
+  });
 
   // Skill routes — sharing is now a direct PUT /permissions write; the
   // audit signal is surfaced as a per-version label, not a gate.

--- a/ornn-api/src/domains/skills/mirror/routes.ts
+++ b/ornn-api/src/domains/skills/mirror/routes.ts
@@ -39,6 +39,7 @@ import {
 import { AppError } from "../../../shared/types/index";
 import { isMidMaskSentinel, midMaskSecret } from "../../../infra/crypto";
 import type { MirrorService, ReconcileResult } from "./mirrorService";
+import type { MirrorScheduler, ScheduledRunStatus } from "./scheduler";
 import type { SettingsService, SettingsActor } from "../../settings/types";
 import type { MirrorSection } from "../../settings/sections/mirror";
 import type { SkillRepository } from "../crud/repository";
@@ -79,6 +80,14 @@ export interface MirrorRoutesConfig {
    * status endpoint's mirror-counts aggregation.
    */
   skillRepo: SkillRepository;
+  /**
+   * In-process scheduler — the status endpoint reads the last scheduled
+   * fire's outcome from here (persisted in `agendaJobs`, multipod-safe).
+   * Optional: when the scheduler failed to start at boot, this is
+   * `null` and the status endpoint reports `never_run` for the
+   * scheduled-run block.
+   */
+  mirrorScheduler: MirrorScheduler | null;
 }
 
 interface ReconcileRunState {
@@ -93,7 +102,7 @@ interface ReconcileRunState {
 export function createMirrorRoutes(
   config: MirrorRoutesConfig,
 ): Hono<{ Variables: AuthVariables }> {
-  const { mirrorService, settingsService, skillRepo } = config;
+  const { mirrorService, settingsService, skillRepo, mirrorScheduler } = config;
   const app = new Hono<{ Variables: AuthVariables }>();
   const auth = nyxidAuthMiddleware();
 
@@ -400,19 +409,30 @@ export function createMirrorRoutes(
   // ────────────────────────── Admin: GET /admin/mirror/status ──────────────────────────
 
   /**
-   * Snapshot for the admin overview UI. Combines the in-process
-   * reconcile state, the DB-side mirror counts, and the full mirror
-   * config (App private key mid-masked) so the page can render the
-   * settings form pre-populated without a second round-trip.
+   * Snapshot for the admin overview UI. Combines the persisted
+   * scheduled-run status (from the in-process scheduler reading
+   * Agenda's `agendaJobs` doc), the DB-side mirror counts, and the
+   * full mirror config (App private key mid-masked) so the page can
+   * render the settings form pre-populated without a second round-trip.
+   *
+   * Manual `POST /admin/mirror/reconcile` runs do NOT update
+   * `scheduledRun` — they're tracked in the in-process `reconcileState`
+   * which lives on this pod only and feeds the 409 "already running"
+   * guard. If the dashboard needs to surface manual-run progress, it
+   * should consult that out of band; `scheduledRun` is the canonical,
+   * cluster-wide, persisted view of *scheduled* fires.
    */
   app.get(
     "/admin/mirror/status",
     auth,
     requirePermission("ornn:admin:skill"),
     async (c) => {
-      const [counts, cfg] = await Promise.all([
+      const [counts, cfg, scheduledRun] = await Promise.all([
         skillRepo.getMirrorCounts(),
         settingsService.getMirror(),
+        mirrorScheduler
+          ? mirrorScheduler.getScheduledRunStatus()
+          : Promise.resolve(emptyScheduledRun()),
       ]);
       return c.json({
         data: {
@@ -430,14 +450,7 @@ export function createMirrorRoutes(
               ? counts.oldestUnsyncedAt.toISOString()
               : null,
           },
-          lastReconcile: {
-            status: reconcileState.status,
-            startedAt: reconcileState.startedAt?.toISOString() ?? null,
-            finishedAt: reconcileState.finishedAt?.toISOString() ?? null,
-            durationMs: reconcileState.durationMs,
-            result: reconcileState.result,
-            error: reconcileState.error,
-          },
+          scheduledRun: serializeScheduledRun(scheduledRun),
         },
         error: null,
       });
@@ -445,6 +458,35 @@ export function createMirrorRoutes(
   );
 
   return app;
+}
+
+function emptyScheduledRun(): ScheduledRunStatus {
+  return {
+    status: "never_run",
+    lastRunAt: null,
+    lastFinishedAt: null,
+    lastDurationMs: null,
+    lastError: null,
+    nextRunAt: null,
+  };
+}
+
+function serializeScheduledRun(s: ScheduledRunStatus): {
+  status: ScheduledRunStatus["status"];
+  lastRunAt: string | null;
+  lastFinishedAt: string | null;
+  lastDurationMs: number | null;
+  lastError: string | null;
+  nextRunAt: string | null;
+} {
+  return {
+    status: s.status,
+    lastRunAt: s.lastRunAt?.toISOString() ?? null,
+    lastFinishedAt: s.lastFinishedAt?.toISOString() ?? null,
+    lastDurationMs: s.lastDurationMs,
+    lastError: s.lastError,
+    nextRunAt: s.nextRunAt?.toISOString() ?? null,
+  };
 }
 
 /**

--- a/ornn-api/src/domains/skills/mirror/scheduler.test.ts
+++ b/ornn-api/src/domains/skills/mirror/scheduler.test.ts
@@ -33,6 +33,10 @@ let agendaCalls: {
 };
 const jobHandlers = new Map<string, () => Promise<void>>();
 
+// Mutable canned `queryJobs` result — tests set this per case.
+let queryJobsResult: { jobs: Array<Record<string, unknown>> } = { jobs: [] };
+let queryJobsThrows: Error | null = null;
+
 // Mock the `agenda` + `@agendajs/mongo-backend` modules BEFORE the
 // scheduler module is imported. We re-import the scheduler in each
 // test via dynamic `import()` to ensure it picks up the mocks.
@@ -70,6 +74,10 @@ mock.module("agenda", () => ({
     async stop() {
       agendaCalls.stopped = true;
     }
+    async queryJobs(_opts: { name: string }) {
+      if (queryJobsThrows) throw queryJobsThrows;
+      return queryJobsResult;
+    }
   },
 }));
 mock.module("@agendajs/mongo-backend", () => ({
@@ -91,6 +99,8 @@ function resetAgendaCalls() {
     stopped: false,
   };
   jobHandlers.clear();
+  queryJobsResult = { jobs: [] };
+  queryJobsThrows = null;
 }
 
 function makeSettings(initial: string): SettingsService & {
@@ -287,6 +297,131 @@ describe("createMirrorScheduler", () => {
     await sched.start();
     // And another sync tick should also be tolerated.
     await sched.runSyncNow();
+    await sched.stop();
+  });
+});
+
+describe("MirrorScheduler.getScheduledRunStatus", () => {
+  function makeScheduler() {
+    return createMirrorScheduler({
+      db: FAKE_DB,
+      logger,
+      mirrorService: makeMirrorService(),
+      settingsService: makeSettings("0 2 * * *"),
+    });
+  }
+
+  test("never_run when no agendaJobs doc exists yet", async () => {
+    queryJobsResult = { jobs: [] };
+    const sched = makeScheduler();
+    await sched.start();
+    const s = await sched.getScheduledRunStatus();
+    expect(s.status).toBe("never_run");
+    expect(s.lastRunAt).toBeNull();
+    expect(s.lastFinishedAt).toBeNull();
+    expect(s.lastDurationMs).toBeNull();
+    expect(s.lastError).toBeNull();
+    expect(s.nextRunAt).toBeNull();
+    await sched.stop();
+  });
+
+  test("succeeded when lastFinishedAt set and no recent failure", async () => {
+    const lastRunAt = new Date("2026-05-13T18:00:00.000Z");
+    const lastFinishedAt = new Date("2026-05-13T18:00:04.213Z");
+    const nextRunAt = new Date("2026-05-14T18:00:00.000Z");
+    queryJobsResult = {
+      jobs: [{ lastRunAt, lastFinishedAt, nextRunAt }],
+    };
+    const sched = makeScheduler();
+    await sched.start();
+    const s = await sched.getScheduledRunStatus();
+    expect(s.status).toBe("succeeded");
+    expect(s.lastRunAt?.toISOString()).toBe(lastRunAt.toISOString());
+    expect(s.lastFinishedAt?.toISOString()).toBe(lastFinishedAt.toISOString());
+    expect(s.lastDurationMs).toBe(4213);
+    expect(s.lastError).toBeNull();
+    expect(s.nextRunAt?.toISOString()).toBe(nextRunAt.toISOString());
+    await sched.stop();
+  });
+
+  test("failed when failedAt is the most recent terminal stamp", async () => {
+    const lastRunAt = new Date("2026-05-13T18:00:00.000Z");
+    const lastFinishedAt = new Date("2026-05-13T17:00:01.000Z"); // older
+    const failedAt = new Date("2026-05-13T18:00:02.000Z"); // newer than lastFinishedAt
+    queryJobsResult = {
+      jobs: [
+        {
+          lastRunAt,
+          lastFinishedAt,
+          failedAt,
+          failReason: "github 502: Bad Gateway",
+        },
+      ],
+    };
+    const sched = makeScheduler();
+    await sched.start();
+    const s = await sched.getScheduledRunStatus();
+    expect(s.status).toBe("failed");
+    expect(s.lastError).toBe("github 502: Bad Gateway");
+    await sched.stop();
+  });
+
+  test("failed when failedAt set and lastFinishedAt never set", async () => {
+    const lastRunAt = new Date("2026-05-13T18:00:00.000Z");
+    const failedAt = new Date("2026-05-13T18:00:02.000Z");
+    queryJobsResult = {
+      jobs: [{ lastRunAt, failedAt, failReason: "boom" }],
+    };
+    const sched = makeScheduler();
+    await sched.start();
+    const s = await sched.getScheduledRunStatus();
+    expect(s.status).toBe("failed");
+    expect(s.lastError).toBe("boom");
+    await sched.stop();
+  });
+
+  test("running when lockedAt is set (regardless of other stamps)", async () => {
+    queryJobsResult = {
+      jobs: [
+        {
+          lastRunAt: new Date("2026-05-13T18:00:00.000Z"),
+          lockedAt: new Date("2026-05-14T18:00:00.000Z"),
+          // Even a stale failedAt doesn't override `running`.
+          failedAt: new Date("2026-05-13T18:01:00.000Z"),
+          failReason: "old failure",
+        },
+      ],
+    };
+    const sched = makeScheduler();
+    await sched.start();
+    const s = await sched.getScheduledRunStatus();
+    expect(s.status).toBe("running");
+    expect(s.lastError).toBeNull();
+    await sched.stop();
+  });
+
+  test("lastDurationMs is null when only lastRunAt set (mid-flight, no finish yet)", async () => {
+    queryJobsResult = {
+      jobs: [
+        {
+          lastRunAt: new Date("2026-05-13T18:00:00.000Z"),
+          lockedAt: new Date("2026-05-13T18:00:00.000Z"),
+        },
+      ],
+    };
+    const sched = makeScheduler();
+    await sched.start();
+    const s = await sched.getScheduledRunStatus();
+    expect(s.lastDurationMs).toBeNull();
+    await sched.stop();
+  });
+
+  test("queryJobs throw → returns never_run, doesn't propagate", async () => {
+    queryJobsThrows = new Error("mongo unreachable");
+    const sched = makeScheduler();
+    await sched.start();
+    const s = await sched.getScheduledRunStatus();
+    expect(s.status).toBe("never_run");
     await sched.stop();
   });
 });

--- a/ornn-api/src/domains/skills/mirror/scheduler.ts
+++ b/ornn-api/src/domains/skills/mirror/scheduler.ts
@@ -72,6 +72,28 @@ export interface MirrorSchedulerDeps {
   processEvery?: string | number;
 }
 
+/**
+ * Snapshot of the recurring `mirror-reconcile` job's last execution.
+ * Derived from the timestamps Agenda stamps on the recurring-job doc;
+ * survives pod restarts and aggregates correctly across replicas.
+ */
+export interface ScheduledRunStatus {
+  /**
+   * Derived status of the most recent scheduled fire:
+   *   - `succeeded` — last fire finished cleanly.
+   *   - `failed`    — last fire threw; `lastError` carries the message.
+   *   - `running`   — a fire is currently in flight on some pod.
+   *   - `never_run` — no doc yet (fresh boot / schedule disabled).
+   */
+  status: "succeeded" | "failed" | "running" | "never_run";
+  lastRunAt: Date | null;
+  lastFinishedAt: Date | null;
+  lastDurationMs: number | null;
+  /** Failure message from the last fire; null when not in `failed` state. */
+  lastError: string | null;
+  nextRunAt: Date | null;
+}
+
 export interface MirrorScheduler {
   /** Spin up Agenda + register both jobs + kick off the first sync. */
   start(): Promise<void>;
@@ -82,6 +104,13 @@ export interface MirrorScheduler {
    * waiting for the next minute. Returns once the tick completes.
    */
   runSyncNow(): Promise<void>;
+  /**
+   * Read-only snapshot of the last scheduled fire's outcome, for the
+   * admin UI. Persisted source (Agenda's `agendaJobs` doc), so it
+   * survives pod restarts and reflects the cluster-wide latest run
+   * rather than per-pod in-process state.
+   */
+  getScheduledRunStatus(): Promise<ScheduledRunStatus>;
 }
 
 export function createMirrorScheduler(deps: MirrorSchedulerDeps): MirrorScheduler {
@@ -204,5 +233,72 @@ export function createMirrorScheduler(deps: MirrorSchedulerDeps): MirrorSchedule
     async runSyncNow() {
       await agenda.now(JOB_SYNC_SCHEDULE);
     },
+    async getScheduledRunStatus(): Promise<ScheduledRunStatus> {
+      let result;
+      try {
+        result = await agenda.queryJobs({ name: JOB_RECONCILE });
+      } catch (err) {
+        // Querying agenda is a single Mongo find; failure here means
+        // the DB is unreachable. Treat as `never_run` rather than
+        // crashing the admin endpoint — the dashboard's poll will
+        // recover on the next tick when DB comes back.
+        logger.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "getScheduledRunStatus: queryJobs failed — returning never_run",
+        );
+        return emptyStatus();
+      }
+      const job = result.jobs[0];
+      if (!job) return emptyStatus();
+
+      const lastRunAt = job.lastRunAt ?? null;
+      const lastFinishedAt = job.lastFinishedAt ?? null;
+      const failedAt = job.failedAt ?? null;
+      const lockedAt = job.lockedAt ?? null;
+
+      // Derivation priority:
+      //   1. Locked → running (a pod is executing it right now).
+      //   2. failedAt is the most recent terminal stamp → failed.
+      //   3. lastFinishedAt set → succeeded.
+      //   4. Nothing set yet → never_run.
+      let status: ScheduledRunStatus["status"];
+      if (lockedAt) {
+        status = "running";
+      } else if (
+        failedAt &&
+        (!lastFinishedAt || failedAt.getTime() >= lastFinishedAt.getTime())
+      ) {
+        status = "failed";
+      } else if (lastFinishedAt) {
+        status = "succeeded";
+      } else {
+        status = "never_run";
+      }
+
+      const lastDurationMs =
+        lastFinishedAt && lastRunAt
+          ? lastFinishedAt.getTime() - lastRunAt.getTime()
+          : null;
+
+      return {
+        status,
+        lastRunAt,
+        lastFinishedAt,
+        lastDurationMs,
+        lastError: status === "failed" ? (job.failReason ?? null) : null,
+        nextRunAt: job.nextRunAt ?? null,
+      };
+    },
+  };
+}
+
+function emptyStatus(): ScheduledRunStatus {
+  return {
+    status: "never_run",
+    lastRunAt: null,
+    lastFinishedAt: null,
+    lastDurationMs: null,
+    lastError: null,
+    nextRunAt: null,
   };
 }

--- a/ornn-web/src/hooks/useGithubMirror.ts
+++ b/ornn-web/src/hooks/useGithubMirror.ts
@@ -52,10 +52,10 @@ export function useMirrorStatus() {
   return useQuery<MirrorStatus>({
     queryKey: STATUS_KEY,
     queryFn: fetchMirrorStatus,
-    // Poll fast while a reconcile is running so the UI shows progress
-    // landing without a manual refresh; back off when idle.
+    // Poll fast while a scheduled reconcile is running so the UI shows
+    // progress landing without a manual refresh; back off when idle.
     refetchInterval: (q) =>
-      q.state.data?.lastReconcile.status === "running" ? 5_000 : 30_000,
+      q.state.data?.scheduledRun.status === "running" ? 5_000 : 30_000,
     staleTime: 0,
   });
 }

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -1064,7 +1064,13 @@
           "customHint": "5-field cron expression (minute hour day month weekday).",
           "invalidHint": "Invalid cron expression.",
           "nextRun": "Next run: {{at}}",
-          "nextRunUnavailable": "Next run: —"
+          "nextRunUnavailable": "Next run: —",
+          "lastRun": "Last run: {{at}}",
+          "lastRunUnavailable": "Last run: —",
+          "lastRunSucceeded": "✓ Succeeded",
+          "lastRunFailed": "✗ Failed",
+          "lastRunRunning": "⟳ Running…",
+          "lastRunDuration": "{{seconds}}s"
         },
         "openDashboard": "Open mirror dashboard →"
       },

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -1064,7 +1064,13 @@
           "customHint": "5 位 cron 表达式 (分 时 日 月 周)。",
           "invalidHint": "无效的 cron 表达式。",
           "nextRun": "下次运行：{{at}}",
-          "nextRunUnavailable": "下次运行：—"
+          "nextRunUnavailable": "下次运行：—",
+          "lastRun": "上次运行：{{at}}",
+          "lastRunUnavailable": "上次运行：—",
+          "lastRunSucceeded": "✓ 成功",
+          "lastRunFailed": "✗ 失败",
+          "lastRunRunning": "⟳ 进行中…",
+          "lastRunDuration": "{{seconds}} 秒"
         },
         "openDashboard": "打开镜像看板 →"
       },

--- a/ornn-web/src/pages/admin/MirrorPage.tsx
+++ b/ornn-web/src/pages/admin/MirrorPage.tsx
@@ -233,8 +233,13 @@ export function MirrorPage() {
     }
   };
 
-  const lastRun = status?.lastReconcile;
-  const reconcileRunning = lastRun?.status === "running";
+  // Last *scheduled* reconcile — sourced from the persisted `scheduledRun`
+  // block (Agenda's `agendaJobs` doc), so it survives pod restarts and
+  // aggregates across replicas. Manual `Reconcile now` clicks are tracked
+  // server-side via in-process state for the 409 guard; their progress is
+  // not surfaced in this widget.
+  const lastRun = status?.scheduledRun;
+  const scheduledFireRunning = lastRun?.status === "running";
   const credsConfigured = !!status && !!status.appId && !!status.installationId && !!status.appPrivateKey;
 
   return (
@@ -296,31 +301,25 @@ export function MirrorPage() {
               </div>
               <div className="text-right font-text text-xs text-meta">
                 <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-meta">
-                  {t("adminMirror.lastReconcile", "Last reconcile")}
+                  {t("adminMirror.lastReconcile", "Last scheduled reconcile")}
                 </div>
                 <div className="mt-0.5 text-strong">
-                  {reconcileRunning
+                  {scheduledFireRunning
                     ? t("adminMirror.runningSince", "Running since {{when}}", {
-                        when: formatTime(lastRun?.startedAt ?? null),
+                        when: formatTime(lastRun?.lastRunAt ?? null),
                       })
-                    : lastRun?.finishedAt
-                      ? formatTime(lastRun.finishedAt)
+                    : lastRun?.lastFinishedAt
+                      ? formatTime(lastRun.lastFinishedAt)
                       : t("adminMirror.never", "Never")}
                 </div>
-                {!reconcileRunning && lastRun?.durationMs !== null && lastRun?.durationMs !== undefined && (
+                {!scheduledFireRunning && lastRun?.lastDurationMs != null && (
                   <div>
-                    {t("adminMirror.duration", "Duration")} {formatDuration(lastRun.durationMs)}
+                    {t("adminMirror.duration", "Duration")} {formatDuration(lastRun.lastDurationMs)}
                   </div>
                 )}
-                {lastRun?.error && (
-                  <div className="mt-1 max-w-xs truncate text-danger" title={lastRun.error}>
-                    {t("adminMirror.lastError", "Last error")}: {lastRun.error}
-                  </div>
-                )}
-                {!reconcileRunning && lastRun?.result && (
-                  <div className="mt-1 font-mono text-[11px]">
-                    +{lastRun.result.added} ~{lastRun.result.updated} −{lastRun.result.removed} ={" "}
-                    {lastRun.result.unchanged}
+                {lastRun?.lastError && (
+                  <div className="mt-1 max-w-xs truncate text-danger" title={lastRun.lastError}>
+                    {t("adminMirror.lastError", "Last error")}: {lastRun.lastError}
                   </div>
                 )}
               </div>
@@ -383,12 +382,12 @@ export function MirrorPage() {
               <Button
                 onClick={handleReconcile}
                 disabled={
-                  !status.enabled || !credsConfigured || reconcileRunning || triggerReconcile.isPending
+                  !status.enabled || !credsConfigured || scheduledFireRunning || triggerReconcile.isPending
                 }
-                loading={triggerReconcile.isPending || reconcileRunning}
+                loading={triggerReconcile.isPending || scheduledFireRunning}
               >
-                {reconcileRunning
-                  ? t("adminMirror.reconcileRunning", "Running…")
+                {scheduledFireRunning
+                  ? t("adminMirror.scheduledFireRunning", "Running…")
                   : t("adminMirror.reconcileButton", "Reconcile now")}
               </Button>
             </Card>

--- a/ornn-web/src/pages/admin/settings/sections/MirrorSection.tsx
+++ b/ornn-web/src/pages/admin/settings/sections/MirrorSection.tsx
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { CronExpressionParser } from "cron-parser";
+import { useQuery } from "@tanstack/react-query";
 import { SectionShell } from "@/components/admin/settings/SectionShell";
 import { UnsavedChangesGuard } from "@/components/admin/settings/UnsavedChangesGuard";
 import { useSectionForm } from "@/components/admin/settings/useSectionForm";
@@ -27,6 +28,10 @@ import {
   putSection,
   type MirrorSection as MS,
 } from "@/services/settingsApi";
+import {
+  fetchMirrorStatus,
+  type MirrorScheduledRun,
+} from "@/services/githubMirrorApi";
 
 /**
  * Validates a cron string client-side via `cron-parser`. Empty string
@@ -81,6 +86,16 @@ export function MirrorSection() {
   const secretIsSentinel = draft
     ? isSecretPreserveValue(draft.appPrivateKey)
     : false;
+
+  // Poll the mirror status endpoint every 30s for `scheduledRun`
+  // (last-run outcome of the in-process scheduler). Independent of
+  // the form state so saving the form doesn't invalidate the poll.
+  const statusQuery = useQuery({
+    queryKey: ["admin", "mirror", "status"] as const,
+    queryFn: fetchMirrorStatus,
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+  });
 
   return (
     <>
@@ -159,6 +174,7 @@ export function MirrorSection() {
             <ScheduleField
               value={draft.reconcileSchedule}
               onChange={(v) => form.patchDraft({ reconcileSchedule: v })}
+              scheduledRun={statusQuery.data?.scheduledRun ?? null}
             />
 
             <Link
@@ -212,9 +228,11 @@ function Field({
 function ScheduleField({
   value,
   onChange,
+  scheduledRun,
 }: {
   value: string;
   onChange: (next: string) => void;
+  scheduledRun: MirrorScheduledRun | null;
 }) {
   const { t, i18n } = useTranslation();
   const isPreset = PRESET_VALUES.has(value as (typeof SCHEDULE_PRESETS)[number]["value"]);
@@ -303,7 +321,80 @@ function ScheduleField({
       {nextRunLabel && (
         <span className="font-mono text-[10px] text-meta">{nextRunLabel}</span>
       )}
+      <LastRunLine scheduledRun={scheduledRun} locale={i18n.language || "en"} />
     </div>
+  );
+}
+
+/**
+ * One-line "Last run" summary under the schedule field. Renders only
+ * for scheduled fires (manual `Reconcile now` clicks don't populate
+ * `scheduledRun`). Three real states + a placeholder:
+ *
+ *   • succeeded   → `Last run: <SGT timestamp> · ✓ Succeeded · <ms>s`
+ *   • failed      → same + `✗ Failed`, with the error message on a
+ *                   second line so it can wrap freely.
+ *   • running     → `Last run: <SGT timestamp> · ⟳ Running…` (no
+ *                   duration yet — `lastFinishedAt` is null mid-flight)
+ *   • never_run   → `Last run: —` (no doc yet, or schedule is disabled)
+ */
+function LastRunLine({
+  scheduledRun,
+  locale,
+}: {
+  scheduledRun: MirrorScheduledRun | null;
+  locale: string;
+}) {
+  const { t } = useTranslation();
+  if (!scheduledRun || scheduledRun.status === "never_run") {
+    return (
+      <span className="font-mono text-[10px] text-meta">
+        {t("adminSettings.sections.mirror.schedule.lastRunUnavailable")}
+      </span>
+    );
+  }
+  const formattedAt = scheduledRun.lastRunAt
+    ? new Date(scheduledRun.lastRunAt).toLocaleString(locale, {
+        timeZone: "Asia/Singapore",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+  const statusLabel = (() => {
+    switch (scheduledRun.status) {
+      case "succeeded":
+        return t("adminSettings.sections.mirror.schedule.lastRunSucceeded");
+      case "failed":
+        return t("adminSettings.sections.mirror.schedule.lastRunFailed");
+      case "running":
+        return t("adminSettings.sections.mirror.schedule.lastRunRunning");
+    }
+  })();
+  const durationLabel =
+    scheduledRun.lastDurationMs != null
+      ? t("adminSettings.sections.mirror.schedule.lastRunDuration", {
+          seconds: (scheduledRun.lastDurationMs / 1000).toFixed(1),
+        })
+      : null;
+  return (
+    <>
+      <span className="font-mono text-[10px] text-meta">
+        {t("adminSettings.sections.mirror.schedule.lastRun", {
+          at: formattedAt ? `${formattedAt} SGT` : "—",
+        })}
+        {" · "}
+        {statusLabel}
+        {durationLabel && ` · ${durationLabel}`}
+      </span>
+      {scheduledRun.lastError && (
+        <span className="font-mono text-[10px] text-[var(--color-danger,#c33)] break-words">
+          {scheduledRun.lastError}
+        </span>
+      )}
+    </>
   );
 }
 

--- a/ornn-web/src/services/githubMirrorApi.ts
+++ b/ornn-web/src/services/githubMirrorApi.ts
@@ -69,6 +69,22 @@ export interface MirrorReconcileResult {
   unchanged: number;
 }
 
+/**
+ * Persisted snapshot of the most recent *scheduled* mirror reconcile
+ * fire. Sourced from the in-process scheduler reading Agenda's
+ * `agendaJobs` doc — survives pod restarts, aggregates across replicas.
+ * Manual `Reconcile now` clicks do NOT update this.
+ */
+export interface MirrorScheduledRun {
+  status: "succeeded" | "failed" | "running" | "never_run";
+  lastRunAt: string | null;
+  lastFinishedAt: string | null;
+  lastDurationMs: number | null;
+  /** Last failure message; non-null only when `status === "failed"`. */
+  lastError: string | null;
+  nextRunAt: string | null;
+}
+
 export interface MirrorStatus {
   enabled: boolean;
   repo: { owner: string; repo: string; branch: string };
@@ -88,14 +104,7 @@ export interface MirrorStatus {
     /** ISO of the oldest never-synced skill's `createdOn`, null when none. */
     oldestUnsyncedAt: string | null;
   };
-  lastReconcile: {
-    status: "idle" | "running";
-    startedAt: string | null;
-    finishedAt: string | null;
-    durationMs: number | null;
-    result: MirrorReconcileResult | null;
-    error: string | null;
-  };
+  scheduledRun: MirrorScheduledRun;
 }
 
 export async function fetchGithubRepo(): Promise<GithubRepoConfig> {


### PR DESCRIPTION
Closes #475.

## Summary

- `GET /admin/mirror/status` returns a new `scheduledRun` block sourced from Agenda's persisted `agendaJobs` doc — survives pod restarts and is consistent across replicas. The old per-pod `lastReconcile` block is gone.
- Settings page (`/admin/settings/mirror`) shows a "Last run" line below "Next run", with status (✓ Succeeded / ✗ Failed / ⟳ Running… / —), duration, and (on failure) the error message.
- Legacy dashboard (`/admin/mirror`) repoints its "Last reconcile" tile at the same persisted data; relabeled to "Last *scheduled* reconcile" since manual `Reconcile now` clicks no longer feed into this widget.
- Manual `Reconcile now` still works; its 409 "already running" guard via per-pod in-process state is unchanged.

## Commit stack

```
feat(api):  MirrorScheduler exposes getScheduledRunStatus()
feat(api):  GET /admin/mirror/status returns scheduledRun
feat(web):  show last scheduled-run status on settings page + dashboard
docs:       changeset for #475
```

## Test plan

- [x] `bun test` in `ornn-api` — 550/550 pass (added 7 new tests covering every `status` derivation branch + `queryJobs` failure path).
- [x] `bun run test` in `ornn-web` — 80/80 pass.
- [x] `bunx tsc --noEmit` clean for both packages.
- [x] `bun run build:web` clean.
- [ ] CI green (will watch + merge).
- [ ] Smoke on local cluster after deploy: settings page shows "Last run: —" before first fire; after a manual `agenda.now('mirror-reconcile')`, shows "Last run: <ts> · ✓ Succeeded · Xs"; introduce a transient failure (point at a bad repo) and the line flips to "✗ Failed" with the error message.

## Design notes

**Why settings-page-only for scheduled fires:** the user explicitly scoped this to scheduled fires, not manual ones. Manual reconciles have a separate code path (in-process per-pod state used purely for the 409 guard) and don't write to `agendaJobs`. Unifying the two paths (e.g., routing manual reconciles through Agenda's one-shot queue) would be a larger change and isn't needed for this UX request.

**Status derivation** uses Agenda's own timestamp fields on the recurring-job doc:
- `lockedAt` set → `running` (a pod is mid-fire right now)
- `failedAt >= lastFinishedAt` (or `lastFinishedAt` never set, `failedAt` is) → `failed`
- `lastFinishedAt` set, no recent failure → `succeeded`
- Nothing set yet, or the doc doesn't exist (fresh boot / schedule disabled) → `never_run`

**Drift fix on the legacy dashboard:** the old "Last reconcile" tile read from per-pod in-process state, which (a) reset on every pod restart and (b) only reflected this specific pod's view. Reading from the persisted scheduler doc fixes both — there's exactly one source of truth across the cluster.

Follow-up to #437 / #455.