### PR TITLE
docs: prep release v0.7.1 (web copy polish)

### DIFF
--- a/.changeset/web-copy-v0-7-1.md
+++ b/.changeset/web-copy-v0-7-1.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+Web copy + layout polish (patch). The Contact page is restructured into a three-channel routing guide — `support@chrono-ai.fun` for private matters, GitHub Discussions for public community Q&A / ideas / show-and-tell, GitHub Issues / PRs for actionable maintainer work — with a per-category quick-jump table for all six GitHub Discussions categories. The cookie consent banner is now vendor-agnostic; the third-party analytics processor name is no longer inlined in the consent copy (still itemised in the privacy policy where it belongs). No behaviour change in `ornn-api` itself — patch bump because the two repos are version-linked in fixed mode.

--- a/.github/release-notes-20260514.md
+++ b/.github/release-notes-20260514.md
@@ -1,0 +1,13 @@
+## Fixed
+
+- Few technical bugs fixed.
+
+## New Feature
+
+- Technical enhancement.
+
+## Changed
+
+- Contact page restructured: three channels (Email / Discussions / Issues) with a per-category Discussions guide.
+- Cookie consent banner is now vendor-agnostic.
+- Technical enhancement.


### PR DESCRIPTION
Closes #486.

Adds a real patch-bump changeset + the dated release-notes file (`release-notes-20260514.md`) so the next `develop → main` cut produces a tagged **v0.7.1** Release. Without this prep, the two empty changesets on develop would just get consumed by `changeset version` with no version bump — the new web copy would land on main but no GitHub Release entry would exist.

## Test plan

- [ ] CI green
- After merge: open `develop → main` release PR, repeat the standard release flow.