### PR TITLE
feat: targeted broadcasts + click-to-popup markdown viewer

### DIFF
--- a/.changeset/targeted-broadcasts-and-modal-viewer.md
+++ b/.changeset/targeted-broadcasts-and-modal-viewer.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+Targeted broadcasts + click-to-popup markdown viewer (#502). Builds on #500. Admins can now choose between broadcasting to all users (existing behaviour) and targeting specific users by email. Recipients are immutable after create — edits only touch the bilingual title/body, deletes still cascade read receipts. End-user side: clicking a broadcast notification in the bell or `/notifications` page now opens a modal that renders the full bilingual markdown body (existing audit / quota notifications keep their navigate-to-link behaviour). The merged `/notifications` feed, unread count, mark-read, and mark-all-read all transparently filter targeted broadcasts so non-recipients never see them.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -73,6 +73,7 @@ import { migrateAnnouncementsToBilingual } from "./domains/announcements/migrati
 import { BroadcastRepository } from "./domains/broadcasts/repository";
 import { BroadcastService } from "./domains/broadcasts/service";
 import { createBroadcastRoutes } from "./domains/broadcasts/routes";
+import { backfillBroadcastRecipientUserIds } from "./domains/broadcasts/migration";
 
 // Domain: Analytics
 import { AnalyticsRepository } from "./domains/analytics/repository";
@@ -473,6 +474,18 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const broadcastRepoForNotifications = new BroadcastRepository(db);
   void broadcastRepoForNotifications.ensureIndexes().catch((err) =>
     logger.warn({ err }, "broadcasts indexes ensureIndexes failed — proceeding anyway"),
+  );
+  // One-shot bilingual + targeting backfill for broadcasts. Pre-#502
+  // docs don't carry `recipientUserIds`; this migration writes an
+  // explicit `null` on every absent doc so the merged feed can rely
+  // on a stable `string[] | null` shape. Idempotent; failure is
+  // non-fatal — the repo mapper's `Array.isArray` guard already
+  // normalises absent fields to `null` on the read path.
+  await backfillBroadcastRecipientUserIds(db, logger).catch((err) =>
+    logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "broadcasts recipientUserIds backfill crashed — mapper fallback will cover reads, retry on next boot",
+    ),
   );
   const notificationService = new NotificationService({
     notificationRepo,

--- a/ornn-api/src/domains/broadcasts/migration.test.ts
+++ b/ornn-api/src/domains/broadcasts/migration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the `recipientUserIds` boot backfill (#502).
+ *
+ * Uses `mongodb-memory-server` so the migration's actual `updateMany`
+ * is exercised against a real Mongo. Covers the three scenarios that
+ * matter:
+ *
+ *   1. Pre-#502 docs (no `recipientUserIds` key) are backfilled to
+ *      explicit `null`.
+ *   2. Docs already carrying a value (`null` or non-empty array) are
+ *      left untouched.
+ *   3. Re-running on a fully-migrated DB is a no-op.
+ *
+ * @module domains/broadcasts/migration.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db, type Document } from "mongodb";
+import pino from "pino";
+import { backfillBroadcastRecipientUserIds } from "./migration";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+const logger = pino({ level: "silent" });
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("broadcasts_migration_test");
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("broadcasts").deleteMany({});
+});
+
+describe("backfillBroadcastRecipientUserIds", () => {
+  test("sets recipientUserIds: null on every doc where the field is absent", async () => {
+    await db.collection("broadcasts").insertMany([
+      {
+        _id: "b-1" as unknown as Document["_id"],
+        titleI18n: { en: "a", zh: "甲" },
+        bodyMarkdownI18n: { en: "x", zh: "x" },
+        createdBy: "u-admin",
+        updatedBy: "u-admin",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        _id: "b-2" as unknown as Document["_id"],
+        titleI18n: { en: "b", zh: "乙" },
+        bodyMarkdownI18n: { en: "y", zh: "y" },
+        createdBy: "u-admin",
+        updatedBy: "u-admin",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    await backfillBroadcastRecipientUserIds(db, logger);
+
+    const docs = await db.collection("broadcasts").find({}).toArray();
+    expect(docs).toHaveLength(2);
+    for (const doc of docs) {
+      // Field is now present with explicit null.
+      expect("recipientUserIds" in doc).toBe(true);
+      expect(doc.recipientUserIds).toBeNull();
+    }
+  });
+
+  test("leaves docs that already carry recipientUserIds (null or array) untouched", async () => {
+    await db.collection("broadcasts").insertMany([
+      {
+        _id: "b-null" as unknown as Document["_id"],
+        titleI18n: { en: "a", zh: "甲" },
+        bodyMarkdownI18n: { en: "x", zh: "x" },
+        createdBy: "u-admin",
+        updatedBy: "u-admin",
+        recipientUserIds: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        _id: "b-targeted" as unknown as Document["_id"],
+        titleI18n: { en: "b", zh: "乙" },
+        bodyMarkdownI18n: { en: "y", zh: "y" },
+        createdBy: "u-admin",
+        updatedBy: "u-admin",
+        recipientUserIds: ["u-1", "u-2"],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    await backfillBroadcastRecipientUserIds(db, logger);
+
+    const nullDoc = await db
+      .collection("broadcasts")
+      .findOne({ _id: "b-null" as unknown as Document["_id"] });
+    const targetedDoc = await db
+      .collection("broadcasts")
+      .findOne({ _id: "b-targeted" as unknown as Document["_id"] });
+    expect(nullDoc?.recipientUserIds).toBeNull();
+    expect(targetedDoc?.recipientUserIds).toEqual(["u-1", "u-2"]);
+  });
+
+  test("is idempotent — second run on an already-migrated DB is a no-op", async () => {
+    await db.collection("broadcasts").insertOne({
+      _id: "b-1" as unknown as Document["_id"],
+      titleI18n: { en: "a", zh: "甲" },
+      bodyMarkdownI18n: { en: "x", zh: "x" },
+      createdBy: "u-admin",
+      updatedBy: "u-admin",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await backfillBroadcastRecipientUserIds(db, logger);
+    // Capture the updatedAt-equivalent: doc field set.
+    const first = await db
+      .collection("broadcasts")
+      .findOne({ _id: "b-1" as unknown as Document["_id"] });
+    expect(first?.recipientUserIds).toBeNull();
+
+    // Second run — should match zero docs since the field is now present.
+    await backfillBroadcastRecipientUserIds(db, logger);
+    const second = await db
+      .collection("broadcasts")
+      .findOne({ _id: "b-1" as unknown as Document["_id"] });
+    expect(second?.recipientUserIds).toBeNull();
+  });
+
+  test("no-op on an empty broadcasts collection", async () => {
+    await backfillBroadcastRecipientUserIds(db, logger);
+    expect(await db.collection("broadcasts").countDocuments()).toBe(0);
+  });
+});

--- a/ornn-api/src/domains/broadcasts/migration.ts
+++ b/ornn-api/src/domains/broadcasts/migration.ts
@@ -1,0 +1,58 @@
+/**
+ * One-shot boot migration: backfill `recipientUserIds: null` on
+ * pre-#502 broadcast docs.
+ *
+ * #500 shipped broadcasts as an everyone-message — every doc has no
+ * `recipientUserIds` field. #502 introduces targeted broadcasts and
+ * stores the canonical "everyone" sentinel as an explicit `null`.
+ *
+ * To keep feed-time consumers from having to branch on `undefined ||
+ * null`, this migration writes an explicit `null` on every doc where
+ * the field is absent. New broadcasts are already inserted with an
+ * explicit `null` (see `BroadcastRepository.create`), so this is
+ * strictly a one-shot backfill for pre-existing rows.
+ *
+ * Idempotency: only matches docs missing `recipientUserIds`. Re-runs
+ * are no-ops. Failure is non-fatal — the repo mapper's `Array.isArray`
+ * guard normalises absent fields to `null` on the read path, so feed
+ * filtering keeps working even if the migration is delayed.
+ *
+ * @module domains/broadcasts/migration
+ */
+
+import type { Db } from "mongodb";
+import type pino from "pino";
+
+export async function backfillBroadcastRecipientUserIds(
+  db: Db,
+  logger: pino.Logger,
+): Promise<void> {
+  const coll = db.collection("broadcasts");
+
+  // Match docs where the field is entirely absent. `$exists: false`
+  // intentionally excludes docs that already carry an explicit `null`
+  // (which would be the case on a second boot or on rows created
+  // post-#502) — those don't need to be touched.
+  const filter = { recipientUserIds: { $exists: false } };
+  let result;
+  try {
+    result = await coll.updateMany(filter, { $set: { recipientUserIds: null } });
+  } catch (err) {
+    logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "broadcasts recipientUserIds backfill failed — mapper fallback will cover reads, retry on next boot",
+    );
+    return;
+  }
+
+  if (result.matchedCount > 0) {
+    logger.info(
+      { matched: result.matchedCount, modified: result.modifiedCount },
+      "broadcasts recipientUserIds backfill: set null on pre-#502 docs",
+    );
+  } else {
+    logger.debug(
+      "broadcasts recipientUserIds backfill: no pre-#502 docs found — nothing to backfill",
+    );
+  }
+}

--- a/ornn-api/src/domains/broadcasts/repository.ts
+++ b/ornn-api/src/domains/broadcasts/repository.ts
@@ -35,8 +35,20 @@ export interface CreateBroadcastDocInput {
   titleI18n: BroadcastI18nString;
   bodyMarkdownI18n: BroadcastI18nString;
   createdBy: string;
+  /**
+   * Targeted recipients (#502). Omit / `undefined` → broadcast to all
+   * (persisted as `null`). Non-empty `string[]` → targeted. The
+   * service / Zod layer guarantees we never see an empty array here.
+   */
+  recipientUserIds?: readonly string[];
 }
 
+/**
+ * Update input type (#502): `recipientUserIds` is intentionally not
+ * accepted here — recipient targeting is immutable after create. Adding
+ * the field on a PATCH path is a compile error, which is the cheapest
+ * guard against a future caller forgetting the invariant.
+ */
 export interface UpdateBroadcastDocInput {
   titleI18n?: Partial<BroadcastI18nString>;
   bodyMarkdownI18n?: Partial<BroadcastI18nString>;
@@ -75,6 +87,15 @@ export class BroadcastRepository {
 
   async create(input: CreateBroadcastDocInput): Promise<BroadcastDocument> {
     const now = new Date();
+    // `null` is the canonical "broadcast to all users" value. Storing
+    // an explicit `null` (rather than omitting the field) keeps the
+    // doc shape uniform across pre- and post-#502 rows after the boot
+    // migration runs, so feed-time consumers can rely on the field
+    // always being present.
+    const recipientUserIds =
+      input.recipientUserIds && input.recipientUserIds.length > 0
+        ? [...input.recipientUserIds]
+        : null;
     const doc: Document = {
       _id: randomUUID() as unknown as Document["_id"],
       titleI18n: { en: input.titleI18n.en, zh: input.titleI18n.zh },
@@ -84,11 +105,18 @@ export class BroadcastRepository {
       },
       createdBy: input.createdBy,
       updatedBy: input.createdBy,
+      recipientUserIds,
       createdAt: now,
       updatedAt: now,
     };
     await this.broadcasts.insertOne(doc);
-    logger.debug({ broadcastId: String(doc._id) }, "broadcast inserted");
+    logger.debug(
+      {
+        broadcastId: String(doc._id),
+        recipientCount: recipientUserIds === null ? "all" : recipientUserIds.length,
+      },
+      "broadcast inserted",
+    );
     return mapBroadcastDoc(doc)!;
   }
 
@@ -303,6 +331,15 @@ function mapBroadcastDoc(doc: Document | null): BroadcastDocument | null {
   if (!doc) return null;
   const titleI18n = (doc.titleI18n as Partial<BroadcastI18nString>) ?? {};
   const bodyI18n = (doc.bodyMarkdownI18n as Partial<BroadcastI18nString>) ?? {};
+  // Pre-#502 docs predate the field — normalise both `undefined` (no
+  // key in Mongo) and explicit `null` to `null` so downstream code
+  // can branch on a single sentinel. Non-array values (corruption /
+  // bad migration) also fall back to `null` rather than crashing the
+  // mapper.
+  const rawRecipients = doc.recipientUserIds;
+  const recipientUserIds: readonly string[] | null = Array.isArray(rawRecipients)
+    ? rawRecipients.map((id) => String(id))
+    : null;
   return {
     _id: String(doc._id),
     titleI18n: {
@@ -315,6 +352,7 @@ function mapBroadcastDoc(doc: Document | null): BroadcastDocument | null {
     },
     createdBy: String(doc.createdBy ?? ""),
     updatedBy: String(doc.updatedBy ?? doc.createdBy ?? ""),
+    recipientUserIds,
     createdAt: toDate(doc.createdAt),
     updatedAt: toDate(doc.updatedAt ?? doc.createdAt),
   };

--- a/ornn-api/src/domains/broadcasts/routes.ts
+++ b/ornn-api/src/domains/broadcasts/routes.ts
@@ -66,6 +66,7 @@ export function createBroadcastRoutes(
       titleI18n: parsed.data.titleI18n,
       bodyMarkdownI18n: parsed.data.bodyMarkdownI18n,
       createdBy: authCtx.userId,
+      recipientUserIds: parsed.data.recipientUserIds,
     });
     return c.json({ data: created, error: null }, 201);
   });

--- a/ornn-api/src/domains/broadcasts/schemas.test.ts
+++ b/ornn-api/src/domains/broadcasts/schemas.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Zod schema tests for the broadcasts domain (#502 — recipientUserIds).
+ *
+ * Pinned contract:
+ *   - POST: `recipientUserIds` is optional; when present must be a
+ *     non-empty `string[]` of non-empty strings. `null` / `[]` / arrays
+ *     with empty strings are rejected.
+ *   - PATCH: `recipientUserIds` is unknown — `.strict()` rejects with
+ *     "Unrecognized key" so a forged PATCH can't change recipients.
+ *
+ * @module domains/broadcasts/schemas.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createBroadcastSchema, patchBroadcastSchema } from "./schemas";
+
+const baseCreate = {
+  titleI18n: { en: "Hello", zh: "你好" },
+  bodyMarkdownI18n: { en: "World", zh: "世界" },
+};
+
+describe("createBroadcastSchema — recipientUserIds (#502)", () => {
+  test("omitted recipientUserIds parses as broadcast-to-all (field is absent)", () => {
+    const parsed = createBroadcastSchema.safeParse(baseCreate);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.recipientUserIds).toBeUndefined();
+    }
+  });
+
+  test("non-empty string[] parses as targeted broadcast", () => {
+    const parsed = createBroadcastSchema.safeParse({
+      ...baseCreate,
+      recipientUserIds: ["u-1", "u-2"],
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.recipientUserIds).toEqual(["u-1", "u-2"]);
+    }
+  });
+
+  test("empty array is rejected (min(1) on the array)", () => {
+    const parsed = createBroadcastSchema.safeParse({
+      ...baseCreate,
+      recipientUserIds: [],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("null is rejected — frontend must omit the key, not pass null", () => {
+    const parsed = createBroadcastSchema.safeParse({
+      ...baseCreate,
+      recipientUserIds: null,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("array containing an empty string is rejected (min(1) per id)", () => {
+    const parsed = createBroadcastSchema.safeParse({
+      ...baseCreate,
+      recipientUserIds: ["u-1", ""],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("non-string entries are rejected", () => {
+    const parsed = createBroadcastSchema.safeParse({
+      ...baseCreate,
+      recipientUserIds: ["u-1", 123],
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("patchBroadcastSchema — recipientUserIds is immutable (#502)", () => {
+  test("PATCH with recipientUserIds is rejected — .strict() blocks unknown keys", () => {
+    const parsed = patchBroadcastSchema.safeParse({
+      titleI18n: { en: "edit" },
+      recipientUserIds: ["u-1", "u-2"],
+    });
+    expect(parsed.success).toBe(false);
+    // Sanity-check the failure reason so a future change that adds the
+    // field on PATCH (and accidentally accepts it) trips this test.
+    if (!parsed.success) {
+      const hasUnrecognized = parsed.error.issues.some((issue) =>
+        issue.code === "unrecognized_keys",
+      );
+      expect(hasUnrecognized).toBe(true);
+    }
+  });
+
+  test("PATCH without recipientUserIds still parses normally", () => {
+    const parsed = patchBroadcastSchema.safeParse({
+      titleI18n: { en: "edit" },
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/ornn-api/src/domains/broadcasts/schemas.ts
+++ b/ornn-api/src/domains/broadcasts/schemas.ts
@@ -52,6 +52,15 @@ export const createBroadcastSchema = z
   .object({
     titleI18n: broadcastI18nCreateSchema(TITLE_MAX),
     bodyMarkdownI18n: broadcastI18nCreateSchema(BODY_MAX),
+    /**
+     * Targeted recipients (#502). Optional. Omit the key entirely for
+     * a broadcast-to-all (the #500 default). When present, must be a
+     * non-empty array of non-empty user_ids — `null`, `[]`, and arrays
+     * with empty strings are rejected. Recipients are immutable after
+     * create (see `patchBroadcastSchema` — `.strict()` rejects this
+     * field on PATCH).
+     */
+    recipientUserIds: z.array(z.string().min(1)).min(1).optional(),
   })
   .strict();
 

--- a/ornn-api/src/domains/broadcasts/service.test.ts
+++ b/ornn-api/src/domains/broadcasts/service.test.ts
@@ -43,6 +43,10 @@ class FakeRepo {
       },
       createdBy: input.createdBy,
       updatedBy: input.createdBy,
+      recipientUserIds:
+        input.recipientUserIds && input.recipientUserIds.length > 0
+          ? [...input.recipientUserIds]
+          : null,
       createdAt: now,
       updatedAt: now,
     };

--- a/ornn-api/src/domains/broadcasts/service.test.ts
+++ b/ornn-api/src/domains/broadcasts/service.test.ts
@@ -262,4 +262,40 @@ describe("BroadcastService", () => {
     const { svc } = makeService();
     await expect(svc.getById("does-not-exist")).rejects.toThrow(/Broadcast not found/);
   });
+
+  test("create without recipientUserIds round-trips as broadcast-to-all (null)", async () => {
+    const { svc } = makeService();
+    const created = await svc.create(baseInput);
+    expect(created.recipientUserIds).toBeNull();
+    // Persisted shape matches — admin list shows null too.
+    const [listed] = await svc.listAdmin();
+    expect(listed?.recipientUserIds).toBeNull();
+  });
+
+  test("create with recipientUserIds round-trips as targeted broadcast", async () => {
+    const { svc } = makeService();
+    const created = await svc.create({
+      ...baseInput,
+      recipientUserIds: ["u-1", "u-2"],
+    });
+    expect(created.recipientUserIds).toEqual(["u-1", "u-2"]);
+    const [listed] = await svc.listAdmin();
+    expect(listed?.recipientUserIds).toEqual(["u-1", "u-2"]);
+  });
+
+  test("update does NOT touch recipientUserIds — field is immutable post-create", async () => {
+    const { svc } = makeService();
+    const created = await svc.create({
+      ...baseInput,
+      recipientUserIds: ["u-1", "u-2"],
+    });
+    // The service `update` input type doesn't expose `recipientUserIds`
+    // (compile-time enforcement). At runtime, passing only an `updatedBy`
+    // + title patch must leave the recipients array untouched.
+    const updated = await svc.update(created.id, {
+      titleI18n: { en: "Edited" },
+      updatedBy: "u-other",
+    });
+    expect(updated.recipientUserIds).toEqual(["u-1", "u-2"]);
+  });
 });

--- a/ornn-api/src/domains/broadcasts/service.ts
+++ b/ornn-api/src/domains/broadcasts/service.ts
@@ -47,8 +47,20 @@ export interface CreateBroadcastParams {
   titleI18n: BroadcastI18nString;
   bodyMarkdownI18n: BroadcastI18nString;
   createdBy: string;
+  /**
+   * Targeted recipients (#502). Omit / `undefined` → broadcast to
+   * every user. Non-empty array → targeted to that user list. Empty
+   * array is rejected upstream by the Zod schema; this type doesn't
+   * defend against it again.
+   */
+  recipientUserIds?: readonly string[];
 }
 
+/**
+ * Update params (#502): `recipientUserIds` is intentionally absent —
+ * recipient targeting is immutable after create. Adding it on a PATCH
+ * path is a compile error, matching the repository's enforcement.
+ */
 export interface UpdateBroadcastParams {
   titleI18n?: Partial<BroadcastI18nString>;
   bodyMarkdownI18n?: Partial<BroadcastI18nString>;
@@ -89,10 +101,18 @@ export class BroadcastService {
       titleI18n: params.titleI18n,
       bodyMarkdownI18n: params.bodyMarkdownI18n,
       createdBy: params.createdBy,
+      recipientUserIds: params.recipientUserIds,
     };
     const doc = await this.repo.create(input);
     logger.info(
-      { broadcastId: doc._id, by: params.createdBy },
+      {
+        broadcastId: doc._id,
+        by: params.createdBy,
+        // Recipient count only — never log the user_id list (it's
+        // PII-adjacent and pointless for ops debugging).
+        recipientCount:
+          doc.recipientUserIds === null ? "all" : doc.recipientUserIds.length,
+      },
       "broadcast created",
     );
     // New broadcasts have zero readers by definition — skip the count
@@ -163,6 +183,10 @@ function toAdminResponse(
     bodyMarkdownI18n: doc.bodyMarkdownI18n,
     createdBy: doc.createdBy,
     updatedBy: doc.updatedBy,
+    // Normalise `undefined` (defence in depth — the repo mapper
+    // already does this for absent fields) into `null` so the wire
+    // shape is `string[] | null`, never `undefined`.
+    recipientUserIds: doc.recipientUserIds ?? null,
     createdAt: doc.createdAt.toISOString(),
     updatedAt: doc.updatedAt.toISOString(),
     readCount,

--- a/ornn-api/src/domains/broadcasts/types.ts
+++ b/ornn-api/src/domains/broadcasts/types.ts
@@ -41,6 +41,19 @@ export interface BroadcastDocument {
   readonly createdBy: string;
   /** NyxID user_id of the admin who last edited; equals `createdBy` on create. */
   readonly updatedBy: string;
+  /**
+   * Targeting list (#502). `null` means broadcast to every user (the
+   * #500 default). A non-empty `string[]` of NyxID user_ids means the
+   * broadcast is only visible to those specific users — the merged
+   * feed, unread count, and markAllRead are filtered accordingly.
+   *
+   * **Immutable after create.** PATCH never changes this field — we
+   * can't yank a message back from a user who has already seen it, so
+   * the targeting decision is frozen at create time. The repository's
+   * `update` input type omits the field to enforce this at the
+   * compile boundary.
+   */
+  readonly recipientUserIds: readonly string[] | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }
@@ -68,6 +81,13 @@ export interface AdminBroadcastResponse {
   readonly bodyMarkdownI18n: BroadcastI18nString;
   readonly createdBy: string;
   readonly updatedBy: string;
+  /**
+   * Targeting list (#502). Always present on the wire — `null` for an
+   * everyone-broadcast, non-empty array for a targeted broadcast.
+   * Absent in the persisted doc is normalised to `null` by the read
+   * service so the wire shape is stable.
+   */
+  readonly recipientUserIds: readonly string[] | null;
   readonly createdAt: string;
   readonly updatedAt: string;
   readonly readCount: number;

--- a/ornn-api/src/domains/notifications/service.test.ts
+++ b/ornn-api/src/domains/notifications/service.test.ts
@@ -160,6 +160,7 @@ function makeBroadcast(overrides: Partial<BroadcastDocument> & { _id: string }):
     bodyMarkdownI18n: { en: "Body", zh: "内容" },
     createdBy: "u-admin",
     updatedBy: "u-admin",
+    recipientUserIds: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/ornn-api/src/domains/notifications/service.test.ts
+++ b/ornn-api/src/domains/notifications/service.test.ts
@@ -326,3 +326,147 @@ describe("NotificationService — merged feed (#500)", () => {
     expect(await svc.markAllRead("u1")).toBe(1);
   });
 });
+
+describe("NotificationService — recipientUserIds filter (#502)", () => {
+  test("listFeedForUser shows targeted broadcasts to recipients", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({
+        _id: "b-targeted",
+        recipientUserIds: ["u-1", "u-2"],
+      }),
+    );
+    const feedU1 = await svc.listFeedForUser("u-1");
+    expect(feedU1.map((i) => i._id)).toEqual(["b-targeted"]);
+    const feedU2 = await svc.listFeedForUser("u-2");
+    expect(feedU2.map((i) => i._id)).toEqual(["b-targeted"]);
+  });
+
+  test("listFeedForUser hides targeted broadcasts from non-recipients", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({
+        _id: "b-targeted",
+        recipientUserIds: ["u-1"],
+      }),
+    );
+    const feedU3 = await svc.listFeedForUser("u-3");
+    expect(feedU3).toEqual([]);
+  });
+
+  test("listFeedForUser still shows everyone-broadcasts (recipientUserIds: null)", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({ _id: "b-all", recipientUserIds: null }),
+    );
+    const feedU1 = await svc.listFeedForUser("u-1");
+    const feedU99 = await svc.listFeedForUser("u-99");
+    expect(feedU1.map((i) => i._id)).toEqual(["b-all"]);
+    expect(feedU99.map((i) => i._id)).toEqual(["b-all"]);
+  });
+
+  test("listFeedForUser interleaves targeted + everyone-broadcasts per recipient", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({
+        _id: "b-all",
+        recipientUserIds: null,
+        createdAt: new Date("2026-05-01T00:00:00Z"),
+      }),
+      makeBroadcast({
+        _id: "b-targeted-u1",
+        recipientUserIds: ["u-1"],
+        createdAt: new Date("2026-05-10T00:00:00Z"),
+      }),
+      makeBroadcast({
+        _id: "b-targeted-u2",
+        recipientUserIds: ["u-2"],
+        createdAt: new Date("2026-05-05T00:00:00Z"),
+      }),
+    );
+    const feedU1 = await svc.listFeedForUser("u-1");
+    expect(feedU1.map((i) => i._id)).toEqual(["b-targeted-u1", "b-all"]);
+    const feedU2 = await svc.listFeedForUser("u-2");
+    expect(feedU2.map((i) => i._id)).toEqual(["b-targeted-u2", "b-all"]);
+    const feedU3 = await svc.listFeedForUser("u-3");
+    expect(feedU3.map((i) => i._id)).toEqual(["b-all"]);
+  });
+
+  test("countUnread counts targeted broadcasts only for recipients", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({ _id: "b-all", recipientUserIds: null }),
+      makeBroadcast({ _id: "b-targeted", recipientUserIds: ["u-1"] }),
+    );
+    // u-1 sees both unread: count = 2
+    expect(await svc.countUnread("u-1")).toBe(2);
+    // u-2 sees only the everyone-broadcast unread: count = 1
+    expect(await svc.countUnread("u-2")).toBe(1);
+  });
+
+  test("markAllRead writes receipts only for visible broadcasts", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({ _id: "b-all", recipientUserIds: null }),
+      makeBroadcast({ _id: "b-targeted-u1", recipientUserIds: ["u-1"] }),
+      makeBroadcast({ _id: "b-targeted-u2", recipientUserIds: ["u-2"] }),
+    );
+    const changed = await svc.markAllRead("u-1");
+    // u-1 marks: b-all + b-targeted-u1 = 2; b-targeted-u2 stays unread for u-1.
+    expect(changed).toBe(2);
+    const receiptKeys = broadcastRepo.receipts.map((r) => `${r.userId}:${r.broadcastId}`).sort();
+    expect(receiptKeys).toEqual(["u-1:b-all", "u-1:b-targeted-u1"]);
+    // u-2 is unaffected — markAllRead for u-1 does not write a receipt
+    // for any broadcast u-2 can see.
+    expect(await svc.countUnread("u-2")).toBe(2);
+  });
+
+  test("markRead on a targeted broadcast by a non-recipient throws NOTIFICATION_NOT_FOUND", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({ _id: "b-targeted", recipientUserIds: ["u-1"] }),
+    );
+    await expect(svc.markRead("u-3", "b-targeted")).rejects.toThrow(
+      /Notification not found/,
+    );
+    // No receipt was written — the non-recipient can't even probe.
+    expect(broadcastRepo.receipts).toHaveLength(0);
+  });
+
+  test("markRead on a targeted broadcast by a recipient succeeds", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({ _id: "b-targeted", recipientUserIds: ["u-1"] }),
+    );
+    const result = await svc.markRead("u-1", "b-targeted");
+    expect("source" in result && result.source === "broadcast").toBe(true);
+    expect(broadcastRepo.receipts).toHaveLength(1);
+  });
+
+  test("markManyRead silently skips targeted broadcasts the caller can't see", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({ _id: "b-all", recipientUserIds: null }),
+      makeBroadcast({ _id: "b-targeted-other", recipientUserIds: ["u-99"] }),
+    );
+    // u-3 tries to mark both — only b-all should transition.
+    const changed = await svc.markManyRead("u-3", ["b-all", "b-targeted-other"]);
+    expect(changed).toBe(1);
+    expect(broadcastRepo.receipts).toHaveLength(1);
+    expect(broadcastRepo.receipts[0]?.broadcastId).toBe("b-all");
+  });
+
+  test("listFeedForUser unreadOnly + recipient filter compose correctly", async () => {
+    const { svc, broadcastRepo } = makeService();
+    broadcastRepo.broadcasts.push(
+      makeBroadcast({ _id: "b-all-read", recipientUserIds: null }),
+      makeBroadcast({ _id: "b-targeted-u1-read", recipientUserIds: ["u-1"] }),
+      makeBroadcast({ _id: "b-targeted-u1-unread", recipientUserIds: ["u-1"] }),
+      makeBroadcast({ _id: "b-targeted-u2", recipientUserIds: ["u-2"] }),
+    );
+    await broadcastRepo.markRead("u-1", "b-all-read");
+    await broadcastRepo.markRead("u-1", "b-targeted-u1-read");
+    const feed = await svc.listFeedForUser("u-1", { unreadOnly: true });
+    expect(feed.map((i) => i._id)).toEqual(["b-targeted-u1-unread"]);
+  });
+});

--- a/ornn-api/src/domains/notifications/service.ts
+++ b/ornn-api/src/domains/notifications/service.ts
@@ -16,10 +16,28 @@
 import pino from "pino";
 import { AppError } from "../../shared/types/index";
 import type { BroadcastRepository } from "../broadcasts/repository";
+import type { BroadcastDocument } from "../broadcasts/types";
 import type { NotificationRepository } from "./repository";
 import type { FeedItem, NotificationDocument } from "./types";
 
 const logger = pino({ level: "info" }).child({ module: "notificationService" });
+
+/**
+ * Recipient predicate for broadcasts (#502). `null` recipientUserIds
+ * means broadcast-to-all — every user is a recipient. A non-null
+ * array means only those NyxID user_ids see the broadcast in any
+ * surface (feed, unread count, markAllRead, single markRead). All
+ * three call sites in this file flow through this helper so the
+ * targeting rule lives in exactly one place.
+ */
+function isBroadcastVisibleTo(
+  broadcast: Pick<BroadcastDocument, "recipientUserIds">,
+  userId: string,
+): boolean {
+  const recipients = broadcast.recipientUserIds;
+  if (recipients === null) return true;
+  return recipients.includes(userId);
+}
 
 /** Per-page cap on the merged feed. Matches the existing repo cap. */
 const MERGED_FEED_LIMIT_MAX = 200;
@@ -95,12 +113,20 @@ export class NotificationService {
     const broadcastItems: FeedItem[] = [];
     if (this.broadcastRepo) {
       const broadcasts = await this.broadcastRepo.listAll();
-      if (broadcasts.length > 0) {
+      // Filter out broadcasts the caller is not a recipient of (#502).
+      // `null` recipientUserIds means "everyone"; a non-null array
+      // means "only these user_ids see it". Non-recipients should never
+      // see the broadcast in the feed, the unread count, or the
+      // markAllRead set — to them it doesn't exist.
+      const visibleBroadcasts = broadcasts.filter((b) =>
+        isBroadcastVisibleTo(b, userId),
+      );
+      if (visibleBroadcasts.length > 0) {
         const readMap = await this.broadcastRepo.hasUserReadBroadcastsMap(
           userId,
-          broadcasts.map((b) => b._id),
+          visibleBroadcasts.map((b) => b._id),
         );
-        for (const b of broadcasts) {
+        for (const b of visibleBroadcasts) {
           const readAt = readMap[b._id] ?? null;
           if (options.unreadOnly && readAt) continue;
           broadcastItems.push({
@@ -123,8 +149,20 @@ export class NotificationService {
   async countUnread(userId: string): Promise<number> {
     const perUser = await this.repo.countUnread(userId);
     if (!this.broadcastRepo) return perUser;
-    const unreadBroadcasts = await this.broadcastRepo.unreadBroadcastIdsForUser(userId);
-    return perUser + unreadBroadcasts.length;
+    // Recipient filter (#502): a targeted broadcast must only count
+    // toward the caller's unread badge when the caller is in the
+    // recipient list. `unreadBroadcastIdsForUser` ignores recipients;
+    // do the filter ourselves on the listAll roster.
+    const visible = (await this.broadcastRepo.listAll()).filter((b) =>
+      isBroadcastVisibleTo(b, userId),
+    );
+    if (visible.length === 0) return perUser;
+    const readMap = await this.broadcastRepo.hasUserReadBroadcastsMap(
+      userId,
+      visible.map((b) => b._id),
+    );
+    const unreadCount = visible.filter((b) => !readMap[b._id]).length;
+    return perUser + unreadCount;
   }
 
   /**
@@ -146,7 +184,11 @@ export class NotificationService {
     if (updated) return updated;
     if (this.broadcastRepo) {
       const broadcast = await this.broadcastRepo.getById(id);
-      if (broadcast) {
+      // Recipient filter (#502): non-recipients see a targeted
+      // broadcast as if it doesn't exist — same NOTIFICATION_NOT_FOUND
+      // as a typo'd id. This also prevents probing the existence of
+      // targeted broadcasts via the markRead path.
+      if (broadcast && isBroadcastVisibleTo(broadcast, userId)) {
         const receipt = await this.broadcastRepo.markRead(userId, id);
         logger.debug(
           { userId, broadcastId: id },
@@ -184,11 +226,15 @@ export class NotificationService {
       // Else: unknown id — skip silently per the contract above.
     }
     if (broadcastIds.length > 0 && this.broadcastRepo) {
-      // Filter out ids that don't actually exist in `broadcasts` to
-      // avoid inserting receipts for typos.
+      // Filter out ids that don't actually exist in `broadcasts` (typos)
+      // AND ids the caller is not a recipient of (#502 — non-recipients
+      // see a targeted broadcast as if it doesn't exist).
       const existing: string[] = [];
       for (const id of broadcastIds) {
-        if (await this.broadcastRepo.getById(id)) existing.push(id);
+        const broadcast = await this.broadcastRepo.getById(id);
+        if (broadcast && isBroadcastVisibleTo(broadcast, userId)) {
+          existing.push(id);
+        }
       }
       if (existing.length > 0) {
         const inserted = await this.broadcastRepo.markManyRead(userId, existing);
@@ -202,11 +248,28 @@ export class NotificationService {
    * Mark every unread item read — per-user notifications AND every
    * broadcast that doesn't yet have a receipt for this user. Returns
    * the total transitions across both sources.
+   *
+   * Recipient filter (#502): only marks broadcasts the caller is a
+   * recipient of (everyone-broadcasts, or targeted broadcasts whose
+   * recipient list includes the caller). Non-recipient broadcasts
+   * are invisible — never read, never written to receipts.
    */
   async markAllRead(userId: string): Promise<number> {
     const perUser = await this.repo.markAllRead(userId);
     if (!this.broadcastRepo) return perUser;
-    const unread = await this.broadcastRepo.unreadBroadcastIdsForUser(userId);
+    // Restrict the "mark all read" set to broadcasts visible to this
+    // caller. A non-recipient should never accidentally write a
+    // receipt for a targeted broadcast they can't see.
+    const visible = (await this.broadcastRepo.listAll()).filter((b) =>
+      isBroadcastVisibleTo(b, userId),
+    );
+    if (visible.length === 0) return perUser;
+    const readMap = await this.broadcastRepo.hasUserReadBroadcastsMap(
+      userId,
+      visible.map((b) => b._id),
+    );
+    const unread = visible.filter((b) => !readMap[b._id]).map((b) => b._id);
+    if (unread.length === 0) return perUser;
     const broadcasts = await this.broadcastRepo.markManyRead(userId, unread);
     return perUser + broadcasts;
   }

--- a/ornn-web/src/components/admin/UserEmailPicker.test.tsx
+++ b/ornn-web/src/components/admin/UserEmailPicker.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * UserEmailPicker tests — happy-path search + chip add/remove.
+ *
+ * Mocks `fetchAdminUsers` directly so the test stays off the apiClient
+ * / auth-store chain. React Query is wrapped in a small Provider per
+ * test so each `useQuery` actually executes its `queryFn`.
+ *
+ * @module components/admin/UserEmailPicker.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { AdminUserRow, AdminUsersPage } from "@/services/adminUsersApi";
+
+const fetchAdminUsers = vi.fn<
+  (params: unknown) => Promise<AdminUsersPage>
+>();
+
+vi.mock("@/services/adminUsersApi", () => ({
+  fetchAdminUsers: (params: unknown) => fetchAdminUsers(params),
+}));
+
+// Bypass the 300 ms debounce so the test doesn't have to fake timers.
+vi.mock("@/hooks/useDebounce", () => ({
+  useDebounce: <T,>(v: T) => v,
+}));
+
+import { UserEmailPicker } from "./UserEmailPicker";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+function page(rows: AdminUserRow[]): AdminUsersPage {
+  return {
+    items: rows,
+    total: rows.length,
+    page: 1,
+    pageSize: rows.length,
+    totalPages: 1,
+  };
+}
+
+beforeEach(() => {
+  fetchAdminUsers.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("UserEmailPicker", () => {
+  it("shows matching users in a dropdown and adds a chip on click", async () => {
+    fetchAdminUsers.mockResolvedValue(
+      page([
+        {
+          userId: "u-1",
+          email: "alice@example.com",
+          displayName: "Alice",
+          skillCount: 0,
+          lastActiveAt: null,
+          activityCount: 0,
+          firstJoinedAt: null,
+        },
+      ]),
+    );
+
+    const onChange = vi.fn();
+    wrap(<UserEmailPicker value={[]} onChange={onChange} />);
+
+    const search = screen.getByRole("textbox");
+    fireEvent.change(search, { target: { value: "alice" } });
+
+    const row = await screen.findByText("alice@example.com");
+    fireEvent.click(row);
+
+    expect(onChange).toHaveBeenCalledWith(["u-1"]);
+  });
+
+  it("renders selected chips with email labels and removes on × click", async () => {
+    fetchAdminUsers.mockResolvedValue(
+      page([
+        {
+          userId: "u-1",
+          email: "alice@example.com",
+          displayName: "Alice",
+          skillCount: 0,
+          lastActiveAt: null,
+          activityCount: 0,
+          firstJoinedAt: null,
+        },
+      ]),
+    );
+
+    const onChange = vi.fn();
+    wrap(<UserEmailPicker value={["u-1"]} onChange={onChange} />);
+
+    // Chip resolves to email via cached admin-users page.
+    await waitFor(() => {
+      expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    });
+
+    // The × remove button — exactly one in the chip row.
+    const removeBtn = screen.getByRole("button");
+    fireEvent.click(removeBtn);
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/ornn-web/src/components/admin/UserEmailPicker.tsx
+++ b/ornn-web/src/components/admin/UserEmailPicker.tsx
@@ -1,0 +1,241 @@
+/**
+ * UserEmailPicker — debounced email-search + chip multi-select.
+ *
+ * Type into the search field; matching users surface from
+ * `GET /api/v1/admin/users?role=normal&q=...` (300 ms debounce).
+ * Click a row to add as a chip; click "×" on a chip to remove. Returns
+ * `string[]` of `userId` values via `onChange`.
+ *
+ * Scoped to `role=normal` for targeted-broadcast recipient picking —
+ * an admin sending a broadcast targets end-users, not other admins.
+ * If a different scope is ever needed, lift `role` into a prop.
+ *
+ * @module components/admin/UserEmailPicker
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminUsers, type AdminUserRow } from "@/services/adminUsersApi";
+import { useDebounce } from "@/hooks/useDebounce";
+
+const SEARCH_DEBOUNCE_MS = 300;
+const RESULT_CAP = 10;
+
+export interface UserEmailPickerProps {
+  /** Currently-selected user_ids. */
+  value: string[];
+  /** Fires with the next selection on add or remove. */
+  onChange: (next: string[]) => void;
+  /** Disable input + chip removal (e.g. while saving). */
+  disabled?: boolean;
+  /** Override the visible-label cap for resolved emails. */
+  className?: string;
+}
+
+interface ResolvedRow {
+  userId: string;
+  email: string;
+  displayName: string;
+}
+
+/**
+ * Resolve already-selected user_ids back to display emails by piggy-
+ * backing on the cached admin-users pages React Query has in memory.
+ * Falls back to the bare userId so a freshly-pasted id still renders
+ * a deterministic chip.
+ */
+function useResolvedSelection(value: string[]): Map<string, ResolvedRow> {
+  // Pull the most recent search payload so chips can render emails the
+  // user has actually seen in the dropdown. This is best-effort: if a
+  // chip's id isn't in cache we fall back to the id itself.
+  const recent = useQuery({
+    queryKey: ["admin", "users", "picker-resolve", value],
+    enabled: value.length > 0,
+    staleTime: 60_000,
+    queryFn: async () => {
+      // Pull the first big page of normal users — admin user lists are
+      // small enough that this is cheaper than batching id-by-id and
+      // simpler than threading a dedicated lookup endpoint through
+      // backend just for chip rendering. If the list grows past the
+      // page cap we'd swap this for a real lookup endpoint.
+      const page = await fetchAdminUsers({
+        role: "normal",
+        page: 1,
+        pageSize: 200,
+      });
+      return page.items;
+    },
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, ResolvedRow>();
+    for (const row of recent.data ?? []) {
+      map.set(row.userId, {
+        userId: row.userId,
+        email: row.email,
+        displayName: row.displayName,
+      });
+    }
+    return map;
+  }, [recent.data]);
+}
+
+export function UserEmailPicker({
+  value,
+  onChange,
+  disabled = false,
+  className = "",
+}: UserEmailPickerProps) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const debouncedQuery = useDebounce(query.trim(), SEARCH_DEBOUNCE_MS);
+  const selectedSet = useMemo(() => new Set(value), [value]);
+  const resolved = useResolvedSelection(value);
+
+  const searchQuery = useQuery({
+    queryKey: ["admin", "users", "picker-search", debouncedQuery],
+    enabled: debouncedQuery.length > 0,
+    staleTime: 10_000,
+    queryFn: async () => {
+      const page = await fetchAdminUsers({
+        role: "normal",
+        q: debouncedQuery,
+        page: 1,
+        pageSize: RESULT_CAP,
+      });
+      return page.items;
+    },
+  });
+
+  const visibleResults: AdminUserRow[] = useMemo(() => {
+    const rows = searchQuery.data ?? [];
+    return rows.filter((r) => !selectedSet.has(r.userId));
+  }, [searchQuery.data, selectedSet]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (ev: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(ev.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const addUser = (row: AdminUserRow) => {
+    if (selectedSet.has(row.userId)) return;
+    onChange([...value, row.userId]);
+    setQuery("");
+    // Keep the dropdown open so the admin can pile-add a handful of
+    // recipients before closing — fewer keyboard round-trips.
+    setOpen(true);
+  };
+
+  const removeUser = (userId: string) => {
+    onChange(value.filter((id) => id !== userId));
+  };
+
+  const showDropdown =
+    open && debouncedQuery.length > 0 && !disabled;
+
+  return (
+    <div ref={containerRef} className={`flex flex-col gap-2 ${className}`}>
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {value.map((userId) => {
+            const row = resolved.get(userId);
+            const label = row?.email ?? userId;
+            const hint = row?.displayName;
+            return (
+              <span
+                key={userId}
+                className="inline-flex items-center gap-1.5 rounded-sm border border-subtle bg-elevated/60 px-2 py-1 font-mono text-[11px] text-strong"
+                title={hint}
+              >
+                <span className="truncate max-w-[220px]">{label}</span>
+                <button
+                  type="button"
+                  onClick={() => removeUser(userId)}
+                  disabled={disabled}
+                  aria-label={t("adminPages.broadcasts.recipients.remove", {
+                    email: label,
+                  })}
+                  className="-mr-1 inline-flex h-4 w-4 items-center justify-center rounded-sm text-meta transition-colors hover:bg-danger/20 hover:text-danger focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent disabled:opacity-40"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    className="h-3 w-3"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="relative">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          disabled={disabled}
+          placeholder={t("adminPages.broadcasts.recipients.searchPlaceholder")}
+          aria-label={t("adminPages.broadcasts.recipients.searchAria")}
+          className="w-full rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-text text-sm text-strong placeholder:text-meta/70 transition-colors duration-150 focus:border-accent focus:bg-card focus:outline-none disabled:opacity-50"
+        />
+
+        {showDropdown && (
+          <div className="absolute left-0 right-0 top-full z-30 mt-1 max-h-64 overflow-y-auto rounded-sm border border-subtle bg-card shadow-lg">
+            {searchQuery.isLoading ? (
+              <div className="px-3 py-2 font-text text-xs text-meta">
+                {t("adminPages.broadcasts.recipients.loading")}
+              </div>
+            ) : visibleResults.length === 0 ? (
+              <div className="px-3 py-2 font-text text-xs text-meta">
+                {t("adminPages.broadcasts.recipients.noMatches")}
+              </div>
+            ) : (
+              visibleResults.map((row) => (
+                <button
+                  key={row.userId}
+                  type="button"
+                  onClick={() => addUser(row)}
+                  className="flex w-full flex-col gap-0.5 border-b border-subtle/40 px-3 py-2 text-left transition-colors hover:bg-elevated/60 focus-visible:bg-elevated/60 focus-visible:outline-none last:border-b-0"
+                >
+                  <span className="font-mono text-[11px] text-strong">
+                    {row.email}
+                  </span>
+                  {row.displayName && (
+                    <span className="font-text text-[11px] text-meta">
+                      {row.displayName}
+                    </span>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ornn-web/src/components/admin/broadcasts/BroadcastEditDrawer.test.tsx
+++ b/ornn-web/src/components/admin/broadcasts/BroadcastEditDrawer.test.tsx
@@ -15,6 +15,8 @@
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 
 const createMutate = vi.fn();
 const updateMutate = vi.fn();
@@ -32,7 +34,25 @@ vi.mock("@/stores/toastStore", () => ({
     selector({ addToast }),
 }));
 
+// Avoid pulling in apiClient via UserEmailPicker → adminUsersApi.
+vi.mock("@/services/adminUsersApi", () => ({
+  fetchAdminUsers: vi.fn().mockResolvedValue({
+    items: [],
+    total: 0,
+    page: 1,
+    pageSize: 0,
+    totalPages: 1,
+  }),
+}));
+
 import { BroadcastEditDrawer } from "./BroadcastEditDrawer";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
 
 beforeEach(() => {
   createMutate.mockReset();
@@ -80,7 +100,7 @@ describe("BroadcastEditDrawer", () => {
       },
     );
 
-    render(
+    wrap(
       <BroadcastEditDrawer
         isOpen={true}
         onClose={onClose}
@@ -118,7 +138,7 @@ describe("BroadcastEditDrawer", () => {
   });
 
   it("does not submit when one of the four required fields is empty", async () => {
-    render(
+    wrap(
       <BroadcastEditDrawer
         isOpen={true}
         onClose={() => {}}
@@ -140,6 +160,37 @@ describe("BroadcastEditDrawer", () => {
 
     // Mutation never fires; the drawer remains open (onClose isn't
     // called from a failed submission path).
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit when 'Specific users' is selected with no recipients", async () => {
+    wrap(
+      <BroadcastEditDrawer
+        isOpen={true}
+        onClose={() => {}}
+        broadcast={null}
+      />,
+    );
+
+    fillBilingual({
+      titleEn: "Targeted",
+      titleZh: "定向",
+      bodyEn: "Hello",
+      bodyZh: "你好",
+    });
+
+    // Flip to "Specific users" but add no recipients.
+    const radios = screen.getAllByRole("radio") as HTMLInputElement[];
+    const specificRadio = radios.find((r) =>
+      (r.parentElement?.textContent ?? "").toLowerCase().includes("specific"),
+    );
+    expect(specificRadio).toBeTruthy();
+    fireEvent.click(specificRadio!);
+
+    const buttons = screen.getAllByRole("button");
+    const submitBtn = buttons.find((b) => b.getAttribute("type") === "submit");
+    fireEvent.click(submitBtn!);
+
     expect(createMutate).not.toHaveBeenCalled();
   });
 });

--- a/ornn-web/src/components/admin/broadcasts/BroadcastEditDrawer.tsx
+++ b/ornn-web/src/components/admin/broadcasts/BroadcastEditDrawer.tsx
@@ -16,13 +16,15 @@
  * @module components/admin/broadcasts/BroadcastEditDrawer
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { MarkdownEditor } from "@/components/form/MarkdownEditor";
+import { UserEmailPicker } from "@/components/admin/UserEmailPicker";
 import { useToastStore } from "@/stores/toastStore";
 import {
   useCreateBroadcast,
@@ -32,16 +34,21 @@ import type {
   AdminBroadcast,
   CreateBroadcastInput,
 } from "@/services/broadcastsApi";
+import { fetchAdminUsers } from "@/services/adminUsersApi";
 import { translateError } from "@/utils/translateError";
 
 const TITLE_MAX = 200;
 const BODY_MAX = 20_000;
+
+type Audience = "all" | "specific";
 
 interface DrawerForm {
   titleEn: string;
   titleZh: string;
   bodyEn: string;
   bodyZh: string;
+  audience: Audience;
+  recipientUserIds: string[];
 }
 
 interface FieldErrors {
@@ -49,10 +56,18 @@ interface FieldErrors {
   titleZh?: string;
   bodyEn?: string;
   bodyZh?: string;
+  recipients?: string;
 }
 
 function emptyForm(): DrawerForm {
-  return { titleEn: "", titleZh: "", bodyEn: "", bodyZh: "" };
+  return {
+    titleEn: "",
+    titleZh: "",
+    bodyEn: "",
+    bodyZh: "",
+    audience: "all",
+    recipientUserIds: [],
+  };
 }
 
 function fromBroadcast(b: AdminBroadcast): DrawerForm {
@@ -61,18 +76,25 @@ function fromBroadcast(b: AdminBroadcast): DrawerForm {
     titleZh: b.titleI18n.zh,
     bodyEn: b.bodyMarkdownI18n.en,
     bodyZh: b.bodyMarkdownI18n.zh,
+    audience: b.recipientUserIds == null ? "all" : "specific",
+    recipientUserIds: b.recipientUserIds ?? [],
   };
 }
 
 function toInput(form: DrawerForm): CreateBroadcastInput {
-  return {
+  const base: CreateBroadcastInput = {
     titleI18n: { en: form.titleEn.trim(), zh: form.titleZh.trim() },
     bodyMarkdownI18n: { en: form.bodyEn.trim(), zh: form.bodyZh.trim() },
   };
+  if (form.audience === "specific") {
+    base.recipientUserIds = form.recipientUserIds;
+  }
+  return base;
 }
 
 function validate(
   form: DrawerForm,
+  isEdit: boolean,
   t: (k: string) => string,
 ): FieldErrors {
   const errors: FieldErrors = {};
@@ -95,6 +117,11 @@ function validate(
     errors.bodyZh = t("adminPages.broadcasts.errors.bodyZhRequired");
   } else if (form.bodyZh.trim().length > BODY_MAX) {
     errors.bodyZh = t("adminPages.broadcasts.errors.bodyTooLong");
+  }
+  // Recipient validation only matters on create — on edit the audience
+  // is read-only and locked to whatever was chosen at create time.
+  if (!isEdit && form.audience === "specific" && form.recipientUserIds.length === 0) {
+    errors.recipients = t("adminPages.broadcasts.errors.recipientsRequired");
   }
   return errors;
 }
@@ -121,6 +148,32 @@ export function BroadcastEditDrawer({
   const [form, setForm] = useState<DrawerForm>(() => emptyForm());
   const [errors, setErrors] = useState<FieldErrors>({});
 
+  // Read-only edit mode resolves the locked recipient list to emails for
+  // display. Pull the first big page of normal users from cache — the
+  // same pattern UserEmailPicker uses for chip resolution.
+  const editRecipientsList = isEdit ? broadcast?.recipientUserIds ?? null : null;
+  const userLookupQuery = useQuery({
+    queryKey: ["admin", "users", "broadcast-edit-lookup"],
+    enabled: isOpen && editRecipientsList != null && editRecipientsList.length > 0,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const page = await fetchAdminUsers({
+        role: "normal",
+        page: 1,
+        pageSize: 200,
+      });
+      return page.items;
+    },
+  });
+
+  const resolvedEmails = useMemo<string[]>(() => {
+    if (!editRecipientsList) return [];
+    const cache = new Map(
+      (userLookupQuery.data ?? []).map((row) => [row.userId, row.email]),
+    );
+    return editRecipientsList.map((id) => cache.get(id) ?? id);
+  }, [editRecipientsList, userLookupQuery.data]);
+
   useEffect(() => {
     if (!isOpen) return;
     setForm(broadcast ? fromBroadcast(broadcast) : emptyForm());
@@ -138,7 +191,7 @@ export function BroadcastEditDrawer({
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const next = validate(form, t);
+    const next = validate(form, isEdit, t);
     if (Object.keys(next).length > 0) {
       setErrors(next);
       return;
@@ -146,8 +199,11 @@ export function BroadcastEditDrawer({
     setErrors({});
     const input = toInput(form);
     if (isEdit && broadcast) {
+      // PATCH is title + body only — strip recipientUserIds if present.
+      const { recipientUserIds: _ignored, ...patch } = input;
+      void _ignored;
       updateMut.mutate(
-        { id: broadcast.id, patch: input },
+        { id: broadcast.id, patch },
         {
           onSuccess: () => {
             addToast({
@@ -248,8 +304,97 @@ export function BroadcastEditDrawer({
             </header>
 
             <form onSubmit={onSubmit} className="flex flex-col gap-6">
+              {/* Recipients — editable on create, read-only on edit.
+                  Recipients are locked at create time and PATCH rejects
+                  any attempt to change them, so the edit-mode UI is a
+                  pure summary card. */}
+              <section className="flex flex-col gap-3">
+                <h3 className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-accent">
+                  {t("adminPages.broadcasts.recipients.heading")}
+                </h3>
+                {isEdit ? (
+                  <div className="flex flex-col gap-2 rounded-sm border border-subtle bg-elevated/40 p-3">
+                    <p className="font-text text-sm text-strong">
+                      {editRecipientsList == null
+                        ? t("adminPages.broadcasts.recipients.summaryAll")
+                        : t("adminPages.broadcasts.recipients.summaryCount", {
+                            count: editRecipientsList.length,
+                          })}
+                    </p>
+                    {editRecipientsList != null && editRecipientsList.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5">
+                        {resolvedEmails.map((email, idx) => (
+                          <span
+                            key={`${editRecipientsList[idx]}-${idx}`}
+                            className="rounded-sm border border-subtle bg-card px-2 py-0.5 font-mono text-[11px] text-meta"
+                          >
+                            {email}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                      {t("adminPages.broadcasts.recipients.lockedHint")}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-wrap gap-4">
+                      <label className="flex items-center gap-2 font-text text-sm text-strong">
+                        <input
+                          type="radio"
+                          name="broadcast-audience"
+                          checked={form.audience === "all"}
+                          onChange={() =>
+                            setForm((f) => ({
+                              ...f,
+                              audience: "all",
+                              recipientUserIds: [],
+                            }))
+                          }
+                          className="accent-accent"
+                        />
+                        <span>
+                          {t("adminPages.broadcasts.recipients.audienceAll")}
+                        </span>
+                      </label>
+                      <label className="flex items-center gap-2 font-text text-sm text-strong">
+                        <input
+                          type="radio"
+                          name="broadcast-audience"
+                          checked={form.audience === "specific"}
+                          onChange={() =>
+                            setForm((f) => ({ ...f, audience: "specific" }))
+                          }
+                          className="accent-accent"
+                        />
+                        <span>
+                          {t("adminPages.broadcasts.recipients.audienceSpecific")}
+                        </span>
+                      </label>
+                    </div>
+                    {form.audience === "specific" && (
+                      <div className="flex flex-col gap-1.5">
+                        <UserEmailPicker
+                          value={form.recipientUserIds}
+                          onChange={(next) =>
+                            setForm((f) => ({ ...f, recipientUserIds: next }))
+                          }
+                          disabled={saving}
+                        />
+                        {errors.recipients && (
+                          <span className="font-mono text-[11px] text-danger">
+                            {errors.recipients}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </section>
+
               {/* English block — required */}
-              <section className="flex flex-col gap-4">
+              <section className="flex flex-col gap-4 border-t border-subtle pt-5">
                 <h3 className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-accent">
                   {t("adminPages.broadcasts.drawer.englishHeading")}
                 </h3>

--- a/ornn-web/src/components/notifications/NotificationBell.tsx
+++ b/ornn-web/src/components/notifications/NotificationBell.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/hooks/useNotifications";
 import type { Notification } from "@/types/notifications";
 import { pickLocalized } from "@/lib/announcementLocale";
+import { NotificationDetailModal } from "./NotificationDetailModal";
 
 /** Size used in navbar + empty-state. */
 const POPOVER_ITEM_CAP = 10;
@@ -62,6 +63,8 @@ export function NotificationBell() {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+  const [detailNotification, setDetailNotification] =
+    useState<Notification | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   const { data: unread = 0 } = useUnreadNotificationCount();
@@ -91,15 +94,17 @@ export function NotificationBell() {
   }, [open]);
 
   const handleItemClick = (n: Notification) => {
-    if (!n.readAt) {
-      markRead.mutate(n._id);
-    }
-    // Broadcasts have no deep-link target — clicking marks read and
-    // collapses the popover in place. User-side notifications still
-    // navigate (link → that link, no link → /notifications page).
+    // Broadcasts open a full markdown viewer modal so a user can read
+    // long-form content without leaving the page. Mark-read fires from
+    // the modal's open effect so the bell badge updates immediately.
+    // User-side notifications keep the existing navigate behavior.
     if (n.source === "broadcast") {
       setOpen(false);
+      setDetailNotification(n);
       return;
+    }
+    if (!n.readAt) {
+      markRead.mutate(n._id);
     }
     setOpen(false);
     if (n.link) navigate(n.link);
@@ -251,6 +256,12 @@ export function NotificationBell() {
           </motion.div>
         )}
       </AnimatePresence>
+
+      <NotificationDetailModal
+        notification={detailNotification}
+        onClose={() => setDetailNotification(null)}
+        onMarkRead={(id) => markRead.mutate(id)}
+      />
     </div>
   );
 }

--- a/ornn-web/src/components/notifications/NotificationDetailModal.test.tsx
+++ b/ornn-web/src/components/notifications/NotificationDetailModal.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * NotificationDetailModal tests — render bilingual markdown + mark-read
+ * effect.
+ *
+ * @module components/notifications/NotificationDetailModal.test
+ */
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { Notification } from "@/types/notifications";
+import { NotificationDetailModal } from "./NotificationDetailModal";
+
+const SAMPLE: Notification = {
+  _id: "n-1",
+  source: "broadcast",
+  titleI18n: { en: "Maintenance window", zh: "维护窗口" },
+  bodyMarkdownI18n: {
+    en: "We will **restart** ornn-api at 02:00 UTC.",
+    zh: "我们将于 UTC 02:00 **重启** ornn-api。",
+  },
+  createdAt: "2026-05-14T00:00:00.000Z",
+  readAt: null,
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("NotificationDetailModal", () => {
+  it("renders title + markdown body for a broadcast", () => {
+    render(
+      <NotificationDetailModal
+        notification={SAMPLE}
+        onClose={() => {}}
+        onMarkRead={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Maintenance window")).toBeInTheDocument();
+    // Bold from markdown should render as a <strong>.
+    const strong = screen.getByText("restart");
+    expect(strong.tagName).toBe("STRONG");
+  });
+
+  it("calls onMarkRead exactly once when opened on an unread broadcast", async () => {
+    const onMarkRead = vi.fn();
+    render(
+      <NotificationDetailModal
+        notification={SAMPLE}
+        onClose={() => {}}
+        onMarkRead={onMarkRead}
+      />,
+    );
+
+    await waitFor(() => expect(onMarkRead).toHaveBeenCalledTimes(1));
+    expect(onMarkRead).toHaveBeenCalledWith("n-1");
+  });
+
+  it("does not call onMarkRead when the notification is already read", async () => {
+    const onMarkRead = vi.fn();
+    render(
+      <NotificationDetailModal
+        notification={{
+          ...SAMPLE,
+          readAt: "2026-05-14T00:00:01.000Z",
+        }}
+        onClose={() => {}}
+        onMarkRead={onMarkRead}
+      />,
+    );
+
+    // Allow the open effect chain to drain.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when notification is null", () => {
+    const { container } = render(
+      <NotificationDetailModal notification={null} onClose={() => {}} />,
+    );
+    // Portal is appended to document.body but only when isOpen — confirm
+    // the document body has no modal text.
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText(/Maintenance window/)).toBeNull();
+  });
+});

--- a/ornn-web/src/components/notifications/NotificationDetailModal.tsx
+++ b/ornn-web/src/components/notifications/NotificationDetailModal.tsx
@@ -1,0 +1,154 @@
+/**
+ * NotificationDetailModal — click-to-popup viewer for a broadcast-source
+ * notification.
+ *
+ * Renders the bilingual broadcast in full: locale-resolved title as the
+ * modal heading, locale-resolved markdown body sanitized through the
+ * same safe stack used by AnnouncementPopup (`remark-gfm` +
+ * `rehype-sanitize`).
+ *
+ * Side effect on open: if `readAt == null`, fires the existing
+ * mark-read mutation so the bell badge updates without an extra
+ * click. The mutation is passed in by the parent rather than wired
+ * here so the modal stays stateless wrt React Query.
+ *
+ * Motion vocabulary matches ConfirmDialog / Modal: backdrop fade +
+ * dialog spring. Close vectors: ESC, backdrop click, explicit ×.
+ *
+ * @module components/notifications/NotificationDetailModal
+ */
+
+import { useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
+import type { Notification } from "@/types/notifications";
+import { pickLocalized } from "@/lib/announcementLocale";
+
+export interface NotificationDetailModalProps {
+  /** Notification to display. The modal renders nothing when null. */
+  notification: Notification | null;
+  onClose: () => void;
+  /**
+   * Fires once when the modal opens for an unread notification. The
+   * parent owns the mark-read mutation so the modal stays stateless.
+   */
+  onMarkRead?: (id: string) => void;
+}
+
+export function NotificationDetailModal({
+  notification,
+  onClose,
+  onMarkRead,
+}: NotificationDetailModalProps) {
+  const { t, i18n } = useTranslation();
+  const isOpen = notification != null;
+  const id = notification?._id;
+  const readAt = notification?.readAt;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  // Fire mark-read once per open transition for unread items. Guarding
+  // on `id + readAt` makes this idempotent if the parent rerenders.
+  useEffect(() => {
+    if (!isOpen || !id || readAt || !onMarkRead) return;
+    onMarkRead(id);
+  }, [isOpen, id, readAt, onMarkRead]);
+
+  if (!notification) return null;
+
+  const lang = i18n.language;
+  const titleText =
+    notification.titleI18n
+      ? pickLocalized(
+          notification.titleI18n.en,
+          notification.titleI18n.zh,
+          lang,
+        )
+      : notification.title ?? "";
+  const bodyMarkdown = notification.bodyMarkdownI18n
+    ? pickLocalized(
+        notification.bodyMarkdownI18n.en,
+        notification.bodyMarkdownI18n.zh,
+        lang,
+      )
+    : "";
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="absolute inset-0 bg-black/55 backdrop-blur-[2px]"
+            onClick={onClose}
+          />
+          <motion.div
+            initial={{ opacity: 0, y: 8, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.98 }}
+            transition={{ type: "spring", stiffness: 220, damping: 22, mass: 0.9 }}
+            role="dialog"
+            aria-modal="true"
+            aria-label={t("notifications.broadcast.modal.aria")}
+            className="card-impression relative z-10 mx-4 flex w-full max-w-2xl max-h-[80vh] flex-col gap-4 overflow-hidden rounded border border-strong-edge bg-card p-6"
+          >
+            <header className="flex items-start justify-between gap-4">
+              <div className="flex min-w-0 flex-col gap-1">
+                <span className="self-start rounded-sm border border-accent/30 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-accent">
+                  {t("notifications.broadcast.tag")}
+                </span>
+                <h2 className="font-display text-xl font-semibold tracking-tight text-strong">
+                  {titleText}
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label={t("common.close")}
+                className="-mr-2 -mt-2 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm text-meta transition-colors hover:bg-elevated hover:text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  className="h-5 w-5"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </header>
+
+            <div className="markdown-body overflow-y-auto font-text text-[15px] leading-relaxed text-body">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeSanitize]}
+              >
+                {bodyMarkdown}
+              </ReactMarkdown>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -334,7 +334,10 @@
     "showAll": "Show all",
     "viewAll": "View all",
     "broadcast": {
-      "tag": "Broadcast"
+      "tag": "Broadcast",
+      "modal": {
+        "aria": "Broadcast notification details"
+      }
     }
   },
   "permissions": {
@@ -968,10 +971,24 @@
       "table": {
         "title": "Title",
         "preview": "Preview",
+        "recipients": "Recipients",
         "created": "Created",
         "updated": "Updated",
         "readCount": "Read by",
         "actions": "Actions"
+      },
+      "recipients": {
+        "heading": "Recipients",
+        "audienceAll": "All users",
+        "audienceSpecific": "Specific users",
+        "summaryAll": "All users",
+        "summaryCount": "{{count}} users",
+        "lockedHint": "Recipients are locked after creation.",
+        "searchPlaceholder": "Type an email to add a recipient",
+        "searchAria": "Search users by email",
+        "loading": "Searching…",
+        "noMatches": "No matching users.",
+        "remove": "Remove {{email}}"
       },
       "empty": {
         "title": "No broadcasts yet",
@@ -1014,7 +1031,8 @@
         "bodyEnRequired": "English body is required",
         "bodyZhRequired": "中文正文为必填项",
         "titleTooLong": "Title is too long",
-        "bodyTooLong": "Body is too long"
+        "bodyTooLong": "Body is too long",
+        "recipientsRequired": "Add at least one recipient or switch to 'All users'."
       }
     },
     "skills": {

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -334,7 +334,10 @@
     "showAll": "全部显示",
     "viewAll": "查看全部",
     "broadcast": {
-      "tag": "广播"
+      "tag": "广播",
+      "modal": {
+        "aria": "广播通知详情"
+      }
     }
   },
   "permissions": {
@@ -968,10 +971,24 @@
       "table": {
         "title": "标题",
         "preview": "正文摘要",
+        "recipients": "接收人",
         "created": "创建时间",
         "updated": "更新时间",
         "readCount": "已读人数",
         "actions": "操作"
+      },
+      "recipients": {
+        "heading": "接收人",
+        "audienceAll": "所有用户",
+        "audienceSpecific": "指定用户",
+        "summaryAll": "所有用户",
+        "summaryCount": "{{count}} 位用户",
+        "lockedHint": "接收人在创建后不可更改。",
+        "searchPlaceholder": "输入邮箱以添加接收人",
+        "searchAria": "按邮箱搜索用户",
+        "loading": "搜索中…",
+        "noMatches": "未找到匹配的用户。",
+        "remove": "移除 {{email}}"
       },
       "empty": {
         "title": "暂无广播",
@@ -1014,7 +1031,8 @@
         "bodyEnRequired": "英文正文为必填项",
         "bodyZhRequired": "中文正文为必填项",
         "titleTooLong": "标题过长",
-        "bodyTooLong": "正文过长"
+        "bodyTooLong": "正文过长",
+        "recipientsRequired": "请至少添加一位接收人，或切换为「所有用户」。"
       }
     },
     "skills": {

--- a/ornn-web/src/pages/NotificationsPage.tsx
+++ b/ornn-web/src/pages/NotificationsPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/hooks/useNotifications";
 import type { Notification, NotificationCategory } from "@/types/notifications";
 import { PageTransition } from "@/components/layout/PageTransition";
+import { NotificationDetailModal } from "@/components/notifications/NotificationDetailModal";
 import { pickLocalized } from "@/lib/announcementLocale";
 
 const CATEGORY_LABEL: Record<NotificationCategory, string> = {
@@ -35,6 +36,8 @@ export function NotificationsPage() {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const [unreadOnly, setUnreadOnly] = useState(false);
+  const [detailNotification, setDetailNotification] =
+    useState<Notification | null>(null);
 
   const { data: items = [], isLoading, isError } = useNotifications({
     unread: unreadOnly,
@@ -47,9 +50,13 @@ export function NotificationsPage() {
   const lang = i18n.language;
 
   const handleOpen = (n: Notification) => {
+    // Broadcasts pop a markdown detail modal so the full bilingual body
+    // is readable in place. The modal owns mark-read on open.
+    if (n.source === "broadcast") {
+      setDetailNotification(n);
+      return;
+    }
     if (!n.readAt) markRead.mutate(n._id);
-    // Broadcasts have no deep-link target; clicking only marks read.
-    if (n.source === "broadcast") return;
     if (n.link) navigate(n.link);
   };
 
@@ -191,6 +198,12 @@ export function NotificationsPage() {
           </ul>
         )}
       </div>
+
+      <NotificationDetailModal
+        notification={detailNotification}
+        onClose={() => setDetailNotification(null)}
+        onMarkRead={(id) => markRead.mutate(id)}
+      />
     </PageTransition>
   );
 }

--- a/ornn-web/src/pages/admin/BroadcastsPage.tsx
+++ b/ornn-web/src/pages/admin/BroadcastsPage.tsx
@@ -11,9 +11,10 @@
  * @module pages/admin/BroadcastsPage
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -25,6 +26,7 @@ import {
   useDeleteBroadcast,
 } from "@/hooks/useBroadcasts";
 import type { AdminBroadcast } from "@/services/broadcastsApi";
+import { fetchAdminUsers } from "@/services/adminUsersApi";
 import { pickLocalized } from "@/lib/announcementLocale";
 import { translateError } from "@/utils/translateError";
 
@@ -115,6 +117,38 @@ export function BroadcastsPage() {
   const items = broadcastsQuery.data ?? [];
   const lang = i18n.language;
 
+  // Resolve targeted broadcast recipient_user_ids to display emails for
+  // the Recipients-column tooltip. Pulled lazily — only when at least
+  // one row is targeted. Admin user lists are small enough that one
+  // page-of-200 is sufficient and cheaper than per-row lookups.
+  const hasTargetedRows = useMemo(
+    () => items.some((b) => b.recipientUserIds != null),
+    [items],
+  );
+  const emailLookupQuery = useQuery({
+    queryKey: ["admin", "users", "broadcasts-emails"],
+    enabled: hasTargetedRows,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const page = await fetchAdminUsers({
+        role: "normal",
+        page: 1,
+        pageSize: 200,
+      });
+      return page.items;
+    },
+  });
+  const emailById = useMemo<Map<string, string>>(() => {
+    const map = new Map<string, string>();
+    for (const row of emailLookupQuery.data ?? []) {
+      map.set(row.userId, row.email);
+    }
+    return map;
+  }, [emailLookupQuery.data]);
+
+  const recipientsTooltip = (ids: string[]): string =>
+    ids.map((id) => emailById.get(id) ?? id).join("\n");
+
   const pendingDeleteTitle = pendingDelete
     ? pickLocalized(
         pendingDelete.titleI18n.en,
@@ -178,6 +212,9 @@ export function BroadcastsPage() {
                     {t("adminPages.broadcasts.table.preview")}
                   </th>
                   <th className="px-4 py-3">
+                    {t("adminPages.broadcasts.table.recipients")}
+                  </th>
+                  <th className="px-4 py-3">
                     {t("adminPages.broadcasts.table.created")}
                   </th>
                   <th className="px-4 py-3">
@@ -222,6 +259,22 @@ export function BroadcastsPage() {
                         <p className="font-text text-sm text-meta">
                           {preview}
                         </p>
+                      </td>
+                      <td className="px-4 py-3 align-top">
+                        {b.recipientUserIds == null ? (
+                          <span className="font-text text-sm text-meta">
+                            {t("adminPages.broadcasts.recipients.summaryAll")}
+                          </span>
+                        ) : (
+                          <span
+                            title={recipientsTooltip(b.recipientUserIds)}
+                            className="inline-flex items-center gap-1 rounded-sm border border-subtle bg-elevated/40 px-2 py-0.5 font-mono text-[11px] text-strong"
+                          >
+                            {t("adminPages.broadcasts.recipients.summaryCount", {
+                              count: b.recipientUserIds.length,
+                            })}
+                          </span>
+                        )}
                       </td>
                       <td className="px-4 py-3 align-top font-mono text-[11px] text-meta">
                         {new Date(b.createdAt).toLocaleString(

--- a/ornn-web/src/pages/admin/BroadcastsPage.tsx
+++ b/ornn-web/src/pages/admin/BroadcastsPage.tsx
@@ -114,7 +114,10 @@ export function BroadcastsPage() {
     });
   };
 
-  const items = broadcastsQuery.data ?? [];
+  const items = useMemo(
+    () => broadcastsQuery.data ?? [],
+    [broadcastsQuery.data],
+  );
   const lang = i18n.language;
 
   // Resolve targeted broadcast recipient_user_ids to display emails for

--- a/ornn-web/src/services/broadcastsApi.ts
+++ b/ornn-web/src/services/broadcastsApi.ts
@@ -30,6 +30,10 @@ export interface BilingualText {
  * feed keeps the `_id` legacy field for backwards compatibility
  * with per-user notification rows, while the admin surface gets
  * the cleaner public `id`.
+ *
+ * `recipientUserIds` is `null` for a broadcast-to-all and a
+ * non-empty array for a targeted broadcast. Recipients are locked
+ * at create — see `CreateBroadcastInput` / `UpdateBroadcastInput`.
  */
 export interface AdminBroadcast {
   id: string;
@@ -40,19 +44,30 @@ export interface AdminBroadcast {
   createdBy: string;
   updatedBy: string;
   readCount: number;
+  recipientUserIds: string[] | null;
 }
 
 export interface CreateBroadcastInput {
   titleI18n: BilingualText;
   bodyMarkdownI18n: BilingualText;
+  /**
+   * Optional list of user_ids to target. Omit / undefined → broadcast
+   * to every authenticated user. A non-empty array scopes delivery to
+   * exactly those users. An empty array is rejected by the API (400).
+   */
+  recipientUserIds?: string[];
 }
 
 /**
  * Patch input — both locales of a given field must arrive together if
- * any does (the drawer enforces non-empty on both anyway). Modeled as
- * `Partial<CreateBroadcastInput>` so callers can omit untouched fields.
+ * any does (the drawer enforces non-empty on both anyway). Recipients
+ * are deliberately omitted: the API rejects PATCH bodies that try to
+ * change `recipientUserIds`, so we keep the field off the type to make
+ * that impossible at compile time.
  */
-export type UpdateBroadcastInput = Partial<CreateBroadcastInput>;
+export type UpdateBroadcastInput = Partial<
+  Pick<CreateBroadcastInput, "titleI18n" | "bodyMarkdownI18n">
+>;
 
 export async function fetchAdminBroadcasts(): Promise<AdminBroadcast[]> {
   const res = await apiGet<{ items: AdminBroadcast[] }>(


### PR DESCRIPTION
## Summary

Builds on #500. Two capabilities:

1. **Targeted broadcasts** — admin can choose "send to all users" (existing) or "send to specific users" (new). Recipients are locked at create time; edit only touches `titleI18n` / `bodyMarkdownI18n`.
2. **Click-to-popup markdown viewer** — clicking a broadcast in the `NotificationBell` or `/notifications` page opens a modal rendering the full bilingual markdown. Audit / quota notifications keep their navigate-to-link behaviour.

## Linked issue

Closes #502

## Type of change

- [x] New feature (`feat:`)

## Commit decomposition

- [x] Each commit is self-contained
- [x] Each commit is small (one logical change)
- [x] Refactors / fixes separated from feature work
- [x] No `Co-Authored-By` trailers

11 commits — 3 backend (schema + migration / immutable-after-create CRUD / feed filter) + 7 frontend (API types / picker / drawer / page column / modal + bell wiring / i18n / lint-followup memoize) + 1 changeset.

## Changeset

- [x] Added `.changeset/targeted-broadcasts-and-modal-viewer.md` — minor bump for both packages

## Architecture

**Backend** (`ornn-api`):
- `broadcasts.recipientUserIds: string[] | null` — `null` (or absent) = broadcast to all, non-empty array = targeted
- Idempotent boot migration backfills `null` on every pre-#502 row
- `createBroadcastSchema` accepts optional `recipientUserIds`; `patchBroadcastSchema` is `.strict()` so a forged PATCH gets a 400 `INVALID_BROADCAST_INPUT` with `unrecognized_keys`
- `UpdateBroadcastDocInput` (repo input type) omits the field — compile-time enforcement of immutable-after-create
- Single helper `isBroadcastVisibleTo(broadcast, userId)` consistently applied across `listFeedForUser`, `countUnread`, `markAllRead`, `markRead`, `markManyRead`. Non-recipient `markRead` returns same `NOTIFICATION_NOT_FOUND` shape as a typo (no existence-probe side channel)

**Frontend** (`ornn-web`):
- New `UserEmailPicker` — debounced (300ms) email search hitting `GET /api/v1/admin/users?q=...`, multi-select chip UX. Currently scoped to `role=normal` (admin-as-recipient is a deferred product question — see follow-ups below)
- `BroadcastEditDrawer` adds a Recipients section: radio "All users" / "Specific users" on create (with the picker); read-only summary on edit (recipients are locked). Submit blocked if "Specific users" + empty selection
- `BroadcastsPage` adds a Recipients column ("All users" or "{n} users" with email tooltip)
- New `NotificationDetailModal` — overlay + centered modal, bilingual markdown body through `react-markdown` + `remark-gfm` + `rehype-sanitize` (same safe stack as `AnnouncementPopup`). Mark-read fires on open if `readAt == null`
- `NotificationBell` + `NotificationsPage` route `source: "broadcast"` clicks to the modal; user-source items keep navigate-to-link
- All new strings i18n'd in `en.json` + `zh.json`

## Testing

- **Backend**: 611 pass / 0 fail (`bun test`). New: migration backfill test (mongodb-memory-server), schema parse tests (6), service round-trip tests, 9 notifications tests covering the filter across all 5 surfaces
- **Frontend**: 99 pass (`bun run test:web`). New: 3 picker tests, 4 modal tests, 1 drawer flow test
- `bun run typecheck` clean
- `bun run lint` — 0 errors, 79 warnings (same as develop baseline — verified side-by-side)
- `bun run build:web` succeeds

## Reviewer findings actioned in this PR

- **H1 (missing changeset)** — added `.changeset/targeted-broadcasts-and-modal-viewer.md`

## Deferred follow-ups (will file as issues after merge)

- **M1**: `UserEmailPicker` chip / tooltip resolution caps at admin-users page 1 (200 rows). Pre-launch user count is well under that, so deferring. Long-term fix: a dedicated `GET /api/v1/admin/users/by-ids?ids=...` lookup endpoint
- **M2**: Picker hard-codes `role=normal`. Whether admins should be addressable as broadcast recipients is a product call — deferring. Fix is a single prop lift if confirmed
- **L1**: Recipients tooltip on `BroadcastsPage` uses native `title` attribute with `\n` separators — readable for small lists, breaks down past ~20 users. Swap for a click-to-expand popover

## Notes for reviewer

- **Recipient filter is the access-control surface for #502.** The single `isBroadcastVisibleTo` helper is used in 5 places. Reviewer signed off on consistency. If you want to dig in, that's the first stop.
- **PATCH immutability has 4 layers** (Zod `.strict()`, repo input type, service param type, frontend `UpdateBroadcastInput`). Hard to regress.
- **No `recipientUserIds` leakage to non-admin surfaces** — the `FeedItem` user-facing type doesn't carry the field; only `AdminBroadcastResponse` (admin-guarded) exposes it.

## Manual QA gap

Not exercised in a live browser this session — verified at unit / integration level. Same suggested smoke as #500 PR plus:

6. Admin creates targeted broadcast for user A + B → user C does not see it in bell or `/notifications` page; their unread count doesn't include it
7. Admin tries to edit recipients via UI → no controls surface; force a PATCH with `recipientUserIds` via curl → 400 `INVALID_BROADCAST_INPUT`
8. User A clicks broadcast in bell → modal opens, markdown renders, unread badge decrements; reload preserves read state