### PR TITLE
feat(web): landing-page launch-celebration popup (#511)

### DIFF
--- a/.changeset/landing-launch-celebration-popup.md
+++ b/.changeset/landing-launch-celebration-popup.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Landing-page launch-celebration popup. Hardcoded, bilingual (en / zh) modal that fires on every visit to `/` for both anonymous and signed-in users, announcing the public-launch free-credit promo (200 Playground + 200 Skill Generation credits for the first 500 users who star the GitHub repo and sign in). Dismissal is session-only — no localStorage write — so the popup reappears on any return visit until the component is unmounted from `LandingPage` at the end of the launch window. Independent of the dynamic announcements collection on purpose.

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -690,6 +690,22 @@
     "languageLabel": "Language",
     "languageEnglish": "English",
     "languageChinese": "中文",
+    "launchPopup": {
+      "eyebrow": "[§ LAUNCH — ORNN]",
+      "date": "May 13, 2026",
+      "title": "To celebrate Ornn's official launch, we've set aside extra free credit for our users as a heartfelt thank-you.",
+      "intro": "To celebrate Ornn's official launch, we've set aside extra free credit for our users as a heartfelt thank-you.",
+      "creditsLead": "The first 500 users can redeem an exclusive code for:",
+      "creditItem1": "200 Playground conversation credits (GPT-5.5)",
+      "creditItem2": "200 Skill Generation credits (GPT-5.5)",
+      "conditionsHeading": "How to redeem",
+      "conditionsBodyStart": "Head over to our GitHub repo",
+      "conditionsBodyEnd": "and drop a ⭐ Star, then sign in with the same GitHub account to claim your free credit.",
+      "callout": "Slots are limited — first come, first served. Claim your perk now! First-time Ornn users, please use NyxID invite code —",
+      "dismiss": "Dismiss",
+      "cta": "Star on GitHub",
+      "dismissAria": "Dismiss launch announcement"
+    },
     "hero": {
       "headlineStart": "Start with",
       "headlineNothing": "nothing",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -690,6 +690,22 @@
     "languageLabel": "语言",
     "languageEnglish": "English",
     "languageChinese": "中文",
+    "launchPopup": {
+      "eyebrow": "[§ LAUNCH — ORNN]",
+      "date": "2026年5月13日",
+      "title": "为庆祝 Ornn 正式上线，我们特别为用户准备了额外的免费使用额度，以表达我们诚挚的感谢。",
+      "intro": "为庆祝 Ornn 正式上线，我们特别为用户准备了额外的免费使用额度，以表达我们诚挚的感谢。",
+      "creditsLead": "前 500 位用户 可凭专属兑换码，免费领取：",
+      "creditItem1": "200 条 Playground 对话额度（GPT-5.5）",
+      "creditItem2": "200 条 Skill Generation 额度（GPT-5.5）",
+      "conditionsHeading": "兑换条件",
+      "conditionsBodyStart": "前往我们的 GitHub 仓库",
+      "conditionsBodyEnd": "点亮 ⭐ Star，并使用同一 GitHub 账号登录平台，即可领取免费额度。",
+      "callout": "名额有限，先到先得，立即兑换您的专属福利！第一次登录 Ornn 的用户请使用 NyxID 邀请码 —",
+      "dismiss": "关闭",
+      "cta": "前往 GitHub 点 Star",
+      "dismissAria": "关闭上线公告"
+    },
     "hero": {
       "headlineStart": "从",
       "headlineNothing": "零",

--- a/ornn-web/src/pages/LandingPage.tsx
+++ b/ornn-web/src/pages/LandingPage.tsx
@@ -19,6 +19,7 @@ import { HeroStage } from "@/pages/landing/HeroStage";
 import { LandingFooter } from "@/pages/landing/LandingFooter";
 import { LandingChrome } from "@/pages/landing/LandingChrome";
 import { AnnouncementPopup } from "@/pages/landing/AnnouncementPopup";
+import { LaunchCelebrationPopup } from "@/pages/landing/LaunchCelebrationPopup";
 
 export function LandingPage() {
   return (
@@ -35,6 +36,7 @@ export function LandingPage() {
       </main>
       <LandingFooter />
       <AnnouncementPopup />
+      <LaunchCelebrationPopup />
     </div>
   );
 }

--- a/ornn-web/src/pages/landing/LaunchCelebrationPopup.test.tsx
+++ b/ornn-web/src/pages/landing/LaunchCelebrationPopup.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * LaunchCelebrationPopup tests.
+ *
+ * Locks in the load-bearing contract: the popup is hardcoded (no DB
+ * dependency) and shows on every landing-page mount, even after the
+ * user dismissed it on a prior visit. Closing only sets local state;
+ * a re-mount must reopen it.
+ *
+ * @module pages/landing/LaunchCelebrationPopup.test
+ */
+
+import { describe, expect, it, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+
+import { LaunchCelebrationPopup } from "./LaunchCelebrationPopup";
+
+const DISMISS_BUTTON_NAME = "Dismiss";
+
+describe("LaunchCelebrationPopup", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders open on mount", () => {
+    render(<LaunchCelebrationPopup />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+  });
+
+  it("close button hides the modal", async () => {
+    render(<LaunchCelebrationPopup />);
+    fireEvent.click(screen.getByRole("button", { name: DISMISS_BUTTON_NAME }));
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
+  });
+
+  it("re-opens on remount (no persistence between visits)", async () => {
+    const { unmount } = render(<LaunchCelebrationPopup />);
+    fireEvent.click(screen.getByRole("button", { name: DISMISS_BUTTON_NAME }));
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
+    unmount();
+
+    render(<LaunchCelebrationPopup />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
+++ b/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
@@ -1,0 +1,238 @@
+/**
+ * LaunchCelebrationPopup — hardcoded launch-day modal on the landing
+ * page (`/`). Independent of the dynamic announcements collection: the
+ * content is baked into the frontend bundle so the public-launch notice
+ * cannot be edited away or expire from the admin panel.
+ *
+ * Behavior:
+ *   - Opens on every mount of LandingPage (anonymous + signed-in).
+ *   - Closing only sets local state — no localStorage write. If the
+ *     user navigates away and returns to `/`, the popup shows again.
+ *     This is intentional for the launch window; remove the component
+ *     from LandingPage when the offer ends.
+ *
+ * Design language mirrors AnnouncementPopup (ember card on obsidian
+ * letterpress, Space Grotesk display title, JetBrains Mono bracketed
+ * micro-label) but sized one step larger ("大一点的 popup") because the
+ * launch notice carries more body content than a routine announcement.
+ *
+ * @module pages/landing/LaunchCelebrationPopup
+ */
+
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+const GITHUB_URL = "https://github.com/ChronoAIProject/Ornn";
+const INVITE_CODE = "NYX-2XXJI08A";
+
+export function LaunchCelebrationPopup() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const close = () => setOpen(false);
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="absolute inset-0 bg-black/60 backdrop-blur-[2px]"
+            onClick={close}
+          />
+          <motion.div
+            initial={{ opacity: 0, y: 12, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 12, scale: 0.97 }}
+            transition={{ type: "spring", stiffness: 220, damping: 22, mass: 0.9 }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="launch-popup-title"
+            className="
+              relative z-10 mx-4 w-full max-w-2xl max-h-[85vh] overflow-y-auto
+              rounded-[3px] border border-[var(--color-ember-deep)] bg-accent
+              p-7 sm:p-9
+            "
+          >
+            {/* Letterpress shadow plate in ember-deep. */}
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 -z-10 translate-x-[6px] translate-y-[6px] rounded-[3px] bg-[var(--color-ember-deep)]"
+            />
+
+            {/* Eyebrow row: bracketed mono micro-label + date + close. */}
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div className="flex flex-col gap-1">
+                <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--color-obsidian)]/85">
+                  {t("landing.launchPopup.eyebrow")}
+                </p>
+                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--color-obsidian)]/70">
+                  {t("landing.launchPopup.date")}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={close}
+                aria-label={t("landing.launchPopup.dismissAria")}
+                className="
+                  -mr-2 -mt-1 inline-flex h-8 w-8 items-center justify-center rounded-[2px]
+                  text-[var(--color-obsidian)]/85
+                  transition-colors duration-150
+                  hover:bg-[rgba(11,9,7,0.12)] hover:text-[var(--color-obsidian)]
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)]
+                "
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.75}
+                  className="h-5 w-5"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            <h2
+              id="launch-popup-title"
+              className="
+                font-display font-bold
+                text-[var(--color-obsidian)]
+                text-[24px] sm:text-[28px] leading-[1.18] tracking-[-0.015em]
+              "
+            >
+              {t("landing.launchPopup.title")}
+            </h2>
+
+            {/* Welded-seam divider. */}
+            <div className="relative mt-5 mb-5 h-px w-full bg-[rgba(11,9,7,0.35)]">
+              <span
+                aria-hidden
+                className="absolute -top-[2.5px] left-[25%] h-[5px] w-[5px] rounded-full bg-[var(--color-ember-deep)]"
+              />
+              <span
+                aria-hidden
+                className="absolute -top-[2.5px] left-[75%] h-[5px] w-[5px] rounded-full bg-[var(--color-ember-deep)]"
+              />
+            </div>
+
+            <p className="text-[15px] leading-[1.65] text-[var(--color-obsidian)]/90">
+              {t("landing.launchPopup.intro")}
+            </p>
+
+            <p className="mt-5 text-[15px] leading-[1.65] text-[var(--color-obsidian)]">
+              {t("landing.launchPopup.creditsLead")}
+            </p>
+            <ul className="mt-3 ml-4 space-y-2">
+              <li className="text-[15px] font-semibold text-[var(--color-obsidian)]">
+                {t("landing.launchPopup.creditItem1")}
+              </li>
+              <li className="text-[15px] font-semibold text-[var(--color-obsidian)]">
+                {t("landing.launchPopup.creditItem2")}
+              </li>
+            </ul>
+
+            <h3 className="mt-7 font-display font-bold uppercase text-[var(--color-obsidian)] text-[18px] tracking-[-0.01em]">
+              {t("landing.launchPopup.conditionsHeading")}
+            </h3>
+            <p className="mt-2 text-[15px] leading-[1.65] text-[var(--color-obsidian)]/90">
+              {t("landing.launchPopup.conditionsBodyStart")}{" "}
+              <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono font-semibold underline decoration-[var(--color-ember-deep)] decoration-2 underline-offset-2 text-[var(--color-ember-deep)] hover:text-[var(--color-obsidian)]"
+              >
+                github.com/ChronoAIProject/Ornn
+              </a>{" "}
+              {t("landing.launchPopup.conditionsBodyEnd")}
+            </p>
+
+            {/* Highlighted footer note — left border in ember-deep,
+                muted obsidian text, mono-emphasis on the invite code. */}
+            <div className="mt-6 border-l-[3px] border-[var(--color-ember-deep)] bg-[rgba(11,9,7,0.06)] px-4 py-3">
+              <p className="text-[13px] italic leading-[1.6] text-[var(--color-obsidian)]/85">
+                {t("landing.launchPopup.callout")}{" "}
+                <span className="font-mono not-italic font-semibold text-[var(--color-obsidian)]">
+                  {INVITE_CODE}
+                </span>
+              </p>
+            </div>
+
+            <div className="mt-7 flex flex-wrap items-center justify-end gap-3">
+              <button
+                type="button"
+                onClick={close}
+                className="
+                  inline-flex items-center justify-center
+                  rounded-[2px] border border-[var(--color-obsidian)]/55
+                  bg-transparent
+                  px-4 py-2
+                  font-mono text-[11px] font-semibold uppercase tracking-[0.18em]
+                  text-[var(--color-obsidian)]
+                  transition-[transform,background-color,border-color] duration-150
+                  hover:bg-[rgba(11,9,7,0.1)] hover:border-[var(--color-obsidian)]
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)]
+                  motion-reduce:transition-none
+                "
+              >
+                {t("landing.launchPopup.dismiss")}
+              </button>
+              <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={close}
+                style={{ boxShadow: "4px 4px 0 0 var(--color-ember-deep)" }}
+                className="
+                  relative inline-flex items-center justify-center gap-2
+                  rounded-[2px] border border-[var(--color-obsidian)]
+                  bg-[var(--color-obsidian)]
+                  px-5 py-2
+                  font-mono text-[11px] font-semibold uppercase tracking-[0.16em]
+                  text-[var(--color-accent)]
+                  transition-[transform,box-shadow,background-color] duration-150
+                  hover:translate-x-[2px] hover:translate-y-[2px]
+                  hover:shadow-[2px_2px_0_0_var(--color-ember-deep)]
+                  active:translate-x-[4px] active:translate-y-[4px]
+                  active:shadow-none
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-accent)]
+                  motion-reduce:hover:translate-x-0 motion-reduce:hover:translate-y-0
+                  motion-reduce:active:translate-x-0 motion-reduce:active:translate-y-0
+                "
+              >
+                {t("landing.launchPopup.cta")}
+                <svg
+                  aria-hidden
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  className="h-3.5 w-3.5"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M14 5h5v5M19 5L9 15M5 11v8h8" />
+                </svg>
+              </a>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}


### PR DESCRIPTION
Closes #511.

## Summary

Hardcoded launch-day modal on the landing page. Fires on every mount of `/` for both anonymous and signed-in visitors. Dismissal is session-only (no localStorage write) — leaving the page and returning reopens the popup, by design for the launch window.

Independent of the dynamic announcements collection on purpose: the launch notice carries a one-off invite code + promo, and we don't want it editable from the admin panel or dependent on `/announcements/active` uptime during launch traffic.

## What changed

- `ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx` — new component. Ember-plate visual matches the existing `AnnouncementPopup` (Industrial Forge per DESIGN.md) sized one step larger (`max-w-2xl`) to fit the launch body content.
- `ornn-web/src/pages/landing/LaunchCelebrationPopup.test.tsx` — locks in the load-bearing contract: opens on mount, closes on dismiss, **reopens on remount**.
- `ornn-web/src/pages/LandingPage.tsx` — mounts the popup next to the existing `AnnouncementPopup`.
- `ornn-web/src/i18n/en.json` + `zh.json` — new `landing.launchPopup.*` keys (bilingual).
- `.changeset/landing-launch-celebration-popup.md` — `ornn-web` patch.

## Content

Eyebrow `[§ LAUNCH — ORNN]` + date `2026年5月13日`, then the launch title, credit list (200 Playground + 200 Skill Generation for the first 500 GitHub stargazers), redemption steps, callout with NyxID invite code `NYX-2XXJI08A`, CTA opens the GitHub repo in a new tab.

## Teardown

When the launch window ends: delete the import + `<LaunchCelebrationPopup />` line from `LandingPage.tsx`. Component + tests can stay parked for the next launch event or be removed entirely.

## Test plan

- [x] `bun run test src/pages/landing/` — 7/7 pass (4 existing `AnnouncementPopup` + 3 new).
- [x] `bun run lint` — no new TS errors introduced (3 pre-existing develop errors unchanged: `SkillForm.tsx`, `CreateSkillGuidedPage.tsx` form resolver typing, `MirrorSection.tsx` missing `cron-parser` module).
- [ ] Local visual check after deploy: visit `/` anonymous and signed-in, popup appears each time; close and navigate to `/registry`, return to `/`, popup reappears.