### PR TITLE
fix(web): LaunchCelebrationPopup — flip to obsidian surface for contrast (#513)

### DIFF
--- a/.changeset/launch-popup-contrast-fix.md
+++ b/.changeset/launch-popup-contrast-fix.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+LaunchCelebrationPopup contrast fix (#513). Flips the popup surface from ember orange → obsidian panel with an ember accent border, so the inline GitHub repo link (previously `ember-deep` on `ember`, effectively invisible) reads clearly in ember on dark, and every body paragraph sits at near-maximum contrast against the surface. AnnouncementPopup keeps its ember plate; only the launch-day popup flips.

--- a/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
+++ b/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
@@ -11,10 +11,14 @@
  *     This is intentional for the launch window; remove the component
  *     from LandingPage when the offer ends.
  *
- * Design language mirrors AnnouncementPopup (ember card on obsidian
- * letterpress, Space Grotesk display title, JetBrains Mono bracketed
- * micro-label) but sized one step larger ("大一点的 popup") because the
- * launch notice carries more body content than a routine announcement.
+ * Surface flips AnnouncementPopup's ember plate to an obsidian panel
+ * with parchment ink + ember accents. Same Industrial-Forge vocabulary
+ * (Space Grotesk display title, JetBrains Mono bracketed micro-label,
+ * welded-seam divider, hard-offset letterpress shadow, press-down CTA),
+ * but every body string sits at near-maximum contrast against the
+ * surface so the launch notice — especially the GitHub link — reads
+ * clearly. AnnouncementPopup keeps the ember plate; this popup is the
+ * one-off "big notice" surface.
  *
  * @module pages/landing/LaunchCelebrationPopup
  */
@@ -51,7 +55,7 @@ export function LaunchCelebrationPopup() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.18 }}
-            className="absolute inset-0 bg-black/60 backdrop-blur-[2px]"
+            className="absolute inset-0 bg-black/75 backdrop-blur-[2px]"
             onClick={close}
           />
           <motion.div
@@ -64,23 +68,25 @@ export function LaunchCelebrationPopup() {
             aria-labelledby="launch-popup-title"
             className="
               relative z-10 mx-4 w-full max-w-2xl max-h-[85vh] overflow-y-auto
-              rounded-[3px] border border-[var(--color-ember-deep)] bg-accent
+              rounded-[3px] border-2 border-[var(--color-ember)]
+              bg-[var(--color-panel)]
               p-7 sm:p-9
             "
           >
-            {/* Letterpress shadow plate in ember-deep. */}
+            {/* Hard-offset letterpress shadow plate in ember-deep. */}
             <div
               aria-hidden
               className="pointer-events-none absolute inset-0 -z-10 translate-x-[6px] translate-y-[6px] rounded-[3px] bg-[var(--color-ember-deep)]"
             />
 
-            {/* Eyebrow row: bracketed mono micro-label + date + close. */}
+            {/* Eyebrow row: bracketed mono micro-label in ember + date in
+                ash, then the close affordance. */}
             <div className="mb-4 flex items-start justify-between gap-3">
               <div className="flex flex-col gap-1">
-                <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--color-obsidian)]/85">
+                <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--color-ember)]">
                   {t("landing.launchPopup.eyebrow")}
                 </p>
-                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--color-obsidian)]/70">
+                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--color-ash)]">
                   {t("landing.launchPopup.date")}
                 </p>
               </div>
@@ -90,10 +96,10 @@ export function LaunchCelebrationPopup() {
                 aria-label={t("landing.launchPopup.dismissAria")}
                 className="
                   -mr-2 -mt-1 inline-flex h-8 w-8 items-center justify-center rounded-[2px]
-                  text-[var(--color-obsidian)]/85
+                  text-[var(--color-bone)]
                   transition-colors duration-150
-                  hover:bg-[rgba(11,9,7,0.12)] hover:text-[var(--color-obsidian)]
-                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)]
+                  hover:bg-[rgba(241,236,222,0.08)] hover:text-[var(--color-parchment)]
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ember)]
                 "
               >
                 <svg
@@ -112,63 +118,70 @@ export function LaunchCelebrationPopup() {
               id="launch-popup-title"
               className="
                 font-display font-bold
-                text-[var(--color-obsidian)]
+                text-[var(--color-parchment)]
                 text-[24px] sm:text-[28px] leading-[1.18] tracking-[-0.015em]
               "
             >
               {t("landing.launchPopup.title")}
             </h2>
 
-            {/* Welded-seam divider. */}
-            <div className="relative mt-5 mb-5 h-px w-full bg-[rgba(11,9,7,0.35)]">
+            {/* Welded-seam divider. Hairline in bone-soft, rivet pair in
+                ember so it reads as a forged seam against the dark panel. */}
+            <div className="relative mt-5 mb-5 h-px w-full bg-[rgba(201,191,173,0.22)]">
               <span
                 aria-hidden
-                className="absolute -top-[2.5px] left-[25%] h-[5px] w-[5px] rounded-full bg-[var(--color-ember-deep)]"
+                className="absolute -top-[2.5px] left-[25%] h-[5px] w-[5px] rounded-full bg-[var(--color-ember)]"
               />
               <span
                 aria-hidden
-                className="absolute -top-[2.5px] left-[75%] h-[5px] w-[5px] rounded-full bg-[var(--color-ember-deep)]"
+                className="absolute -top-[2.5px] left-[75%] h-[5px] w-[5px] rounded-full bg-[var(--color-ember)]"
               />
             </div>
 
-            <p className="text-[15px] leading-[1.65] text-[var(--color-obsidian)]/90">
+            <p className="text-[15px] leading-[1.65] text-[var(--color-bone)]">
               {t("landing.launchPopup.intro")}
             </p>
 
-            <p className="mt-5 text-[15px] leading-[1.65] text-[var(--color-obsidian)]">
+            <p className="mt-5 text-[15px] leading-[1.65] text-[var(--color-parchment)]">
               {t("landing.launchPopup.creditsLead")}
             </p>
             <ul className="mt-3 ml-4 space-y-2">
-              <li className="text-[15px] font-semibold text-[var(--color-obsidian)]">
+              <li className="text-[15px] font-semibold text-[var(--color-parchment)]">
                 {t("landing.launchPopup.creditItem1")}
               </li>
-              <li className="text-[15px] font-semibold text-[var(--color-obsidian)]">
+              <li className="text-[15px] font-semibold text-[var(--color-parchment)]">
                 {t("landing.launchPopup.creditItem2")}
               </li>
             </ul>
 
-            <h3 className="mt-7 font-display font-bold uppercase text-[var(--color-obsidian)] text-[18px] tracking-[-0.01em]">
+            <h3 className="mt-7 font-display font-bold uppercase text-[var(--color-parchment)] text-[18px] tracking-[-0.01em]">
               {t("landing.launchPopup.conditionsHeading")}
             </h3>
-            <p className="mt-2 text-[15px] leading-[1.65] text-[var(--color-obsidian)]/90">
+            <p className="mt-2 text-[15px] leading-[1.65] text-[var(--color-bone)]">
               {t("landing.launchPopup.conditionsBodyStart")}{" "}
               <a
                 href={GITHUB_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-mono font-semibold underline decoration-[var(--color-ember-deep)] decoration-2 underline-offset-2 text-[var(--color-ember-deep)] hover:text-[var(--color-obsidian)]"
+                className="
+                  font-mono font-semibold
+                  text-[var(--color-ember)]
+                  underline decoration-2 underline-offset-[3px] decoration-[var(--color-ember-dim)]
+                  transition-colors duration-150
+                  hover:text-[var(--color-molten)] hover:decoration-[var(--color-molten)]
+                "
               >
                 github.com/ChronoAIProject/Ornn
               </a>{" "}
               {t("landing.launchPopup.conditionsBodyEnd")}
             </p>
 
-            {/* Highlighted footer note — left border in ember-deep,
-                muted obsidian text, mono-emphasis on the invite code. */}
-            <div className="mt-6 border-l-[3px] border-[var(--color-ember-deep)] bg-[rgba(11,9,7,0.06)] px-4 py-3">
-              <p className="text-[13px] italic leading-[1.6] text-[var(--color-obsidian)]/85">
+            {/* Highlighted footer note — ember left bar, slightly elevated
+                surface, italic bone body, mono molten-gold invite code. */}
+            <div className="mt-6 border-l-[3px] border-[var(--color-ember)] bg-[var(--color-elevated)] px-4 py-3">
+              <p className="text-[13px] italic leading-[1.6] text-[var(--color-bone)]">
                 {t("landing.launchPopup.callout")}{" "}
-                <span className="font-mono not-italic font-semibold text-[var(--color-obsidian)]">
+                <span className="font-mono not-italic font-semibold tracking-[0.04em] text-[var(--color-molten)]">
                   {INVITE_CODE}
                 </span>
               </p>
@@ -180,14 +193,14 @@ export function LaunchCelebrationPopup() {
                 onClick={close}
                 className="
                   inline-flex items-center justify-center
-                  rounded-[2px] border border-[var(--color-obsidian)]/55
+                  rounded-[2px] border border-[var(--color-bone)]/40
                   bg-transparent
                   px-4 py-2
                   font-mono text-[11px] font-semibold uppercase tracking-[0.18em]
-                  text-[var(--color-obsidian)]
-                  transition-[transform,background-color,border-color] duration-150
-                  hover:bg-[rgba(11,9,7,0.1)] hover:border-[var(--color-obsidian)]
-                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)]
+                  text-[var(--color-bone)]
+                  transition-[transform,background-color,border-color,color] duration-150
+                  hover:bg-[rgba(241,236,222,0.08)] hover:border-[var(--color-parchment)] hover:text-[var(--color-parchment)]
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ember)]
                   motion-reduce:transition-none
                 "
               >
@@ -201,17 +214,17 @@ export function LaunchCelebrationPopup() {
                 style={{ boxShadow: "4px 4px 0 0 var(--color-ember-deep)" }}
                 className="
                   relative inline-flex items-center justify-center gap-2
-                  rounded-[2px] border border-[var(--color-obsidian)]
-                  bg-[var(--color-obsidian)]
+                  rounded-[2px] border border-[var(--color-ember)]
+                  bg-[var(--color-ember)]
                   px-5 py-2
                   font-mono text-[11px] font-semibold uppercase tracking-[0.16em]
-                  text-[var(--color-accent)]
+                  text-[var(--color-obsidian)]
                   transition-[transform,box-shadow,background-color] duration-150
                   hover:translate-x-[2px] hover:translate-y-[2px]
                   hover:shadow-[2px_2px_0_0_var(--color-ember-deep)]
                   active:translate-x-[4px] active:translate-y-[4px]
                   active:shadow-none
-                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-accent)]
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-parchment)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-panel)]
                   motion-reduce:hover:translate-x-0 motion-reduce:hover:translate-y-0
                   motion-reduce:active:translate-x-0 motion-reduce:active:translate-y-0
                 "


### PR DESCRIPTION
Closes #513.

## Summary

The launch popup shipped on the same ember-orange plate as `AnnouncementPopup`, but its inline GitHub repo link uses `ember-deep` — a dark shade in the same orange family — so the most actionable string was effectively invisible. Body paragraphs also read muddy because most strings were obsidian at `/85`–`/90` opacity instead of full ink.

This PR flips **only the launch popup** to an obsidian panel + ember accent border + parchment / bone / ember body palette. `AnnouncementPopup` keeps its ember plate (the routine "what's new" surface).

## Palette changes

| Element | Before | After |
|---|---|---|
| Surface | `bg-accent` (ember) | `bg-[var(--color-panel)]` (#14110B) |
| Border | `border-ember-deep` | `border-2 border-ember` |
| Title / strong body | `text-obsidian` | `text-parchment` |
| Body | `text-obsidian/90` | `text-bone` |
| Date / meta | `text-obsidian/70` | `text-ash` |
| Eyebrow label | `text-obsidian/85` | `text-ember` |
| GitHub link | `text-ember-deep` (invisible) | `text-ember` w/ ember-dim underline |
| Invite code | `text-obsidian` mono | `text-molten` mono |
| Callout bg | `rgba(11,9,7,0.06)` over ember | `bg-elevated` over panel |
| CTA | `bg-obsidian` / `text-accent` | `bg-ember` / `text-obsidian` |

Letterpress shadow, welded-seam rivet divider, press-down hover, hard-offset shadow on CTA — unchanged.

## Test plan

- [x] `bun run test src/pages/landing/LaunchCelebrationPopup.test.tsx` — 3/3 pass (palette swap doesn't touch open/close/remount contract).
- [x] `bun run lint` — no new TS errors (3 pre-existing develop errors unchanged).
- [ ] Local visual check after deploy: title, body, callout, link, and invite code all clearly legible at default viewport. GitHub link reads as a high-contrast accent against the dark panel.