### PR TITLE
fix(web): LaunchCelebrationPopup — plate as sibling fixes stacking-context bug (#517)

### DIFF
--- a/.changeset/launch-popup-stacking-fix.md
+++ b/.changeset/launch-popup-stacking-fix.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+LaunchCelebrationPopup — fix letterpress plate stacking-context bug (#517). The shadow plate was a child of the card div, with `z-index: -10` to sit behind. But the card itself created a stacking context via `position: relative + z-index: 10`, so the plate's negative-z child painted **over** the card's bg instead of behind it — invisible in dark mode (both colors are dark ember tones) but catastrophic in light mode (white card with a rust-red plate covering it). Restructured so the plate is a sibling of the card inside a positioning wrapper; paint order = document order; no z-index needed.

--- a/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
+++ b/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
@@ -88,22 +88,32 @@ export function LaunchCelebrationPopup() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 14, scale: 0.97 }}
             transition={{ type: "spring", stiffness: 220, damping: 22, mass: 0.9 }}
+            className="relative z-10 mx-4 w-full max-w-2xl"
+          >
+            {/* Hard-offset letterpress plate in ember-deep (DESIGN.md
+                Material & Print vocabulary — card-shadow impression
+                color, theme-aware). Solid color, not a soft shadow.
+                Painted as a SIBLING of the card (not a child) so the
+                card's opaque bg sits cleanly on top of it. Earlier
+                version used `-z-10` on a child of the card; because
+                the card establishes its own stacking context via
+                `position: relative + z-index: 10`, the negative-z
+                child paints OVER the card's bg, not behind it —
+                visible immediately on the light-mode white card. */}
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 translate-x-[6px] translate-y-[6px] rounded-[3px] bg-ember-deep"
+            />
+          <div
             role="dialog"
             aria-modal="true"
             aria-labelledby="launch-popup-title"
             className="
-              relative z-10 mx-4 w-full max-w-2xl max-h-[88vh] overflow-y-auto
+              relative max-h-[88vh] overflow-y-auto
               rounded-[3px] border-2 border-accent bg-card
               p-6 sm:p-9
             "
           >
-            {/* Hard-offset letterpress plate in ember-deep (DESIGN.md
-                Material & Print vocabulary — card-shadow impression
-                color, theme-aware). Solid color, not a soft shadow. */}
-            <div
-              aria-hidden
-              className="pointer-events-none absolute inset-0 -z-10 translate-x-[6px] translate-y-[6px] rounded-[3px] bg-ember-deep"
-            />
 
             {/* Header row — bracketed mono section-cite + date stacked
                 top-left, close affordance top-right. */}
@@ -311,6 +321,7 @@ export function LaunchCelebrationPopup() {
                 </svg>
               </a>
             </div>
+          </div>
           </motion.div>
         </div>
       )}


### PR DESCRIPTION
Closes #517. Caught during visual verification of #515.

## TL;DR

The letterpress plate was painting **over** the card surface, not behind it, because of a CSS stacking-context trap. Dark mode masked the bug (both colors are dark ember tones); light mode showed it catastrophically (white card buried under a rust plate).

## Before / After

Verified on the cluster after merge (`https://ornn.ornn-cluster.local`). Screenshots in dark + light + mobile attached as a comment after the rebuild lands so they cite the production-deployed code, not a local-dev artifact.

## Root cause

```jsx
// before
<motion.div className="relative z-10 ... bg-card ...">       // ← stacking context
  <div className="absolute inset-0 -z-10 translate-x-[6px] translate-y-[6px] bg-ember-deep" />
  ...
</motion.div>
```

`position: relative` + `z-index: 10` on the card creates a stacking context. Inside it, a child with `z-index: -10` paints **between** the card's bg and its content — not behind the card. So the plate sat on top of `bg-card` (white in light mode), hiding it entirely except for the 6×6 px L-corner that the translate doesn't reach.

`getComputedStyle(card).backgroundColor` returned `rgb(255, 255, 255)` correctly, but pixel inspection showed the plate's `rgb(110, 34, 7)` painted over it.

## Fix

Move the plate from card-child to card-sibling inside a positioning wrapper. Paint order then equals document order; no z-index needed.

```jsx
// after
<motion.div className="relative z-10 ...">                   // animated wrapper
  <div aria-hidden className="absolute inset-0 translate-x-[6px] translate-y-[6px] bg-ember-deep" />
  <div role="dialog" className="relative bg-card ...">      // card on top
    ...
  </div>
</motion.div>
```

- Animation moves up one level (wrapper is now the `motion.div`; plate + card animate together)
- ARIA semantics move down one level (`role="dialog"`, `aria-modal`, `aria-labelledby` on the inner card)
- Existing tests still pass — they query by `role`, which finds the inner card

## Out of scope

`AnnouncementPopup` has the same structural bug but doesn't read visually because its card is `bg-accent` (ember) and its plate is `bg-ember-deep` (deeper ember) — both warm orange tones. Filed as a follow-up rather than expanding this PR's blast radius. Will track and fix separately.

## Test plan

- [x] `bun run test src/pages/landing/LaunchCelebrationPopup.test.tsx` — 3/3 pass (opens on mount, closes on dismiss, reopens on remount)
- [x] `bun run lint` — no new TS errors (same 3 pre-existing develop errors as before)
- [ ] Visual verification after rebuild: light card surface = white, dark card surface = obsidian; plate only visible at 6px bottom-right offset in both themes