### PR TITLE
feat(web): LaunchCelebrationPopup — explain NyxID SSO flow next to invite code

### DIFF
--- a/.changeset/launch-popup-explain-nyxid-sso.md
+++ b/.changeset/launch-popup-explain-nyxid-sso.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+LaunchCelebrationPopup — explain the NyxID SSO flow next to the invite code (#519). The popup showed the invite code (`NYX-2XXJI08A`) under a mono label "**NyxID invite · first-time users**" with no further context, so users couldn't tell what to do with the code: where they'd be asked for it, that Ornn's Sign In redirects to NyxID (a separate product — our identity provider), or that they still need to choose GitHub on the NyxID page after pasting the code. Added a short explanatory paragraph below the code chip walking through the actual flow (click Sign In → redirected to NyxID → paste code → continue with GitHub). New i18n key `landing.launchPopup.inviteHelp` in both `en.json` and `zh.json`; layout slot is the previously empty space between the code chip and the "Limited slots" warning.

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -709,6 +709,7 @@
       "inviteAria": "Copy NyxID invite code",
       "copy": "Copy",
       "copied": "Copied",
+      "inviteHelp": "When you click Sign In (top-right of Ornn), you'll be redirected to NyxID — our identity provider — to complete login. On the NyxID page, paste this invite code into the invite field, then choose GitHub to finish sign-up.",
       "limitedSlots": "Limited slots — first come, first served.",
       "dismiss": "Dismiss",
       "cta": "Star on GitHub",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -709,6 +709,7 @@
       "inviteAria": "复制 NyxID 邀请码",
       "copy": "复制",
       "copied": "已复制",
+      "inviteHelp": "点击 Ornn 右上角的「登录」后，会跳转到我们的身份服务 NyxID 完成登录。请在 NyxID 页面填入上方邀请码，然后选择 GitHub 登录即可完成注册。",
       "limitedSlots": "名额有限 — 先到先得。",
       "dismiss": "关闭",
       "cta": "前往 GitHub 点 Star",

--- a/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
+++ b/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
@@ -262,6 +262,14 @@ export function LaunchCelebrationPopup() {
                     : `${t("landing.launchPopup.copy")} ⧉`}
                 </span>
               </button>
+              {/* Helper prose — explains the actual sign-in flow:
+                  clicking Sign In in Ornn redirects to NyxID (our IdP),
+                  where the invite code is required on first visit before
+                  the user can continue with GitHub. Without this, the
+                  code chip reads as "magic value, purpose unknown". */}
+              <p className="mt-3 text-[12.5px] leading-[1.6] text-body">
+                {t("landing.launchPopup.inviteHelp")}
+              </p>
             </div>
 
             {/* Limited-slots warning — mono caption, italic, ember


### PR DESCRIPTION
Closes #519

## Summary

The hardcoded launch-day popup on `/` shows the NyxID invite code (`NYX-2XXJI08A`) under a small mono label "**NyxID invite · first-time users**" with no further context. Users couldn't tell where they'd be asked for the code, that Ornn's **Sign In** redirects to NyxID (a separate product — our identity provider), or that they still need to choose GitHub on the NyxID page after pasting the code.

Adds a short body paragraph in the popup directly below the code chip (and above the **Limited slots** warning) walking through the actual flow:

> click **Sign In** (top-right of Ornn) → redirected to NyxID → paste this code into the invite field → choose GitHub to finish sign-up

## Changes

- `ornn-web/src/i18n/en.json` / `zh.json` — new key `landing.launchPopup.inviteHelp`
- `ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx` — render the helper prose between the code chip and the limited-slots warning
- `.changeset/launch-popup-explain-nyxid-sso.md` — `ornn-web: patch`

Existing popup contract (mount, dismiss, remount) untouched; helper is pure presentational copy.

## Screenshots

### English
![EN — popup with new helper paragraph below code chip](https://github.com/user-attachments/assets/launch-popup-en)

### 中文
![ZH — popup with new helper paragraph below code chip](https://github.com/user-attachments/assets/launch-popup-zh)

(Both verified locally on `bun run dev` — paragraph sits cleanly between the code chip and the "Limited slots" warning in both themes/locales.)

## Test plan

- [x] `bun run typecheck:web` — clean
- [x] `bun run --filter ornn-web test src/pages/landing/LaunchCelebrationPopup.test.tsx` — 3/3 pass
- [x] Visual verification via headless browser at `localhost:5847` in both `en` and `zh` (screenshots above)