### PR TITLE
fix(web): rail tabs — icon + tooltip handles, fix CJK upside-down labels

### DIFF
--- a/.changeset/rail-tab-icon-handles.md
+++ b/.changeset/rail-tab-icon-handles.md
@@ -1,0 +1,9 @@
+---
+"ornn-web": patch
+---
+
+Fix the right-edge rail tabs on Playground and the AI Skill Generation page — labels were rendering upside-down for CJK because of a `writing-mode: vertical-rl` + `rotate(180deg)` combo intended only for vertical English.
+
+Replaced the rotated text with icon-only tab handles (`SkillIcon`, `EnvIcon`, `PackageIcon`) and a horizontal mono-uppercase tooltip that fades in on hover (`[§ SKILL]` / `[§ ENV]` / `[§ PACKAGE]`, matching the drawer header voice). All three tabs are now equal-height — previously `PACKAGE` was ~1.7× taller than `ENV` because of letter count. `aria-label` keeps using the i18n string so screen readers stay locale-correct.
+
+Closes #522.

--- a/ornn-web/src/components/icons/index.tsx
+++ b/ornn-web/src/components/icons/index.tsx
@@ -49,3 +49,58 @@ export function UploadIcon({ className }: IconProps) {
     </svg>
   );
 }
+
+/** Skill icon — document with content lines (SKILL.md metaphor). */
+export function SkillIcon({ className }: IconProps) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M7 4h7l4 4v12a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M13 4v4h5M9 13h7M9 17h4"
+      />
+    </svg>
+  );
+}
+
+/** Env icon — key (env vars as secrets). */
+export function EnvIcon({ className }: IconProps) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <circle cx="8" cy="15" r="3.5" strokeWidth={1.5} />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M10.5 12.5 19 4M16 7l3 3M14 9l2 2"
+      />
+    </svg>
+  );
+}
+
+/** Package icon — cube / shipping box. */
+export function PackageIcon({ className }: IconProps) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="m3.27 6.96 8.73 5.05 8.73-5.05M12 22.08V12"
+      />
+    </svg>
+  );
+}

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -933,6 +933,8 @@
     "dismissAnnouncement": "Dismiss announcement",
     "legal": "Legal",
     "productOverview": "{{brand}} product overview",
+    "playgroundSkillDrawer": "Skill drawer",
+    "playgroundEnvDrawer": "Env drawer",
     "skillPackageDrawer": "Skill package drawer",
     "skillPackagePreview": "Skill package preview",
     "generating": "Generating",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -933,6 +933,8 @@
     "dismissAnnouncement": "关闭公告",
     "legal": "法律信息",
     "productOverview": "{{brand}} 产品概览",
+    "playgroundSkillDrawer": "技能抽屉",
+    "playgroundEnvDrawer": "环境变量抽屉",
     "skillPackageDrawer": "技能包抽屉",
     "skillPackagePreview": "技能包预览",
     "generating": "生成中",

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -328,14 +328,14 @@ export function PlaygroundPage() {
   // which renders CJK upside-down.
   const railTabs: Array<{
     key: DrawerKey;
-    label: string;
+    ariaLabel: string;
     tip: string;
     Icon: ComponentType<IconProps>;
     warn?: boolean;
   }> = [
     {
       key: "skill",
-      label: t("playground.tabSkill", "Skill"),
+      ariaLabel: t("aria.playgroundSkillDrawer"),
       tip: "SKILL",
       Icon: SkillIcon,
     },
@@ -343,7 +343,7 @@ export function PlaygroundPage() {
       ? [
           {
             key: "env" as const,
-            label: t("playground.tabEnv", "Env"),
+            ariaLabel: t("aria.playgroundEnvDrawer"),
             tip: "ENV",
             Icon: EnvIcon,
             warn: envIncomplete,
@@ -352,7 +352,7 @@ export function PlaygroundPage() {
       : []),
     {
       key: "package",
-      label: t("playground.tabPackage", "Package"),
+      ariaLabel: t("aria.skillPackageDrawer"),
       tip: "PACKAGE",
       Icon: PackageIcon,
     },
@@ -566,7 +566,7 @@ export function PlaygroundPage() {
                     ? "border-accent/60 bg-card text-accent"
                     : "border-subtle bg-card/80 text-meta hover:border-accent/40 hover:text-strong"
                 }`}
-                aria-label={`${tab.label} drawer`}
+                aria-label={tab.ariaLabel}
               >
                 <Icon className="h-4 w-4" />
 

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -18,7 +18,7 @@
  * @module pages/PlaygroundPage
  */
 
-import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback, type ComponentType } from "react";
 import { useSearchParams, Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { PageTransition } from "@/components/layout/PageTransition";
@@ -30,6 +30,7 @@ import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { ModelPicker } from "@/components/models/ModelPicker";
 import { OverLimitPage } from "@/components/quota/OverLimitPage";
 import { QuotaInline } from "@/components/quota/QuotaInline";
+import { SkillIcon, EnvIcon, PackageIcon, type IconProps } from "@/components/icons";
 import { useSkill } from "@/hooks/useSkills";
 import { useSkillPackage } from "@/hooks/useSkillPackage";
 import { usePlaygroundChat } from "@/hooks/usePlaygroundChat";
@@ -321,13 +322,40 @@ export function PlaygroundPage() {
   const starters = defaultPromptStarters(skillName, t);
   const conversationActive = messages.length > 0 || !!currentAssistantContent || isStreaming;
 
-  // Right-edge rail tabs (visible on the right side of the chat).
-  const railTabs: Array<{ key: DrawerKey; label: string; warn?: boolean }> = [
-    { key: "skill", label: t("playground.tabSkill", "Skill") },
+  // Right-edge rail tabs. Each tab renders as a compact icon handle —
+  // the `tip` is a horizontal mono-uppercase label shown on hover (matches
+  // the drawer header `[§ NAME]` voice). Avoids vertical-text rotation
+  // which renders CJK upside-down.
+  const railTabs: Array<{
+    key: DrawerKey;
+    label: string;
+    tip: string;
+    Icon: ComponentType<IconProps>;
+    warn?: boolean;
+  }> = [
+    {
+      key: "skill",
+      label: t("playground.tabSkill", "Skill"),
+      tip: "SKILL",
+      Icon: SkillIcon,
+    },
     ...(needsEnvVars
-      ? [{ key: "env" as const, label: t("playground.tabEnv", "Env"), warn: envIncomplete }]
+      ? [
+          {
+            key: "env" as const,
+            label: t("playground.tabEnv", "Env"),
+            tip: "ENV",
+            Icon: EnvIcon,
+            warn: envIncomplete,
+          },
+        ]
       : []),
-    { key: "package", label: t("playground.tabPackage", "Package") },
+    {
+      key: "package",
+      label: t("playground.tabPackage", "Package"),
+      tip: "PACKAGE",
+      Icon: PackageIcon,
+    },
   ];
 
   return (
@@ -526,28 +554,37 @@ export function PlaygroundPage() {
         >
           {railTabs.map((tab) => {
             const active = activeDrawer === tab.key;
+            const Icon = tab.Icon;
             return (
               <button
                 key={tab.key}
                 type="button"
                 onMouseEnter={() => openHover(tab.key)}
                 onClick={() => togglePin(tab.key)}
-                className={`group relative flex items-center gap-1.5 rounded-l-sm border-y border-l px-2.5 py-3 transition-all ${
+                className={`group relative flex h-11 w-9 items-center justify-center rounded-l-sm border-y border-l transition-colors ${
                   active
                     ? "border-accent/60 bg-card text-accent"
                     : "border-subtle bg-card/80 text-meta hover:border-accent/40 hover:text-strong"
                 }`}
                 aria-label={`${tab.label} drawer`}
               >
-                <span
-                  className="font-mono text-[10px] uppercase tracking-[0.18em]"
-                  style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
-                >
-                  {tab.label}
-                </span>
+                <Icon className="h-4 w-4" />
+
+                {/* Horizontal tooltip — fades in on hover when the drawer
+                    for this tab is not already open. Matches the drawer
+                    header voice `[§ NAME]`. */}
+                {!active && (
+                  <span
+                    className="pointer-events-none absolute right-full top-1/2 mr-2 -translate-y-1/2 whitespace-nowrap rounded-sm border border-subtle bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-strong opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+                    aria-hidden
+                  >
+                    [§&nbsp;{tab.tip}]
+                  </span>
+                )}
+
                 {tab.warn && (
                   <span
-                    className="absolute -left-1 top-2 h-1.5 w-1.5 rounded-full bg-warning"
+                    className="absolute -left-1 top-1.5 h-1.5 w-1.5 rounded-full bg-warning"
                     aria-hidden
                   />
                 )}

--- a/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
@@ -30,6 +30,7 @@ import { GenerationChatMessage } from "@/components/skill/GenerationChatMessage"
 import { ModelPicker } from "@/components/models/ModelPicker";
 import { OverLimitPage } from "@/components/quota/OverLimitPage";
 import { QuotaInline } from "@/components/quota/QuotaInline";
+import { PackageIcon } from "@/components/icons";
 import { useSkillGeneration } from "@/hooks/useSkillGeneration";
 import { useCreateSkill } from "@/hooks/useSkills";
 import { useMyQuota } from "@/hooks/useQuota";
@@ -360,22 +361,29 @@ export function CreateSkillGenerativePage() {
             type="button"
             onMouseEnter={openHover}
             onClick={togglePin}
-            className={`group relative flex items-center gap-1.5 rounded-l-sm border-y border-l px-2.5 py-3 transition-all ${
+            className={`group relative flex h-11 w-9 items-center justify-center rounded-l-sm border-y border-l transition-colors ${
               drawerOpen
                 ? "border-accent/60 bg-card text-accent"
                 : "border-subtle bg-card/80 text-meta hover:border-accent/40 hover:text-strong"
             }`}
             aria-label={t("aria.skillPackageDrawer")}
           >
-            <span
-              className="font-mono text-[10px] uppercase tracking-[0.18em]"
-              style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
-            >
-              {t("generative.tabPackage", "Package")}
-            </span>
+            <PackageIcon className="h-4 w-4" />
+
+            {/* Horizontal tooltip — fades in on hover when the drawer is
+                not already open. Matches the drawer header voice. */}
+            {!drawerOpen && (
+              <span
+                className="pointer-events-none absolute right-full top-1/2 mr-2 -translate-y-1/2 whitespace-nowrap rounded-sm border border-subtle bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-strong opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+                aria-hidden
+              >
+                [§&nbsp;PACKAGE]
+              </span>
+            )}
+
             {hasFrontmatterErrors && (
               <span
-                className="absolute -left-1 top-2 h-1.5 w-1.5 rounded-full bg-warning"
+                className="absolute -left-1 top-1.5 h-1.5 w-1.5 rounded-full bg-warning"
                 aria-hidden
               />
             )}


### PR DESCRIPTION
## Summary

- The right-edge rail tabs on **PlaygroundPage** (Skill / Env / Package) and **CreateSkillGenerativePage** (Package) rendered their labels with `writing-mode: vertical-rl` plus `transform: rotate(180deg)`. That combination is a vertical-English convention — for CJK characters it flips every glyph upside-down, leaving Chinese users with a column of inverted text that reads as "this is broken."
- Replaces rotated labels with **icon-only tab handles** + a **horizontal mono-uppercase tooltip** on hover (`[§ SKILL]` / `[§ ENV]` / `[§ PACKAGE]` — same voice as the drawer header). Three new SVG icons added to the shared `components/icons/` module in the existing 1.5 px stroke style.
- Tab handles fixed to `h-11 w-9` — all tabs are now equal height (previously PACKAGE was ~1.7× taller than ENV because of letter count). `aria-label` still uses the i18n string so screen readers stay locale-correct. Warn dot + pin indicator preserved.

Closes #522.

## Commits (stacked in dependency order)

1. `feat(web): add SkillIcon, EnvIcon, PackageIcon to shared icons module`
2. `fix(web): playground rail tabs — icon + tooltip handles, fix CJK upside-down labels (#522)`
3. `fix(web): skill-gen rail tab — icon + tooltip handle, fix CJK upside-down label (#522)`
4. `docs: changeset for #522`

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 80 tests pass
- [x] `bun run build` — production build succeeds
- [ ] Visual: hover each rail tab on Playground → tooltip fades in to the left in mono uppercase; click pins drawer open; tooltip hides while drawer is open
- [ ] Visual: same check on the AI Skill Generation page
- [ ] Visual: language switch to 中文 — `aria-label` should localise (inspect element); visible tooltip stays `[§ NAME]` by design (matches drawer header voice)
- [ ] Visual: env-incomplete warn dot still appears top-left of the Env tab when env vars are unset