### PR TITLE
feat(web): LaunchCelebrationPopup — molten edge flow + caption consistency

### DIFF
--- a/.changeset/launch-popup-offer-tile-flow-and-caption.md
+++ b/.changeset/launch-popup-offer-tile-flow-and-caption.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+LaunchCelebrationPopup — molten edge flow on offer tiles + caption consistency fix (#526). The two "200 credits" tiles (Playground + Skill Generation) were flat matte rectangles and the eye drifted past them, even though they're the whole reason to read the popup. Added a "molten edge flow" effect: a single bright ember-to-gold comet travels around each tile's perimeter over 5s (staggered by 50% across the two tiles so they read as independent objects), with a soft outer ember halo so the tile radiates heat at rest. Pure CSS via `@property --offer-angle` + conic-gradient + mask-composite; no JS, no Framer Motion. Reduced-motion safe — rotation suppressed, ring falls back to a static diagonal molten gradient. Also fixed a caption inconsistency: both tiles spend the same conversation-credit pool but `credit2Caption` was labeled `"Drafts"` / `"创建额度"` while `credit1Caption` was `"Conversations"` / `"对话额度"`, which read as two different credit types. Aligned `credit2Caption` to match.

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -700,7 +700,7 @@
       "credit1Caption": "Conversations · GPT-5.5",
       "credit2Number": "200",
       "credit2Title": "Skill Generation",
-      "credit2Caption": "Drafts · GPT-5.5",
+      "credit2Caption": "Conversations · GPT-5.5",
       "conditionsHeading": "How to redeem",
       "step1Before": "Star",
       "step1After": "on GitHub",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -700,7 +700,7 @@
       "credit1Caption": "对话额度 · GPT-5.5",
       "credit2Number": "200",
       "credit2Title": "Skill Generation",
-      "credit2Caption": "创建额度 · GPT-5.5",
+      "credit2Caption": "对话额度 · GPT-5.5",
       "conditionsHeading": "兑换条件",
       "step1Before": "前往",
       "step1After": "点亮 ⭐ Star。",

--- a/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
+++ b/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
@@ -193,6 +193,7 @@ export function LaunchCelebrationPopup() {
                 count={t("landing.launchPopup.credit2Number")}
                 label={t("landing.launchPopup.credit2Title")}
                 caption={t("landing.launchPopup.credit2Caption")}
+                animationOffsetSeconds={-2.5}
               />
             </div>
 
@@ -369,23 +370,43 @@ function OfferTile({
   count,
   label,
   caption,
+  animationOffsetSeconds,
 }: {
   count: string;
   label: string;
   caption: string;
+  /**
+   * Negative-valued seconds passed as `animation-delay` on the glow
+   * pseudo-element. Stagger the two tiles by ~50% of the 5s cycle
+   * (-2.5s on the second tile) so the molten "comets" travel out of
+   * phase — feels like two independent objects, not CSS clones. The
+   * delay only takes effect on the `::before`, which we can't target
+   * directly inline; we expose it as a CSS custom property and have
+   * the stylesheet pick it up. CSS reference: see `.offer-tile-glow`
+   * in styles/neon.css.
+   */
+  animationOffsetSeconds?: number;
 }) {
+  const styleVars =
+    animationOffsetSeconds !== undefined
+      ? ({
+          ["--offer-tile-anim-delay" as never]: `${animationOffsetSeconds}s`,
+        } as React.CSSProperties)
+      : undefined;
   return (
-    <div className="rounded-[2px] border border-subtle bg-elevated p-4 sm:p-5">
-      <p className="font-display text-[42px] sm:text-[48px] font-bold leading-none tracking-[-0.02em] text-accent">
-        {count}
-      </p>
-      <div className="mt-3 h-px w-8 bg-accent-muted" aria-hidden />
-      <p className="mt-3 font-mono text-[12px] font-semibold uppercase tracking-[0.16em] text-strong">
-        {label}
-      </p>
-      <p className="mt-1 font-mono text-[11px] uppercase tracking-[0.12em] text-meta">
-        {caption}
-      </p>
+    <div className="offer-tile-glow" style={styleVars}>
+      <div className="rounded-[2px] border border-subtle bg-elevated p-4 sm:p-5">
+        <p className="font-display text-[42px] sm:text-[48px] font-bold leading-none tracking-[-0.02em] text-accent">
+          {count}
+        </p>
+        <div className="mt-3 h-px w-8 bg-accent-muted" aria-hidden />
+        <p className="mt-3 font-mono text-[12px] font-semibold uppercase tracking-[0.16em] text-strong">
+          {label}
+        </p>
+        <p className="mt-1 font-mono text-[11px] uppercase tracking-[0.12em] text-meta">
+          {caption}
+        </p>
+      </div>
     </div>
   );
 }

--- a/ornn-web/src/styles/neon.css
+++ b/ornn-web/src/styles/neon.css
@@ -325,6 +325,87 @@ html {
   100% { transform: translateX(-50%); }
 }
 
+/* Offer-tile molten edge flow — used by LaunchCelebrationPopup's
+   "200 credit" tiles to draw the eye to the benefit at first glance.
+   One bright ember-to-gold "comet" travels around each tile's perimeter
+   over 5s, with a soft outer ember halo so the tile reads as radiating
+   heat (not just framed). The brightest peak is in molten gold
+   (--color-accent-support) with ember (--color-accent) trailing on
+   either side, fading to transparent across the back half of the
+   perimeter — only one half glows at any moment, which keeps the
+   effect premium-feeling rather than gaudy.
+
+   Implementation: an `::before` pseudo-element holds a conic-gradient
+   whose `from` angle is a custom property; the `@property` declaration
+   registers --offer-angle as <angle> so it can animate smoothly. A
+   composite mask (xor / exclude) carves out the interior so only the
+   1.5px perimeter ring shows. The two tiles stagger by 50% of the
+   cycle via inline `animation-delay: -2.5s` on the second tile so
+   they read as independent objects.
+
+   Reduced-motion safe: the rotation is suppressed and the ring falls
+   back to a static diagonal molten gradient. The halo box-shadow
+   stays in both modes (it's not motion). */
+@property --offer-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes offer-tile-rotate {
+  to { --offer-angle: 360deg; }
+}
+
+.offer-tile-glow {
+  position: relative;
+  border-radius: 2px;
+  /* Soft outer ember halo — suggests heat radiating from the tile
+     even before the eye tracks the rotating ring. Layered: short
+     bright inner halo + longer diffuse outer glow. */
+  box-shadow:
+    0 0 4px -1px rgba(232, 179, 65, 0.28),
+    0 0 28px -8px rgba(255, 115, 34, 0.42);
+}
+
+.offer-tile-glow::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 3px;
+  padding: 1.5px;
+  background: conic-gradient(
+    from var(--offer-angle),
+    transparent 0deg,
+    rgba(255, 115, 34, 0.35) 25deg,
+    var(--color-accent) 55deg,
+    var(--color-accent-support) 85deg,
+    var(--color-accent) 115deg,
+    rgba(255, 115, 34, 0.35) 145deg,
+    transparent 180deg,
+    transparent 360deg
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  pointer-events: none;
+  animation: offer-tile-rotate 5s linear infinite;
+  animation-delay: var(--offer-tile-anim-delay, 0s);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .offer-tile-glow::before {
+    animation: none;
+    background: linear-gradient(
+      135deg,
+      var(--color-accent) 0%,
+      var(--color-accent-support) 50%,
+      var(--color-accent-muted) 100%
+    );
+  }
+}
+
 /* Background grid pattern — restrained dot grid in ember tone. */
 .bg-grid {
   background-image: radial-gradient(


### PR DESCRIPTION
Closes #526

## Summary

Two polish items for the hardcoded launch popup on `/`, bundled because they touch the same offer-tile component.

### Commit 1 — molten edge flow on offer tiles

The two "200 credits" tiles are the central benefit of the popup but sat as flat matte rectangles; the eye drifted past them. Added a single bright ember-to-gold "comet" that travels around each tile's perimeter over 5s, with a soft outer ember halo so each tile radiates heat even at rest. The two tiles stagger by 50% (-2.5s on tile 2) so they read as independent objects.

Pure CSS — `@property --offer-angle` + conic-gradient + `mask-composite: exclude` + box-shadow halo. No JS, no Framer Motion, no per-frame React work. The lit portion of the conic-gradient is ~180deg out of 360, so only one half of the perimeter glows at any moment — keeps the effect premium rather than gaudy.

**Reduced-motion safe** — rotation suppressed, ring falls back to a static diagonal molten gradient; halo stays in both modes.

### Commit 2 — caption consistency fix

`credit2Caption` was `"Drafts · GPT-5.5"` / `"创建额度 · GPT-5.5"` while `credit1Caption` was `"Conversations · GPT-5.5"` / `"对话额度 · GPT-5.5"`. Both tiles spend the same conversation-credit pool, so the divergence read as "two different credit types" — misleading. Aligned `credit2Caption` to match `credit1Caption` in both locales.

## Changes

- `ornn-web/src/styles/neon.css` — new `@property --offer-angle`, `@keyframes offer-tile-rotate`, `.offer-tile-glow` utility (+ reduced-motion fallback)
- `ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx` — wrap `OfferTile` content with the glow class; new optional `animationOffsetSeconds` prop wired through to CSS via `--offer-tile-anim-delay`
- `ornn-web/src/i18n/{en,zh}.json` — `credit2Caption` aligned to `credit1Caption`
- `.changeset/launch-popup-offer-tile-flow-and-caption.md` — `ornn-web: patch`

## Test plan

- [x] `bun run typecheck:web` — clean
- [x] `bun run --filter ornn-web test src/pages/landing/LaunchCelebrationPopup.test.tsx` — 3/3 pass
- [x] Visual verification via headless browser (`localhost:5847`):
  - 4-frame capture at 1.2s intervals confirms the comet travels around each tile and the two tiles are out of phase
  - Dark + light themes both read correctly (dark: bright arc on dim card / light: bright arc on cream card + visible halo on bg)
  - Caption fix renders: both ZH tiles show `"对话额度 · GPT-5.5"`, both EN tiles show `"Conversations · GPT-5.5"`