### PR TITLE
fix(web): open detail modal for non-broadcast notifications missing a link (#532)

### DIFF
--- a/.changeset/notification-modal-opens-non-broadcast.md
+++ b/.changeset/notification-modal-opens-non-broadcast.md
@@ -1,0 +1,9 @@
+---
+"ornn-web": patch
+---
+
+Make `NotificationDetailModal` source-agnostic so clicking a quota notification (or any non-broadcast row without a deep-link) opens it in place instead of silently marking it read. Closes #532.
+
+Quota credit notifications (`quota.credits_granted`) are emitted without a `link` by design — the API service comment explicitly notes there's no good deep-link target — so the `cursor-pointer` row on `/notifications` and the bell popover looked clickable but did nothing visible. Long admin notes (e.g. `Note: Redeemed code Y69H…`) were truncated by the row width with no way to read them.
+
+The modal now branches on `source`: broadcasts keep their bilingual markdown rendering; user-source rows render `title` + plain-text `body` with a category-resolved tag chip (Audit / Quota). The category labels reuse the same hardcoded map that `NotificationsPage` already shipped — separate follow-up if/when we localize them. Both surfaces (full page + bell) now route non-broadcast rows through the modal when the row has body content but no link; rows with a link still navigate (audit deep-links continue to work).

--- a/ornn-web/src/components/notifications/NotificationBell.tsx
+++ b/ornn-web/src/components/notifications/NotificationBell.tsx
@@ -97,18 +97,31 @@ export function NotificationBell() {
     // Broadcasts open a full markdown viewer modal so a user can read
     // long-form content without leaving the page. Mark-read fires from
     // the modal's open effect so the bell badge updates immediately.
-    // User-side notifications keep the existing navigate behavior.
     if (n.source === "broadcast") {
       setOpen(false);
       setDetailNotification(n);
       return;
     }
-    if (!n.readAt) {
-      markRead.mutate(n._id);
+    // User notifications: link wins (audit deep-links go to the audit
+    // page). If there's no link but the row carries body text, open
+    // the detail modal in place — quota notes are emitted without a
+    // link but the body is what the user wants to see (#532). Bare
+    // notifications with neither still hand off to the full list page
+    // so the click isn't lost.
+    if (n.link) {
+      if (!n.readAt) markRead.mutate(n._id);
+      setOpen(false);
+      navigate(n.link);
+      return;
     }
+    if (n.body) {
+      setOpen(false);
+      setDetailNotification(n);
+      return;
+    }
+    if (!n.readAt) markRead.mutate(n._id);
     setOpen(false);
-    if (n.link) navigate(n.link);
-    else navigate("/notifications");
+    navigate("/notifications");
   };
 
   /** Resolve the display title for either source. */

--- a/ornn-web/src/components/notifications/NotificationDetailModal.test.tsx
+++ b/ornn-web/src/components/notifications/NotificationDetailModal.test.tsx
@@ -113,4 +113,39 @@ describe("NotificationDetailModal", () => {
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText(/Maintenance window/)).toBeNull();
   });
+
+  // #532 — quota credit notifications used to be a dead click because
+  // they carry no `link` and broadcasts were the only thing the modal
+  // would open for. The fix routes them through this same modal in
+  // plain-text mode.
+  it("renders title + plain-text body + category tag for a user-source notification (#532)", () => {
+    const userNotification: Notification = {
+      _id: "n-2",
+      source: "user",
+      category: "quota.credits_granted",
+      title: "Admin granted you +100 playground credits",
+      body: "Granted by Shining Wang 2. Note: Redeemed code Y69HABCDE.\nEnjoy.",
+      createdAt: "2026-05-14T00:00:00.000Z",
+      readAt: null,
+    };
+
+    render(
+      <NotificationDetailModal
+        notification={userNotification}
+        onClose={() => {}}
+        onMarkRead={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText("Admin granted you +100 playground credits"),
+    ).toBeInTheDocument();
+    // Plain text — no markdown bolding, no extra DOM transforms; whole
+    // note (including newline) survives as one block.
+    expect(
+      screen.getByText(/Redeemed code Y69HABCDE/),
+    ).toBeInTheDocument();
+    // Category tag resolves to "Quota" (not the broadcast tag).
+    expect(screen.getByText("Quota")).toBeInTheDocument();
+  });
 });

--- a/ornn-web/src/components/notifications/NotificationDetailModal.tsx
+++ b/ornn-web/src/components/notifications/NotificationDetailModal.tsx
@@ -1,11 +1,15 @@
 /**
- * NotificationDetailModal — click-to-popup viewer for a broadcast-source
- * notification.
+ * NotificationDetailModal — click-to-popup viewer for any notification
+ * row that has body content the list view can't show in full.
  *
- * Renders the bilingual broadcast in full: locale-resolved title as the
- * modal heading, locale-resolved markdown body sanitized through the
- * same safe stack used by AnnouncementPopup (`remark-gfm` +
- * `rehype-sanitize`).
+ * Two render shapes share the same chrome:
+ *   - `source === "broadcast"` — bilingual `titleI18n` / `bodyMarkdownI18n`
+ *     resolved against the active locale, body rendered as sanitized
+ *     markdown (remark-gfm + rehype-sanitize).
+ *   - `source !== "broadcast"` — plain `title` / `body` strings emitted
+ *     by the per-user notification service. Body is rendered as
+ *     pre-wrapped plain text so admin-supplied notes (#532) survive
+ *     newlines and long redemption-code strings without HTML risk.
  *
  * Side effect on open: if `readAt == null`, fires the existing
  * mark-read mutation so the bell badge updates without an extra
@@ -25,8 +29,17 @@ import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
-import type { Notification } from "@/types/notifications";
+import type {
+  Notification,
+  NotificationCategory,
+} from "@/types/notifications";
 import { pickLocalized } from "@/lib/announcementLocale";
+
+const CATEGORY_LABEL: Record<NotificationCategory, string> = {
+  "audit.completed": "Audit",
+  "audit.risky_for_consumer": "Audit",
+  "quota.credits_granted": "Quota",
+};
 
 export interface NotificationDetailModalProps {
   /** Notification to display. The modal renders nothing when null. */
@@ -100,6 +113,7 @@ export function NotificationDetailModal({
   if (!notification) return null;
 
   const lang = i18n.language;
+  const isBroadcast = notification.source === "broadcast";
   const titleText =
     notification.titleI18n
       ? pickLocalized(
@@ -115,6 +129,15 @@ export function NotificationDetailModal({
         lang,
       )
     : "";
+  const tagLabel = isBroadcast
+    ? t("notifications.broadcast.tag")
+    : notification.category
+      ? CATEGORY_LABEL[notification.category]
+      : "";
+  const ariaLabel = isBroadcast
+    ? t("notifications.broadcast.modal.aria")
+    : t("notifications.detail.modal.aria");
+  const plainBody = !isBroadcast ? notification.body ?? "" : "";
 
   return createPortal(
     <AnimatePresence>
@@ -135,14 +158,16 @@ export function NotificationDetailModal({
             transition={{ type: "spring", stiffness: 220, damping: 22, mass: 0.9 }}
             role="dialog"
             aria-modal="true"
-            aria-label={t("notifications.broadcast.modal.aria")}
+            aria-label={ariaLabel}
             className="card-impression relative z-10 mx-4 flex w-full max-w-2xl max-h-[80vh] flex-col gap-4 overflow-hidden rounded border border-strong-edge bg-card p-6"
           >
             <header className="flex items-start justify-between gap-4">
               <div className="flex min-w-0 flex-col gap-1">
-                <span className="self-start rounded-sm border border-accent/30 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-accent">
-                  {t("notifications.broadcast.tag")}
-                </span>
+                {tagLabel && (
+                  <span className="self-start rounded-sm border border-accent/30 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-accent">
+                    {tagLabel}
+                  </span>
+                )}
                 <h2 className="font-display text-xl font-semibold tracking-tight text-strong">
                   {titleText}
                 </h2>
@@ -170,12 +195,16 @@ export function NotificationDetailModal({
             </header>
 
             <div className="markdown-body overflow-y-auto font-text text-[15px] leading-relaxed text-body">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeSanitize]}
-              >
-                {bodyMarkdown}
-              </ReactMarkdown>
+              {isBroadcast ? (
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeSanitize]}
+                >
+                  {bodyMarkdown}
+                </ReactMarkdown>
+              ) : (
+                <p className="whitespace-pre-wrap break-words">{plainBody}</p>
+              )}
             </div>
           </motion.div>
         </div>

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -338,6 +338,11 @@
       "modal": {
         "aria": "Broadcast notification details"
       }
+    },
+    "detail": {
+      "modal": {
+        "aria": "Notification details"
+      }
     }
   },
   "permissions": {

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -338,6 +338,11 @@
       "modal": {
         "aria": "广播通知详情"
       }
+    },
+    "detail": {
+      "modal": {
+        "aria": "通知详情"
+      }
     }
   },
   "permissions": {

--- a/ornn-web/src/pages/NotificationsPage.tsx
+++ b/ornn-web/src/pages/NotificationsPage.tsx
@@ -56,8 +56,21 @@ export function NotificationsPage() {
       setDetailNotification(n);
       return;
     }
+    // User notifications: prefer the deep-link target when present
+    // (audit items carry one) — navigating is more useful than a
+    // modal. Otherwise, if there's body text, open the modal so the
+    // row isn't a dead click (#532 — quota notes are emitted without
+    // a link by design but still carry the full note in `body`).
+    if (n.link) {
+      if (!n.readAt) markRead.mutate(n._id);
+      navigate(n.link);
+      return;
+    }
+    if (n.body) {
+      setDetailNotification(n);
+      return;
+    }
     if (!n.readAt) markRead.mutate(n._id);
-    if (n.link) navigate(n.link);
   };
 
   const resolveTitle = (n: Notification): string => {


### PR DESCRIPTION
Closes #532.

## Summary

Quota credit notifications (`quota.credits_granted`) carry no `link` by design — the API service comment says so explicitly:

> *No deep link target today — settings/profile would be the closest match; leaving undefined so the bell renders the notification without a click affordance.*

But the row still rendered with `cursor-pointer` + hover state, so users clicked expecting *something* and got nothing visible. Long admin notes like `Granted by Shining Wang 2. Note: Redeemed code Y69H…` were also row-truncated with no escape hatch.

This PR makes `NotificationDetailModal` source-agnostic and routes non-broadcast rows that have body content into it.

## Routing matrix (after this change)

| `source` | `link` | `body` | Behavior |
|---|---|---|---|
| `broadcast` | — | — | open modal (bilingual markdown) — unchanged |
| `user` | present | — | mark-read + navigate — unchanged (audit deep-links) |
| `user` | absent | present | **NEW: open modal (plain-text `body`)** |
| `user` | absent | absent | bell → `/notifications`; page → silent mark-read |

Both surfaces — `NotificationsPage` and `NotificationBell` — get the same routing so behavior is consistent.

## Modal changes

`NotificationDetailModal` now branches on `source`:

- Broadcast → `titleI18n` + sanitized `bodyMarkdownI18n` markdown (unchanged)
- User-source → `title` + plain-text `body` in `<p className="whitespace-pre-wrap break-words">` so newlines and long redemption-code strings survive without HTML risk
- Tag chip resolves to `notifications.broadcast.tag` (broadcast) or the existing category map (Audit / Quota)
- aria-label switches between `notifications.broadcast.modal.aria` and the new `notifications.detail.modal.aria` (en + zh added)

The mark-read effect and ref-based loop guard from #509 stay exactly as they were — no behavior change there.

## Commits (decomposed for review)

1. `feat(web): NotificationDetailModal renders user-source body (#532)` — generalize modal + i18n keys + test
2. `feat(web): open detail modal for non-broadcast rows missing a link (#532)` — wire `handleOpen` / `handleItemClick`
3. `docs: changeset for #532`

Each compiles + tests pass independently.

## Backend left untouched

The `notifyQuotaCreditsGranted` service still emits without a `link` — that decision stands until we have a real "credit history" page worth linking to (Phase 3 territory). The frontend modal is the safety net for the no-link path.

## Test plan

- [x] `bun run lint` (tsc) clean
- [x] `bun run test` — 104/104 pass; new test case in `NotificationDetailModal.test.tsx` covers the user-source render
- [ ] Manual: open `/notifications`, click a QUOTA row → modal opens with full note + `Quota` tag + correct aria-label
- [ ] Manual: click bell → QUOTA item → same modal
- [ ] Manual: click an Audit notification → still navigates to the audit page (regression check)
- [ ] Manual: click a Broadcast notification → still opens markdown modal (regression check)