### PR TITLE
refactor(web): preview + chat drawers — flatten layout, pin actions, restrain palette

### DIFF
--- a/.changeset/preview-drawer-redesign.md
+++ b/.changeset/preview-drawer-redesign.md
@@ -1,0 +1,12 @@
+---
+"ornn-web": patch
+---
+
+Skill package preview + Playground / Skill-generation drawers — flatten layout, drop the multi-colour badge palette, pin action buttons.
+
+- `SkillPackagePreview` identity strip is now a single flat section (no nested cards). Category renders as mono `[§ CATEGORY]` ember-bracketed, tags as `tag · tag · tag` dot-separated mono in `text-meta`. Drops the cyan/magenta/yellow/green pill palette entirely.
+- Both pane headers (`FileTree`, `SkillFileViewer`) lock to `h-9` so the seam is straight; the viewer drops the redundant `FILE` prefix and shows the filename as the header.
+- AI Skill Generation drawer widens (`520px` → `min(960px, 65vw)`), clears the 60 px navbar (`top-4` → `top-[68px]`), and pins the `Start over` / `Save skill` buttons at the bottom — the preview panes scroll internally instead of scrolling the whole drawer.
+- Playground's three drawers (Skill / Env / Package) pick up the same voice: flat identity strip, mono status indicators (no rainbow `Badge`), `Skill page` registry link pinned to the drawer footer. Drawer widens to `min(560px, 40vw)`.
+
+Closes #547.

--- a/ornn-web/src/components/editor/FileTree.tsx
+++ b/ornn-web/src/components/editor/FileTree.tsx
@@ -337,9 +337,9 @@ export function FileTree({
 
   return (
     <div className={`flex flex-col h-full ${className}`}>
-      {/* Header — same vertical rhythm as the file-viewer header on the
-          right so they line up across the unified panel. */}
-      <div className="flex shrink-0 items-center border-b border-subtle bg-elevated/40 px-4 py-2">
+      {/* Header — locked to h-9 so it lines up exactly with the file
+          viewer header on the right. */}
+      <div className="flex h-9 shrink-0 items-center border-b border-subtle bg-elevated/40 px-4">
         <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-meta">
           Files
         </span>

--- a/ornn-web/src/components/skill/SkillFileViewer.tsx
+++ b/ornn-web/src/components/skill/SkillFileViewer.tsx
@@ -77,13 +77,7 @@ function ViewerHeader({
   trailing?: React.ReactNode;
 }) {
   return (
-    <div className="flex shrink-0 items-center gap-3 border-b border-subtle bg-elevated/40 px-4 py-2">
-      <span
-        aria-hidden
-        className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-meta"
-      >
-        FILE
-      </span>
+    <div className="flex h-9 shrink-0 items-center gap-3 border-b border-subtle bg-elevated/40 px-4">
       <span className="min-w-0 flex-1 truncate font-mono text-sm text-strong">
         {filename}
       </span>

--- a/ornn-web/src/components/skill/SkillPackagePreview.tsx
+++ b/ornn-web/src/components/skill/SkillPackagePreview.tsx
@@ -8,9 +8,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { FileTree, type FileNode } from "@/components/editor/FileTree";
 import { SkillFileViewer } from "@/components/skill/SkillFileViewer";
-import { Badge } from "@/components/ui/Badge";
 import type { SkillMetadata } from "@/types/skillPackage";
-import type { SkillCategory } from "@/utils/constants";
 
 export interface SkillPackagePreviewProps {
   /** FileTree data structure */
@@ -32,27 +30,6 @@ export interface SkillPackagePreviewProps {
   /** Author name (display only) */
   authorName?: string;
   className?: string;
-}
-
-/** Badge color mapping for categories */
-const CATEGORY_BADGE_COLORS: Record<SkillCategory, "cyan" | "magenta" | "yellow" | "green"> = {
-  plain: "cyan",
-  "tool-based": "magenta",
-  "runtime-based": "yellow",
-  mixed: "green",
-};
-
-/** Tag color palette using deterministic hash */
-const TAG_COLORS: Array<"cyan" | "magenta" | "yellow" | "green"> = [
-  "cyan",
-  "magenta",
-  "yellow",
-  "green",
-];
-
-function getTagColor(tag: string): "cyan" | "magenta" | "yellow" | "green" {
-  const hash = tag.split("").reduce((a, c) => a + c.charCodeAt(0), 0);
-  return TAG_COLORS[hash % TAG_COLORS.length];
 }
 
 /**
@@ -111,7 +88,7 @@ function ResizablePanes({
   style?: React.CSSProperties;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [leftWidth, setLeftWidth] = useState(30); // percentage
+  const [leftWidth, setLeftWidth] = useState(26); // percentage
   const isDragging = useRef(false);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -212,48 +189,56 @@ export function SkillPackagePreview({
     }
   };
 
+  // Restrained mono labels — DESIGN.md says ember is the action voice,
+  // not a rainbow tag palette. Tags render as dot-separated plain text
+  // in the meta colour; the category gets the single bracketed accent
+  // marker to match the drawer-header `[§ NAME]` voice and read as the
+  // primary identity hint.
+  const tagLine = metadata?.metadata.tag ?? [];
+
   return (
-    <div className={`flex flex-col ${className}`}>
-      {/* Metadata summary bar — kept as its own card above the package
-          panel; this is a different concern (skill identity) from the
-          file browser below. */}
+    <div
+      className={`card-impression flex flex-col overflow-hidden rounded border border-subtle bg-card ${className}`}
+    >
+      {/* Identity strip — flat section, no nested card. Three rows:
+          name + author, mono category + tags, description. */}
       {metadata && (
-        <div className="card-impression mb-4 rounded border border-subtle bg-card p-4">
-          <div className="flex flex-wrap items-center gap-3">
-            <h3 className="font-display text-lg font-semibold text-strong">
+        <div className="shrink-0 border-b border-subtle bg-elevated/30 px-5 py-4">
+          <div className="flex items-baseline justify-between gap-4">
+            <h3 className="truncate font-display text-xl font-semibold leading-tight text-strong">
               {metadata.name}
             </h3>
-            <Badge color={CATEGORY_BADGE_COLORS[metadata.metadata.category]}>
-              {metadata.metadata.category}
-            </Badge>
-            {metadata.metadata.tag.map((tag) => (
-              <Badge key={tag} color={getTagColor(tag)}>
-                {tag}
-              </Badge>
-            ))}
             {authorName && (
-              <span className="ml-auto font-text text-xs text-meta">
-                by {authorName}
+              <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                by&nbsp;{authorName}
               </span>
             )}
           </div>
+
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-[0.14em]">
+            <span className="text-accent">
+              [§&nbsp;{metadata.metadata.category}]
+            </span>
+            {tagLine.length > 0 && (
+              <span className="text-meta">
+                {tagLine.join("  ·  ")}
+              </span>
+            )}
+          </div>
+
           {metadata.description && (
-            <p className="mt-2 font-text text-sm text-meta">
+            <p className="mt-3 font-text text-sm leading-relaxed text-body">
               {metadata.description}
             </p>
           )}
         </div>
       )}
 
-      {/* Unified package panel: the file tree and the viewer share one
-          rounded letterpressed surface, separated by a hairline draggable
-          divider. No double borders, no nested cards. */}
-      <div
-        className="card-impression flex-1 overflow-hidden rounded border border-subtle bg-card"
-        style={{ minHeight: "300px" }}
-      >
+      {/* File tree + content viewer share one surface, separated by a
+          hairline draggable divider. Each pane scrolls internally so the
+          host page can pin its action buttons. */}
+      <div className="min-h-0 flex-1 overflow-hidden">
         <ResizablePanes className="h-full min-h-0">
-          {/* Left: file tree (no outer chrome — parent panel owns it) */}
           <div className="flex h-full flex-col">
             <FileTree
               files={files}
@@ -265,7 +250,6 @@ export function SkillPackagePreview({
             />
           </div>
 
-          {/* Right: file content viewer (also naked) */}
           <div className="h-full min-w-0">
             {selectedFileId ? (
               <SkillFileViewer

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -23,7 +23,6 @@ import { useSearchParams, Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { Badge } from "@/components/ui/Badge";
 import { ChatInput, type ChatInputHandle } from "@/components/playground/ChatInput";
 import { ChatMessage } from "@/components/playground/ChatMessage";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
@@ -81,17 +80,6 @@ function ThinkingBubble() {
         </div>
       </div>
     </motion.div>
-  );
-}
-
-/** Welded-seam horizontal divider with a rivet dot in the middle. */
-function WeldedSeam({ className = "" }: { className?: string }) {
-  return (
-    <div className={`flex items-center gap-2 ${className}`} aria-hidden>
-      <span className="h-px flex-1 bg-strong-edge/40" />
-      <span className="h-1 w-1 rounded-full bg-accent/40" />
-      <span className="h-px flex-1 bg-strong-edge/40" />
-    </div>
   );
 }
 
@@ -623,7 +611,7 @@ export function PlaygroundPage() {
                 transition={{ duration: 0.18, ease: "easeOut" }}
                 onMouseEnter={() => openHover(activeDrawer)}
                 onMouseLeave={scheduleHoverClose}
-                className="card-impression fixed right-10 top-4 bottom-4 z-40 flex w-[420px] max-w-[calc(100vw-3rem)] flex-col rounded-md border border-subtle bg-card"
+                className="card-impression fixed right-10 top-[68px] bottom-4 z-40 flex w-[min(560px,40vw)] max-w-[calc(100vw-3rem)] flex-col rounded-md border border-subtle bg-card"
                 role="complementary"
                 aria-label={`${activeDrawer} panel`}
               >
@@ -664,73 +652,43 @@ export function PlaygroundPage() {
                 </div>
 
                 {/* Drawer body */}
-                <div className="min-h-0 flex-1 overflow-y-auto">
+                <div className="flex min-h-0 flex-1 flex-col">
                   {activeDrawer === "skill" && skill && (
-                    <div className="space-y-4 p-4">
-                      <div className="flex items-start gap-3">
-                        <div
-                          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-sm border border-strong-edge bg-warning-soft text-accent"
-                          aria-hidden
-                        >
-                          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                            <polyline points="16 18 22 12 16 6" />
-                            <polyline points="8 6 2 12 8 18" />
-                          </svg>
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <h2 className="break-words font-display text-base font-semibold leading-tight tracking-tight text-strong">
+                    <div className="flex min-h-0 flex-1 flex-col">
+                      {/* Identity strip — flat, hairline-separated, matches
+                          the SkillPackagePreview redesign on the gen page. */}
+                      <div className="shrink-0 border-b border-subtle bg-elevated/30 px-5 py-4">
+                        <div className="flex items-baseline justify-between gap-4">
+                          <h2 className="truncate font-display text-xl font-semibold leading-tight text-strong">
                             {skill.name}
                           </h2>
-                          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
-                            <span className="inline-flex items-center rounded-sm border border-strong-edge px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-strong">
-                              v{skill.version}
-                            </span>
+                          <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+                            v{skill.version}
+                          </span>
+                        </div>
+                        {(skillCategory || (skill.tags && skill.tags.length > 0)) && (
+                          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-[0.14em]">
                             {skillCategory && (
-                              <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
-                                {skillCategory}
+                              <span className="text-accent">
+                                [§&nbsp;{skillCategory}]
+                              </span>
+                            )}
+                            {skill.tags && skill.tags.length > 0 && (
+                              <span className="text-meta">
+                                {skill.tags.join("  ·  ")}
                               </span>
                             )}
                           </div>
-                        </div>
+                        )}
+                        {skill.description && (
+                          <p className="mt-3 break-words font-text text-sm leading-relaxed text-body">
+                            {skill.description}
+                          </p>
+                        )}
                       </div>
 
-                      {skill.description && (
-                        <>
-                          <WeldedSeam />
-                          <div>
-                            <div className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
-                              {t("playground.aboutThisSkill", "About")}
-                            </div>
-                            <p className="break-words font-text text-sm leading-relaxed text-body">
-                              {skill.description}
-                            </p>
-                          </div>
-                        </>
-                      )}
-
-                      {skill.tags && skill.tags.length > 0 && (
-                        <>
-                          <WeldedSeam />
-                          <div>
-                            <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
-                              {t("playground.tags", "Tags")}
-                            </div>
-                            <div className="flex flex-wrap gap-1.5">
-                              {skill.tags.map((tag) => (
-                                <span
-                                  key={tag}
-                                  className="inline-flex items-center rounded-sm border border-subtle bg-elevated/40 px-1.5 py-0.5 font-mono text-[10px] text-body"
-                                >
-                                  #{tag}
-                                </span>
-                              ))}
-                            </div>
-                          </div>
-                        </>
-                      )}
-
-                      <WeldedSeam />
-                      <div className="flex items-center justify-between">
+                      {/* Footer — registry link pinned at the bottom. */}
+                      <div className="mt-auto flex shrink-0 items-center justify-between border-t border-subtle bg-elevated/30 px-5 py-3">
                         <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
                           {t("playground.openDetail", "Skill page")}
                         </span>
@@ -745,50 +703,57 @@ export function PlaygroundPage() {
                   )}
 
                   {activeDrawer === "env" && needsEnvVars && (
-                    <div className="space-y-4 p-4">
-                      <div>
+                    <div className="flex min-h-0 flex-1 flex-col">
+                      {/* Header strip — same flat voice as the skill drawer. */}
+                      <div className="shrink-0 border-b border-subtle bg-elevated/30 px-5 py-4">
                         <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
-                          {t("playground.envVars")}
+                          [§&nbsp;{t("playground.envVars")}]
                         </div>
-                        <p className="mt-1 font-text text-xs leading-relaxed text-body">
+                        <p className="mt-2 font-text text-sm leading-relaxed text-body">
                           {t("playground.envVarsDesc")}
                         </p>
                       </div>
-                      <WeldedSeam />
-                      <div className="space-y-3">
-                        {envVarKeys.map((key) => (
-                          <div key={key} className="space-y-1">
-                            <div className="flex items-center justify-between">
-                              <label className="block max-w-full truncate font-mono text-[11px] text-strong" title={key}>
-                                {key}
-                              </label>
-                              {envVars[key]?.trim() ? (
-                                <Badge color="green">{t("common.set")}</Badge>
-                              ) : (
-                                <Badge color="cyan">{t("common.required")}</Badge>
-                              )}
+
+                      {/* Form */}
+                      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-4">
+                        {envVarKeys.map((key) => {
+                          const filled = !!envVars[key]?.trim();
+                          return (
+                            <div key={key} className="space-y-1">
+                              <div className="flex items-center justify-between gap-2">
+                                <label
+                                  className="block min-w-0 flex-1 truncate font-mono text-[11px] text-strong"
+                                  title={key}
+                                >
+                                  {key}
+                                </label>
+                                <span
+                                  className={`shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] ${
+                                    filled ? "text-success" : "text-meta"
+                                  }`}
+                                >
+                                  {filled ? t("common.set") : t("common.required")}
+                                </span>
+                              </div>
+                              <input
+                                type="text"
+                                value={envVars[key] ?? ""}
+                                onChange={(e) => handleEnvVarChange(key, e.target.value)}
+                                placeholder={t("playground.enterValue")}
+                                className="w-full rounded-sm border border-subtle bg-page px-2.5 py-1.5 font-mono text-xs text-strong placeholder:text-meta/50 focus:border-accent/60 focus:outline-none"
+                              />
                             </div>
-                            <input
-                              type="text"
-                              value={envVars[key] ?? ""}
-                              onChange={(e) => handleEnvVarChange(key, e.target.value)}
-                              placeholder={t("playground.enterValue")}
-                              className="w-full rounded-sm border border-subtle bg-page px-2.5 py-1.5 font-mono text-xs text-strong placeholder:text-meta/50 focus:border-accent/60 focus:outline-none"
-                            />
-                          </div>
-                        ))}
-                      </div>
-                      {!allEnvVarsFilled && (
-                        <>
-                          <WeldedSeam />
-                          <p className="font-text text-[11px] leading-relaxed text-meta">
+                          );
+                        })}
+                        {!allEnvVarsFilled && (
+                          <p className="pt-2 font-text text-[11px] leading-relaxed text-meta">
                             {t(
                               "playground.envVarsLockHint",
                               "Chat is locked until every required env var has a value.",
                             )}
                           </p>
-                        </>
-                      )}
+                        )}
+                      </div>
                     </div>
                   )}
 

--- a/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
@@ -418,7 +418,7 @@ export function CreateSkillGenerativePage() {
                 transition={{ duration: 0.18, ease: "easeOut" }}
                 onMouseEnter={openHover}
                 onMouseLeave={scheduleHoverClose}
-                className="card-impression fixed right-10 top-4 bottom-4 z-40 flex w-[520px] max-w-[calc(100vw-3rem)] flex-col rounded-md border border-subtle bg-card"
+                className="card-impression fixed right-10 top-[68px] bottom-4 z-40 flex w-[min(960px,65vw)] max-w-[calc(100vw-3rem)] flex-col rounded-md border border-subtle bg-card"
                 role="complementary"
                 aria-label={t("aria.skillPackagePreview")}
               >
@@ -458,10 +458,14 @@ export function CreateSkillGenerativePage() {
                   </div>
                 </div>
 
-                {/* Drawer body */}
-                <div className="min-h-0 flex-1 overflow-y-auto">
+                {/* Drawer body — flex column with the preview claiming the
+                    space between validation errors (top) and action buttons
+                    (bottom). The body itself does NOT scroll; scrolling lives
+                    inside the preview's panes so Start over / Save skill stay
+                    visible at all times. */}
+                <div className="flex min-h-0 flex-1 flex-col">
                   {hasPreview ? (
-                    <div className="flex flex-col gap-4 p-4">
+                    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
                       {hasFrontmatterErrors && (
                         <ValidationErrorPanel
                           errors={validationErrors}
@@ -480,11 +484,12 @@ export function CreateSkillGenerativePage() {
                         onContentChange={generation.updateFileContent}
                         onFileDelete={generation.deleteFile}
                         authorName={user?.displayName ?? undefined}
+                        className="min-h-0 flex-1"
                       />
 
-                      <WeldedSeam />
+                      <WeldedSeam className="shrink-0" />
 
-                      <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3">
                         <Button variant="secondary" size="sm" onClick={generation.reset}>
                           {t("generative.startOver", "Start over")}
                         </Button>


### PR DESCRIPTION
## Summary

- **Skill package preview**: flat identity strip + single ember-bracketed category + dot-separated mono tags. Drops the cyan/magenta/yellow/green badge palette entirely (DESIGN.md restrains ember as the only action voice). Equalises both pane headers to `h-9`; drops the redundant `FILE` prefix so the filename *is* the header.
- **AI Skill Generation drawer**: widens to `min(960px, 65vw)`, clears the 60 px navbar, pins `Start over` / `Save skill` at the bottom — file panes scroll internally instead of scrolling the whole drawer.
- **Playground drawers** (Skill / Env / Package): same voice as the gen page — flat identity strip, mono-uppercase status (no rainbow `Badge`), `Skill page` link pinned in a hairline-bordered footer. Drawer widens to `min(560px, 40vw)` — moderate, doesn't push the chat hero.

Closes #547.

## Commits (stacked in dependency order)

1. `refactor(web): unify Skill / File pane headers — equal h-9, drop redundant FILE prefix (#547)`
2. `refactor(web): SkillPackagePreview — flat identity strip, drop multi-colour badge palette (#547)`
3. `fix(web): CreateSkillGenerativePage drawer — widen, pin actions, push past navbar (#547)`
4. `refactor(web): PlaygroundPage drawers — flat identity strip, mono status, match generative voice (#547)`
5. `docs: changeset for #547`

## Test plan

- [x] `bunx tsc --noEmit` clean (project's 3 pre-existing `react-hook-form` / `cron-parser` errors unrelated)
- [x] `bun run test` — 103/103 pass
- [x] `bun run build` — production bundle generated
- [x] Local deploy verified: drawer no longer clipped behind navbar; action buttons stay visible on long previews; tags read as `tag · tag · tag` (no rainbow); pane seam straight.
- [ ] Reviewer: open `/skills/new/generate`, send a starter prompt, confirm the preview drawer fits, Save button stays visible, and the redesigned identity strip reads cleanly.
- [ ] Reviewer: open `/playground?skill=<any>`, hover each of the three rail tabs, confirm new flat-section drawers match the generative voice.