### PR TITLE
chore(api): mask redemption code with **** instead of ellipsis (#549)

### DIFF
--- a/.changeset/redemption-note-mask-stars.md
+++ b/.changeset/redemption-note-mask-stars.md
@@ -1,0 +1,7 @@
+---
+"ornn-api": patch
+---
+
+Swap the privacy-mask glyph in redemption-code grant notes from `…` (U+2026) to `****`. The ellipsis is unambiguous in the audit log but reads as "text truncated, click to see more" in the new `/notifications` detail modal (#532), so users kept asking why the full code was hidden. The mask now signals *masked* rather than *truncated*. Only the first four chars of the code still leak — privacy intent unchanged. Closes #549.
+
+Affects new audit + notification rows generated after this lands; historical rows continue to carry `…` (no migration — old rows are clearly QUOTA-tagged and redemption-sourced, no semantic loss).

--- a/ornn-api/src/domains/redemption-codes/service.test.ts
+++ b/ornn-api/src/domains/redemption-codes/service.test.ts
@@ -128,6 +128,32 @@ describe("RedemptionCodeService.redeem — happy path", () => {
     const audits = await db.collection("quota_grants_audit").countDocuments();
     expect(audits).toBe(2);
   });
+
+  // The grant audit / quota notification carries a privacy-masked note
+  // so the full redemption code never leaks downstream. Mask glyph is
+  // `****` (NOT `…`) because users see the full body in the
+  // /notifications detail modal (#532) and an ellipsis reads as "text
+  // truncated, click to see more" — which it isn't. See #549.
+  test("writes a privacy-masked redemption note on each grant audit row", async () => {
+    const doc = await service.mint({
+      admin: ADMIN,
+      grants: [{ surface: "playground", amount: 7 }],
+      expiresAt: plusDays(7),
+    });
+    await service.redeem({
+      code: doc.code,
+      redeemer: REDEEMER,
+      permissions: [],
+    });
+    const expectedNote = `Redeemed code ${doc.code.slice(0, 4)}****`;
+    const audits = await db
+      .collection<{ note?: string }>("quota_grants_audit")
+      .find({})
+      .toArray();
+    expect(audits.length).toBe(1);
+    expect(audits[0]?.note).toBe(expectedNote);
+    expect(audits[0]?.note).not.toContain("…");
+  });
 });
 
 describe("RedemptionCodeService.redeem — race", () => {

--- a/ornn-api/src/domains/redemption-codes/service.ts
+++ b/ornn-api/src/domains/redemption-codes/service.ts
@@ -273,7 +273,11 @@ export class RedemptionCodeService {
       // The redeemer is passed as both `admin` and `targetUserId` —
       // grant() requires admin metadata for the audit row. The audit
       // entry transparently shows a self-grant; the note carries the
-      // code prefix so it's clear this came from a redemption.
+      // first four chars of the code so it's clear this came from a
+      // redemption while keeping the remainder of the token masked.
+      // Mask glyph is `****` rather than `…` because the ellipsis
+      // reads as "text truncated" in the detail modal users now see
+      // (#549) — `****` is unambiguously a privacy mask.
       // Deliberately NO rollback if a later grant fails: the code is
       // already consumed by the atomic pivot above. An admin can
       // top-up the missing surface manually from the audit log.
@@ -282,7 +286,7 @@ export class RedemptionCodeService {
         targetUserId: params.redeemer.userId,
         surface: grant.surface,
         amount: grant.amount,
-        note: `Redeemed code ${codePrefix}…`,
+        note: `Redeemed code ${codePrefix}****`,
         now,
       });
       applied.push({


### PR DESCRIPTION
Closes #549. Follow-up to #532.

## Why

After #532 landed, users can finally read the full body of a quota credit notification in the detail modal. What they see for redemption-sourced grants:

> Granted by Shining Wang 2. Note: Redeemed code Y69H…

The trailing `…` is the privacy mask we deliberately write into the note (`ornn-api/src/domains/redemption-codes/service.ts:285` — only the first 4 chars of the code leak). It works fine in the audit log where the row context is clear, but in the modal it reads as *"text was truncated, click for more"* — because that is what an ellipsis means in every other UI surface. Users repeatedly asked why the modal was hiding their full code.

## What

Swap the mask glyph from `…` (U+2026) to `****`:

```diff
- note: `Redeemed code ${codePrefix}…`,
+ note: `Redeemed code ${codePrefix}****`,
```

`****` is unambiguously a privacy mask, not a truncation marker.

- Privacy intent unchanged: still only the first four chars of the code in the note
- Historical rows keep `…` — no migration; QUOTA tag + "Redeemed code" prefix already make provenance unambiguous, and these are notifications, not load-bearing data
- New regression test asserts the literal note format on each grant audit row and explicitly rejects `…`, so a future tidy-up can't accidentally walk this back

## Commits

1. `chore(api): mask redemption code with **** instead of ellipsis (#549)` — service.ts one-liner + regression test
2. `docs: changeset for #549`

## Test plan

- [x] `bun test src/domains/redemption-codes/service.test.ts` — 14/14 (was 13 + new regression case)
- [x] `bun test` (full backend) — 612/612 pass
- [ ] After deploy: redeem a code on staging, confirm the resulting notification body ends in `****` not `…`