### PR TITLE
refactor(web): drawer consolidation — playground absorbs Skill tab, gen-page pulses on new iterations

### DIFF
--- a/.changeset/drawer-consolidation.md
+++ b/.changeset/drawer-consolidation.md
@@ -1,0 +1,9 @@
+---
+"ornn-web": patch
+---
+
+Playground Package drawer absorbs the redundant Skill drawer (`SkillPackagePreview` now renders the same identity strip on both pages, so two tabs showing the same info was confusing). Drawer width on Playground unified to the gen page's `min(960px, 65vw)`. Fixed a flex-wrapper bug where the Playground Package drawer's file viewer overflowed past the footer. `ResizablePanes` default split 26 % → 32 % so typical skill folder names like `ornn-agent-manual-cli` no longer truncate.
+
+On the AI Skill Generation page, the Package rail tab now pulses ember-accent (steady ring + animated `ping` ripple + dot) when a new iteration lands while the drawer is closed — so multi-turn refinement gives a visible "new artifact ready" cue. Clears the moment the user opens the drawer.
+
+Closes #551.

--- a/ornn-web/src/components/skill/SkillPackagePreview.tsx
+++ b/ornn-web/src/components/skill/SkillPackagePreview.tsx
@@ -88,7 +88,10 @@ function ResizablePanes({
   style?: React.CSSProperties;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [leftWidth, setLeftWidth] = useState(26); // percentage
+  // 32 % gives ~300 px on a 960 px drawer — enough for typical skill folder
+  // names like `ornn-agent-manual-cli` without ellipsis truncation. User can
+  // drag the divider in either direction; this is just the rest state.
+  const [leftWidth, setLeftWidth] = useState(32);
   const isDragging = useRef(false);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -271,6 +271,31 @@ export function PlaygroundPage() {
 
   const activeDrawer = pinnedDrawer ?? hoverDrawer;
 
+  const skillCategory = (skill?.metadata as Record<string, unknown> | null)?.category as string | undefined;
+
+  // Synthesise a SkillMetadata-shaped object from the registry skill record
+  // so SkillPackagePreview can render the same flat identity strip as the
+  // generative page. The preview only reads name / description / category /
+  // tag, so we don't need to faithfully reproduce the rest of the shape —
+  // `createDefaultSkillMetadata` fills the unused fields with safe defaults.
+  // Declared above the early-return guards so the hook order is stable.
+  const previewMetadata = useMemo<SkillMetadata | null>(() => {
+    if (!skill) return null;
+    return createDefaultSkillMetadata({
+      name: skill.name,
+      description: skill.description ?? "",
+      version: skill.version,
+      metadata: {
+        category: (skillCategory as SkillCategory) ?? "plain",
+        runtime: [],
+        runtimeDependency: [],
+        runtimeEnvVar: [],
+        toolList: [],
+        tag: skill.tags ?? [],
+      },
+    });
+  }, [skill, skillCategory]);
+
   // No skill specified
   if (!skillName) {
     return (
@@ -310,30 +335,6 @@ export function PlaygroundPage() {
       </PageTransition>
     );
   }
-
-  const skillCategory = (skill?.metadata as Record<string, unknown> | null)?.category as string | undefined;
-
-  // Synthesise a SkillMetadata-shaped object from the registry skill record
-  // so SkillPackagePreview can render the same flat identity strip as the
-  // generative page. The preview only reads name / description / category /
-  // tag, so we don't need to faithfully reproduce the rest of the shape —
-  // `createDefaultSkillMetadata` fills the unused fields with safe defaults.
-  const previewMetadata = useMemo<SkillMetadata | null>(() => {
-    if (!skill) return null;
-    return createDefaultSkillMetadata({
-      name: skill.name,
-      description: skill.description ?? "",
-      version: skill.version,
-      metadata: {
-        category: (skillCategory as SkillCategory) ?? "plain",
-        runtime: [],
-        runtimeDependency: [],
-        runtimeEnvVar: [],
-        toolList: [],
-        tag: skill.tags ?? [],
-      },
-    });
-  }, [skill, skillCategory]);
 
   const starters = defaultPromptStarters(skillName, t);
   const conversationActive = messages.length > 0 || !!currentAssistantContent || isStreaming;

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -29,7 +29,12 @@ import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { ModelPicker } from "@/components/models/ModelPicker";
 import { OverLimitPage } from "@/components/quota/OverLimitPage";
 import { QuotaInline } from "@/components/quota/QuotaInline";
-import { SkillIcon, EnvIcon, PackageIcon, type IconProps } from "@/components/icons";
+import { EnvIcon, PackageIcon, type IconProps } from "@/components/icons";
+import {
+  createDefaultSkillMetadata,
+  type SkillMetadata,
+} from "@/types/skillPackage";
+import type { SkillCategory } from "@/utils/constants";
 import { useSkill } from "@/hooks/useSkills";
 import { useSkillPackage } from "@/hooks/useSkillPackage";
 import { usePlaygroundChat } from "@/hooks/usePlaygroundChat";
@@ -113,7 +118,7 @@ function defaultPromptStarters(skillName: string, t: TFunc): PromptStarter[] {
   ];
 }
 
-type DrawerKey = "skill" | "package" | "env";
+type DrawerKey = "package" | "env";
 
 export function PlaygroundPage() {
   const { t } = useTranslation();
@@ -307,13 +312,37 @@ export function PlaygroundPage() {
   }
 
   const skillCategory = (skill?.metadata as Record<string, unknown> | null)?.category as string | undefined;
+
+  // Synthesise a SkillMetadata-shaped object from the registry skill record
+  // so SkillPackagePreview can render the same flat identity strip as the
+  // generative page. The preview only reads name / description / category /
+  // tag, so we don't need to faithfully reproduce the rest of the shape —
+  // `createDefaultSkillMetadata` fills the unused fields with safe defaults.
+  const previewMetadata = useMemo<SkillMetadata | null>(() => {
+    if (!skill) return null;
+    return createDefaultSkillMetadata({
+      name: skill.name,
+      description: skill.description ?? "",
+      version: skill.version,
+      metadata: {
+        category: (skillCategory as SkillCategory) ?? "plain",
+        runtime: [],
+        runtimeDependency: [],
+        runtimeEnvVar: [],
+        toolList: [],
+        tag: skill.tags ?? [],
+      },
+    });
+  }, [skill, skillCategory]);
+
   const starters = defaultPromptStarters(skillName, t);
   const conversationActive = messages.length > 0 || !!currentAssistantContent || isStreaming;
 
   // Right-edge rail tabs. Each tab renders as a compact icon handle —
   // the `tip` is a horizontal mono-uppercase label shown on hover (matches
-  // the drawer header `[§ NAME]` voice). Avoids vertical-text rotation
-  // which renders CJK upside-down.
+  // the drawer header `[§ NAME]` voice). The Package drawer now hosts the
+  // skill identity (name + category + tags + description) at the top of
+  // `SkillPackagePreview`, so a separate Skill tab would be redundant.
   const railTabs: Array<{
     key: DrawerKey;
     ariaLabel: string;
@@ -321,12 +350,6 @@ export function PlaygroundPage() {
     Icon: ComponentType<IconProps>;
     warn?: boolean;
   }> = [
-    {
-      key: "skill",
-      ariaLabel: t("aria.playgroundSkillDrawer"),
-      tip: "SKILL",
-      Icon: SkillIcon,
-    },
     ...(needsEnvVars
       ? [
           {
@@ -611,7 +634,7 @@ export function PlaygroundPage() {
                 transition={{ duration: 0.18, ease: "easeOut" }}
                 onMouseEnter={() => openHover(activeDrawer)}
                 onMouseLeave={scheduleHoverClose}
-                className="card-impression fixed right-10 top-[68px] bottom-4 z-40 flex w-[min(560px,40vw)] max-w-[calc(100vw-3rem)] flex-col rounded-md border border-subtle bg-card"
+                className="card-impression fixed right-10 top-[68px] bottom-4 z-40 flex w-[min(960px,65vw)] max-w-[calc(100vw-3rem)] flex-col rounded-md border border-subtle bg-card"
                 role="complementary"
                 aria-label={`${activeDrawer} panel`}
               >
@@ -653,55 +676,6 @@ export function PlaygroundPage() {
 
                 {/* Drawer body */}
                 <div className="flex min-h-0 flex-1 flex-col">
-                  {activeDrawer === "skill" && skill && (
-                    <div className="flex min-h-0 flex-1 flex-col">
-                      {/* Identity strip — flat, hairline-separated, matches
-                          the SkillPackagePreview redesign on the gen page. */}
-                      <div className="shrink-0 border-b border-subtle bg-elevated/30 px-5 py-4">
-                        <div className="flex items-baseline justify-between gap-4">
-                          <h2 className="truncate font-display text-xl font-semibold leading-tight text-strong">
-                            {skill.name}
-                          </h2>
-                          <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
-                            v{skill.version}
-                          </span>
-                        </div>
-                        {(skillCategory || (skill.tags && skill.tags.length > 0)) && (
-                          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-[0.14em]">
-                            {skillCategory && (
-                              <span className="text-accent">
-                                [§&nbsp;{skillCategory}]
-                              </span>
-                            )}
-                            {skill.tags && skill.tags.length > 0 && (
-                              <span className="text-meta">
-                                {skill.tags.join("  ·  ")}
-                              </span>
-                            )}
-                          </div>
-                        )}
-                        {skill.description && (
-                          <p className="mt-3 break-words font-text text-sm leading-relaxed text-body">
-                            {skill.description}
-                          </p>
-                        )}
-                      </div>
-
-                      {/* Footer — registry link pinned at the bottom. */}
-                      <div className="mt-auto flex shrink-0 items-center justify-between border-t border-subtle bg-elevated/30 px-5 py-3">
-                        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
-                          {t("playground.openDetail", "Skill page")}
-                        </span>
-                        <Link
-                          to={`/skills/${encodeURIComponent(skill.name)}`}
-                          className="font-mono text-[11px] text-accent hover:underline"
-                        >
-                          /skills/{skill.name} →
-                        </Link>
-                      </div>
-                    </div>
-                  )}
-
                   {activeDrawer === "env" && needsEnvVars && (
                     <div className="flex min-h-0 flex-1 flex-col">
                       {/* Header strip — same flat voice as the skill drawer. */}
@@ -758,32 +732,21 @@ export function PlaygroundPage() {
                   )}
 
                   {activeDrawer === "package" && (
-                    <div className="flex h-full flex-col">
-                      <div className="flex shrink-0 items-center justify-between border-b border-subtle px-4 py-2">
-                        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-meta">
-                          {skill ? `${skill.name}@v${skill.version}` : ""}
-                        </span>
-                        {skill && (
-                          <Link
-                            to={`/skills/${encodeURIComponent(skill.name)}`}
-                            className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta transition-colors hover:text-accent"
-                          >
-                            {t("playground.openInRegistry", "Open in registry →")}
-                          </Link>
-                        )}
-                      </div>
-                      <div className="min-h-0 flex-1">
+                    <div className="flex min-h-0 flex-1 flex-col">
+                      {/* Padded content area — must itself be a flex column
+                          so the preview's `flex-1 min-h-0` actually claims
+                          the remaining height and the file viewer scrolls
+                          internally instead of bleeding past the footer. */}
+                      <div className="flex min-h-0 flex-1 flex-col p-4">
                         {packageLoading ? (
-                          <div className="p-4">
-                            <Skeleton lines={8} />
-                          </div>
+                          <Skeleton lines={8} />
                         ) : packageFiles.length > 0 ? (
                           <SkillPackagePreview
                             files={packageFiles}
                             fileContents={packageContents}
-                            metadata={null}
+                            metadata={previewMetadata}
                             editable={false}
-                            className="h-full"
+                            className="min-h-0 flex-1"
                           />
                         ) : (
                           <div className="flex h-32 items-center justify-center">
@@ -791,6 +754,22 @@ export function PlaygroundPage() {
                           </div>
                         )}
                       </div>
+
+                      {/* Footer — registry link pinned at the bottom,
+                          matching the Skill drawer's pattern. */}
+                      {skill && (
+                        <div className="flex shrink-0 items-center justify-between border-t border-subtle bg-elevated/30 px-5 py-3">
+                          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+                            {skill.name}@v{skill.version}
+                          </span>
+                          <Link
+                            to={`/skills/${encodeURIComponent(skill.name)}`}
+                            className="font-mono text-[11px] text-accent hover:underline"
+                          >
+                            {t("playground.openInRegistry", "Open in registry →")}
+                          </Link>
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>

--- a/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
@@ -226,6 +226,28 @@ export function CreateSkillGenerativePage() {
   const hasPreview = generation.metadata !== null;
   const conversationActive = hasMessages || isGenerating;
   const drawerOpen = pinnedOpen || hoverDrawerOpen;
+
+  // New-iteration hint — pulse the rail tab when a generation lands while
+  // the drawer is closed. The chat lets the user refine across many turns,
+  // so each `phase: generating → preview` transition produces a fresh skill
+  // package; without this nudge the only signal is the chat message itself,
+  // which the user may scroll past while typing the next refinement.
+  const [hasUnseenIteration, setHasUnseenIteration] = useState(false);
+  const prevPhaseRef = useRef(generation.phase);
+  useEffect(() => {
+    if (
+      prevPhaseRef.current === "generating" &&
+      generation.phase === "preview" &&
+      !drawerOpen
+    ) {
+      setHasUnseenIteration(true);
+    }
+    prevPhaseRef.current = generation.phase;
+  }, [generation.phase, drawerOpen]);
+  useEffect(() => {
+    if (drawerOpen) setHasUnseenIteration(false);
+  }, [drawerOpen]);
+
   const starters = defaultPromptStarters(t);
 
   const chatInputPlaceholder = isGenerating
@@ -364,11 +386,36 @@ export function CreateSkillGenerativePage() {
             className={`group relative flex h-11 w-9 items-center justify-center rounded-l-sm border-y border-l transition-colors ${
               drawerOpen
                 ? "border-accent/60 bg-card text-accent"
-                : "border-subtle bg-card/80 text-meta hover:border-accent/40 hover:text-strong"
+                : hasUnseenIteration
+                  ? "border-accent bg-card text-accent"
+                  : "border-subtle bg-card/80 text-meta hover:border-accent/40 hover:text-strong"
             }`}
             aria-label={t("aria.skillPackageDrawer")}
           >
             <PackageIcon className="h-4 w-4" />
+
+            {/* New-iteration hint — pulsing ember rings around the tab
+                when a generation lands while the drawer is closed. Two
+                layers: a steady accent ring + an `animate-ping` ring
+                that scales out to draw the eye. Clears on drawer open. */}
+            {hasUnseenIteration && !drawerOpen && (
+              <>
+                <span
+                  className="pointer-events-none absolute -inset-px rounded-l-sm ring-2 ring-accent/70"
+                  aria-hidden
+                />
+                <span
+                  className="pointer-events-none absolute -inset-px animate-ping rounded-l-sm ring-2 ring-accent/40"
+                  aria-hidden
+                />
+                {/* Small ember dot top-right to signal "new" even at the
+                    button's outer edge when ring blends into the card. */}
+                <span
+                  className="pointer-events-none absolute -right-1 -top-1 h-2 w-2 animate-pulse rounded-full bg-accent"
+                  aria-hidden
+                />
+              </>
+            )}
 
             {/* Horizontal tooltip — fades in on hover when the drawer is
                 not already open. Matches the drawer header voice. */}


### PR DESCRIPTION
## Summary

- **Playground Package drawer absorbs the Skill drawer.** `SkillPackagePreview` already renders the full identity strip (name + bracketed category + dot-separated tags + description) on the gen page. Wiring it the same way on the Playground means the Skill tab was showing the same data one tab over; this PR drops the Skill rail tab + drawer body and lets the Package drawer be the single identity surface.
- **Drawer widths unified** — both surfaces now use `w-[min(960px,65vw)]`. Same shared `SkillPackagePreview` component, same drawer geometry.
- **Bug fix: Playground Package drawer body was overflowing past its footer** — the padded content wrapper was a non-flex `div`, so `flex-1 min-h-0` on the preview did nothing and the file viewer grew to its natural height. Wrapping in `flex flex-col` makes the preview claim remaining height and scroll internally.
- **`SkillPackagePreview` file-tree default split 26 % → 32 %** — enough room for `ornn-agent-manual-cli`-length folder names without ellipsis truncation.
- **New on the gen page**: rail tab pulses (ember accent + ring + `animate-ping` ripple + small ember dot) when a new generation lands while the drawer is closed. Clears on drawer open. The chat-driven refinement loop now gives a visible "new artifact ready" cue.

Closes #551.

## Commits

1. `refactor(web): SkillPackagePreview — bump file-tree default split 26 % → 32 % (#551)`
2. `refactor(web): playground drawer — absorb Skill tab into Package, unify width, fix overflow (#551)`
3. `feat(web): skill-gen rail tab — pulse on new iteration while drawer is closed (#551)`
4. `docs: changeset for #551`

## Test plan

- [x] `bunx tsc --noEmit` — clean (project's 3 pre-existing `react-hook-form` / `cron-parser` errors unrelated)
- [x] `bun run test` — 104/104 pass
- [x] `bun run build` — production bundle generated
- [x] Local deploy verified: Playground rail has one Package tab (no redundant Skill tab); drawer matches gen page width; file viewer scrolls internally with footer pinned; folder names no longer truncate.
- [x] Local deploy verified: send a refinement message on the gen page with drawer un-pinned — Package rail tab pulses ember on generation finish; pulse clears the moment drawer opens.
- [ ] Reviewer: open `/playground?skill=<any>`, hover the Package rail tab. Drawer should show full identity strip (name, `[§ category]`, dot-separated tags, description), file tree + viewer, hairline footer with registry link. No "Skill" rail tab anywhere.
- [ ] Reviewer: open `/skills/new/generate`, send a prompt, close the drawer (click ×), send a refinement prompt. When generation finishes, the rail tab should glow + pulse until you reopen the drawer.