### PR TITLE
docs(readme): surface Ornn official website link

### DIFF
--- a/.changeset/readme-website-link.md
+++ b/.changeset/readme-website-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+Surface the Ornn official website (https://ornn.chrono-ai.fun) right under the tagline in the root `README.md` (#572). Previously the only mentions of the domain were buried in the `/docs` sub-path link — first-time readers had no obvious entry point to the product homepage. No `ornn-api` / `ornn-web` code change; empty changeset satisfies the gate.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 <p align="center"><strong>The agent-facing skill-lifecycle API for AI agents.</strong></p>
 
 <p align="center">
+  Ornn official website — <a href="https://ornn.chrono-ai.fun">ornn.chrono-ai.fun</a>
+</p>
+
+<p align="center">
   <a href="#what-is-ornn">What is Ornn</a> ·
   <a href="#how-it-works">How it works</a> ·
   <a href="#quickstart">Quickstart</a> ·


### PR DESCRIPTION
Closes #572

## Summary

- Add a centered line — "Ornn official website — ornn.chrono-ai.fun" — right under the tagline and above the section nav in the root [README.md](README.md).
- Docs-only change. Empty changeset attached to satisfy the `check-changeset.yml` gate.

## Why

The README already linked to `ornn.chrono-ai.fun/docs` in two places, but the bare homepage was nowhere to be found. First-time readers landing on the GitHub repo had no one-click path to the product surface; this puts the website at parity with the badges and the docs link without restructuring the rest of the file.

## Test plan

- [x] Render the README on GitHub PR preview and confirm the new line shows above the section nav and the link resolves to https://ornn.chrono-ai.fun
- [x] `check-changeset.yml` passes (empty changeset)