### PR TITLE
chore(sdk): discovery keywords + npm publish fields (#468)

### DIFF
--- a/.changeset/sdk-keywords-and-topics-468.md
+++ b/.changeset/sdk-keywords-and-topics-468.md
@@ -1,0 +1,4 @@
+---
+---
+
+Discovery metadata pass for the SDKs (#468). Adds `keywords` + npm publish fields (`homepage`, `bugs`, `repository`, `license`) to `@chronoai/ornn-sdk` and expands Python SDK `keywords` to align with the agent-API positioning (`ornn`, `agent`, `skill-registry`, `skill-lifecycle`, `ai-agents`, `model-agnostic`, `mcp`, `llm`, `sdk`). GitHub repo topics set out-of-band via `gh repo edit`. No `ornn-api` / `ornn-web` code change — empty changeset satisfies the gate.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -10,7 +10,17 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Chrono AI" }]
-keywords = ["ornn", "skills", "ai", "agents", "nyxid"]
+keywords = [
+    "ornn",
+    "agent",
+    "skill-registry",
+    "skill-lifecycle",
+    "ai-agents",
+    "model-agnostic",
+    "mcp",
+    "llm",
+    "sdk",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -3,6 +3,27 @@
   "version": "0.2.1",
   "private": true,
   "description": "TypeScript client for Ornn — the end-to-end skill life-cycle manager for AI agents",
+  "keywords": [
+    "ornn",
+    "agent",
+    "skill-registry",
+    "skill-lifecycle",
+    "ai-agents",
+    "model-agnostic",
+    "mcp",
+    "llm",
+    "sdk"
+  ],
+  "homepage": "https://github.com/ChronoAIProject/Ornn#readme",
+  "bugs": {
+    "url": "https://github.com/ChronoAIProject/Ornn/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ChronoAIProject/Ornn.git",
+    "directory": "sdk/typescript"
+  },
+  "license": "MIT",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",


### PR DESCRIPTION
Closes #468.

## What

Discovery-metadata pass on the two SDK manifests so npm + PyPI search land on the same vocabulary the project actually uses.

- `sdk/typescript/package.json` — adds `keywords` + the npm-page fields (`homepage`, `bugs`, `repository`, `license`). `private: true` left alone — npm publish strategy is the scope of #473, this PR is purely metadata.
- `sdk/python/pyproject.toml` — replaces the legacy keyword set with the aligned vocabulary.
- Keyword set across both SDKs: `ornn, agent, skill-registry, skill-lifecycle, ai-agents, model-agnostic, mcp, llm, sdk`.

GitHub repo topics will be set out-of-band via `gh repo edit` after merge:
`agent, skill-registry, ai-agents, model-agnostic, mcp, bun, hono, typescript`.

## Test plan

- [x] Pure metadata — no runtime/test impact
- [ ] CI green
- [ ] Post-merge: confirm repo topics applied