### PR TITLE
fix(api): Zod-validate LLM re-ranker output (#444)

### DIFF
--- a/.changeset/rerank-zod-444.md
+++ b/.changeset/rerank-zod-444.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Validate the LLM re-ranker response with Zod instead of an `as Array<...>` cast (#444). `JSON.parse(...) as Array<...>` is a runtime no-op; a malformed model response previously slipped through the GUID filter and broke downstream score arithmetic with `NaN`/`undefined`. The new `rerankResponseSchema` enforces `id` is a non-empty string and `score` is a finite number before the row reaches the filter; schema failures log a warning with the first three Zod issues and return the empty batch (same fail-safe as before, just observable now).

--- a/ornn-api/src/domains/skills/search/service.ts
+++ b/ornn-api/src/domains/skills/search/service.ts
@@ -9,6 +9,25 @@ import type { SkillRepository } from "../crud/repository";
 import type { NyxLlmClient } from "../../../clients/nyxid/llm";
 import type { SkillDocument, SkillSearchItem, SkillSearchResponse } from "../../../shared/types/index";
 import pino from "pino";
+import { z } from "zod";
+
+/**
+ * Shape the LLM re-ranker contract promises: an array of
+ * `{ id, score, reason? }` rows. Parsed with Zod (#444) instead of an
+ * `as` cast — `JSON.parse(...) as Array<...>` is a runtime no-op and
+ * a malformed model response previously slipped through the GUID
+ * filter and broke downstream score arithmetic with `NaN`.
+ *
+ * Rows with `score <= 0` are still dropped, but that filter is now
+ * applied after schema validation; the schema itself only enforces
+ * the shape.
+ */
+const rerankRowSchema = z.object({
+  id: z.string().min(1),
+  score: z.number().finite(),
+  reason: z.string().optional(),
+});
+const rerankResponseSchema = z.array(rerankRowSchema);
 
 /**
  * Per-item response enrichment context. The system-skill predicate is
@@ -323,12 +342,20 @@ ${JSON.stringify(skillList, null, 2)}`;
         return [];
       }
 
-      const parsed = JSON.parse(jsonMatch[0]) as Array<{ id: string; score: number; reason?: string }>;
+      const parseResult = rerankResponseSchema.safeParse(JSON.parse(jsonMatch[0]));
+      if (!parseResult.success) {
+        logger.warn(
+          { batchSize: batch.length, issues: parseResult.error.issues.slice(0, 3) },
+          "Semantic search: LLM output failed schema validation",
+        );
+        return [];
+      }
+      const parsed = parseResult.data;
 
       // Validate and map
       const validGuids = new Set(batch.map((s) => s.guid));
       return parsed
-        .filter((r) => validGuids.has(r.id) && typeof r.score === "number" && r.score > 0)
+        .filter((r) => validGuids.has(r.id) && r.score > 0)
         .map((r) => ({
           guid: r.id,
           score: Math.min(10, Math.max(0, r.score)),


### PR DESCRIPTION
Closes #444.

## What

The semantic-search re-ranker previously cast the LLM's JSON output with `JSON.parse(...) as Array<...>` — a runtime no-op. A malformed model response slipped through the GUID filter and broke downstream score arithmetic with `NaN`/`undefined`.

Replaces the cast with `rerankResponseSchema` (Zod). Schema failures log a warning with the first three Zod issues and return an empty batch — same fail-safe as before, just observable now.

## Test plan

- [x] `bun test src/domains/skills/search/` — 7/7 pass
- [ ] CI green