### PR TITLE
fix(web): harden ZIP validator with size cap + zip-slip check (#443)

### DIFF
--- a/.changeset/zip-validator-443.md
+++ b/.changeset/zip-validator-443.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Harden the client-side ZIP validator with two new guards (#443): (1) explicit zip-slip / unsafe-path rejection (entries with `..` segments, leading `/`, backslashes, or Windows drive letters) — defence-in-depth on top of JSZip's internal handling so a future unzip-library swap doesn't quietly turn into a path-traversal bug; (2) cumulative uncompressed-size cap (50 MB) read off `_data.uncompressedSize` during `forEach` so a zip-bomb never enters the extraction loop. New i18n keys `errors.zip.unsafePath` and `errors.zip.uncompressedTooLarge` (EN + ZH). 6 unit tests cover both guards.

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -1537,7 +1537,9 @@
       "unrecognizedDirs": "Unrecognized directories found: {{dirs}}. Only scripts/, references/, and assets/ are standard.",
       "frontmatterUnparseable": "Could not extract metadata from SKILL.md frontmatter. You may need to add or fix the YAML frontmatter block.",
       "onlyZipAccepted": "Only .zip files are accepted.",
-      "fileTooLarge": "File too large ({{size}})."
+      "fileTooLarge": "File too large ({{size}}).",
+      "unsafePath": "Unsafe path in ZIP entry: '{{path}}'. Paths may not contain '..', leading slashes, backslashes, or drive-letter prefixes.",
+      "uncompressedTooLarge": "ZIP expands to {{actual}} bytes, which exceeds the limit of {{max}} bytes."
     },
     "frontmatter": {
       "panelTitle": "Frontmatter Validation Errors",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -1537,7 +1537,9 @@
       "unrecognizedDirs": "存在未识别目录：{{dirs}}。仅允许 scripts/、references/、assets/。",
       "frontmatterUnparseable": "无法从 SKILL.md frontmatter 解析元数据。请检查并修复 YAML frontmatter 块。",
       "onlyZipAccepted": "仅接受 .zip 文件。",
-      "fileTooLarge": "文件过大（{{size}}）。"
+      "fileTooLarge": "文件过大（{{size}}）。",
+      "unsafePath": "ZIP 条目路径不安全：'{{path}}'。路径不允许包含 '..'、前导斜杠、反斜杠或盘符前缀。",
+      "uncompressedTooLarge": "ZIP 解压后达到 {{actual}} 字节，超过限制 {{max}} 字节。"
     },
     "frontmatter": {
       "panelTitle": "Frontmatter 校验错误",

--- a/ornn-web/src/utils/zipValidator.test.ts
+++ b/ornn-web/src/utils/zipValidator.test.ts
@@ -16,14 +16,6 @@ import {
   validateSkillZip,
 } from "./zipValidator";
 
-function fileFromZip(zip: JSZip, name = "skill.zip"): File {
-  // jsdom doesn't provide a real File constructor without a Blob shim
-  // — we construct from the underlying Uint8Array and trust the
-  // function only calls arrayBuffer() on it.
-  return new File([], name) as File & { arrayBuffer: () => Promise<ArrayBuffer> } &
-    { _zip: JSZip };
-}
-
 async function zipToFile(zip: JSZip): Promise<File> {
   const blob = await zip.generateAsync({ type: "blob" });
   return new File([blob], "skill.zip");

--- a/ornn-web/src/utils/zipValidator.test.ts
+++ b/ornn-web/src/utils/zipValidator.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the ZIP validator hardening landed in #443:
+ *
+ *   - cumulative uncompressed-size cap (zip-bomb defence)
+ *   - explicit zip-slip / unsafe-path rejection
+ *
+ * Pre-existing happy-path behaviour is exercised via the
+ * SkillUploadPage component tests; this file is scoped to the two
+ * new guards.
+ */
+
+import { describe, expect, test } from "vitest";
+import JSZip from "jszip";
+import {
+  MAX_TOTAL_UNCOMPRESSED_BYTES,
+  validateSkillZip,
+} from "./zipValidator";
+
+function fileFromZip(zip: JSZip, name = "skill.zip"): File {
+  // jsdom doesn't provide a real File constructor without a Blob shim
+  // — we construct from the underlying Uint8Array and trust the
+  // function only calls arrayBuffer() on it.
+  return new File([], name) as File & { arrayBuffer: () => Promise<ArrayBuffer> } &
+    { _zip: JSZip };
+}
+
+async function zipToFile(zip: JSZip): Promise<File> {
+  const blob = await zip.generateAsync({ type: "blob" });
+  return new File([blob], "skill.zip");
+}
+
+describe("validateSkillZip — zip-slip defence (#443)", () => {
+  test("rejects a path with .. segment", async () => {
+    const zip = new JSZip();
+    zip.file("SKILL.md", "---\nname: x\n---\nbody");
+    zip.file("../escape.txt", "i should not exist outside the skill dir");
+    const file = await zipToFile(zip);
+
+    const result = await validateSkillZip(file);
+    // JSZip normalises `../` at archive-write time, so the entry
+    // surfaces with the leading-slash form — the unsafe-path check
+    // still has to fire on the normalised path.
+    expect(result.status).toBe("invalid");
+    expect(result.errors[0]?.key).toBe("errors.zip.unsafePath");
+  });
+
+  test("rejects a path starting with /", async () => {
+    const zip = new JSZip();
+    zip.file("SKILL.md", "---\nname: x\n---\nbody");
+    zip.file("/etc/passwd", "root:x:0:0");
+    const file = await zipToFile(zip);
+
+    const result = await validateSkillZip(file);
+    expect(result.status).toBe("invalid");
+    expect(result.errors[0]?.key).toBe("errors.zip.unsafePath");
+  });
+
+  test("rejects a backslash path (Windows path separator)", async () => {
+    const zip = new JSZip();
+    zip.file("SKILL.md", "---\nname: x\n---\nbody");
+    zip.file("scripts\\nested\\evil.bat", "echo pwned");
+    const file = await zipToFile(zip);
+
+    const result = await validateSkillZip(file);
+    expect(result.status).toBe("invalid");
+    expect(result.errors[0]?.key).toBe("errors.zip.unsafePath");
+  });
+
+  test("rejects a Windows drive-letter prefix", async () => {
+    const zip = new JSZip();
+    zip.file("SKILL.md", "---\nname: x\n---\nbody");
+    // Use a backslash-free version since the backslash check fires first.
+    zip.file("C:/Windows/system32/evil.bat", "echo pwned");
+    const file = await zipToFile(zip);
+
+    const result = await validateSkillZip(file);
+    expect(result.status).toBe("invalid");
+    expect(result.errors[0]?.key).toBe("errors.zip.unsafePath");
+  });
+});
+
+describe("validateSkillZip — uncompressed-size cap (#443)", () => {
+  test("rejects when cumulative uncompressed bytes exceed the cap", async () => {
+    const zip = new JSZip();
+    zip.file("SKILL.md", "---\nname: x\n---\nbody");
+    // Single file just over the cap (highly compressible so the ZIP
+    // itself stays tiny — that's the bomb pattern).
+    const huge = "A".repeat(MAX_TOTAL_UNCOMPRESSED_BYTES + 1);
+    zip.file("references/huge.txt", huge);
+    const file = await zipToFile(zip);
+
+    const result = await validateSkillZip(file);
+    expect(result.status).toBe("invalid");
+    expect(result.errors[0]?.key).toBe("errors.zip.uncompressedTooLarge");
+    expect((result.errors[0]?.params?.max as number) ?? 0).toBe(
+      MAX_TOTAL_UNCOMPRESSED_BYTES,
+    );
+  });
+
+  test("accepts a ZIP comfortably under the cap", async () => {
+    const zip = new JSZip();
+    zip.file("SKILL.md", "---\nname: x\nversion: \"1.0\"\nmetadata:\n  category: text\n---\nbody");
+    zip.file("references/note.md", "small file");
+    const file = await zipToFile(zip);
+
+    const result = await validateSkillZip(file);
+    // The frontmatter parse warning is allowed; what we care about
+    // here is that the cap didn't fire.
+    expect(result.errors.find((e) => e.key === "errors.zip.uncompressedTooLarge")).toBeUndefined();
+  });
+});

--- a/ornn-web/src/utils/zipValidator.ts
+++ b/ornn-web/src/utils/zipValidator.ts
@@ -30,6 +30,37 @@ export interface ZipValidationResult {
 /** Recognized top-level directories in a skill package */
 const RECOGNIZED_DIRS = new Set(["scripts", "references", "assets"]);
 
+/**
+ * Cumulative uncompressed-size cap for a skill ZIP (#443). 50 MB is
+ * larger than any plausible legit skill package today; it caps zip-
+ * bomb expansion before we try to decompress every entry into memory.
+ */
+export const MAX_TOTAL_UNCOMPRESSED_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Explicit zip-slip / unsafe-path predicate (#443). JSZip handles
+ * traversal internally for `.file()` lookups, but the validator's path
+ * logic is string-prefix based; if JSZip's protection ever lapses or
+ * we switch unzip library, the existing code would happily resolve
+ * `../escape.txt` outside the skill directory. Cheap, explicit defence:
+ *
+ *   - reject any segment equal to `..`
+ *   - reject any path that starts with `/` (absolute) or contains `:`
+ *     (Windows drive prefix — `C:\\evil.bat`)
+ *   - reject backslash anywhere (PKZip allows them; some tooling treats
+ *     them as path separators after extraction)
+ */
+function isUnsafeEntryPath(rawPath: string): boolean {
+  if (rawPath.startsWith("/")) return true;
+  if (rawPath.includes("\\")) return true;
+  if (/^[A-Za-z]:/.test(rawPath)) return true;
+  const segments = rawPath.split("/");
+  for (const seg of segments) {
+    if (seg === "..") return true;
+  }
+  return false;
+}
+
 /** OS-generated junk files to filter out */
 const JUNK_FILE_NAMES = new Set([
   ".DS_Store",
@@ -152,12 +183,59 @@ export async function validateSkillZip(
     };
   }
 
-  // Collect all entries, filtering out OS junk files
+  // Collect all entries, filtering out OS junk files. Reject any entry
+  // whose path tries to escape the skill directory (#443) and bail
+  // when the cumulative uncompressed size exceeds the cap. Both checks
+  // run during forEach so we never enter the extraction loop on a
+  // hostile ZIP.
   const rawEntries: Array<{ path: string; dir: boolean }> = [];
+  let unsafePath: string | null = null;
+  let totalUncompressed = 0;
   zip.forEach((relativePath, entry) => {
     if (isJunkPath(relativePath)) return;
+    if (isUnsafeEntryPath(relativePath)) {
+      unsafePath = relativePath;
+      return;
+    }
+    // JSZip exposes uncompressed size through `_data.uncompressedSize`
+    // on the internal CompressedObject. Public API doesn't surface it
+    // pre-decompression; this is the only way to refuse a zip-bomb
+    // without first decompressing it.
+    const entryWithInternal = entry as unknown as {
+      _data?: { uncompressedSize?: number };
+    };
+    const uncompressed = entryWithInternal._data?.uncompressedSize ?? 0;
+    totalUncompressed += uncompressed;
     rawEntries.push({ path: relativePath, dir: entry.dir });
   });
+
+  if (unsafePath !== null) {
+    return {
+      status: "invalid",
+      files: [],
+      metadata: null,
+      errors: [{ key: "errors.zip.unsafePath", params: { path: unsafePath } }],
+      warnings: [],
+    };
+  }
+
+  if (totalUncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES) {
+    return {
+      status: "invalid",
+      files: [],
+      metadata: null,
+      errors: [
+        {
+          key: "errors.zip.uncompressedTooLarge",
+          params: {
+            actual: totalUncompressed,
+            max: MAX_TOTAL_UNCOMPRESSED_BYTES,
+          },
+        },
+      ],
+      warnings: [],
+    };
+  }
 
   const { normalized, prefix } = normalizeEntries(rawEntries);
 


### PR DESCRIPTION
Closes #443.

## What

Two defence-in-depth guards before the ZIP extraction loop:

1. **`isUnsafeEntryPath`** rejects entries with `..` segments, leading `/`, backslashes, or Windows drive-letter prefixes. JSZip handles traversal internally for `.file()` lookups, but the validator's path logic is string-prefix based; if JSZip's protection ever lapses or we swap unzip library, the existing code would happily resolve `../escape.txt` outside the skill directory.
2. **Cumulative uncompressed-size cap** (`MAX_TOTAL_UNCOMPRESSED_BYTES` = 50 MB), read off `_data.uncompressedSize` during `forEach`. The bomb never enters the extraction loop.

New i18n keys (EN + ZH): `errors.zip.unsafePath`, `errors.zip.uncompressedTooLarge`.

## Test plan

- [x] `cd ornn-web && bun run test src/utils/zipValidator.test.ts` — 6/6 pass
- [ ] CI green