### PR TITLE
fix(web): document or fix React keys on Array.map lists (#451)

### DIFF
--- a/.changeset/react-keys-451.md
+++ b/.changeset/react-keys-451.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Document or replace `key={i}` on `Array.map` lists across the web app (#451). Every site flagged in the audit was reviewed: positional lists that never reorder (skeleton cards, OTP cells, code-editor line numbers, table skeletons) keep `key={i}` but now carry a one-line comment so a future audit doesn't churn the file. Data-driven lists that can re-shape (RootLayout breadcrumbs, CreateSkillFreePage validation messages) switch to composite keys that include the data identity, so reconciliation doesn't preserve hover/focus state on the wrong element when the source array changes shape.

--- a/ornn-web/src/components/auth/OtpInput.tsx
+++ b/ornn-web/src/components/auth/OtpInput.tsx
@@ -25,6 +25,9 @@ export function OtpInput({ length = 6, onComplete, disabled, error }: OtpInputPr
   return (
     <div className="flex gap-2 justify-center">
       {Array.from({ length }).map((_, i) => (
+        // OTP cells are positional (cell N is always cell N); the parent
+        // never re-renders with a different `length`, so key={i} is
+        // intentional and reconciliation-stable (#451).
         <input
           key={i}
           type="text"

--- a/ornn-web/src/components/editor/CodeEditor.tsx
+++ b/ornn-web/src/components/editor/CodeEditor.tsx
@@ -195,6 +195,8 @@ function TextAreaEditor({ content, onChange, onSave, readOnly }: TextAreaEditorP
         className="shrink-0 w-12 py-4 pr-2 text-right border-r border-accent/10 bg-card/30 overflow-hidden select-none"
       >
         {Array.from({ length: lineCount }).map((_, i) => (
+          // Line numbers are positional (line N == row index N); never
+          // reorder, key={i} is intentional (#451).
           <div
             key={i}
             className="font-mono text-xs text-meta/50 leading-6 h-6"

--- a/ornn-web/src/components/layout/RootLayout.tsx
+++ b/ornn-web/src/components/layout/RootLayout.tsx
@@ -141,7 +141,11 @@ export function RootLayout() {
             {crumbs.map((crumb, i) => {
               const isLast = i === crumbs.length - 1;
               return (
-                <span key={i} className="flex items-center gap-2">
+                // Breadcrumbs can re-shape when the route changes — use
+                // the crumb destination as a stable key so reconciliation
+                // doesn't preserve hover/focus state on the wrong segment
+                // when the trail length changes (#451).
+                <span key={`${crumb.to ?? ""}-${crumb.label}`} className="flex items-center gap-2">
                   {i > 0 && (
                     <span className="text-meta opacity-50 select-none">/</span>
                   )}

--- a/ornn-web/src/components/skill/SkillGrid.tsx
+++ b/ornn-web/src/components/skill/SkillGrid.tsx
@@ -33,6 +33,7 @@ export function SkillGrid({ skills, isLoading, className = "" }: SkillGridProps)
     return (
       <div className={`grid gap-6 sm:grid-cols-2 lg:grid-cols-3 ${className}`}>
         {Array.from({ length: 6 }).map((_, i) => (
+          // Positional list — never reorders, key={i} is intentional (#451).
           <SkeletonCard key={i} />
         ))}
       </div>

--- a/ornn-web/src/components/ui/NeonSkeleton.tsx
+++ b/ornn-web/src/components/ui/NeonSkeleton.tsx
@@ -67,6 +67,7 @@ export function NeonSkeleton({
     return (
       <div className={`flex flex-col gap-2 ${className}`}>
         {Array.from({ length: lines }).map((_, i) => (
+          // Positional list — never reorders, key={i} is intentional (#451).
           <div
             key={i}
             className={`skeleton-shimmer ${VARIANT_STYLES[variant]}`}
@@ -141,6 +142,7 @@ export function TableRowSkeleton({ columns = 5, className = "" }: TableRowSkelet
   return (
     <tr className={className}>
       {Array.from({ length: columns }).map((_, i) => (
+        // Positional list — never reorders, key={i} is intentional (#451).
         <td key={i} className="px-4 py-3">
           <NeonSkeleton
             variant="text"
@@ -300,6 +302,7 @@ export function SkeletonGrid({ count = 6, columns = 3, className = "" }: Skeleto
   return (
     <div className={`grid gap-6 ${gridCols[columns]} ${className}`}>
       {Array.from({ length: count }).map((_, i) => (
+        // Positional list — never reorders, key={i} is intentional (#451).
         <SkillCardSkeleton key={i} />
       ))}
     </div>

--- a/ornn-web/src/pages/ExplorePage.tsx
+++ b/ornn-web/src/pages/ExplorePage.tsx
@@ -281,6 +281,7 @@ export function ExplorePage() {
             {activeLoading ? (
               <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3 pb-4">
                 {Array.from({ length: 6 }).map((_, i) => (
+                  // Positional list — never reorders, key={i} is intentional (#451).
                   <SkeletonCard key={i} />
                 ))}
               </div>

--- a/ornn-web/src/pages/skill/CreateSkillFreePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillFreePage.tsx
@@ -398,12 +398,15 @@ export function CreateSkillFreePage() {
             }`}
           >
             {validationResult.errors.map((err, i) => (
-              <p key={i} className="font-text text-sm text-danger">
+              // Each error key is unique per validation run; combining
+              // key with index defends against duplicate keys when the
+              // same error fires twice (#451).
+              <p key={`err-${i}-${err.key}`} className="font-text text-sm text-danger">
                 {t(err.key, err.params ?? {})}
               </p>
             ))}
             {validationResult.warnings.map((warn, i) => (
-              <p key={i} className="font-text text-sm text-warning">
+              <p key={`warn-${i}-${warn.key}`} className="font-text text-sm text-warning">
                 {t(warn.key, warn.params ?? {})}
               </p>
             ))}

--- a/ornn-web/src/pages/skill/MySkillsPage.tsx
+++ b/ornn-web/src/pages/skill/MySkillsPage.tsx
@@ -102,6 +102,7 @@ export function MySkillsPage() {
         {isLoading ? (
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 pb-4">
             {Array.from({ length: 6 }).map((_, i) => (
+              // Positional list — never reorders, key={i} is intentional (#451).
               <SkeletonCard key={i} />
             ))}
           </div>


### PR DESCRIPTION
Closes #451.

## What

Every `key={i}` site flagged in the audit was reviewed and either annotated or fixed:

**Documented (positional, never reorders)** — `key={i}` kept, one-line `// … (#451)` comment added:

- `components/ui/NeonSkeleton.tsx` (3 sites)
- `components/skill/SkillGrid.tsx`
- `components/auth/OtpInput.tsx`
- `components/editor/CodeEditor.tsx`
- `pages/ExplorePage.tsx`
- `pages/skill/MySkillsPage.tsx`

**Fixed (data-driven, can re-shape)**:

- `components/layout/RootLayout.tsx` breadcrumbs → `key={`${crumb.to}-${crumb.label}`}` so reconciliation doesn't preserve hover/focus on the wrong crumb when the route trail length changes.
- `pages/skill/CreateSkillFreePage.tsx` validation list → `key={`err-${i}-${err.key}`}` / `warn-…` so the same `i18n` key firing twice doesn't collide.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [ ] CI green