### PR TITLE
fix(web): silence auth/analytics/apiClient/activityApi logs in prod (#584)

### DIFF
--- a/.changeset/frontend-logger-584.md
+++ b/.changeset/frontend-logger-584.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Production-mode console silencing for auth + analytics + apiClient + activityApi (#584). Introduces `ornn-web/src/lib/logger.ts` — a `createLogger(tag)` factory that emits via `console` in development and no-ops in production. Replaces the four ad-hoc per-module loggers that previously leaked auth lifecycle metadata (refresh timing, token expiry, user ids) to browser devtools where it persisted across the session. Dev experience unchanged.

--- a/ornn-web/src/lib/analytics.ts
+++ b/ornn-web/src/lib/analytics.ts
@@ -23,15 +23,9 @@
 import posthog from "posthog-js";
 import { config } from "@/config";
 import { hasConsent, onConsentChange } from "./cookieConsent";
+import { createLogger } from "./logger";
 
-const logger = {
-  info: (msg: string, data?: Record<string, unknown>) =>
-    console.log(`[analytics] ${msg}`, data ?? ""),
-  warn: (msg: string, data?: Record<string, unknown>) =>
-    console.warn(`[analytics] ${msg}`, data ?? ""),
-  error: (msg: string, data?: Record<string, unknown>) =>
-    console.error(`[analytics] ${msg}`, data ?? ""),
-};
+const logger = createLogger("analytics");
 
 /**
  * Strongly-typed event names. Matches the spec in #252 — every call site

--- a/ornn-web/src/lib/logger.ts
+++ b/ornn-web/src/lib/logger.ts
@@ -1,0 +1,44 @@
+/**
+ * Frontend logger (#584).
+ *
+ * In **development** (`import.meta.env.MODE !== "production"`) every
+ * level forwards to the corresponding `console` method so debugging
+ * still works as before.
+ *
+ * In **production** all levels are no-ops. Auth lifecycle events,
+ * analytics ticks, and apiClient errors previously leaked token
+ * metadata (refresh timing, token expiry, auth user ids) to browser
+ * devtools where it persisted across the session.
+ *
+ * `error` is the only level that always logs in dev; in prod even
+ * errors are dropped — the right place for production error reporting
+ * is a real sink (Sentry-style) wired in separately, not browser
+ * devtools.
+ *
+ * Tags are required so the module of origin is visible in dev logs.
+ *
+ * @module lib/logger
+ */
+
+const IS_DEV = import.meta.env.MODE !== "production";
+
+export interface ScopedLogger {
+  info: (msg: string, data?: unknown) => void;
+  warn: (msg: string, data?: unknown) => void;
+  error: (msg: string, data?: unknown) => void;
+  debug: (msg: string, data?: unknown) => void;
+}
+
+export function createLogger(tag: string): ScopedLogger {
+  const prefix = `[${tag}]`;
+  if (!IS_DEV) {
+    const noop = () => {};
+    return { info: noop, warn: noop, error: noop, debug: noop };
+  }
+  return {
+    info: (msg, data) => console.log(`${prefix} ${msg}`, data ?? ""),
+    warn: (msg, data) => console.warn(`${prefix} ${msg}`, data ?? ""),
+    error: (msg, data) => console.error(`${prefix} ${msg}`, data ?? ""),
+    debug: (msg, data) => console.debug(`${prefix} ${msg}`, data ?? ""),
+  };
+}

--- a/ornn-web/src/services/activityApi.ts
+++ b/ornn-web/src/services/activityApi.ts
@@ -6,15 +6,10 @@
 
 import { useAuthStore } from "@/stores/authStore";
 import { config } from "@/config";
+import { createLogger } from "@/lib/logger";
 
 const API_BASE = config.apiBaseUrl;
-
-const logger = {
-  info: (msg: string, data?: Record<string, unknown>) =>
-    console.log(`[activityApi] ${msg}`, data ?? ""),
-  warn: (msg: string, data?: Record<string, unknown>) =>
-    console.warn(`[activityApi] ${msg}`, data ?? ""),
-};
+const logger = createLogger("activityApi");
 
 /**
  * Log a user activity (login or logout).

--- a/ornn-web/src/services/apiClient.ts
+++ b/ornn-web/src/services/apiClient.ts
@@ -8,12 +8,9 @@
 import type { ApiResponse } from "@/types/api";
 import { useAuthStore } from "@/stores/authStore";
 import { config } from "@/config";
+import { createLogger } from "@/lib/logger";
 
-const logger = {
-  error: (msg: string, data?: Record<string, unknown>) =>
-    console.error(`[apiClient] ${msg}`, data ?? ""),
-};
-
+const logger = createLogger("apiClient");
 const API_BASE = config.apiBaseUrl;
 
 /**

--- a/ornn-web/src/stores/authStore.ts
+++ b/ornn-web/src/stores/authStore.ts
@@ -8,13 +8,9 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { AuthUser, NyxIDTokenResponse, NyxIDJwtClaims, NyxIDIdTokenClaims } from "@/types/auth";
 import { config } from "@/config";
+import { createLogger } from "@/lib/logger";
 
-const logger = {
-  info: (msg: string, data?: Record<string, unknown>) =>
-    console.log(`[auth] ${msg}`, data ?? ""),
-  error: (msg: string, data?: Record<string, unknown>) =>
-    console.error(`[auth] ${msg}`, data ?? ""),
-};
+const logger = createLogger("auth");
 
 /** Refresh token 1 minute before expiry. */
 const TOKEN_REFRESH_BUFFER_MS = 60 * 1000;


### PR DESCRIPTION
Closes #584.

## What

Introduces `ornn-web/src/lib/logger.ts` — a `createLogger(tag)` factory that emits via `console` in development and no-ops in production. Migrates the four ad-hoc per-module loggers (`authStore`, `activityApi`, `apiClient`, `analytics`) that previously leaked auth lifecycle metadata to browser devtools.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [ ] CI green
- [ ] Manual: in dev, devtools console still shows tagged logs; production bundle silent