### PR TITLE
fix(api): enforce visibility check on /skills/:idOrName/json (#567)

### DIFF
--- a/.changeset/json-visibility-567.md
+++ b/.changeset/json-visibility-567.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Enforce per-skill visibility on `GET /skills/:idOrName/json` (#567). The endpoint previously gated only on `ornn:skill:read`, so a caller who knew a private skill's name could fetch its full package contents through this route — broader than `/skills/:idOrName`, which applies `canReadSkill`. Now the JSON route loads the skill first and runs the same visibility check (`canReadSkill` against `createdBy` / `sharedWithUsers` / `sharedWithOrgs` + platform-admin permission), returning `SKILL_NOT_FOUND` for inaccessible private skills. Closes the leak surfaced by the `aevatar` `/v1/responses` Ornn bridge.

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -503,6 +503,29 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     async (c) => {
       const idOrName = c.req.param("idOrName");
       logger.info({ idOrName }, "Skill jsonize request");
+
+      // Visibility check (#567) — the package contents endpoint must
+      // not be more permissive than the metadata endpoint. Load the
+      // skill first and reject inaccessible private skills with the
+      // same `SKILL_NOT_FOUND` shape `/skills/:idOrName` uses.
+      const skill = await skillService.getSkill(idOrName);
+      if (skill.isPrivate) {
+        const authCtx = c.get("auth");
+        // `requirePermission` above guarantees authCtx is set.
+        if (!authCtx) {
+          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        }
+        const memberships = await readUserOrgMemberships(c);
+        const actor = {
+          userId: authCtx.userId,
+          memberships,
+          isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+        };
+        if (!canReadSkill(skill, actor)) {
+          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        }
+      }
+
       const result = await skillService.getSkillJson(idOrName);
       // Programmatic pull — closest signal to the north-star metric.
       // Fire-and-forget; the analytics service swallows its own errors.


### PR DESCRIPTION
Closes #567.

## What

`GET /skills/:idOrName/json` previously gated only on `ornn:skill:read` — a caller who knew a private skill's name could fetch its full package contents through this route, broader than `/skills/:idOrName` (which applies `canReadSkill` against `createdBy` / `sharedWithUsers` / `sharedWithOrgs` + platform-admin permission).

Adds the same visibility check before the package download. Inaccessible private skills return `SKILL_NOT_FOUND` — same shape the metadata endpoint uses.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [ ] CI green
- [ ] Manual: caller with `ornn:skill:read` but no grant → 404 on private skill