### PR TITLE
refactor(web): route apiDelete through fetchWithRetry (#578)

### DIFF
--- a/.changeset/apidelete-dedup-578.md
+++ b/.changeset/apidelete-dedup-578.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Route `apiDelete` through `fetchWithRetry` (#578) so the proactive-refresh / 401-retry / redirect-to-login logic lives in one place instead of being copy-pasted between `GET/POST/PATCH/PUT` and DELETE. Behaviour-equivalent: DELETE still proactively refreshes, retries once on 401, redirects to `/login` if refresh fails, and surfaces non-2xx responses as `ApiClientError`. Only observable difference is the default error code on bodyless failures is now `UNKNOWN_ERROR` instead of `DELETE_FAILED` — that string was a dead default, no caller checks it.

--- a/ornn-web/src/services/apiClient.ts
+++ b/ornn-web/src/services/apiClient.ts
@@ -255,53 +255,17 @@ export async function apiPatch<T>(
 
 /**
  * DELETE request with auth.
+ *
+ * Routes through `fetchWithRetry` (#578) so the proactive-refresh /
+ * 401-retry / redirect-to-login logic stays in one place. The DELETE
+ * response is discarded — most ornn-api DELETEs return 204, and the
+ * caller only cares about success vs. an `ApiClientError`.
  */
 export async function apiDelete(path: string): Promise<void> {
-  // Proactively refresh expired tokens before sending
-  if (getAccessToken()) {
-    await useAuthStore.getState().ensureFreshToken();
-  }
-
-  const response = await fetch(buildUrl(path), {
+  await fetchWithRetry<unknown>(buildUrl(path), {
     method: "DELETE",
     headers: createHeaders(),
   });
-
-  // Handle 401 (not 403 — token refresh cannot resolve permission errors).
-  if (response.status === 401) {
-    const refreshSuccess = await attemptTokenRefresh();
-
-    if (refreshSuccess) {
-      const retryResponse = await fetch(buildUrl(path), {
-        method: "DELETE",
-        headers: createHeaders(),
-      });
-
-      if (!retryResponse.ok) {
-        const json = await retryResponse.json().catch(() => null);
-        throw new ApiClientError(
-          (json as ApiResponse<unknown>)?.error?.code ?? "DELETE_FAILED",
-          (json as ApiResponse<unknown>)?.error?.message ?? "Delete failed",
-          retryResponse.status,
-        );
-      }
-      return;
-    }
-
-    logger.error("Token refresh failed during DELETE, redirecting to login");
-    if (typeof window !== "undefined") {
-      window.location.href = "/login";
-    }
-  }
-
-  if (!response.ok) {
-    const json = await response.json().catch(() => null);
-    throw new ApiClientError(
-      (json as ApiResponse<unknown>)?.error?.code ?? "DELETE_FAILED",
-      (json as ApiResponse<unknown>)?.error?.message ?? "Delete failed",
-      response.status,
-    );
-  }
 }
 
 export { ApiClientError as ApiError };


### PR DESCRIPTION
Closes #578.

## What

`apiDelete` was a 45-line near-duplicate of the proactive-refresh + 401-retry + redirect-to-login pipeline that `fetchWithRetry` already implements for GET/POST/PATCH/PUT. Routes DELETE through the shared helper so the auth dance lives in one place.

Behaviour-equivalent. The only observable diff is the default error code on a bodyless DELETE failure: `UNKNOWN_ERROR` instead of `DELETE_FAILED` — that string was a dead default, grep shows no caller checks it.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [ ] CI green