### PR TITLE
fix(web): replace hardcoded hex colors on landing pages with tokens (#452)

### DIFF
--- a/.changeset/landing-tokens-452.md
+++ b/.changeset/landing-tokens-452.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Replace hardcoded hex literals on the landing pages with design tokens (#452). `PhoneMockup` (bezel edges, side buttons, camera lens) and `AnimatedTerminal` (traffic-light dots, terminal-output green) previously inlined `#1a1713`, `#2a2620`, `#0b1520`, `#3a5060`, `#c94a4a`, `#c9a64a`, `#5a9b5a`, `#7dc97d` in `bg-[…]` / `shadow-[…]` / arbitrary-gradient strings. Adds eight tokens under `@theme` in `neon.css` (`--color-bezel-edge`, `-rim`, `-lens-deep`, `-lens-rim`, `-traffic-{red,amber,green}`, `-terminal-ok`) and rewires both files to use the generated `bg-bezel-edge` / `text-terminal-ok` / `var(--color-…)` utilities. Visual output unchanged.

--- a/ornn-web/src/pages/landing/AnimatedTerminal.tsx
+++ b/ornn-web/src/pages/landing/AnimatedTerminal.tsx
@@ -6,9 +6,9 @@ const LINES: Line[] = [
   { t: 500, html: '<span class="text-ember">$</span> <span class="text-parchment">ornn-search-and-run</span> <span class="text-molten">"extract text from PDFs"</span>' },
   { t: 300, html: '<span class="text-ash">  ↳ querying registry...</span>' },
   { t: 400, html: '<span class="text-ash">  ↳ matched 3 candidates</span>' },
-  { t: 400, html: '<span class="text-[#7dc97d]">  ✓ pdf-extract</span>   <span class="text-ash">@chrono · v 2.0.1 · audited</span>' },
+  { t: 400, html: '<span class="text-terminal-ok">  ✓ pdf-extract</span>   <span class="text-ash">@chrono · v 2.0.1 · audited</span>' },
   { t: 300, html: '<span class="text-ash">  ↳ loading SKILL.md into Claude Code...</span>' },
-  { t: 400, html: '<span class="text-[#7dc97d]">  ✓ ready</span>          <span class="text-ash">~/.claude/skills/pdf-extract/</span>' },
+  { t: 400, html: '<span class="text-terminal-ok">  ✓ ready</span>          <span class="text-ash">~/.claude/skills/pdf-extract/</span>' },
   { t: 400, html: "" },
   { t: 200, html: '<span class="text-bone">agent-ready in <span class="text-molten">1.2s</span></span>' },
   { t: 600, html: '<span class="text-ember">$</span> <span class="inline-block h-3.5 w-2 bg-ember align-middle animate-blink"></span>' },
@@ -70,9 +70,9 @@ export function AnimatedTerminal() {
   return (
     <div className="card-letterpress overflow-hidden rounded-[4px] border border-[color:var(--color-border-strong)] [background-color:var(--surface-code)] font-mono text-[13px]">
       <div className="flex items-center gap-2 border-b border-[color:var(--color-border-subtle)] bg-graphite px-3.5 py-2.5">
-        <span className="h-[9px] w-[9px] rounded-full bg-[#c94a4a]" />
-        <span className="h-[9px] w-[9px] rounded-full bg-[#c9a64a]" />
-        <span className="h-[9px] w-[9px] rounded-full bg-[#5a9b5a]" />
+        <span className="h-[9px] w-[9px] rounded-full bg-traffic-red" />
+        <span className="h-[9px] w-[9px] rounded-full bg-traffic-amber" />
+        <span className="h-[9px] w-[9px] rounded-full bg-traffic-green" />
         <span className="ml-auto font-mono text-[11px] tracking-[0.12em] text-meta">
           ~/projects · ornn cli
         </span>

--- a/ornn-web/src/pages/landing/PhoneMockup.tsx
+++ b/ornn-web/src/pages/landing/PhoneMockup.tsx
@@ -26,17 +26,17 @@ export const PhoneMockup = forwardRef<HTMLDivElement, Props>(function PhoneMocku
     >
       <div
         ref={phoneRef}
-        className="group/phone relative z-10 w-[min(290px,100%)] aspect-[9/19] rounded-[44px] bg-obsidian px-[10px] py-[11px] shadow-[0_0_0_1.5px_#2a2620,inset_0_0_0_1px_rgb(255_255_255/0.04),inset_0_0_0_2px_rgb(0_0_0/0.9),12px_12px_0_0_var(--color-shadow-press)] [transform:perspective(1800px)_rotateY(-5deg)_rotateX(2deg)] [transform-origin:50%_50%] [transition:transform_0.6s_cubic-bezier(.2,.8,.3,1),filter_0.6s_ease] data-[settled=true]:[transform:perspective(1800px)_rotateY(0)_rotateX(0)] data-[dimmed=true]:brightness-[0.55] data-[dimmed=true]:saturate-[0.85] before:pointer-events-none before:absolute before:inset-0 before:z-[2] before:rounded-[44px] before:bg-[linear-gradient(135deg,rgb(255_255_255/0.06),rgb(255_255_255/0)_30%,rgb(255_255_255/0)_70%,rgb(255_255_255/0.04))]"
+        className="group/phone relative z-10 w-[min(290px,100%)] aspect-[9/19] rounded-[44px] bg-obsidian px-[10px] py-[11px] shadow-[0_0_0_1.5px_var(--color-bezel-rim),inset_0_0_0_1px_rgb(255_255_255/0.04),inset_0_0_0_2px_rgb(0_0_0/0.9),12px_12px_0_0_var(--color-shadow-press)] [transform:perspective(1800px)_rotateY(-5deg)_rotateX(2deg)] [transform-origin:50%_50%] [transition:transform_0.6s_cubic-bezier(.2,.8,.3,1),filter_0.6s_ease] data-[settled=true]:[transform:perspective(1800px)_rotateY(0)_rotateX(0)] data-[dimmed=true]:brightness-[0.55] data-[dimmed=true]:saturate-[0.85] before:pointer-events-none before:absolute before:inset-0 before:z-[2] before:rounded-[44px] before:bg-[linear-gradient(135deg,rgb(255_255_255/0.06),rgb(255_255_255/0)_30%,rgb(255_255_255/0)_70%,rgb(255_255_255/0.04))]"
       >
         {/* Side buttons on bezel edges */}
-        <span className="absolute -left-[3px] top-[92px] z-[3] h-6 w-[3px] rounded-l-[2px] bg-[#1a1713] shadow-[inset_0_1px_0_rgb(255_255_255/0.05),inset_0_-1px_0_rgb(0_0_0/0.6)]" />
-        <span className="absolute -left-[3px] top-[132px] z-[3] h-[46px] w-[3px] rounded-l-[2px] bg-[#1a1713] shadow-[inset_0_1px_0_rgb(255_255_255/0.05),inset_0_-1px_0_rgb(0_0_0/0.6)]" />
-        <span className="absolute -left-[3px] top-[190px] z-[3] h-[46px] w-[3px] rounded-l-[2px] bg-[#1a1713] shadow-[inset_0_1px_0_rgb(255_255_255/0.05),inset_0_-1px_0_rgb(0_0_0/0.6)]" />
-        <span className="absolute -right-[3px] top-[150px] z-[3] h-[68px] w-[3px] rounded-r-[2px] bg-[#1a1713] shadow-[inset_0_1px_0_rgb(255_255_255/0.05),inset_0_-1px_0_rgb(0_0_0/0.6)]" />
+        <span className="absolute -left-[3px] top-[92px] z-[3] h-6 w-[3px] rounded-l-[2px] bg-bezel-edge shadow-[inset_0_1px_0_rgb(255_255_255/0.05),inset_0_-1px_0_rgb(0_0_0/0.6)]" />
+        <span className="absolute -left-[3px] top-[132px] z-[3] h-[46px] w-[3px] rounded-l-[2px] bg-bezel-edge shadow-[inset_0_1px_0_rgb(255_255_255/0.05),inset_0_-1px_0_rgb(0_0_0/0.6)]" />
+        <span className="absolute -left-[3px] top-[190px] z-[3] h-[46px] w-[3px] rounded-l-[2px] bg-bezel-edge shadow-[inset_0_1px_0_rgb(255_255_255/0.05),inset_0_-1px_0_rgb(0_0_0/0.6)]" />
+        <span className="absolute -right-[3px] top-[150px] z-[3] h-[68px] w-[3px] rounded-r-[2px] bg-bezel-edge shadow-[inset_0_1px_0_rgb(255_255_255/0.05),inset_0_-1px_0_rgb(0_0_0/0.6)]" />
 
         <div className="relative h-full w-full overflow-hidden rounded-[34px] bg-obsidian shadow-[inset_0_0_0_1px_rgb(255_255_255/0.02)]">
           {/* Notch */}
-          <span className="absolute left-1/2 top-2.5 z-[4] h-[26px] w-[88px] -translate-x-1/2 rounded-[16px] bg-black shadow-[0_0_0_0.5px_#1a1713] after:absolute after:right-3 after:top-1/2 after:h-1.5 after:w-1.5 after:-translate-y-1/2 after:rounded-full after:content-[''] after:bg-[radial-gradient(circle_at_30%_30%,#3a5060,#0b1520)]" />
+          <span className="absolute left-1/2 top-2.5 z-[4] h-[26px] w-[88px] -translate-x-1/2 rounded-[16px] bg-black shadow-[0_0_0_0.5px_var(--color-bezel-edge)] after:absolute after:right-3 after:top-1/2 after:h-1.5 after:w-1.5 after:-translate-y-1/2 after:rounded-full after:content-[''] after:bg-[radial-gradient(circle_at_30%_30%,var(--color-lens-rim),var(--color-lens-deep))]" />
 
           {/* Status bar */}
           <div className="flex h-7 items-center justify-between px-[18px] pl-[22px] font-mono text-[10px] tracking-[0.08em] text-parchment">

--- a/ornn-web/src/styles/neon.css
+++ b/ornn-web/src/styles/neon.css
@@ -75,6 +75,19 @@ html {
   --color-arc-soft: rgba(91, 200, 232, 0.10);
   --color-ember-glow: rgba(255, 115, 34, 0.30);      /* hero floor / pulse glows */
 
+  /* Landing-chrome tokens (#452) — referenced from PhoneMockup and
+     AnimatedTerminal so hex literals stay out of JSX. Same values in
+     both themes: the macOS-style traffic-light dots and the phone
+     bezel shadows read consistently on either page background. */
+  --color-bezel-edge: #1A1713;                       /* phone side rails + lens depth shadow */
+  --color-bezel-rim: #2A2620;                        /* phone outer rim */
+  --color-lens-deep: #0B1520;                        /* camera-lens base */
+  --color-lens-rim: #3A5060;                         /* camera-lens specular */
+  --color-traffic-red: #C94A4A;
+  --color-traffic-amber: #C9A64A;
+  --color-traffic-green: #5A9B5A;
+  --color-terminal-ok: #7DC97D;                      /* terminal-output checkmark green */
+
   --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
   --font-text: "Inter", system-ui, sans-serif;
   --font-ui: "Inter", system-ui, sans-serif;


### PR DESCRIPTION
Closes #452.

## What

`PhoneMockup` + `AnimatedTerminal` previously inlined eight hex literals (`#1a1713`, `#2a2620`, `#0b1520`, `#3a5060`, `#c94a4a`, `#c9a64a`, `#5a9b5a`, `#7dc97d`) in `bg-[…]` / `shadow-[…]` / arbitrary-gradient strings, violating DESIGN.md "always use tokens".

Adds eight tokens under `@theme` in `neon.css` (`--color-bezel-edge`, `-rim`, `-lens-deep`, `-lens-rim`, `-traffic-{red,amber,green}`, `-terminal-ok`) and rewires both files. Pixel-identical output.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] No `#hexhex` literals remain in PhoneMockup/AnimatedTerminal
- [ ] CI green