### PR TITLE
fix(api): cap admin skill-search query time + index hot fields (#446)

### DIFF
--- a/.changeset/admin-search-cap-446.md
+++ b/.changeset/admin-search-cap-446.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add `maxTimeMS` + ensure indexes on admin skill search (#446). `GET /admin/skills?q=…` ran an escaped `$regex` against `name` and `description` with no time cap and no documented indexes — a crafted partial-match query on a large collection could pin a Mongo node's CPU indefinitely. Adds a 5 s `maxTimeMS` to both `countDocuments` + `find`, and a new `SkillRepository.ensureIndexes()` (wired into bootstrap) that creates `name` (unique), `description`, `createdBy + createdOn`, `createdOn`, and `isPrivate + createdOn` indexes — partial-regex still can't use a btree, but the secondary filters (`createdBy=…`, `isPrivate=…`) and the `createdOn` sort now hit indexes instead of a full collection scan.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -437,6 +437,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
 
   // ---- Repositories ----
   const skillRepo = new SkillRepository(db);
+  await skillRepo.ensureIndexes();
   const skillVersionRepo = new SkillVersionRepository(db);
   await skillVersionRepo.ensureIndexes();
 

--- a/ornn-api/src/domains/admin/routes.ts
+++ b/ornn-api/src/domains/admin/routes.ts
@@ -101,13 +101,21 @@ export function createAdminRoutes(config: AdminRoutesConfig): Hono<{ Variables: 
         ];
       }
 
-      const total = await skillCollection.countDocuments(filter);
+      // 5-second server-side wall clock (#446) — even with regex
+      // escaping, an unanchored partial-match on a large collection
+      // could pin a Mongo node's CPU. Better to return 500 than to
+      // hold a connection indefinitely.
+      const MAX_QUERY_MS = 5_000;
+      const total = await skillCollection.countDocuments(filter, {
+        maxTimeMS: MAX_QUERY_MS,
+      });
       const offset = (page - 1) * pageSize;
       const docs = await skillCollection
         .find(filter)
         .sort({ createdOn: -1 })
         .skip(offset)
         .limit(pageSize)
+        .maxTimeMS(MAX_QUERY_MS)
         .toArray();
 
       const items = docs.map((d) => ({

--- a/ornn-api/src/domains/skills/crud/repository.ts
+++ b/ornn-api/src/domains/skills/crud/repository.ts
@@ -97,6 +97,29 @@ export class SkillRepository {
     this.collection = db.collection("skills");
   }
 
+  /**
+   * Ensure indexes the skill collection relies on. Idempotent —
+   * MongoDB's createIndex is a no-op when the index already exists
+   * with the same key + options. Called from bootstrap on startup.
+   *
+   * The `name` + `description` indexes feed both the admin regex
+   * search (#446) and the keyword + skill-detail lookups in
+   * service.ts.
+   */
+  async ensureIndexes(): Promise<void> {
+    await Promise.all([
+      this.collection.createIndex({ name: 1 }, { unique: true }),
+      // Partial regex queries can't use a btree index on a long text
+      // field, but having the field indexed at all lets the query
+      // planner skip the COLLSCAN when the regex is anchored or when
+      // the secondary `createdBy` / `isPrivate` filter is present.
+      this.collection.createIndex({ description: 1 }),
+      this.collection.createIndex({ createdBy: 1, createdOn: -1 }),
+      this.collection.createIndex({ createdOn: -1 }),
+      this.collection.createIndex({ isPrivate: 1, createdOn: -1 }),
+    ]);
+  }
+
   async findByGuid(guid: string): Promise<SkillDocument | null> {
     const doc = await this.collection.findOne({ _id: guid as any });
     return mapDoc(doc);


### PR DESCRIPTION
Closes #446.

## What

`GET /admin/skills?q=…` ran an escaped `$regex` on `name` + `description` with no time cap and no documented indexes. Adds two guards:

1. **`maxTimeMS: 5000`** on both `countDocuments` + `find` — server-side wall clock so a hostile query can't pin a Mongo node.
2. **`SkillRepository.ensureIndexes()`** (wired into bootstrap, idempotent) creating `name` (unique), `description`, `createdBy + createdOn`, `createdOn`, and `isPrivate + createdOn`. Partial-regex still can't use a btree, but the secondary filters and the sort now hit indexes.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [ ] CI green
- [ ] Manual on prod: confirm index list via `db.skills.getIndexes()` post-deploy