### PR TITLE
docs: publish SDK_PUBLISHING.md + pre-publish install notes (#473)

### DIFF
--- a/.changeset/sdk-publish-strategy-473.md
+++ b/.changeset/sdk-publish-strategy-473.md
@@ -1,0 +1,4 @@
+---
+---
+
+Publishes `docs/SDK_PUBLISHING.md` (#473) — explicit decision to hold both `@chronoai/ornn-sdk` (npm) and `ornn-sdk` (PyPI) for v1.0 so the surface stops shifting under early adopters during alpha. Adds a v1 publish checklist (drop `private: true`, reserve registry names, extend changeset-release workflow with `npm publish` + `twine upload`, smoke-test on a clean machine) and a "pre-publish install from source" recipe for current users (`bun link` for TS, `pip install -e` / git-subdirectory for Python). Both SDK READMEs gain a "Status: pre-publish" banner pointing at the doc.

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Call Ornn directly from code. The SDKs wrap `/api/v1/*` and handle auth header i
 **TypeScript** ([`sdk/typescript`](sdk/typescript))
 
 ```bash
-# Pre-publish — install from this monorepo via your package manager's
-# workspace / git subdirectory mechanism. See #473 for npm publish status.
-npm install @chronoai/ornn-sdk
+# Pre-publish — install from this monorepo via `bun link` or
+# git-subdirectory pinning. See docs/SDK_PUBLISHING.md.
+bun add @chronoai/ornn-sdk
 ```
 
 ```ts

--- a/docs/SDK_PUBLISHING.md
+++ b/docs/SDK_PUBLISHING.md
@@ -1,0 +1,70 @@
+# SDK Publishing Strategy
+
+Current state of the TypeScript and Python SDKs on the public registries, and the path to v1 publish.
+
+## Status (2026-05)
+
+| Package | Registry name | Currently published? | Blocker |
+|---|---|:---:|---|
+| `@chronoai/ornn-sdk` | npm | **No** | `sdk/typescript/package.json` has `"private": true`. Removing the flag is the v1 step. |
+| `ornn-sdk` | PyPI | **No** | Not yet uploaded; name not reserved. |
+
+Until both ship, the SDKs are usable only from this monorepo. Consumers should pin to a specific git ref / tag and install from source — see [Pre-publish install](#pre-publish-install) below.
+
+This matches the project's overall posture: Ornn is in **alpha (0.x)** per [`docs/API_STABILITY.md`](API_STABILITY.md), and no SDK-shape compatibility guarantees apply yet. Publishing now would bake in surface decisions that may move at v1.
+
+## Decision
+
+**Hold both packages for v1.0.** Publishing while the SDK contract may still shift creates an upgrade-treadmill for early adopters; the v1 release will publish both packages on the same tag.
+
+The v1 release checklist (lives in milestone planning, not yet a doc):
+
+1. `sdk/typescript/package.json` — drop `"private": true`, confirm `keywords`/`repository`/`license` are set (already done in [#468](https://github.com/ChronoAIProject/Ornn/pull/589)).
+2. `sdk/python/pyproject.toml` — confirm `keywords`/`classifiers`/`urls` are set (already done in [#468](https://github.com/ChronoAIProject/Ornn/pull/589)).
+3. Reserve `@chronoai/ornn-sdk` on npm — owner: `chronoai`.
+4. Reserve `ornn-sdk` on PyPI — owner: `chronoai`.
+5. Extend `.github/workflows/changeset-release.yml` to run `npm publish --access public` on the TS workspace and `twine upload` on the Python wheel when the bump PR lands on `main`.
+6. Add the npm + PyPI tokens to org secrets.
+7. Cut v1.0 — verify both packages resolve, smoke-test `npm install @chronoai/ornn-sdk` and `pip install ornn-sdk` against a clean machine.
+
+## Pre-publish install
+
+Until v1 ships, both SDKs are install-from-source:
+
+### TypeScript
+
+This is a Bun workspace; consumers depending on `@chronoai/ornn-sdk` from another local checkout can use `bun link`:
+
+```bash
+# From inside this monorepo
+cd sdk/typescript
+bun link
+
+# From the consuming project
+bun link @chronoai/ornn-sdk
+```
+
+Or pin to the monorepo via your package manager's git-subdirectory support. Most clients reach for `npm install <git-url>#<commit>`; the workspace layout means you need a builder that understands monorepo subdirs (pnpm, bun, yarn-berry).
+
+### Python
+
+Install editable from this monorepo:
+
+```bash
+pip install -e ./sdk/python
+# or
+pip install "git+https://github.com/ChronoAIProject/Ornn.git#subdirectory=sdk/python"
+```
+
+The Python form works out of the box because `pyproject.toml` is hatch-built.
+
+## What does not change in alpha
+
+- The SDK surface is unstable; pin to a specific commit, not `develop`.
+- `OrnnError`, `OrnnClient`, the `.search()` / `.get()` / `.listVersions()` methods are the *intended* v1 surface — they may gain options but should not lose them.
+- Sample code in `examples/` always tracks the SDK on `develop`, not a published release. Use those examples as the canonical reference shape.
+
+## Open questions
+
+1. Will the TS SDK be ESM-only or dual ESM+CJS at v1? Current source is ESM (`"type": "module"`); the publish step needs to decide whether to ship CJS too.
+2. PyPI name `ornn-sdk` is unreserved. We should reserve it before someone else does, even if we hold publication. (Tracked separately.)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -8,6 +8,18 @@ Wraps the `/api/v1/*` HTTP surface with auth injection, response-envelope unwrap
 
 ## Install
 
+> **Status: pre-publish.** Not yet on PyPI — both SDKs are held for v1.0 so the surface stops shifting under early adopters. See [`docs/SDK_PUBLISHING.md`](../../docs/SDK_PUBLISHING.md) and [#473](https://github.com/ChronoAIProject/Ornn/issues/473).
+
+Until v1 ships, install editable from source:
+
+```bash
+pip install -e ./sdk/python
+# or pin via git
+pip install "git+https://github.com/ChronoAIProject/Ornn.git#subdirectory=sdk/python"
+```
+
+Once v1 publishes:
+
 ```bash
 pip install ornn-sdk
 # or with uv / poetry / pdm — whichever you prefer

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -8,7 +8,20 @@ Wraps the `/api/v1/*` HTTP surface with auth injection, response-envelope unwrap
 
 ## Install
 
-This package lives inside the Ornn monorepo. Once published to npm:
+> **Status: pre-publish.** Not yet on npm — both SDKs are held for v1.0 so the surface stops shifting under early adopters. See [`docs/SDK_PUBLISHING.md`](../../docs/SDK_PUBLISHING.md) and [#473](https://github.com/ChronoAIProject/Ornn/issues/473).
+
+Until v1 ships, install from source via `bun link`:
+
+```bash
+# Inside the Ornn monorepo
+cd sdk/typescript
+bun link
+
+# Then in the consuming project
+bun link @chronoai/ornn-sdk
+```
+
+After v1 publishes:
 
 ```bash
 bun add @chronoai/ornn-sdk


### PR DESCRIPTION
Closes #473.

## What

Makes the SDK publish decision explicit + actionable:

- New `docs/SDK_PUBLISHING.md` — current status table per registry, the decision (**hold both for v1.0** so alpha surface doesn't start an upgrade-treadmill), v1 publish checklist, and pre-publish install recipes.
- `sdk/typescript/README.md` + `sdk/python/README.md` — "Status: pre-publish" banner up top, `bun link` / `pip install -e` install paths that actually work today, post-v1 paths kept for reference.
- Main `README.md` SDK quickstart — install caveat now points at `SDK_PUBLISHING.md` instead of the bare `#473` reference.

## Test plan

- [x] All in-doc links resolve
- [ ] CI green