### PR TITLE
ci(python-sdk): add ruff + mypy gates, clean up flagged code (#583)

### DIFF
--- a/.changeset/python-sdk-ruff-mypy-583.md
+++ b/.changeset/python-sdk-ruff-mypy-583.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add ruff + mypy gates to the Python SDK CI job (#583). `python-sdk-test` previously only ran pytest with respx mocking — lint + type errors could land on develop without detection. Adds ruff config (E/W/F/I/B/UP + per-file exceptions for tests) and a strict-mypy config (boundary `Any` from httpx/respx allowed, internal code stays strict). CI runs `ruff check`, `ruff format --check`, and `mypy` before pytest. Source edits to satisfy the new gates: drop unused `httpx` import in a test fixture, split one over-long line, cast `httpx.Response.content` to `bytes` (typeshed annotates it as `Any`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Install ornn-sdk (python)
         working-directory: sdk/python
         run: pip install -e ".[dev]"
+      - name: Lint (ruff)
+        working-directory: sdk/python
+        run: ruff check .
+      - name: Format check (ruff)
+        working-directory: sdk/python
+        run: ruff format --check .
+      - name: Type check (mypy)
+        working-directory: sdk/python
+        run: mypy
       - name: Run pytest
         working-directory: sdk/python
         run: pytest -q

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -44,6 +44,8 @@ dev = [
     "pytest>=9.0.3,<10",
     "respx>=0.21,<1.0",
     "pytest-asyncio>=0.23,<2.0",
+    "ruff>=0.6",
+    "mypy>=1.11",
 ]
 
 [project.urls]
@@ -56,3 +58,50 @@ packages = ["src/ornn_sdk"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+# ──────────────── ruff (#583) ────────────────
+# Lint + format the SDK. Default ruleset (E, W, F) + isort (I) + a few
+# refinements that catch the bugs we'd actually see in a thin HTTP
+# client: pyflakes is the floor, bugbear catches misuse, pyupgrade
+# keeps us on modern Python.
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "UP"]
+ignore = [
+    # pytest fixtures legitimately use names that shadow outer scope.
+    "F811",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    # Test fixtures shadow names freely; allowed.
+    "F811",
+    # Tests use long mock data strings.
+    "E501",
+]
+
+# ──────────────── mypy (#583) ────────────────
+# Strict-ish gate on the SDK surface; the public client is the one
+# place we cannot let type drift go unobserved. Tests run in a looser
+# config because respx fixtures are dynamically typed.
+[tool.mypy]
+python_version = "3.10"
+files = ["src"]
+strict = true
+# `Any` from upstream (httpx, respx) is expected at the boundary;
+# our internal code stays strict.
+disallow_any_unimported = false
+warn_unused_ignores = true
+show_error_codes = true
+# httpx ships its own inline types; older typeshed stubs may not
+# expose every method. Permit the import without per-line ignores.
+[[tool.mypy.overrides]]
+module = "httpx.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+ignore_errors = true

--- a/sdk/python/src/ornn_sdk/client.py
+++ b/sdk/python/src/ornn_sdk/client.py
@@ -80,7 +80,7 @@ class OrnnClient:
     def close(self) -> None:
         self._http.close()
 
-    def __enter__(self) -> "OrnnClient":
+    def __enter__(self) -> OrnnClient:
         return self
 
     def __exit__(self, *_: Any) -> None:
@@ -138,10 +138,14 @@ class OrnnClient:
 
     def download_package(self, guid: str, version: str) -> bytes:
         """Download a skill package ZIP. Returns raw bytes."""
-        res = self._raw_request("GET", f"/skills/{_quote(guid)}/versions/{_quote(version)}/download")
+        path = f"/skills/{_quote(guid)}/versions/{_quote(version)}/download"
+        res = self._raw_request("GET", path)
         if res.status_code >= 400:
             raise _build_error(res)
-        return res.content
+        # httpx exposes res.content as bytes at runtime; the typeshed
+        # stub annotates it as Any. Cast explicitly so strict mypy is
+        # happy without disabling the rule.
+        return bytes(res.content)
 
     def publish(self, zip_bytes: bytes, *, skip_validation: bool = False) -> SkillDetail:
         """Publish a new skill from a ZIP package (raw bytes)."""

--- a/sdk/python/src/ornn_sdk/types.py
+++ b/sdk/python/src/ornn_sdk/types.py
@@ -35,7 +35,7 @@ class SkillSummary:
     _extra: dict[str, Any] = field(default_factory=dict, repr=False)
 
     @classmethod
-    def from_dict(cls, raw: dict[str, Any]) -> "SkillSummary":
+    def from_dict(cls, raw: dict[str, Any]) -> SkillSummary:
         known = {
             "id",
             "name",
@@ -72,7 +72,7 @@ class SkillDetail(SkillSummary):
     shared_with_orgs: list[str] = field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, raw: dict[str, Any]) -> "SkillDetail":
+    def from_dict(cls, raw: dict[str, Any]) -> SkillDetail:
         base = SkillSummary.from_dict(raw).__dict__
         base.pop("_extra")
         known_extra = {"ownerId", "storageKey", "sharedWithUsers", "sharedWithOrgs"}
@@ -88,11 +88,7 @@ class SkillDetail(SkillSummary):
             "latestVersion",
             "metadata",
         }
-        extra = {
-            k: v
-            for k, v in raw.items()
-            if k not in summary_known and k not in known_extra
-        }
+        extra = {k: v for k, v in raw.items() if k not in summary_known and k not in known_extra}
         return cls(
             **base,
             owner_id=raw.get("ownerId", ""),
@@ -113,7 +109,7 @@ class SkillVersionEntry:
     deprecation_note: str | None = None
 
     @classmethod
-    def from_dict(cls, raw: dict[str, Any]) -> "SkillVersionEntry":
+    def from_dict(cls, raw: dict[str, Any]) -> SkillVersionEntry:
         return cls(
             version=raw["version"],
             created_on=raw.get("createdOn", ""),
@@ -134,7 +130,7 @@ class SkillSearchResult:
     mode: str | None = None
 
     @classmethod
-    def from_dict(cls, raw: dict[str, Any]) -> "SkillSearchResult":
+    def from_dict(cls, raw: dict[str, Any]) -> SkillSearchResult:
         return cls(
             items=[SkillSummary.from_dict(i) for i in raw.get("items") or []],
             total=int(raw.get("total", 0)),

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import httpx
 import pytest
 import respx
 
@@ -13,7 +12,6 @@ from ornn_sdk import (
     SkillSearchResult,
     UpdateSkillMetadata,
 )
-
 
 BASE = "https://ornn.example.com"
 
@@ -44,9 +42,7 @@ class TestAuth:
 
     @respx.mock
     def test_resolver_takes_precedence(self) -> None:
-        route = respx.get(f"{BASE}/api/v1/me").respond(
-            200, json={"data": {}, "error": None}
-        )
+        route = respx.get(f"{BASE}/api/v1/me").respond(200, json={"data": {}, "error": None})
         with make_client(
             token="tok_static",
             token_resolver=lambda: "tok_dynamic",
@@ -56,9 +52,7 @@ class TestAuth:
 
     @respx.mock
     def test_no_auth_header_when_no_token(self) -> None:
-        route = respx.get(f"{BASE}/api/v1/public").respond(
-            200, json={"data": {}, "error": None}
-        )
+        route = respx.get(f"{BASE}/api/v1/public").respond(200, json={"data": {}, "error": None})
         with make_client() as ornn:
             ornn.request("GET", "/public")
         assert "authorization" not in route.calls.last.request.headers


### PR DESCRIPTION
Closes #583.

## What

`python-sdk-test` previously only ran pytest. Lint + type errors could land on develop undetected.

- `pyproject.toml` — add ruff (E/W/F/I/B/UP) + strict-mypy config; tests are looser per `[tool.mypy.overrides]`.
- `.github/workflows/ci.yml` — `python-sdk-test` runs `ruff check`, `ruff format --check`, `mypy` before pytest. Separate steps so the PR check view shows which gate failed.
- Source edits to clear the new gates: drop unused `httpx` import in a test fixture, split one over-long line, cast `httpx.Response.content` → `bytes`.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy` — clean
- [ ] CI green