### PR TITLE
feat!: lowercase_snake_case error codes (#585)

### DIFF
--- a/.changeset/lowercase-error-codes-585.md
+++ b/.changeset/lowercase-error-codes-585.md
@@ -1,0 +1,8 @@
+---
+"ornn-api": minor
+"ornn-web": patch
+---
+
+**BREAKING:** every error `code` emitted by `/api/v1/*` is now `lowercase_snake_case` per CONVENTIONS.md §1.4 (#585). `SKILL_NOT_FOUND` → `skill_not_found`, `INVALID_BODY` → `invalid_body`, `FORBIDDEN` → `forbidden`, etc. One-for-one lowercase translation: every existing code keeps its specificity, the parent §1.4 catalog (`validation_error`, `permission_denied`, `resource_not_found`, …) is the taxonomy these subcodes hang under. Clients pinned to the old strings need to switch — `docs/ERRORS.md` ships the full migration map.
+
+Web call sites that branch on specific codes (`AGENTSEAL_DISABLED`, `OLD_REPO_NOT_CONFIRMED`, `AUDIT_NOT_FOUND`) migrated to the lowercase equivalents in the same PR. No code-aware logic in the published SDK code paths today, so SDK consumers only need to update their own catch-by-code handlers.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -8,7 +8,9 @@ type: https://github.com/ChronoAIProject/Ornn/blob/main/docs/ERRORS.md#<code>
 
 The catalog is normative — handlers MUST NOT invent new codes. Adding or renaming a code requires updating this doc and `docs/CONVENTIONS.md` §1.4 in the same PR.
 
-> **Note — code-case migration.** [`docs/CONVENTIONS.md`](CONVENTIONS.md) §1.4 mandates `lowercase_snake_case` codes; the current implementation still emits `SCREAMING_SNAKE_CASE`. Tracked in [#585](https://github.com/ChronoAIProject/Ornn/issues/585). Until that lands, headings below show **both** forms so an anchor link works no matter which the server emitted today.
+All codes are `lowercase_snake_case` per CONVENTIONS.md §1.4. The §1.4 catalog defines the **parent** taxonomy (`validation_error`, `permission_denied`, `resource_not_found`, …); specific subcodes (e.g. `skill_not_found` under `resource_not_found`) live under the parent's section here and follow the same lowercase format.
+
+The pre-#585 `SCREAMING_SNAKE_CASE` shape (`SKILL_NOT_FOUND`, `INVALID_BODY`, …) is no longer emitted. Clients that pinned to those strings need to switch to the lowercase form on the next SDK bump.
 
 ---
 
@@ -27,14 +29,14 @@ The catalog is normative — handlers MUST NOT invent new codes. Adding or renam
 - 500 — [`internal_error`](#internal_error)
 - 502 / 503 — [`upstream_unavailable`](#upstream_unavailable)
 
-**Implementation-code appendix** — every `SCREAMING_SNAKE_CASE` code currently emitted by the server, with the target lowercase code it maps to: [Appendix](#appendix-current-implementation-codes).
+**Pre-#585 migration map** — every `SCREAMING_SNAKE_CASE` code clients used to receive, with the new `lowercase_snake_case` it became: [Appendix](#appendix-pre-585-migration-map).
 
 ---
 
 ## validation_error
 
 **HTTP:** `400 Bad Request`
-**Current code (pre-#585):** `INVALID_BODY`, `INVALID_QUERY`, `INVALID_PARAMS`, `INVALID_CONTENT_TYPE`, `INVALID_*`, `EMPTY_BODY`, `MISSING_*`, `FRONTMATTER_VALIDATION_FAILED`, `INVALID_PERMISSIONS`, …
+**Common subcodes (lowercase post-#585):** `invalid_body`, `invalid_query`, `invalid_params`, `invalid_*` (per-field), `empty_body`, `missing_*`, `frontmatter_validation_failed`, `invalid_permissions`, …
 
 Request body, query string, or path parameter failed validation. Per-field details are in `errors[]`.
 
@@ -62,7 +64,7 @@ Content-Type: application/problem+json
 ## authentication_required
 
 **HTTP:** `401 Unauthorized`
-**Current code (pre-#585):** `AUTH_MISSING`, `AUTH_INVALID`
+**Common subcodes (lowercase post-#585):** `auth_missing`, `auth_invalid`
 
 No identity could be resolved from the request — either no `Authorization` header, an unparseable header, or the token is expired / revoked.
 
@@ -73,7 +75,7 @@ No identity could be resolved from the request — either no `Authorization` hea
 ## permission_denied
 
 **HTTP:** `403 Forbidden`
-**Current code (pre-#585):** `FORBIDDEN`, `INSUFFICIENT_PERMISSIONS`
+**Common subcodes (lowercase post-#585):** `forbidden`, `insufficient_permissions`
 
 The caller is authenticated but lacks the permission required for this resource or action. The response `detail` names the missing permission when safe to disclose.
 
@@ -84,7 +86,7 @@ The caller is authenticated but lacks the permission required for this resource 
 ## resource_not_found
 
 **HTTP:** `404 Not Found`
-**Current code (pre-#585):** `SKILL_NOT_FOUND`, `SKILL_VERSION_NOT_FOUND`, `ORG_NOT_FOUND`, `PROVIDER_NOT_FOUND`, `ANNOUNCEMENT_NOT_FOUND`, `BROADCAST_NOT_FOUND`, `NOTIFICATION_NOT_FOUND`, `AUDIT_NOT_FOUND`, `REDEMPTION_CODE_NOT_FOUND`, …
+**Common subcodes (lowercase post-#585):** `skill_not_found`, `skill_version_not_found`, `org_not_found`, `provider_not_found`, `announcement_not_found`, `broadcast_not_found`, `notification_not_found`, `audit_not_found`, `redemption_code_not_found`, …
 
 The target resource does not exist, **or** it exists but is not visible to the caller (private skill outside their access scope). The two cases are intentionally not distinguished — disclosing existence is itself information.
 
@@ -95,7 +97,7 @@ The target resource does not exist, **or** it exists but is not visible to the c
 ## resource_conflict
 
 **HTTP:** `409 Conflict`
-**Current code (pre-#585):** `SKILL_NAME_EXISTS`, `NAME_CONFLICT`, `VERSION_CONFLICT`, `RECONCILE_ALREADY_RUNNING`, …
+**Common subcodes (lowercase post-#585):** `skill_name_exists`, `reconcile_already_running`, `redemption_code_expired`, `redemption_code_already_redeemed`, `redemption_code_already_invalidated`, `old_repo_not_confirmed`, …
 
 The request collides with current state — a duplicate skill name on create, a concurrent modification, a job that's already running, etc.
 
@@ -106,7 +108,7 @@ The request collides with current state — a duplicate skill name on create, a 
 ## payload_too_large
 
 **HTTP:** `413 Payload Too Large`
-**Current code (pre-#585):** `PAYLOAD_TOO_LARGE`
+**Common subcodes (lowercase post-#585):** `payload_too_large`
 
 The upload exceeds the per-endpoint size cap (currently 5 MB on `/skills` upload; see `ornn-api/src/middleware/uploadLimit.ts`).
 
@@ -117,7 +119,7 @@ The upload exceeds the per-endpoint size cap (currently 5 MB on `/skills` upload
 ## unsupported_media_type
 
 **HTTP:** `415 Unsupported Media Type`
-**Current code (pre-#585):** `INVALID_CONTENT_TYPE`
+**Common subcodes (lowercase post-#585):** `invalid_content_type`
 
 The `Content-Type` header is missing or names a representation this endpoint does not accept. Skill upload requires `application/zip`; most write endpoints require `application/json`.
 
@@ -128,7 +130,7 @@ The `Content-Type` header is missing or names a representation this endpoint doe
 ## rate_limited
 
 **HTTP:** `429 Too Many Requests`
-**Current code (pre-#585):** *not yet emitted — see [#439](https://github.com/ChronoAIProject/Ornn/issues/439) (rate limit middleware).*
+**Common subcodes (lowercase post-#585):** *not yet emitted — see [#439](https://github.com/ChronoAIProject/Ornn/issues/439) (rate limit middleware).*
 
 Caller exceeded a rate limit (per-IP for unauthenticated routes, per-user for authenticated). Once [#460](https://github.com/ChronoAIProject/Ornn/issues/460) lands, response will also include the standard RFC 9239 headers (`RateLimit-Limit`, `RateLimit-Remaining`, `Retry-After`).
 
@@ -139,7 +141,7 @@ Caller exceeded a rate limit (per-IP for unauthenticated routes, per-user for au
 ## internal_error
 
 **HTTP:** `500 Internal Server Error`
-**Current code (pre-#585):** `INTERNAL_ERROR`, `INTERNAL`
+**Common subcodes (lowercase post-#585):** `internal_error`
 
 Unhandled server error — should never appear under normal operation. The `requestId` is the load-bearing field for log correlation.
 
@@ -150,7 +152,7 @@ Unhandled server error — should never appear under normal operation. The `requ
 ## upstream_unavailable
 
 **HTTP:** `502 Bad Gateway` / `503 Service Unavailable`
-**Current code (pre-#585):** `UPSTREAM_DOWN`, `MIRROR_DISABLED`, `AGENTSEAL_DISABLED`, `PULL_FAILED`, `REPO_FETCH_FAILED`, …
+**Common subcodes (lowercase post-#585):** `upstream_down`, `mirror_disabled`, `agentseal_disabled`, `pull_failed`, `repo_fetch_failed`, `refresh_failed`, `refresh_preview_failed`, `auth_service_error`, `audit_package_unavailable`, `package_download_failed`, …
 
 A dependency Ornn relies on (NyxID, OpenSandbox, LLM provider, mirror target, …) is unavailable or refused the request. Distinct from `internal_error` — Ornn itself is fine but couldn't complete the work.
 
@@ -158,47 +160,44 @@ A dependency Ornn relies on (NyxID, OpenSandbox, LLM provider, mirror target, �
 
 ---
 
-## Appendix: current implementation codes
+## Appendix: pre-#585 migration map
 
-The table below maps every `SCREAMING_SNAKE_CASE` code currently emitted by the server to its target lowercase code from `docs/CONVENTIONS.md` §1.4. Tracking renames lives in [#585](https://github.com/ChronoAIProject/Ornn/issues/585).
+Clients pinned to the old `SCREAMING_SNAKE_CASE` codes need to switch to the lowercase forms below. Every code is now a one-for-one lowercase translation — the §1.4 parent category is the same.
 
-| Current code | HTTP | Target |
-|---|---|---|
-| `AGENTSEAL_DISABLED` | 503 | `upstream_unavailable` |
-| `ANNOUNCEMENT_NOT_FOUND` | 404 | `resource_not_found` |
-| `AUDIT_NOT_FOUND` | 404 | `resource_not_found` |
-| `AUTH_INVALID` | 401 | `authentication_required` |
-| `AUTH_MISSING` | 401 | `authentication_required` |
-| `BROADCAST_NOT_FOUND` | 404 | `resource_not_found` |
-| `EMPTY_BODY` | 400 | `validation_error` |
-| `EMPTY_SOURCE` | 400 | `validation_error` |
-| `FORBIDDEN` | 403 | `permission_denied` |
-| `FRONTMATTER_VALIDATION_FAILED` | 400 | `validation_error` |
-| `INSUFFICIENT_PERMISSIONS` | 403 | `permission_denied` |
-| `INTERNAL` | 500 | `internal_error` |
-| `INTERNAL_ERROR` | 500 | `internal_error` |
-| `INVALID_*` (`_ANNOUNCEMENT_INPUT`, `_BODY`, `_CONTENT_TYPE`, `_GRANT_AMOUNT`, `_PERMISSIONS`, `_PROVIDER_INPUT`, `_RANGE`, `_REDEMPTION_CODE_BODY`, `_REDEMPTION_CODE_ID`, `_ROLE`, `_SCOPE`, `_SETTING`, `_SURFACE`, `_USER_ID`, `_VERSION`, `_PARAMS`, `_QUERY`) | 400 / 415 | `validation_error` / `unsupported_media_type` |
-| `MIRROR_DISABLED` | 503 | `upstream_unavailable` |
-| `MISSING_FRONTMATTER` | 400 | `validation_error` |
-| `MISSING_PROMPT` | 400 | `validation_error` |
-| `MISSING_SKILL_MD` | 400 | `validation_error` |
-| `MISSING_SPEC` | 400 | `validation_error` |
-| `NOTIFICATION_NOT_FOUND` | 404 | `resource_not_found` |
-| `NO_UPDATE` | 400 | `validation_error` |
-| `ORG_NOT_FOUND` | 404 | `resource_not_found` |
-| `PAYLOAD_TOO_LARGE` | 413 | `payload_too_large` |
-| `PROVIDER_NOT_FOUND` | 404 | `resource_not_found` |
-| `PULL_FAILED` | 502 | `upstream_unavailable` |
-| `QUOTA_EXCEEDED` | 429 | `rate_limited` |
-| `RECONCILE_ALREADY_RUNNING` | 409 | `resource_conflict` |
-| `REDEMPTION_CODE_EXPIRED` | 409 | `resource_conflict` |
-| `REDEMPTION_CODE_NOT_FOUND` | 404 | `resource_not_found` |
-| `REFRESH_FAILED` | 502 | `upstream_unavailable` |
-| `REFRESH_PREVIEW_FAILED` | 502 | `upstream_unavailable` |
-| `REPO_FETCH_FAILED` | 502 | `upstream_unavailable` |
-| `SKILL_NAME_EXISTS` | 409 | `resource_conflict` |
-| `SKILL_NOT_FOUND` | 404 | `resource_not_found` |
-| `SKILL_VERSION_NOT_FOUND` | 404 | `resource_not_found` |
-| `UPSTREAM_DOWN` | 502 | `upstream_unavailable` |
+| Pre-#585 code | HTTP | New code | §1.4 parent |
+|---|---|---|---|
+| `AGENTSEAL_DISABLED` | 503 | `agentseal_disabled` | `upstream_unavailable` |
+| `ANNOUNCEMENT_NOT_FOUND` | 404 | `announcement_not_found` | `resource_not_found` |
+| `AUDIT_NOT_FOUND` | 404 | `audit_not_found` | `resource_not_found` |
+| `AUTH_INVALID` | 401 | `auth_invalid` | `authentication_required` |
+| `AUTH_MISSING` | 401 | `auth_missing` | `authentication_required` |
+| `AUTH_SERVICE_ERROR` | 503 | `auth_service_error` | `upstream_unavailable` |
+| `BROADCAST_NOT_FOUND` | 404 | `broadcast_not_found` | `resource_not_found` |
+| `EMPTY_BODY` | 400 | `empty_body` | `validation_error` |
+| `EMPTY_SOURCE` | 400 | `empty_source` | `validation_error` |
+| `FORBIDDEN` | 403 | `forbidden` | `permission_denied` |
+| `FRONTMATTER_VALIDATION_FAILED` | 400 | `frontmatter_validation_failed` | `validation_error` |
+| `INTERNAL` / `INTERNAL_ERROR` | 500 | `internal_error` | `internal_error` |
+| `INVALID_*` (per-field) | 400 | `invalid_*` (per-field) | `validation_error` |
+| `INVALID_CONTENT_TYPE` | 415 | `invalid_content_type` | `unsupported_media_type` |
+| `MIRROR_DISABLED` | 503 | `mirror_disabled` | `upstream_unavailable` |
+| `MISSING_*` | 400 | `missing_*` | `validation_error` |
+| `NOTIFICATION_NOT_FOUND` | 404 | `notification_not_found` | `resource_not_found` |
+| `NO_UPDATE` | 400 | `no_update` | `validation_error` |
+| `OLD_REPO_NOT_CONFIRMED` | 409 | `old_repo_not_confirmed` | `resource_conflict` |
+| `ORG_NOT_FOUND` | 404 | `org_not_found` | `resource_not_found` |
+| `PACKAGE_DOWNLOAD_FAILED` | 500 | `package_download_failed` | `upstream_unavailable` |
+| `PAYLOAD_TOO_LARGE` | 413 | `payload_too_large` | `payload_too_large` |
+| `PROVIDER_NOT_FOUND` | 404 | `provider_not_found` | `resource_not_found` |
+| `PULL_FAILED` | 502 | `pull_failed` | `upstream_unavailable` |
+| `QUOTA_EXCEEDED` | 429 | `quota_exceeded` | `rate_limited` |
+| `RECONCILE_ALREADY_RUNNING` | 409 | `reconcile_already_running` | `resource_conflict` |
+| `REDEMPTION_CODE_*` | 404 / 409 / 410 | `redemption_code_*` | `resource_not_found` / `resource_conflict` |
+| `REFRESH_FAILED` / `REFRESH_PREVIEW_FAILED` | 502 | `refresh_failed` / `refresh_preview_failed` | `upstream_unavailable` |
+| `REPO_FETCH_FAILED` | 502 | `repo_fetch_failed` | `upstream_unavailable` |
+| `SKILL_NAME_EXISTS` | 409 | `skill_name_exists` | `resource_conflict` |
+| `SKILL_NOT_FOUND` | 404 | `skill_not_found` | `resource_not_found` |
+| `SKILL_VERSION_NOT_FOUND` | 404 | `skill_version_not_found` | `resource_not_found` |
+| `UPSTREAM_DOWN` | 502 | `upstream_down` | `upstream_unavailable` |
 
-This list is exhaustive at the time of writing — if you spot a code that's emitted in production but missing here, open a `[Docs]` issue.
+Format rule for future codes: lowercase ASCII, words joined by `_`, no leading/trailing `_`. Pick from the parent §1.4 vocabulary when generic; add a specific subcode only when the caller needs to branch on it.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -879,13 +879,13 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     analyticsEmitter.trackApiError({
       userId,
       statusCode: 500,
-      errorCode: "INTERNAL_ERROR",
+      errorCode: "internal_error",
       method: c.req.method,
       path: c.req.path,
       requestId,
     });
     return c.json(
-      { data: null, error: { code: "INTERNAL_ERROR", message: "Internal server error" } },
+      { data: null, error: { code: "internal_error", message: "Internal server error" } },
       500,
     );
   });

--- a/ornn-api/src/clients/nyxid/auth.ts
+++ b/ornn-api/src/clients/nyxid/auth.ts
@@ -31,7 +31,7 @@ export class AuthClient implements IAuthClient {
 
     if (!res.ok) {
       if (res.status === 404 || res.status === 401) return null;
-      throw AppError.serviceUnavailable("AUTH_SERVICE_ERROR", `Auth service returned ${res.status}`);
+      throw AppError.serviceUnavailable("auth_service_error", `Auth service returned ${res.status}`);
     }
 
     const json = await res.json() as { data: ApiKeyInfo | null };

--- a/ornn-api/src/domains/admin-users/routes.ts
+++ b/ornn-api/src/domains/admin-users/routes.ts
@@ -48,7 +48,7 @@ export function createAdminUsersRoutes(
     async (c) => {
       const roleParse = roleSchema.safeParse(c.req.query("role") ?? "normal");
       if (!roleParse.success) {
-        throw new AppError(400, "INVALID_ROLE", "role must be 'admin' or 'normal'");
+        throw new AppError(400, "invalid_role", "role must be 'admin' or 'normal'");
       }
       const role: Role = roleParse.data;
       const page = Math.max(1, Number(c.req.query("page")) || 1);

--- a/ornn-api/src/domains/admin/quota/routes.test.ts
+++ b/ornn-api/src/domains/admin/quota/routes.test.ts
@@ -69,7 +69,7 @@ beforeAll(async () => {
       );
     }
     return c.json(
-      { data: null, error: { code: "INTERNAL", message: e.message } },
+      { data: null, error: { code: "internal_error", message: e.message } },
       500,
     );
   });

--- a/ornn-api/src/domains/admin/quota/routes.ts
+++ b/ornn-api/src/domains/admin/quota/routes.ts
@@ -71,7 +71,7 @@ export function createAdminQuotaRoutes(
       const surfaceParam = c.req.query("surface") ?? "playground";
       const parsedSurface = surfaceSchema.safeParse(surfaceParam);
       if (!parsedSurface.success) {
-        throw new AppError(400, "INVALID_SURFACE", "Invalid surface query parameter");
+        throw new AppError(400, "invalid_surface", "Invalid surface query parameter");
       }
       const surface = parsedSurface.data;
       const page = Math.max(1, Number(c.req.query("page")) || 1);
@@ -127,11 +127,11 @@ export function createAdminQuotaRoutes(
     requirePermission(QUOTA_ADMIN_PERMISSION),
     async (c) => {
       const userId = c.req.param("userId");
-      if (!userId) throw new AppError(400, "INVALID_USER_ID", "userId is required");
+      if (!userId) throw new AppError(400, "invalid_user_id", "userId is required");
       const surfaceParam = c.req.query("surface") ?? "playground";
       const parsedSurface = surfaceSchema.safeParse(surfaceParam);
       if (!parsedSurface.success) {
-        throw new AppError(400, "INVALID_SURFACE", "Invalid surface query parameter");
+        throw new AppError(400, "invalid_surface", "Invalid surface query parameter");
       }
       const surface = parsedSurface.data;
       const buckets = await quotaService.getLifetime(userId, surface);
@@ -186,7 +186,7 @@ export function createAdminQuotaRoutes(
         });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        throw new AppError(400, "INVALID_GRANT_AMOUNT", msg);
+        throw new AppError(400, "invalid_grant_amount", msg);
       }
     },
   );

--- a/ornn-api/src/domains/admin/redemption-codes/routes.test.ts
+++ b/ornn-api/src/domains/admin/redemption-codes/routes.test.ts
@@ -71,7 +71,7 @@ beforeAll(async () => {
       );
     }
     return c.json(
-      { data: null, error: { code: "INTERNAL", message: e.message } },
+      { data: null, error: { code: "internal_error", message: e.message } },
       500,
     );
   });
@@ -175,7 +175,7 @@ describe("POST /admin/redemption-codes/:id/invalidate", () => {
     );
     expect(res.status).toBe(409);
     const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("REDEMPTION_CODE_ALREADY_REDEEMED");
+    expect(json.error.code).toBe("redemption_code_already_redeemed");
   });
 
   test("on already-invalidated → 409 ALREADY_INVALIDATED", async () => {
@@ -194,7 +194,7 @@ describe("POST /admin/redemption-codes/:id/invalidate", () => {
     );
     expect(res.status).toBe(409);
     const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("REDEMPTION_CODE_ALREADY_INVALIDATED");
+    expect(json.error.code).toBe("redemption_code_already_invalidated");
   });
 
   test("unknown id → 404", async () => {

--- a/ornn-api/src/domains/admin/redemption-codes/routes.ts
+++ b/ornn-api/src/domains/admin/redemption-codes/routes.ts
@@ -64,23 +64,23 @@ function serializeCode(doc: RedemptionCodeDoc): Record<string, unknown> {
 
 function mapInvalidateError(message: string): AppError {
   if (message.startsWith("NOT_FOUND:")) {
-    return new AppError(404, "REDEMPTION_CODE_NOT_FOUND", "Redemption code not found");
+    return new AppError(404, "redemption_code_not_found", "Redemption code not found");
   }
   if (message.startsWith("ALREADY_REDEEMED:")) {
     return new AppError(
       409,
-      "REDEMPTION_CODE_ALREADY_REDEEMED",
+      "redemption_code_already_redeemed",
       "Redeemed codes cannot be invalidated",
     );
   }
   if (message.startsWith("ALREADY_INVALIDATED:")) {
     return new AppError(
       409,
-      "REDEMPTION_CODE_ALREADY_INVALIDATED",
+      "redemption_code_already_invalidated",
       "Code is already invalidated",
     );
   }
-  return AppError.internalError("REDEMPTION_CODE_INVALIDATE_FAILED", message);
+  return AppError.internalError("redemption_code_invalidate_failed", message);
 }
 
 export function createAdminRedemptionCodesRoutes(
@@ -95,7 +95,7 @@ export function createAdminRedemptionCodesRoutes(
     "/admin/redemption-codes",
     auth,
     requirePermission(QUOTA_ADMIN_PERMISSION),
-    validateBody(mintCodeSchema, "INVALID_REDEMPTION_CODE_BODY"),
+    validateBody(mintCodeSchema, "invalid_redemption_code_body"),
     async (c) => {
       const authCtx = getAuth(c);
       const body = getValidatedBody<MintCodeInput>(c);
@@ -123,9 +123,9 @@ export function createAdminRedemptionCodesRoutes(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.startsWith("INVALID_GRANTS:") || msg.startsWith("INVALID_EXPIRES_AT:")) {
-          throw AppError.badRequest("INVALID_REDEMPTION_CODE_BODY", msg);
+          throw AppError.badRequest("invalid_redemption_code_body", msg);
         }
-        throw AppError.internalError("REDEMPTION_CODE_MINT_FAILED", msg);
+        throw AppError.internalError("redemption_code_mint_failed", msg);
       }
     },
   );
@@ -175,11 +175,11 @@ export function createAdminRedemptionCodesRoutes(
     async (c) => {
       const id = c.req.param("id");
       if (!id) {
-        throw AppError.badRequest("INVALID_REDEMPTION_CODE_ID", "id is required");
+        throw AppError.badRequest("invalid_redemption_code_id", "id is required");
       }
       const doc = await redemptionCodeService.findById(id);
       if (!doc) {
-        throw new AppError(404, "REDEMPTION_CODE_NOT_FOUND", "Redemption code not found");
+        throw new AppError(404, "redemption_code_not_found", "Redemption code not found");
       }
       return c.json({ data: { code: serializeCode(doc) }, error: null });
     },
@@ -194,7 +194,7 @@ export function createAdminRedemptionCodesRoutes(
       const authCtx = getAuth(c);
       const id = c.req.param("id");
       if (!id) {
-        throw AppError.badRequest("INVALID_REDEMPTION_CODE_ID", "id is required");
+        throw AppError.badRequest("invalid_redemption_code_id", "id is required");
       }
       try {
         const doc = await redemptionCodeService.invalidate({

--- a/ornn-api/src/domains/admin/routes.ts
+++ b/ornn-api/src/domains/admin/routes.ts
@@ -201,7 +201,7 @@ export function createAdminRoutes(config: AdminRoutesConfig): Hono<{ Variables: 
           {
             data: null,
             error: {
-              code: "AGENTSEAL_DISABLED",
+              code: "agentseal_disabled",
               message: "AgentSeal scanner is not configured on this deployment",
             },
           },

--- a/ornn-api/src/domains/analytics/routes.ts
+++ b/ornn-api/src/domains/analytics/routes.ts
@@ -49,7 +49,7 @@ export function createAnalyticsRoutes(
     const authCtx = c.get("auth");
     const skill = await skillService.getSkill(idOrName);
     if (!authCtx && skill.isPrivate) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
     }
     if (authCtx && skill.isPrivate) {
       const memberships = await readUserOrgMemberships(c);
@@ -59,7 +59,7 @@ export function createAnalyticsRoutes(
         isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
       };
       if (!canReadSkill(skill, actor)) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
     }
     return { skillGuid: skill.guid };
@@ -101,13 +101,13 @@ export function createAnalyticsRoutes(
       const from = fromQ ? new Date(fromQ) : undefined;
       const to = toQ ? new Date(toQ) : undefined;
       if (fromQ && from && Number.isNaN(from.getTime())) {
-        throw AppError.badRequest("INVALID_RANGE", "'from' is not a valid ISO date");
+        throw AppError.badRequest("invalid_range", "'from' is not a valid ISO date");
       }
       if (toQ && to && Number.isNaN(to.getTime())) {
-        throw AppError.badRequest("INVALID_RANGE", "'to' is not a valid ISO date");
+        throw AppError.badRequest("invalid_range", "'to' is not a valid ISO date");
       }
       if (from && to && from >= to) {
-        throw AppError.badRequest("INVALID_RANGE", "'from' must be earlier than 'to'");
+        throw AppError.badRequest("invalid_range", "'from' must be earlier than 'to'");
       }
       const versionParam = c.req.query("version") || undefined;
 

--- a/ornn-api/src/domains/announcements/routes.ts
+++ b/ornn-api/src/domains/announcements/routes.ts
@@ -142,7 +142,7 @@ export function createAnnouncementRoutes(
     const parsed = createSchema.safeParse(body);
     if (!parsed.success) {
       throw AppError.badRequest(
-        "INVALID_ANNOUNCEMENT_INPUT",
+        "invalid_announcement_input",
         parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
       );
     }
@@ -170,12 +170,12 @@ export function createAnnouncementRoutes(
     const parsed = updateSchema.safeParse(body);
     if (!parsed.success) {
       throw AppError.badRequest(
-        "INVALID_ANNOUNCEMENT_INPUT",
+        "invalid_announcement_input",
         parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
       );
     }
     if (Object.keys(parsed.data).length === 0) {
-      throw AppError.badRequest("INVALID_ANNOUNCEMENT_INPUT", "No fields to update");
+      throw AppError.badRequest("invalid_announcement_input", "No fields to update");
     }
     const updated = await announcementService.update(id, parsed.data);
     return c.json({ data: toAdminDto(updated), error: null });

--- a/ornn-api/src/domains/announcements/service.ts
+++ b/ornn-api/src/domains/announcements/service.ts
@@ -77,7 +77,7 @@ export class AnnouncementService {
   async getById(id: string): Promise<AnnouncementDocument> {
     const doc = await this.repo.findById(id);
     if (!doc) {
-      throw AppError.notFound("ANNOUNCEMENT_NOT_FOUND", "Announcement not found");
+      throw AppError.notFound("announcement_not_found", "Announcement not found");
     }
     return doc;
   }
@@ -103,7 +103,7 @@ export class AnnouncementService {
     }
     const updated = await this.repo.update(id, patch);
     if (!updated) {
-      throw AppError.notFound("ANNOUNCEMENT_NOT_FOUND", "Announcement not found");
+      throw AppError.notFound("announcement_not_found", "Announcement not found");
     }
     logger.info({ announcementId: id, enabled: updated.enabled }, "Announcement updated");
     return updated;
@@ -112,7 +112,7 @@ export class AnnouncementService {
   async delete(id: string): Promise<void> {
     const removed = await this.repo.delete(id);
     if (!removed) {
-      throw AppError.notFound("ANNOUNCEMENT_NOT_FOUND", "Announcement not found");
+      throw AppError.notFound("announcement_not_found", "Announcement not found");
     }
     logger.info({ announcementId: id }, "Announcement deleted");
   }

--- a/ornn-api/src/domains/broadcasts/routes.ts
+++ b/ornn-api/src/domains/broadcasts/routes.ts
@@ -56,7 +56,7 @@ export function createBroadcastRoutes(
     const parsed = createBroadcastSchema.safeParse(body);
     if (!parsed.success) {
       throw AppError.badRequest(
-        "INVALID_BROADCAST_INPUT",
+        "invalid_broadcast_input",
         parsed.error.issues
           .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
           .join("; "),
@@ -80,7 +80,7 @@ export function createBroadcastRoutes(
     const parsed = patchBroadcastSchema.safeParse(body);
     if (!parsed.success) {
       throw AppError.badRequest(
-        "INVALID_BROADCAST_INPUT",
+        "invalid_broadcast_input",
         parsed.error.issues
           .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
           .join("; "),

--- a/ornn-api/src/domains/broadcasts/service.ts
+++ b/ornn-api/src/domains/broadcasts/service.ts
@@ -91,7 +91,7 @@ export class BroadcastService {
   async getById(id: string): Promise<BroadcastDocument> {
     const doc = await this.repo.getById(id);
     if (!doc) {
-      throw AppError.notFound("BROADCAST_NOT_FOUND", "Broadcast not found");
+      throw AppError.notFound("broadcast_not_found", "Broadcast not found");
     }
     return doc;
   }
@@ -131,7 +131,7 @@ export class BroadcastService {
     };
     const updated = await this.repo.update(id, patch);
     if (!updated) {
-      throw AppError.notFound("BROADCAST_NOT_FOUND", "Broadcast not found");
+      throw AppError.notFound("broadcast_not_found", "Broadcast not found");
     }
     logger.info(
       { broadcastId: id, by: params.updatedBy },
@@ -154,7 +154,7 @@ export class BroadcastService {
     // "ok, deleted nothing" on a typo.
     const removed = await this.repo.delete(id);
     if (!removed) {
-      throw AppError.notFound("BROADCAST_NOT_FOUND", "Broadcast not found");
+      throw AppError.notFound("broadcast_not_found", "Broadcast not found");
     }
     try {
       const receiptsRemoved = await this.repo.deleteAllForBroadcast(id);

--- a/ornn-api/src/domains/me/routes.ts
+++ b/ornn-api/src/domains/me/routes.ts
@@ -182,7 +182,7 @@ export function createMeRoutes(config: MeRoutesConfig): Hono<{ Variables: AuthVa
       // No caller token forwarded by the proxy — we can't act on their
       // behalf. Return 404-shaped response so the UI can show "unknown
       // org" without special-casing another error code.
-      throw AppError.notFound("ORG_NOT_FOUND", `Org '${orgId}' not found`);
+      throw AppError.notFound("org_not_found", `Org '${orgId}' not found`);
     }
 
     const baseUrl = await resolveBaseUrl();
@@ -190,7 +190,7 @@ export function createMeRoutes(config: MeRoutesConfig): Hono<{ Variables: AuthVa
       headers: { Authorization: `Bearer ${token}` },
     });
     if (resp.status === 404 || resp.status === 403) {
-      throw AppError.notFound("ORG_NOT_FOUND", `Org '${orgId}' not found`);
+      throw AppError.notFound("org_not_found", `Org '${orgId}' not found`);
     }
     if (!resp.ok) {
       const body = await resp.text().catch(() => "");

--- a/ornn-api/src/domains/notifications/service.ts
+++ b/ornn-api/src/domains/notifications/service.ts
@@ -197,7 +197,7 @@ export class NotificationService {
         return { source: "broadcast", readAt: receipt.readAt };
       }
     }
-    throw AppError.notFound("NOTIFICATION_NOT_FOUND", "Notification not found");
+    throw AppError.notFound("notification_not_found", "Notification not found");
   }
 
   /**

--- a/ornn-api/src/domains/platform/routes.ts
+++ b/ornn-api/src/domains/platform/routes.ts
@@ -61,7 +61,7 @@ export function createPlatformSettingsRoutes(
       const n = Number(body.auditWaiverThreshold);
       if (!Number.isFinite(n) || n < 0 || n > 10) {
         throw AppError.badRequest(
-          "INVALID_SETTING",
+          "invalid_setting",
           "'auditWaiverThreshold' must be a number between 0 and 10",
         );
       }
@@ -72,7 +72,7 @@ export function createPlatformSettingsRoutes(
       const lp = body.llmProvider;
       if (!lp || typeof lp !== "object") {
         throw AppError.badRequest(
-          "INVALID_SETTING",
+          "invalid_setting",
           "'llmProvider' must be an object with optional gatewayUrl + apiKey",
         );
       }
@@ -83,7 +83,7 @@ export function createPlatformSettingsRoutes(
         const u = lpObj.gatewayUrl;
         if (typeof u !== "string") {
           throw AppError.badRequest(
-            "INVALID_SETTING",
+            "invalid_setting",
             "'llmProvider.gatewayUrl' must be a string (empty = use env default)",
           );
         }
@@ -93,7 +93,7 @@ export function createPlatformSettingsRoutes(
             new URL(trimmed); // validate
           } catch {
             throw AppError.badRequest(
-              "INVALID_SETTING",
+              "invalid_setting",
               "'llmProvider.gatewayUrl' must be a valid URL",
             );
           }
@@ -109,7 +109,7 @@ export function createPlatformSettingsRoutes(
         const k = lpObj.apiKey;
         if (typeof k !== "string") {
           throw AppError.badRequest(
-            "INVALID_SETTING",
+            "invalid_setting",
             "'llmProvider.apiKey' must be a string (empty = clear)",
           );
         }
@@ -131,7 +131,7 @@ export function createPlatformSettingsRoutes(
     }
 
     if (Object.keys(patch).length === 0) {
-      throw AppError.badRequest("INVALID_SETTING", "No valid setting fields in body");
+      throw AppError.badRequest("invalid_setting", "No valid setting fields in body");
     }
 
     const updated = await platformSettingsService.patch(patch);

--- a/ornn-api/src/domains/quota/routes.ts
+++ b/ornn-api/src/domains/quota/routes.ts
@@ -50,5 +50,5 @@ export function throwQuotaError(decision: {
   surface: Surface;
   message: string;
 }): never {
-  throw new AppError(429, "QUOTA_EXCEEDED", decision.message);
+  throw new AppError(429, "quota_exceeded", decision.message);
 }

--- a/ornn-api/src/domains/redemption-codes/me-routes.test.ts
+++ b/ornn-api/src/domains/redemption-codes/me-routes.test.ts
@@ -64,7 +64,7 @@ beforeAll(async () => {
       );
     }
     return c.json(
-      { data: null, error: { code: "INTERNAL", message: e.message } },
+      { data: null, error: { code: "internal_error", message: e.message } },
       500,
     );
   });
@@ -133,7 +133,7 @@ describe("POST /me/redemption-codes/redeem", () => {
     });
     expect(res.status).toBe(404);
     const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("REDEMPTION_CODE_NOT_FOUND");
+    expect(json.error.code).toBe("redemption_code_not_found");
   });
 
   test("expired → 410 REDEMPTION_CODE_EXPIRED", async () => {
@@ -148,7 +148,7 @@ describe("POST /me/redemption-codes/redeem", () => {
     });
     expect(res.status).toBe(410);
     const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("REDEMPTION_CODE_EXPIRED");
+    expect(json.error.code).toBe("redemption_code_expired");
   });
 
   test("invalidated → 410 REDEMPTION_CODE_INVALIDATED", async () => {
@@ -168,7 +168,7 @@ describe("POST /me/redemption-codes/redeem", () => {
     });
     expect(res.status).toBe(410);
     const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("REDEMPTION_CODE_INVALIDATED");
+    expect(json.error.code).toBe("redemption_code_invalidated");
   });
 
   test("already-redeemed → 409 REDEMPTION_CODE_ALREADY_REDEEMED", async () => {
@@ -185,7 +185,7 @@ describe("POST /me/redemption-codes/redeem", () => {
     });
     expect(res.status).toBe(409);
     const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("REDEMPTION_CODE_ALREADY_REDEEMED");
+    expect(json.error.code).toBe("redemption_code_already_redeemed");
   });
 });
 

--- a/ornn-api/src/domains/redemption-codes/me-routes.ts
+++ b/ornn-api/src/domains/redemption-codes/me-routes.ts
@@ -36,26 +36,26 @@ export interface MeRedemptionCodesRoutesConfig {
 
 function mapRedeemError(message: string): AppError {
   if (message.startsWith("NOT_FOUND:")) {
-    return new AppError(404, "REDEMPTION_CODE_NOT_FOUND", "Code not found");
+    return new AppError(404, "redemption_code_not_found", "Code not found");
   }
   if (message.startsWith("EXPIRED:")) {
-    return new AppError(410, "REDEMPTION_CODE_EXPIRED", "This code has expired");
+    return new AppError(410, "redemption_code_expired", "This code has expired");
   }
   if (message.startsWith("ALREADY_INVALIDATED:")) {
     return new AppError(
       410,
-      "REDEMPTION_CODE_INVALIDATED",
+      "redemption_code_invalidated",
       "This code has been revoked",
     );
   }
   if (message.startsWith("ALREADY_REDEEMED:")) {
     return new AppError(
       409,
-      "REDEMPTION_CODE_ALREADY_REDEEMED",
+      "redemption_code_already_redeemed",
       "This code has already been redeemed",
     );
   }
-  return AppError.internalError("REDEMPTION_CODE_REDEEM_FAILED", message);
+  return AppError.internalError("redemption_code_redeem_failed", message);
 }
 
 function serializeHistoryItem(doc: RedemptionCodeDoc): Record<string, unknown> {

--- a/ornn-api/src/domains/settings/exportImport/routes.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/routes.test.ts
@@ -78,7 +78,7 @@ function makeApp(opts: {
   // AppError is a domain error; the test app needs a tiny error handler so
   // 4xx surfaces with the expected status (otherwise Hono returns 500).
   app.onError((err, c) => {
-    const code = (err as { code?: string }).code ?? "INTERNAL_ERROR";
+    const code = (err as { code?: string }).code ?? "internal_error";
     const status = (err as { statusCode?: number }).statusCode ?? 500;
     return c.json(
       { data: null, error: { code, message: err.message } },

--- a/ornn-api/src/domains/settings/exportImport/routes.ts
+++ b/ornn-api/src/domains/settings/exportImport/routes.ts
@@ -114,7 +114,7 @@ export function createSettingsExportImportRoutes(
           {
             data: null,
             error: {
-              code: "PAYLOAD_TOO_LARGE",
+              code: "payload_too_large",
               message: `import body must be ≤ ${importMaxBytes} bytes`,
             },
           },
@@ -124,7 +124,7 @@ export function createSettingsExportImportRoutes(
     async (c) => {
       const body = await c.req.json().catch(() => null);
       if (!body || typeof body !== "object") {
-        throw AppError.badRequest("INVALID_BODY", "JSON body required");
+        throw AppError.badRequest("invalid_body", "JSON body required");
       }
       // Accept dryRun from either the body (the SPA path) OR the
       // query string (curl / scripts). Body takes precedence. Was

--- a/ornn-api/src/domains/settings/llmProviders/routes.test.ts
+++ b/ornn-api/src/domains/settings/llmProviders/routes.test.ts
@@ -69,7 +69,7 @@ describe("LlmProviders POST", () => {
     });
     app.route("/api/v1", routes);
     app.onError((err, c) => {
-      const code = (err as { code?: string }).code ?? "INTERNAL_ERROR";
+      const code = (err as { code?: string }).code ?? "internal_error";
       const status = (err as { statusCode?: number }).statusCode ?? 500;
       return c.json(
         { data: null, error: { code, message: err.message } },

--- a/ornn-api/src/domains/settings/llmProviders/routes.ts
+++ b/ornn-api/src/domains/settings/llmProviders/routes.ts
@@ -87,7 +87,7 @@ export function createLlmProvidersRoutes(
 
   app.post(base, auth, adminGuard, async (c) => {
     const body = await c.req.json().catch(() => null);
-    if (!body) throw AppError.badRequest("INVALID_BODY", "JSON body required");
+    if (!body) throw AppError.badRequest("invalid_body", "JSON body required");
     const actor = currentActor(c);
     const created = await llmProvidersService.create(body, actor);
     // Re-fetch through the admin path so the 201 body never carries
@@ -100,7 +100,7 @@ export function createLlmProvidersRoutes(
     const id = c.req.param("id");
     const item = await llmProvidersService.getForAdmin(id);
     if (!item) {
-      throw AppError.notFound("PROVIDER_NOT_FOUND", `No provider ${id}`);
+      throw AppError.notFound("provider_not_found", `No provider ${id}`);
     }
     return c.json({ data: item, error: null });
   });
@@ -108,7 +108,7 @@ export function createLlmProvidersRoutes(
   app.put(`${base}/:id`, auth, adminGuard, async (c) => {
     const id = c.req.param("id");
     const body = await c.req.json().catch(() => null);
-    if (!body) throw AppError.badRequest("INVALID_BODY", "JSON body required");
+    if (!body) throw AppError.badRequest("invalid_body", "JSON body required");
     const actor = currentActor(c);
     await llmProvidersService.update(id, body, actor);
     const masked = await llmProvidersService.getForAdmin(id);
@@ -119,7 +119,7 @@ export function createLlmProvidersRoutes(
     const id = c.req.param("id");
     const ok = await llmProvidersService.deleteById(id);
     if (!ok) {
-      throw AppError.notFound("PROVIDER_NOT_FOUND", `No provider ${id}`);
+      throw AppError.notFound("provider_not_found", `No provider ${id}`);
     }
     return c.body(null, 204);
   });
@@ -146,7 +146,7 @@ export function createLlmProvidersRoutes(
       const providerId = c.req.param("id");
       const modelId = c.req.param("modelId");
       const body = await c.req.json().catch(() => null);
-      if (!body) throw AppError.badRequest("INVALID_BODY", "JSON body required");
+      if (!body) throw AppError.badRequest("invalid_body", "JSON body required");
       const actor = currentActor(c);
       await llmProvidersService.patchModel(providerId, modelId, body, actor);
       const masked = await llmProvidersService.getForAdmin(providerId);
@@ -176,7 +176,7 @@ export function createLlmPickerRoutes(
     const parsed = surfaceSchema.safeParse(surfaceRaw);
     if (!parsed.success) {
       throw AppError.badRequest(
-        "INVALID_SURFACE",
+        "invalid_surface",
         "Query param 'surface' must be 'playground' or 'skillGen'",
       );
     }

--- a/ornn-api/src/domains/settings/llmProviders/service.ts
+++ b/ornn-api/src/domains/settings/llmProviders/service.ts
@@ -399,7 +399,7 @@ export class LlmProvidersService {
   ): Promise<LlmProvider> {
     const existing = await this.repo.findById(id);
     if (!existing) {
-      throw AppError.notFound("PROVIDER_NOT_FOUND", `No provider ${id}`);
+      throw AppError.notFound("provider_not_found", `No provider ${id}`);
     }
     const patch = parse(providerUpdateSchema, input);
 
@@ -480,7 +480,7 @@ export class LlmProvidersService {
     const flags = parse(modelFlagsPatchSchema, input);
     const existing = await this.repo.findById(providerId);
     if (!existing) {
-      throw AppError.notFound("PROVIDER_NOT_FOUND", `No provider ${providerId}`);
+      throw AppError.notFound("provider_not_found", `No provider ${providerId}`);
     }
     const idx = existing.models.findIndex((m) => m.id === modelId);
     if (idx === -1) {
@@ -570,7 +570,7 @@ export class LlmProvidersService {
   }> {
     const existing = await this.repo.findById(id);
     if (!existing) {
-      throw AppError.notFound("PROVIDER_NOT_FOUND", `No provider ${id}`);
+      throw AppError.notFound("provider_not_found", `No provider ${id}`);
     }
     const decryptedAuth = this.decryptAuth(existing.auth);
     let upstream: ReadonlyArray<{ id: string; displayName: string }>;
@@ -808,5 +808,5 @@ function zodToAppError(err: ZodError): AppError {
   const first = err.issues[0];
   const path = first.path.join(".");
   const msg = path.length > 0 ? `${path}: ${first.message}` : first.message;
-  return AppError.badRequest("INVALID_PROVIDER_INPUT", msg);
+  return AppError.badRequest("invalid_provider_input", msg);
 }

--- a/ornn-api/src/domains/settings/routes.ts
+++ b/ornn-api/src/domains/settings/routes.ts
@@ -51,7 +51,7 @@ export function createSettingsRoutes(
     app.put(path, auth, adminGuard, async (c) => {
       const body = await c.req.json().catch(() => null);
       if (!body || typeof body !== "object") {
-        throw AppError.badRequest("INVALID_BODY", "request body must be a JSON object");
+        throw AppError.badRequest("invalid_body", "request body must be a JSON object");
       }
       const actor = currentActor(c);
       const result = await settingsService.putSection<Record<string, unknown>>(

--- a/ornn-api/src/domains/settings/service.test.ts
+++ b/ornn-api/src/domains/settings/service.test.ts
@@ -213,7 +213,7 @@ describe("SettingsServiceImpl", () => {
       err = e;
     }
     expect(err).toBeTruthy();
-    expect((err as { code: string }).code).toBe("INVALID_SETTING");
+    expect((err as { code: string }).code).toBe("invalid_setting");
     expect((err as { message: string }).message).toContain("sseKeepAliveMs");
   });
 

--- a/ornn-api/src/domains/settings/service.ts
+++ b/ornn-api/src/domains/settings/service.ts
@@ -266,5 +266,5 @@ function zodToAppError(err: ZodError): AppError {
   const first = err.issues[0];
   const path = first.path.join(".");
   const msg = path.length > 0 ? `${path}: ${first.message}` : first.message;
-  return AppError.badRequest("INVALID_SETTING", msg);
+  return AppError.badRequest("invalid_setting", msg);
 }

--- a/ornn-api/src/domains/skills/audit/routes.ts
+++ b/ornn-api/src/domains/skills/audit/routes.ts
@@ -62,7 +62,7 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
       const skill = await skillService.getSkill(idOrName, version);
 
       if (!authCtx && skill.isPrivate) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
       if (authCtx && skill.isPrivate) {
         const memberships = await readUserOrgMemberships(c);
@@ -72,7 +72,7 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
           isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
         };
         if (!canReadSkill(skill, actor)) {
-          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
         }
       }
 
@@ -80,7 +80,7 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
       if (!record) {
         // No audit yet — surface that as 404 so callers can distinguish
         // from a record that returned zeroes.
-        throw AppError.notFound("AUDIT_NOT_FOUND", "No audit has been run for this skill version");
+        throw AppError.notFound("audit_not_found", "No audit has been run for this skill version");
       }
       return c.json({ data: record, error: null });
     },
@@ -102,7 +102,7 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
 
       const skill = await skillService.getSkill(idOrName);
       if (!authCtx && skill.isPrivate) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
       if (authCtx && skill.isPrivate) {
         const memberships = await readUserOrgMemberships(c);
@@ -112,7 +112,7 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
           isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
         };
         if (!canReadSkill(skill, actor)) {
-          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
         }
       }
 
@@ -139,7 +139,7 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
       const skill = await skillService.getSkill(idOrName);
 
       if (!authCtx && skill.isPrivate) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
       if (authCtx && skill.isPrivate) {
         const memberships = await readUserOrgMemberships(c);
@@ -149,7 +149,7 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
           isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
         };
         if (!canReadSkill(skill, actor)) {
-          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
         }
       }
 
@@ -177,7 +177,7 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
       const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
       if (skill.createdBy !== authCtx.userId && !isPlatformAdmin) {
         throw AppError.forbidden(
-          "NOT_SKILL_OWNER",
+          "not_skill_owner",
           "Only the skill's author or a platform admin can start an audit",
         );
       }

--- a/ornn-api/src/domains/skills/audit/service.ts
+++ b/ornn-api/src/domains/skills/audit/service.ts
@@ -355,7 +355,7 @@ export class AuditService {
     // Prefer the skill doc's presigned URL — `getSkill` already minted one.
     const url = (skillDoc as unknown as { presignedPackageUrl?: string }).presignedPackageUrl;
     if (!url) {
-      throw AppError.internalError("AUDIT_PACKAGE_UNAVAILABLE", "No storage URL for skill package");
+      throw AppError.internalError("audit_package_unavailable", "No storage URL for skill package");
     }
     const res = await fetch(url);
     if (!res.ok) {

--- a/ornn-api/src/domains/skills/crud/repository.ts
+++ b/ornn-api/src/domains/skills/crud/repository.ts
@@ -26,7 +26,7 @@ import pino from "pino";
 function skillId(guid: string): never {
   if (typeof guid !== "string" || guid.length === 0) {
     throw AppError.badRequest(
-      "INVALID_SKILL_ID",
+      "invalid_skill_id",
       "Skill id must be a non-empty string",
     );
   }
@@ -38,7 +38,7 @@ function skillIdList(guids: readonly string[]): never {
   for (const g of guids) {
     if (typeof g !== "string" || g.length === 0) {
       throw AppError.badRequest(
-        "INVALID_SKILL_ID",
+        "invalid_skill_id",
         "Skill id must be a non-empty string",
       );
     }
@@ -203,7 +203,7 @@ export class SkillRepository {
       logger.info({ guid: data.guid, name: data.name }, "Skill created");
     } catch (err: any) {
       if (err?.code === 11000) {
-        throw AppError.conflict("SKILL_NAME_EXISTS", `Skill '${data.name}' already exists`);
+        throw AppError.conflict("skill_name_exists", `Skill '${data.name}' already exists`);
       }
       throw err;
     }

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -207,12 +207,12 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const contentType = c.req.header("content-type") ?? "";
       if (!contentType.includes("application/zip") && !contentType.includes("application/octet-stream")) {
-        throw AppError.badRequest("INVALID_CONTENT_TYPE", "Expected application/zip content type");
+        throw AppError.badRequest("invalid_content_type", "Expected application/zip content type");
       }
 
       const body = await c.req.arrayBuffer();
       if (!body || body.byteLength === 0) {
-        throw AppError.badRequest("EMPTY_BODY", "Request body is empty");
+        throw AppError.badRequest("empty_body", "Request body is empty");
       }
 
       if (body.byteLength > maxFileSize) {
@@ -295,7 +295,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
           path = parsed.path;
         } catch (err) {
           throw AppError.badRequest(
-            "INVALID_GITHUB_URL",
+            "invalid_github_url",
             err instanceof Error ? err.message : String(err),
           );
         }
@@ -305,7 +305,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         path = typeof body.path === "string" ? body.path : undefined;
       } else {
         throw AppError.badRequest(
-          "MISSING_SOURCE",
+          "missing_source",
           "Provide either 'githubUrl' (preferred) or 'repo' (with optional 'ref'/'path').",
         );
       }
@@ -346,7 +346,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       } catch (err) {
         if (err instanceof AppError) throw err;
         const message = err instanceof Error ? err.message : String(err);
-        throw AppError.badRequest("PULL_FAILED", message);
+        throw AppError.badRequest("pull_failed", message);
       }
     },
   );
@@ -376,7 +376,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
       if (existing.createdBy !== authCtx.userId && !isPlatformAdmin) {
         throw AppError.forbidden(
-          "NOT_SKILL_OWNER",
+          "not_skill_owner",
           "Only the skill's author or a platform admin may refresh it",
         );
       }
@@ -391,7 +391,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         } catch (err) {
           if (err instanceof AppError) throw err;
           const message = err instanceof Error ? err.message : String(err);
-          throw AppError.badRequest("REFRESH_PREVIEW_FAILED", message);
+          throw AppError.badRequest("refresh_preview_failed", message);
         }
       }
 
@@ -427,7 +427,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       } catch (err) {
         if (err instanceof AppError) throw err;
         const message = err instanceof Error ? err.message : String(err);
-        throw AppError.badRequest("REFRESH_FAILED", message);
+        throw AppError.badRequest("refresh_failed", message);
       }
     },
   );
@@ -457,7 +457,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
       if (existing.createdBy !== authCtx.userId && !isPlatformAdmin) {
         throw AppError.forbidden(
-          "NOT_SKILL_OWNER",
+          "not_skill_owner",
           "Only the skill's author or a platform admin may set its source",
         );
       }
@@ -469,7 +469,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         githubUrl = body.githubUrl;
       } else {
         throw AppError.badRequest(
-          "INVALID_BODY",
+          "invalid_body",
           "Body must include 'githubUrl' as a string (to link) or null (to unlink).",
         );
       }
@@ -520,7 +520,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         const authCtx = c.get("auth");
         // `requirePermission` above guarantees authCtx is set.
         if (!authCtx) {
-          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
         }
         const memberships = await readUserOrgMemberships(c);
         const actor = {
@@ -529,7 +529,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
           isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
         };
         if (!canReadSkill(skill, actor)) {
-          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
         }
       }
 
@@ -580,7 +580,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       const skill = await skillService.getSkill(idOrName);
       // Anonymous viewers only see public skills.
       if (!authCtx && skill.isPrivate) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
       if (authCtx && skill.isPrivate) {
         const memberships = await readUserOrgMemberships(c);
@@ -590,7 +590,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
           isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
         };
         if (!canReadSkill(skill, actor)) {
-          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
         }
       }
 
@@ -620,7 +620,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const skill = await skillService.getSkill(idOrName);
       if (!authCtx && skill.isPrivate) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
       if (authCtx && skill.isPrivate) {
         const memberships = await readUserOrgMemberships(c);
@@ -630,7 +630,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
           isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
         };
         if (!canReadSkill(skill, actor)) {
-          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
         }
       }
 
@@ -657,7 +657,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       // Anonymous users can only see public skills.
       if (!authCtx && skill.isPrivate) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
 
       // Authenticated users: apply the full ownership/org-visibility rules.
@@ -669,7 +669,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
           isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
         };
         if (!canReadSkill(skill, actor)) {
-          throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
         }
       }
 
@@ -727,7 +727,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         (await skillRepo.findByGuid(idOrName)) ??
         (await skillRepo.findByName(idOrName));
       if (!existing) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
       const memberships = await readUserOrgMemberships(c);
       const actor = {
@@ -737,7 +737,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       };
       if (!canManageSkill(existing, actor)) {
         throw AppError.forbidden(
-          "FORBIDDEN",
+          "forbidden",
           "You do not have permission to manage this skill",
         );
       }
@@ -783,7 +783,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const existing = await skillRepo.findByGuid(guid);
       if (!existing) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
       }
       const memberships = await readUserOrgMemberships(c);
       const actor = {
@@ -793,7 +793,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       };
       if (!canManageSkill(existing, actor)) {
         throw AppError.forbidden(
-          "FORBIDDEN",
+          "forbidden",
           "You do not have permission to update this skill",
         );
       }
@@ -830,7 +830,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       }
 
       if (zipBuffer === undefined && isPrivate === undefined) {
-        throw AppError.badRequest("NO_UPDATE", "No update data provided. Send a ZIP file and/or isPrivate field.");
+        throw AppError.badRequest("no_update", "No update data provided. Send a ZIP file and/or isPrivate field.");
       }
 
       logger.info({ guid, userId: authCtx.userId }, "Skill update via API");
@@ -877,14 +877,14 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     "/skills/:id/permissions",
     auth,
     requirePermission("ornn:skill:update"),
-    validateBody(permissionsPatchSchema, "INVALID_PERMISSIONS"),
+    validateBody(permissionsPatchSchema, "invalid_permissions"),
     async (c) => {
       const guid = c.req.param("id");
       const authCtx = getAuth(c);
 
       const existing = await skillRepo.findByGuid(guid);
       if (!existing) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
       }
       const memberships = await readUserOrgMemberships(c);
       const actor = {
@@ -894,7 +894,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       };
       if (!canManageSkill(existing, actor)) {
         throw AppError.forbidden(
-          "FORBIDDEN",
+          "forbidden",
           "You do not have permission to change this skill's visibility",
         );
       }
@@ -952,14 +952,14 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const existing = await skillRepo.findByGuid(guid);
       if (!existing) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
       }
       const memberships = await readUserOrgMemberships(c);
       const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
       const actor = { userId: authCtx.userId, memberships, isPlatformAdmin };
       if (!canManageSkill(existing, actor)) {
         throw AppError.forbidden(
-          "FORBIDDEN",
+          "forbidden",
           "You do not have permission to change this skill's NyxID service tie",
         );
       }
@@ -1125,7 +1125,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       const authCtx = getAuth(c);
       const skill = await skillRepo.findByGuid(guid);
       if (!skill) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
       }
       const memberships = await readUserOrgMemberships(c);
       const actor = {
@@ -1135,7 +1135,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       };
       if (!canManageSkill(skill, actor)) {
         throw AppError.forbidden(
-          "FORBIDDEN",
+          "forbidden",
           "You do not have permission to delete this skill",
         );
       }
@@ -1177,7 +1177,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       let skill = await skillRepo.findByGuid(idOrName);
       if (!skill) skill = await skillRepo.findByName(idOrName);
       if (!skill) {
-        throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
       const memberships = await readUserOrgMemberships(c);
       const actor = {
@@ -1187,7 +1187,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       };
       if (!canManageSkill(skill, actor)) {
         throw AppError.forbidden(
-          "FORBIDDEN",
+          "forbidden",
           "You do not have permission to delete this skill version",
         );
       }

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -114,7 +114,7 @@ export class SkillService {
       const violations = await this.validateZipFormat(zipBuffer);
       if (violations.length > 0) {
         throw AppError.badRequest(
-          "VALIDATION_FAILED",
+          "validation_failed",
           violations.map((v) => `[${v.rule}] ${v.message}`).join("; "),
         );
       }
@@ -128,7 +128,7 @@ export class SkillService {
     //     action paths and make the skill unreachable via the canonical read.
     if (isReservedVerb("skill", name)) {
       throw AppError.badRequest(
-        "RESERVED_NAME",
+        "reserved_name",
         `Skill name '${name}' is reserved — pick a different name`,
       );
     }
@@ -136,7 +136,7 @@ export class SkillService {
     // 3b. Check name uniqueness
     const existing = await this.skillRepo.findByName(name);
     if (existing) {
-      throw AppError.conflict("SKILL_NAME_EXISTS", `Skill '${name}' already exists`);
+      throw AppError.conflict("skill_name_exists", `Skill '${name}' already exists`);
     }
 
     // 4. Generate GUID and hash
@@ -216,7 +216,7 @@ export class SkillService {
       parseVersion(version);
       const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, version);
       if (!versionDoc) {
-        throw AppError.notFound("SKILL_VERSION_NOT_FOUND", `Version '${version}' not found for skill '${skill.name}'`);
+        throw AppError.notFound("skill_version_not_found", `Version '${version}' not found for skill '${skill.name}'`);
       }
       return this.buildDetailResponse(skill, versionDoc);
     }
@@ -305,7 +305,7 @@ export class SkillService {
       skill = await this.skillRepo.findByName(idOrName);
     }
     if (!skill) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
     }
     return skill;
   }
@@ -330,7 +330,7 @@ export class SkillService {
   ): Promise<SkillDetailResponse> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
     }
 
     // System-skill invariant: a skill tied to an admin NyxID service is
@@ -378,7 +378,7 @@ export class SkillService {
   ): Promise<SkillDetailResponse> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
     }
 
     // System-skill invariant — same as setSkillPermissions. Block
@@ -400,7 +400,7 @@ export class SkillService {
         const violations = await this.validateZipFormat(options.zipBuffer);
         if (violations.length > 0) {
           throw AppError.badRequest(
-            "VALIDATION_FAILED",
+            "validation_failed",
             violations.map((v) => `[${v.rule}] ${v.message}`).join("; "),
           );
         }
@@ -534,7 +534,7 @@ export class SkillService {
   ): Promise<SkillDetailResponse> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
     }
     if (!existing.source || existing.source.type !== "github") {
       throw AppError.badRequest(
@@ -582,7 +582,7 @@ export class SkillService {
   ): Promise<SkillDetailResponse> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
     }
 
     if (githubUrl === null) {
@@ -595,7 +595,7 @@ export class SkillService {
       parsed = parseGithubUrl(githubUrl);
     } catch (err) {
       throw AppError.badRequest(
-        "INVALID_GITHUB_URL",
+        "invalid_github_url",
         err instanceof Error ? err.message : String(err),
       );
     }
@@ -629,7 +629,7 @@ export class SkillService {
   }> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
     }
     if (!existing.source || existing.source.type !== "github") {
       throw AppError.badRequest(
@@ -708,7 +708,7 @@ export class SkillService {
   }> {
     if (fromVersion === toVersion) {
       throw AppError.badRequest(
-        "SAME_VERSION",
+        "same_version",
         `'from' and 'to' refer to the same version '${fromVersion}'`,
       );
     }
@@ -724,13 +724,13 @@ export class SkillService {
     ]);
     if (!fromDoc) {
       throw AppError.notFound(
-        "SKILL_VERSION_NOT_FOUND",
+        "skill_version_not_found",
         `Version '${fromVersion}' not found for skill '${skill.name}'`,
       );
     }
     if (!toDoc) {
       throw AppError.notFound(
-        "SKILL_VERSION_NOT_FOUND",
+        "skill_version_not_found",
         `Version '${toVersion}' not found for skill '${skill.name}'`,
       );
     }
@@ -776,7 +776,7 @@ export class SkillService {
     const res = await fetch(presigned.presignedUrl);
     if (!res.ok) {
       throw AppError.internalError(
-        "PACKAGE_DOWNLOAD_FAILED",
+        "package_download_failed",
         `Failed to download package for key '${storageKey}' (HTTP ${res.status})`,
       );
     }
@@ -799,12 +799,12 @@ export class SkillService {
     let skill = await this.skillRepo.findByGuid(idOrName);
     if (!skill) skill = await this.skillRepo.findByName(idOrName);
     if (!skill) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
     }
     const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, version);
     if (!versionDoc) {
       throw AppError.notFound(
-        "SKILL_VERSION_NOT_FOUND",
+        "skill_version_not_found",
         `Version '${version}' not found for skill '${skill.name}'`,
       );
     }
@@ -871,7 +871,7 @@ export class SkillService {
   ): Promise<SkillDetailResponse> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
     }
 
     // Untie path — wipe all four cached fields, leave `isPrivate` alone.
@@ -924,7 +924,7 @@ export class SkillService {
   async deleteSkill(guid: string): Promise<void> {
     const existing = await this.skillRepo.findByGuid(guid);
     if (!existing) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${guid}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
     }
 
     // Collect every storage key to clean up: the current pointer on the skill
@@ -967,14 +967,14 @@ export class SkillService {
       skill = await this.skillRepo.findByName(idOrName);
     }
     if (!skill) {
-      throw AppError.notFound("SKILL_NOT_FOUND", `Skill '${idOrName}' not found`);
+      throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
     }
 
     // 2. Download ZIP from storage
     const presigned = await this.storageClient.getPresignedUrl((await this.storageBucketResolver()), skill.storageKey);
     const response = await fetch(presigned.presignedUrl);
     if (!response.ok) {
-      throw AppError.internalError("PACKAGE_DOWNLOAD_FAILED", "Failed to download skill package from storage");
+      throw AppError.internalError("package_download_failed", "Failed to download skill package from storage");
     }
     const zipBuffer = new Uint8Array(await response.arrayBuffer());
 
@@ -1045,7 +1045,7 @@ export class SkillService {
     const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, version);
     if (!versionDoc) {
       throw AppError.notFound(
-        "SKILL_VERSION_NOT_FOUND",
+        "skill_version_not_found",
         `Version '${version}' not found for skill '${skill.name}'`,
       );
     }
@@ -1128,13 +1128,13 @@ export class SkillService {
 
     const skillMdEntry = getFile("SKILL.md");
     if (!skillMdEntry) {
-      throw AppError.badRequest("MISSING_SKILL_MD", "SKILL.md not found in package");
+      throw AppError.badRequest("missing_skill_md", "SKILL.md not found in package");
     }
 
     const content = await skillMdEntry.async("string");
     const fmMatch = content.match(FRONTMATTER_REGEX);
     if (!fmMatch) {
-      throw AppError.badRequest("MISSING_FRONTMATTER", "SKILL.md must have a frontmatter section");
+      throw AppError.badRequest("missing_frontmatter", "SKILL.md must have a frontmatter section");
     }
 
     let rawFrontmatter: Record<string, unknown>;
@@ -1155,7 +1155,7 @@ export class SkillService {
     const validation = validateSkillFrontmatter(rawFrontmatter);
     if (!validation.success) {
       const errorMsg = validation.errors.map((e) => `${e.field}: ${e.message}`).join("; ");
-      throw AppError.badRequest("FRONTMATTER_VALIDATION_FAILED", errorMsg);
+      throw AppError.badRequest("frontmatter_validation_failed", errorMsg);
     }
 
     const fm = validation.data;

--- a/ornn-api/src/domains/skills/crud/skillVersionRepository.ts
+++ b/ornn-api/src/domains/skills/crud/skillVersionRepository.ts
@@ -225,7 +225,7 @@ export class SkillVersionRepository {
     const updated = mapDoc(result);
     if (!updated) {
       throw AppError.notFound(
-        "SKILL_VERSION_NOT_FOUND",
+        "skill_version_not_found",
         `Version '${version}' not found for skill '${skillGuid}'`,
       );
     }

--- a/ornn-api/src/domains/skills/crud/version.test.ts
+++ b/ornn-api/src/domains/skills/crud/version.test.ts
@@ -56,7 +56,7 @@ describe("parseVersion", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(AppError);
       expect((err as AppError).statusCode).toBe(400);
-      expect((err as AppError).code).toBe("INVALID_VERSION");
+      expect((err as AppError).code).toBe("invalid_version");
     }
   });
 });

--- a/ornn-api/src/domains/skills/crud/version.ts
+++ b/ornn-api/src/domains/skills/crud/version.ts
@@ -24,12 +24,12 @@ export interface ParsedVersion {
  */
 export function parseVersion(raw: string): ParsedVersion {
   if (typeof raw !== "string") {
-    throw AppError.badRequest("INVALID_VERSION", `version must be a string, got ${typeof raw}`);
+    throw AppError.badRequest("invalid_version", `version must be a string, got ${typeof raw}`);
   }
   const match = raw.match(SKILL_VERSION_REGEX);
   if (!match) {
     throw AppError.badRequest(
-      "INVALID_VERSION",
+      "invalid_version",
       `version "${raw}" is invalid — expected "<major>.<minor>" (non-negative integers, no leading zeroes, no patch digit)`,
     );
   }

--- a/ornn-api/src/domains/skills/format/routes.ts
+++ b/ornn-api/src/domains/skills/format/routes.ts
@@ -92,12 +92,12 @@ export function createFormatRoutes(config: FormatRoutesConfig): Hono<{ Variables
     async (c) => {
       const contentType = c.req.header("content-type") ?? "";
       if (!contentType.includes("application/zip") && !contentType.includes("application/octet-stream")) {
-        throw AppError.badRequest("INVALID_CONTENT_TYPE", "Expected application/zip content type");
+        throw AppError.badRequest("invalid_content_type", "Expected application/zip content type");
       }
 
       const body = await c.req.arrayBuffer();
       if (!body || body.byteLength === 0) {
-        throw AppError.badRequest("EMPTY_BODY", "Request body is empty");
+        throw AppError.badRequest("empty_body", "Request body is empty");
       }
 
       const zipBuffer = new Uint8Array(body);

--- a/ornn-api/src/domains/skills/generation/routes.ts
+++ b/ornn-api/src/domains/skills/generation/routes.ts
@@ -219,7 +219,7 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
         const body = await c.req.parseBody({ all: true });
 
         if (typeof body["prompt"] !== "string" || !body["prompt"]) {
-          throw AppError.badRequest("MISSING_PROMPT", "A 'prompt' field is required");
+          throw AppError.badRequest("missing_prompt", "A 'prompt' field is required");
         }
         prompt = body["prompt"];
 
@@ -252,11 +252,11 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
         }
 
         if (!body.prompt || typeof body.prompt !== "string") {
-          throw AppError.badRequest("MISSING_PROMPT", "A 'prompt' field is required");
+          throw AppError.badRequest("missing_prompt", "A 'prompt' field is required");
         }
         prompt = body.prompt;
       } else {
-        throw AppError.badRequest("INVALID_CONTENT_TYPE", "Expected multipart/form-data or application/json");
+        throw AppError.badRequest("invalid_content_type", "Expected multipart/form-data or application/json");
       }
 
       const signal = c.req.raw.signal;
@@ -315,7 +315,7 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
 
       if (!inlineCode && !repoUrl) {
         throw AppError.badRequest(
-          "MISSING_SOURCE",
+          "missing_source",
           "Provide either 'code' (inline source) or 'repoUrl' (public GitHub URL)",
         );
       }
@@ -347,12 +347,12 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
           );
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          throw AppError.badRequest("REPO_FETCH_FAILED", `Could not fetch repository: ${message}`);
+          throw AppError.badRequest("repo_fetch_failed", `Could not fetch repository: ${message}`);
         }
       }
 
       if (!code.trim()) {
-        throw AppError.badRequest("EMPTY_SOURCE", "Source code is empty — nothing to analyze");
+        throw AppError.badRequest("empty_source", "Source code is empty — nothing to analyze");
       }
 
       logger.info(
@@ -399,7 +399,7 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
       const body = await c.req.json();
 
       if (!body.spec || typeof body.spec !== "string") {
-        throw AppError.badRequest("MISSING_SPEC", "An OpenAPI 'spec' field (JSON or YAML string) is required");
+        throw AppError.badRequest("missing_spec", "An OpenAPI 'spec' field (JSON or YAML string) is required");
       }
 
       const endpoints = Array.isArray(body.endpoints) ? body.endpoints : undefined;

--- a/ornn-api/src/domains/skills/mirror/routes.ts
+++ b/ornn-api/src/domains/skills/mirror/routes.ts
@@ -168,7 +168,7 @@ export function createMirrorRoutes(
       let enabled = current.enabled;
       if ("enabled" in body) {
         if (typeof body.enabled !== "boolean") {
-          throw AppError.badRequest("INVALID_SETTING", "'enabled' must be a boolean.");
+          throw AppError.badRequest("invalid_setting", "'enabled' must be a boolean.");
         }
         enabled = body.enabled;
       }
@@ -181,7 +181,7 @@ export function createMirrorRoutes(
         const v = typeof body.owner === "string" ? body.owner.trim() : "";
         if (v.length > 0 && !OWNER_RE.test(v)) {
           throw AppError.badRequest(
-            "INVALID_OWNER",
+            "invalid_owner",
             "'owner' must be 1–39 chars of letters/digits/dashes, no leading/trailing dash.",
           );
         }
@@ -191,7 +191,7 @@ export function createMirrorRoutes(
         const v = typeof body.repo === "string" ? body.repo.trim() : "";
         if (v.length > 0 && !REPO_RE.test(v)) {
           throw AppError.badRequest(
-            "INVALID_REPO",
+            "invalid_repo",
             "'repo' must be 1–100 chars of letters/digits/dot/dash/underscore.",
           );
         }
@@ -216,7 +216,7 @@ export function createMirrorRoutes(
         const v = typeof body.appId === "string" ? body.appId.trim() : "";
         if (v.length > 0 && !APP_ID_RE.test(v)) {
           throw AppError.badRequest(
-            "INVALID_SETTING",
+            "invalid_setting",
             "'appId' must be 1–15 digits.",
           );
         }
@@ -226,7 +226,7 @@ export function createMirrorRoutes(
         const v = typeof body.installationId === "string" ? body.installationId.trim() : "";
         if (v.length > 0 && !INSTALLATION_ID_RE.test(v)) {
           throw AppError.badRequest(
-            "INVALID_SETTING",
+            "invalid_setting",
             "'installationId' must be 1–20 digits.",
           );
         }
@@ -236,7 +236,7 @@ export function createMirrorRoutes(
         const v = body.appPrivateKey;
         if (typeof v !== "string") {
           throw AppError.badRequest(
-            "INVALID_SETTING",
+            "invalid_setting",
             "'appPrivateKey' must be a string (empty = clear).",
           );
         }
@@ -250,7 +250,7 @@ export function createMirrorRoutes(
           const validated = validateGitHubAppPrivateKey(v);
           if (!validated.ok) {
             throw AppError.badRequest(
-              "INVALID_SETTING",
+              "invalid_setting",
               `'appPrivateKey' ${validated.reason}.`,
             );
           }
@@ -265,7 +265,7 @@ export function createMirrorRoutes(
         const stampedCount = counts.synced + counts.lagging;
         if (stampedCount > 0 && !confirmAbandonOldRepo) {
           throw AppError.conflict(
-            "OLD_REPO_NOT_CONFIRMED",
+            "old_repo_not_confirmed",
             `Changing the mirror to ${owner}/${repo} would abandon ${stampedCount} skill(s) ` +
               `currently mirrored to ${current.owner}/${current.repo}. ` +
               `Pass confirmAbandonOldRepo: true to proceed; the old repo will not be cleaned up automatically.`,
@@ -343,7 +343,7 @@ export function createMirrorRoutes(
           {
             data: null,
             error: {
-              code: "MIRROR_DISABLED",
+              code: "mirror_disabled",
               message: !runtime.enabled
                 ? "GitHub mirror is disabled. Flip the kill switch in the admin UI to enable."
                 : "GitHub mirror is missing required credentials. Set owner/repo/branch + GitHub App credentials in the admin UI.",
@@ -357,7 +357,7 @@ export function createMirrorRoutes(
           {
             data: null,
             error: {
-              code: "RECONCILE_ALREADY_RUNNING",
+              code: "reconcile_already_running",
               message: `A reconcile is already in progress (started at ${reconcileState.startedAt?.toISOString() ?? "unknown"}).`,
             },
           },

--- a/ornn-api/src/domains/skills/search/routes.ts
+++ b/ornn-api/src/domains/skills/search/routes.ts
@@ -72,7 +72,7 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
   app.get(
     "/skill-search",
     optionalAuth,
-    validateQuery(searchQuerySchema, "INVALID_QUERY"),
+    validateQuery(searchQuerySchema, "invalid_query"),
     async (c) => {
       const parsed = getValidatedQuery<z.infer<typeof searchQuerySchema>>(c);
       const { query, mode, page, pageSize, model, systemFilter } = parsed;
@@ -148,7 +148,7 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
     const scopeRaw = (c.req.query("scope") || "public") as string;
     const allowed = ["public", "private", "mixed", "shared-with-me", "mine", "system"] as const;
     if (!(allowed as readonly string[]).includes(scopeRaw)) {
-      throw AppError.badRequest("INVALID_SCOPE", `Unknown scope '${scopeRaw}'`);
+      throw AppError.badRequest("invalid_scope", `Unknown scope '${scopeRaw}'`);
     }
     const scope = scopeRaw as (typeof allowed)[number];
     if ((scope === "mine" || scope === "shared-with-me") && !authCtx) {
@@ -177,7 +177,7 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
     const allowed = ["public", "shared-with-me", "system", "mixed"] as const;
     if (!(allowed as readonly string[]).includes(scopeRaw)) {
       throw AppError.badRequest(
-        "INVALID_SCOPE",
+        "invalid_scope",
         `Unknown or unsupported scope '${scopeRaw}' for authors facet`,
       );
     }

--- a/ornn-api/src/domains/users/routes.ts
+++ b/ornn-api/src/domains/users/routes.ts
@@ -45,7 +45,7 @@ export function createUserRoutes(
   app.get(
     "/users/search",
     auth,
-    validateQuery(searchQuerySchema, "INVALID_QUERY"),
+    validateQuery(searchQuerySchema, "invalid_query"),
     async (c) => {
       const parsed = getValidatedQuery<z.infer<typeof searchQuerySchema>>(c);
       const results = await userDirectoryRepo.searchByEmailPrefix(

--- a/ornn-api/src/infra/analytics/index.test.ts
+++ b/ornn-api/src/infra/analytics/index.test.ts
@@ -85,7 +85,7 @@ describe("AnalyticsEmitter", () => {
     emitter.trackApiError({
       userId: "u-3",
       statusCode: 500,
-      errorCode: "INTERNAL_ERROR",
+      errorCode: "internal_error",
       method: "POST",
       path: "/api/v1/skills",
       requestId: "rid-1",
@@ -95,7 +95,7 @@ describe("AnalyticsEmitter", () => {
     expect(tracker.calls[0]!.event).toBe("api.error");
     expect(tracker.calls[0]!.properties).toMatchObject({
       statusCode: 500,
-      errorCode: "INTERNAL_ERROR",
+      errorCode: "internal_error",
       method: "POST",
       path: "/api/v1/skills",
       requestId: "rid-1",
@@ -110,7 +110,7 @@ describe("AnalyticsEmitter", () => {
     emitter.trackApiError({
       userId: "u-3",
       statusCode: 500,
-      errorCode: "INTERNAL_ERROR",
+      errorCode: "internal_error",
       method: "POST",
       path: "/api/v1/skills",
     });
@@ -126,7 +126,7 @@ describe("AnalyticsEmitter", () => {
     emitter.trackApiError({
       userId: "u-3",
       statusCode: 500,
-      errorCode: "INTERNAL_ERROR",
+      errorCode: "internal_error",
       method: "POST",
       path: "/api/v1/skills",
     });
@@ -142,7 +142,7 @@ describe("AnalyticsEmitter", () => {
     emitter.trackApiError({
       userId: null,
       statusCode: 503,
-      errorCode: "UPSTREAM_DOWN",
+      errorCode: "upstream_down",
       method: "GET",
       path: "/livez",
     });

--- a/ornn-api/src/middleware/nyxidAuth.ts
+++ b/ornn-api/src/middleware/nyxidAuth.ts
@@ -217,7 +217,7 @@ export function nyxidAuthMiddleware() {
   return createMiddleware<{ Variables: AuthVariables }>(async (c, next) => {
     const auth = c.get("auth");
     if (!auth) {
-      throw new AppError(401, "AUTH_MISSING", "Authentication required");
+      throw new AppError(401, "auth_missing", "Authentication required");
     }
     await next();
   });
@@ -243,13 +243,13 @@ export function requirePermission(...required: string[]) {
   return async (c: Context<{ Variables: AuthVariables }>, next: Next) => {
     const auth = c.get("auth");
     if (!auth) {
-      throw new AppError(401, "AUTH_MISSING", "Not authenticated");
+      throw new AppError(401, "auth_missing", "Not authenticated");
     }
 
     for (const perm of required) {
       if (!auth.permissions.includes(perm)) {
         logger.warn({ userId: auth.userId, missing: perm }, "Permission denied");
-        throw new AppError(403, "FORBIDDEN", `Missing permission: ${perm}`);
+        throw new AppError(403, "forbidden", `Missing permission: ${perm}`);
       }
     }
 
@@ -264,12 +264,12 @@ export function requireOwnerOrAdmin(getResourceOwnerId: (c: Context) => Promise<
   return async (c: Context<{ Variables: AuthVariables }>, next: Next) => {
     const auth = c.get("auth");
     if (!auth) {
-      throw new AppError(401, "AUTH_MISSING", "Not authenticated");
+      throw new AppError(401, "auth_missing", "Not authenticated");
     }
 
     const ownerId = await getResourceOwnerId(c);
     if (auth.userId !== ownerId && !auth.permissions.includes("ornn:admin:skill")) {
-      throw new AppError(403, "FORBIDDEN", "You can only operate on your own resources");
+      throw new AppError(403, "forbidden", "You can only operate on your own resources");
     }
 
     await next();
@@ -282,7 +282,7 @@ export function requireOwnerOrAdmin(getResourceOwnerId: (c: Context) => Promise<
 export function getAuth(c: Context<{ Variables: AuthVariables }>): AuthContext {
   const auth = c.get("auth");
   if (!auth) {
-    throw new AppError(401, "AUTH_MISSING", "Not authenticated");
+    throw new AppError(401, "auth_missing", "Not authenticated");
   }
   return auth;
 }

--- a/ornn-api/src/middleware/validate.ts
+++ b/ornn-api/src/middleware/validate.ts
@@ -8,7 +8,7 @@
  *     "/skills",
  *     auth,
  *     requirePermission("ornn:skill:create"),
- *     validateBody(skillCreateSchema, "INVALID_SKILL_BODY"),
+ *     validateBody(skillCreateSchema, "invalid_skill_body"),
  *     async (c) => {
  *       const data = getValidatedBody<z.infer<typeof skillCreateSchema>>(c);
  *       ...
@@ -53,7 +53,7 @@ function formatIssues(issues: z.ZodIssue[]): string {
  */
 export function validateBody<T extends z.ZodTypeAny>(
   schema: T,
-  errorCode: string = "INVALID_BODY",
+  errorCode: string = "invalid_body",
 ): MiddlewareHandler {
   return async (c, next) => {
     let raw: unknown;
@@ -78,7 +78,7 @@ export function validateBody<T extends z.ZodTypeAny>(
  */
 export function validateQuery<T extends z.ZodTypeAny>(
   schema: T,
-  errorCode: string = "INVALID_QUERY",
+  errorCode: string = "invalid_query",
 ): MiddlewareHandler {
   return async (c, next) => {
     const raw: Record<string, string | undefined> = {};
@@ -101,7 +101,7 @@ export function validateQuery<T extends z.ZodTypeAny>(
  */
 export function validateParams<T extends z.ZodTypeAny>(
   schema: T,
-  errorCode: string = "INVALID_PARAMS",
+  errorCode: string = "invalid_params",
 ): MiddlewareHandler {
   return async (c, next) => {
     const result = schema.safeParse(c.req.param());

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -47,11 +47,11 @@ export class AppError extends Error {
   }
 
   static payloadTooLarge(message: string): AppError {
-    return new AppError(413, "PAYLOAD_TOO_LARGE", message);
+    return new AppError(413, "payload_too_large", message);
   }
 
   static internal(message: string): AppError {
-    return new AppError(500, "INTERNAL_ERROR", message);
+    return new AppError(500, "internal_error", message);
   }
 
   static internalError(code: string, message: string): AppError {
@@ -521,7 +521,7 @@ export function createErrorHandler(logger: { error: (...args: unknown[]) => void
       return c.json({ data: null, error: { code: err.code, message: err.message } }, err.statusCode);
     }
     logger.error(err, "Unhandled error");
-    return c.json({ data: null, error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json({ data: null, error: { code: "internal_error", message: "Internal server error" } }, 500);
   };
 }
 

--- a/ornn-web/src/components/agentseal/AgentSealTrustBadge.tsx
+++ b/ornn-web/src/components/agentseal/AgentSealTrustBadge.tsx
@@ -96,7 +96,7 @@ export function AgentSealTrustBadge({
         {},
       );
       if (res.error) {
-        const isDisabled = res.error.code === "AGENTSEAL_DISABLED";
+        const isDisabled = res.error.code === "agentseal_disabled";
         addToast({
           type: "error",
           message: isDisabled

--- a/ornn-web/src/pages/admin/MirrorPage.tsx
+++ b/ornn-web/src/pages/admin/MirrorPage.tsx
@@ -189,7 +189,7 @@ export function MirrorPage() {
       const message = translateError(err);
       const code = err instanceof ApiClientError ? err.code : null;
       // Surface the abandon-confirm path even if the modal was bypassed.
-      if (code === "OLD_REPO_NOT_CONFIRMED") {
+      if (code === "old_repo_not_confirmed") {
         setConfirmModalOpen(true);
       } else {
         addToast({ type: "error", message });

--- a/ornn-web/src/services/auditApi.ts
+++ b/ornn-web/src/services/auditApi.ts
@@ -31,7 +31,7 @@ export async function fetchAudit(
     );
     return res.data ?? null;
   } catch (err) {
-    if (err instanceof ApiClientError && err.code === "AUDIT_NOT_FOUND") {
+    if (err instanceof ApiClientError && err.code === "audit_not_found") {
       return null;
     }
     throw err;


### PR DESCRIPTION
Refs #585. (Behavior-changing — will go under-review post-merge.)

## What

Every error `code` emitted by `/api/v1/*` is now `lowercase_snake_case` per CONVENTIONS.md §1.4.

```
SKILL_NOT_FOUND      → skill_not_found
INVALID_BODY         → invalid_body
FORBIDDEN            → forbidden
AUTH_MISSING         → auth_missing
PAYLOAD_TOO_LARGE    → payload_too_large
QUOTA_EXCEEDED       → quota_exceeded
… (~55 codes, full table in docs/ERRORS.md appendix)
```

One-for-one lowercase rename — every existing code keeps its specificity, the §1.4 parent catalog (`validation_error`, `permission_denied`, `resource_not_found`, …) is the taxonomy these subcodes hang under.

**Web** — 3 sites branched on specific codes (`AGENTSEAL_DISABLED`, `OLD_REPO_NOT_CONFIRMED`, `AUDIT_NOT_FOUND`); all updated to the new lowercase forms.

**docs/ERRORS.md** — "Common subcodes" lists per §1.4 parent now lowercase. The appendix is a pre-#585 migration map (one row per SCREAMING code with its new lowercase form + §1.4 parent), not a case-difference table.

## Test plan

- [x] `bun run test` (ornn-api) → 620/625 pass, 5 todo (unchanged from develop)
- [x] `bunx tsc --noEmit` clean on api + web
- [ ] CI green
- [ ] Manual: confirm error responses on a private skill 404 / a malformed payload / an unauthenticated call all emit lowercase codes