### PR TITLE
feat!: URL + header conventions per CONVENTIONS.md (#586)

### DIFF
--- a/.changeset/url-header-conventions-586.md
+++ b/.changeset/url-header-conventions-586.md
@@ -1,0 +1,13 @@
+---
+"ornn-api": minor
+"ornn-web": patch
+"@chronoai/ornn-sdk": patch
+---
+
+**BREAKING** for two of the three changes — bring URL + header surface in line with CONVENTIONS.md §2/§4/§7 (#586):
+
+1. **`PATCH /skills/:id/versions/:version` + `DELETE /skills/:id/versions/:version`** — write operations now accept the stable GUID only, not `:idOrName`. Callers passing a name should resolve it via `GET /skills/lookup?name=…` first. (§2.2)
+2. **`?q=` is the canonical search param** (§4.1). The legacy `?query=` keeps working as a fallback during the alpha grace window — `q` wins when both are present. Both SDKs and ornn-web migrated to send `q`.
+3. **Deprecation signal is RFC 8594 (`Deprecation: true` + `Link: rel="deprecation"`)** — replaces `X-Skill-Deprecated` / `X-Skill-Deprecation-Note` custom headers (§7).
+
+The fourth violation flagged in the issue — `/skills/:id/json` → content negotiation via `Accept` header (§3.3) — is **deferred** to a focused follow-up PR. That one rewires the playground and several SDK paths and deserves its own review.

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -673,14 +673,23 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         }
       }
 
-      // Signal deprecation via response headers so non-JSON-aware clients
-      // (CLIs, agents) still get the warning. Notes are URL-encoded to keep
-      // header values ASCII-safe per RFC 7230.
+      // Signal deprecation via standard RFC 8594 headers (#586) — no
+      // custom `X-Skill-Deprecated` style. CLIs, agents, and proxies
+      // can read these without an Ornn-specific parser.
+      //
+      //   Deprecation: true
+      //   Link: <…/DEPRECATIONS.md#{guid}>; rel="deprecation"
+      //
+      // The deprecation note lives in the response body
+      // (`deprecationNote` on the SkillDetailResponse), where free-form
+      // text belongs. Sunset header is reserved for when we wire up the
+      // sunset-date field on the doc.
       if (skill.isDeprecated) {
-        c.header("X-Skill-Deprecated", "true");
-        if (skill.deprecationNote) {
-          c.header("X-Skill-Deprecation-Note", encodeURIComponent(skill.deprecationNote));
-        }
+        c.header("Deprecation", "true");
+        c.header(
+          "Link",
+          `<https://github.com/ChronoAIProject/Ornn/blob/main/docs/DEPRECATIONS.md#${skill.guid}>; rel="deprecation"`,
+        );
       }
 
       // Web-side pull. The detail endpoint is what the SkillDetailPage
@@ -709,25 +718,29 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
   );
 
   /**
-   * PATCH /skills/:idOrName/versions/:version
-   * Toggle the deprecation flag on a specific version.
+   * PATCH /skills/:id/versions/:version
+   *
+   * Toggle the deprecation flag on a specific version. Per
+   * CONVENTIONS.md §2.2 (#586): write operations accept only the
+   * stable GUID, not the name. Callers with a name should resolve
+   * via the read endpoint first.
+   *
    * Requires: ornn:skill:update + owner or admin on the skill.
    */
   app.patch(
-    "/skills/:idOrName/versions/:version",
+    "/skills/:id/versions/:version",
     auth,
     requirePermission("ornn:skill:update"),
-    validateBody(deprecationPatchSchema, "INVALID_DEPRECATION_PATCH"),
+    validateBody(deprecationPatchSchema, "invalid_deprecation_patch"),
     async (c) => {
-      const idOrName = c.req.param("idOrName");
+      const id = c.req.param("id");
       const version = c.req.param("version");
       const authCtx = getAuth(c);
 
-      const existing =
-        (await skillRepo.findByGuid(idOrName)) ??
-        (await skillRepo.findByName(idOrName));
+      // GUID-only — name fallback removed in #586.
+      const existing = await skillRepo.findByGuid(id);
       if (!existing) {
-        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${id}' not found`);
       }
       const memberships = await readUserOrgMemberships(c);
       const actor = {
@@ -744,7 +757,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const body = getValidatedBody<z.infer<typeof deprecationPatchSchema>>(c);
       const result = await skillService.setVersionDeprecation(
-        idOrName,
+        id,
         version,
         body.isDeprecated,
         body.deprecationNote ?? null,
@@ -1166,18 +1179,18 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
    * Requires: ornn:skill:delete + owner or admin.
    */
   app.delete(
-    "/skills/:idOrName/versions/:version",
+    "/skills/:id/versions/:version",
     auth,
     requirePermission("ornn:skill:delete"),
     async (c) => {
-      const idOrName = c.req.param("idOrName");
+      // GUID-only on write per CONVENTIONS.md §2.2 (#586).
+      const id = c.req.param("id");
       const version = c.req.param("version");
       const authCtx = getAuth(c);
 
-      let skill = await skillRepo.findByGuid(idOrName);
-      if (!skill) skill = await skillRepo.findByName(idOrName);
+      const skill = await skillRepo.findByGuid(id);
       if (!skill) {
-        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+        throw AppError.notFound("skill_not_found", `Skill '${id}' not found`);
       }
       const memberships = await readUserOrgMemberships(c);
       const actor = {

--- a/ornn-api/src/domains/skills/search/routes.ts
+++ b/ornn-api/src/domains/skills/search/routes.ts
@@ -22,7 +22,12 @@ import pino from "pino";
 const logger = pino({ level: "info" }).child({ module: "skillSearchRoutes" });
 
 const searchQuerySchema = z.object({
-  query: z.string().max(2000).optional().default(""),
+  // Canonical search param is `q` per CONVENTIONS.md §4.1 (#586).
+  // The legacy `query` is still parsed for the duration of the alpha
+  // grace window — clients on the old SDK keep working until they
+  // upgrade. `q` wins when both are present.
+  q: z.string().max(2000).optional(),
+  query: z.string().max(2000).optional(),
   mode: z.enum(["keyword", "semantic"]).optional().default("keyword"),
   scope: z.enum(["public", "private", "mixed", "shared-with-me", "mine"]).optional().default("private"),
   page: z.coerce.number().int().min(1).optional().default(1),
@@ -75,7 +80,9 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
     validateQuery(searchQuerySchema, "invalid_query"),
     async (c) => {
       const parsed = getValidatedQuery<z.infer<typeof searchQuerySchema>>(c);
-      const { query, mode, page, pageSize, model, systemFilter } = parsed;
+      // q wins; legacy `query` is the fallback for un-upgraded clients (#586).
+      const query = parsed.q ?? parsed.query ?? "";
+      const { mode, page, pageSize, model, systemFilter } = parsed;
       const authCtx = c.get("auth");
       const isAnonymous = !authCtx;
 

--- a/ornn-api/src/regression/hardcodeSweep.test.ts
+++ b/ornn-api/src/regression/hardcodeSweep.test.ts
@@ -71,6 +71,10 @@ const URL_ALLOWLIST: Array<string | RegExp> = [
   // API the mirror + skill-pull paths talk to. Token-based auth is
   // configured separately via the `mirror` settings section.
   /https?:\/\/api\.github\.com\b/,
+  // The Ornn repo URL used in RFC 8594 `Link: rel="deprecation"`
+  // headers (#586) — points at docs/DEPRECATIONS.md anchors, not a
+  // runtime endpoint we fetch.
+  /https?:\/\/github\.com\/ChronoAIProject\/Ornn\/blob\b/,
 ];
 
 // Specific filename → line allow-list for unavoidable hits (e.g.

--- a/ornn-web/src/services/searchApi.ts
+++ b/ornn-web/src/services/searchApi.ts
@@ -9,7 +9,8 @@ export async function searchSkills(
   params: SkillSearchParams
 ): Promise<SkillSearchResponse> {
   const queryParams: Record<string, string | number | undefined> = {
-    query: params.query,
+    // Canonical search param is `q` per CONVENTIONS.md §4.1 (#586).
+    q: params.query,
     mode: params.mode,
     scope: params.scope,
     page: params.page,

--- a/sdk/python/src/ornn_sdk/client.py
+++ b/sdk/python/src/ornn_sdk/client.py
@@ -104,7 +104,8 @@ class OrnnClient:
         """Search skills. Returns a paginated :class:`SkillSearchResult`."""
         params: dict[str, str] = {}
         if q is not None:
-            params["query"] = q
+            # Canonical search param is `q` per CONVENTIONS.md §4.1 (#586).
+            params["q"] = q
         if scope is not None:
             params["scope"] = scope
         if category is not None:

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -125,7 +125,7 @@ class TestEnvelope:
 
 class TestSearch:
     @respx.mock
-    def test_maps_q_to_query_param(self) -> None:
+    def test_maps_q_to_canonical_q_param(self) -> None:
         route = respx.get(f"{BASE}/api/v1/skill-search").respond(
             200,
             json={
@@ -143,7 +143,9 @@ class TestSearch:
             result = ornn.search(q="pdf", scope="public", page=2, page_size=50)
         assert isinstance(result, SkillSearchResult)
         req_url = str(route.calls.last.request.url)
-        assert "query=pdf" in req_url
+        # Canonical search param is `q` (CONVENTIONS.md §4.1 / #586).
+        assert "q=pdf" in req_url
+        assert "query=pdf" not in req_url
         assert "scope=public" in req_url
         assert "page=2" in req_url
         assert "pageSize=50" in req_url

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -77,7 +77,8 @@ export class OrnnClient {
   /** Search skills. Returns paginated results with `items` + pagination meta. */
   async search(params: SkillSearchParams = {}): Promise<SkillSearchResult> {
     const query = new URLSearchParams();
-    if (params.q) query.set("query", params.q);
+    // Per CONVENTIONS.md §4.1 (#586) the canonical search param is `q`.
+    if (params.q) query.set("q", params.q);
     if (params.scope) query.set("scope", params.scope);
     if (params.category) query.set("category", params.category);
     if (params.tag) query.set("tag", params.tag);

--- a/sdk/typescript/src/tests/client.test.ts
+++ b/sdk/typescript/src/tests/client.test.ts
@@ -123,7 +123,7 @@ describe("OrnnClient", () => {
     expect(err.code).toBe("unknown_error");
   });
 
-  test("search(): maps q → query and appends params correctly", async () => {
+  test("search(): sends q= and appends params correctly", async () => {
     let capturedUrl = "";
     const fetchMock = mockFetch((url) => {
       capturedUrl = url;
@@ -141,7 +141,9 @@ describe("OrnnClient", () => {
       pageSize: 50,
     });
     expect(capturedUrl).toContain("/api/v1/skill-search?");
-    expect(capturedUrl).toContain("query=pdf");
+    // Canonical search param per CONVENTIONS.md §4.1 (#586).
+    expect(capturedUrl).toContain("q=pdf");
+    expect(capturedUrl).not.toContain("query=pdf");
     expect(capturedUrl).toContain("scope=public");
     expect(capturedUrl).toContain("category=utils");
     expect(capturedUrl).toContain("page=2");


### PR DESCRIPTION
Refs #586. Three of four violations land here; the fourth (`/json` → Accept-header content negotiation) is intentionally deferred to a focused follow-up.

## What

- **§2.2 GUID-only writes** — `PATCH /skills/:id/versions/:version` + `DELETE /skills/:id/versions/:version` no longer accept `:idOrName`. Callers passing a name must resolve via `GET /skills/lookup?name=…` first.
- **§4.1 `?q=` canonical** — Search routes prefer `q`; legacy `?query=` is still parsed as a fallback during the alpha grace window. Both SDKs + ornn-web updated to send `q`.
- **§7 RFC 8594 deprecation headers** — `Deprecation: true` + `Link: rel="deprecation"` replace `X-Skill-Deprecated` / `X-Skill-Deprecation-Note`.

## Deferred

`§3.3 GET /skills/:id/json → Accept-header content negotiation` is a substantial rewire (playground + multiple SDK paths) and gets its own PR.

## Test plan

- [x] `bun run test` (ornn-api) → 620/625 pass, 5 todo
- [x] `bunx tsc --noEmit` clean on api / web
- [x] Hardcode-URL regression sweep allow-lists the `Link: rel="deprecation"` doc URL
- [ ] CI green