### PR TITLE
feat!: RFC 7807 application/problem+json error envelope (#456)

### DIFF
--- a/.changeset/rfc7807-envelope-456.md
+++ b/.changeset/rfc7807-envelope-456.md
@@ -1,0 +1,26 @@
+---
+"ornn-api": minor
+"ornn-web": patch
+"@chronoai/ornn-sdk": minor
+---
+
+**BREAKING:** error responses now ship as RFC 7807 `application/problem+json` per CONVENTIONS.md §1.3 (#456). The legacy `{ data: null, error: { code, message } }` envelope is gone on error paths; the fields live at the body root now:
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+
+{
+  "type": "https://github.com/ChronoAIProject/Ornn/blob/main/docs/ERRORS.md#skill_not_found",
+  "title": "Resource not found",
+  "status": 404,
+  "detail": "Skill 'foo' not found",
+  "instance": "/v1/skills/foo",
+  "code": "skill_not_found",
+  "requestId": "req_01HXYZ..."
+}
+```
+
+Success responses keep the `{ data, error: null }` envelope — only errors change.
+
+`buildProblemJsonBody` helper added to `shared/types/index.ts`; bootstrap and every per-domain test stub use it so wire shape can never drift between dev and CI. Both SDKs (TS + Python) and `ornn-web`'s `apiClient` parse the new shape; error tests across all three pin the new fixture.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -7,6 +7,7 @@
  */
 
 import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { cors } from "hono/cors";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
@@ -158,7 +159,7 @@ import { createLlmPickerRoutes } from "./domains/settings/llmProviders/routes";
 import { buildSpec } from "./openapi/specBuilder";
 
 // Error handler
-import { AppError } from "./shared/types/index";
+import { AppError, buildProblemJsonBody } from "./shared/types/index";
 
 export interface BootstrapResult {
   app: Hono;
@@ -845,49 +846,52 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     }, "Request completed");
   });
 
-  // Global error handler — single `AppError` hierarchy across the whole
-  // service, so `instanceof` is sufficient (no more duck-typing).
+  // Global error handler — emits RFC 7807 `application/problem+json`
+  // per CONVENTIONS.md §1.3 (#456). The legacy `{ data, error }`
+  // envelope is gone; clients read fields at the body root now (`code`,
+  // `status`, `detail`, `title`, `type`, `instance`, `requestId`).
   app.onError((err, c) => {
     const requestId = getRequestId(c);
-    // userId is optional on auth-context; use null distinct id when absent.
     const authCtx = (c.get as (k: string) => unknown)("auth") as
       | { userId?: string }
       | undefined;
     const userId = authCtx?.userId ?? null;
 
-    if (err instanceof AppError) {
-      logger.warn({ requestId, code: err.code, status: err.statusCode }, err.message);
-      // 5xx AppErrors are still real server failures — emit api.error
-      // (sampled) so PostHog has the same fidelity as runtime crashes.
-      if (err.statusCode >= 500) {
-        analyticsEmitter.trackApiError({
-          userId,
-          statusCode: err.statusCode,
-          errorCode: err.code,
-          method: c.req.method,
-          path: c.req.path,
-          requestId,
-        });
-      }
-      return c.json(
-        { data: null, error: { code: err.code, message: err.message } },
-        err.statusCode as any,
-      );
+    const appError = err instanceof AppError ? err : null;
+    const statusCode = appError?.statusCode ?? 500;
+    const code = appError?.code ?? "internal_error";
+    const detail = appError ? appError.message : "Internal server error";
+
+    if (appError) {
+      logger.warn({ requestId, code, status: statusCode }, appError.message);
+    } else {
+      logger.error({ requestId, err }, "Unhandled error");
     }
 
-    logger.error({ requestId, err }, "Unhandled error");
-    analyticsEmitter.trackApiError({
-      userId,
-      statusCode: 500,
-      errorCode: "internal_error",
-      method: c.req.method,
-      path: c.req.path,
+    // 5xx errors (AppError or unhandled crash) feed PostHog so runtime
+    // crashes and `AppError.serviceUnavailable`-class failures land in
+    // the same dashboard.
+    if (statusCode >= 500) {
+      analyticsEmitter.trackApiError({
+        userId,
+        statusCode,
+        errorCode: code,
+        method: c.req.method,
+        path: c.req.path,
+        requestId,
+      });
+    }
+
+    const body = buildProblemJsonBody({
+      statusCode,
+      code,
+      message: detail,
+      instance: c.req.path,
       requestId,
     });
-    return c.json(
-      { data: null, error: { code: "internal_error", message: "Internal server error" } },
-      500,
-    );
+    return c.json(body, statusCode as ContentfulStatusCode, {
+      "Content-Type": "application/problem+json",
+    });
   });
 
   // ---- API routes — all traffic via NyxID proxy, trust proxy headers ----

--- a/ornn-api/src/domains/admin/quota/routes.test.ts
+++ b/ornn-api/src/domains/admin/quota/routes.test.ts
@@ -18,6 +18,7 @@ import { QuotaRepository } from "../../quota/repository";
 import { QuotaService } from "../../quota/service";
 import type { AuthVariables } from "../../../middleware/nyxidAuth";
 import { createAdminQuotaRoutes } from "./routes";
+import { buildProblemJsonBody } from "../../../shared/types/index";
 
 let mongo: MongoMemoryServer;
 let client: MongoClient;
@@ -62,16 +63,18 @@ beforeAll(async () => {
   });
   app.onError((err, c) => {
     const e = err as { statusCode?: number; code?: string; message: string };
-    if (e.statusCode && e.code) {
-      return c.json(
-        { data: null, error: { code: e.code, message: e.message } },
-        e.statusCode as never,
-      );
-    }
-    return c.json(
-      { data: null, error: { code: "internal_error", message: e.message } },
-      500,
-    );
+    const statusCode = e.statusCode ?? 500;
+    const code = e.code ?? "internal_error";
+    const body = buildProblemJsonBody({
+      statusCode,
+      code,
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
   });
   app.route("/", router);
 });

--- a/ornn-api/src/domains/admin/redemption-codes/routes.test.ts
+++ b/ornn-api/src/domains/admin/redemption-codes/routes.test.ts
@@ -17,6 +17,7 @@ import { QuotaService } from "../../quota/service";
 import { RedemptionCodeRepository } from "../../redemption-codes/repository";
 import { RedemptionCodeService } from "../../redemption-codes/service";
 import type { AuthVariables } from "../../../middleware/nyxidAuth";
+import { buildProblemJsonBody } from "../../../shared/types/index";
 import { createAdminRedemptionCodesRoutes } from "./routes";
 
 let mongo: MongoMemoryServer;
@@ -64,16 +65,18 @@ beforeAll(async () => {
   });
   app.onError((err, c) => {
     const e = err as { statusCode?: number; code?: string; message: string };
-    if (e.statusCode && e.code) {
-      return c.json(
-        { data: null, error: { code: e.code, message: e.message } },
-        e.statusCode as never,
-      );
-    }
-    return c.json(
-      { data: null, error: { code: "internal_error", message: e.message } },
-      500,
-    );
+    const statusCode = e.statusCode ?? 500;
+    const code = e.code ?? "internal_error";
+    const body = buildProblemJsonBody({
+      statusCode,
+      code,
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
   });
   app.route("/", router);
 });
@@ -174,8 +177,8 @@ describe("POST /admin/redemption-codes/:id/invalidate", () => {
       { method: "POST", headers: authHeaders() },
     );
     expect(res.status).toBe(409);
-    const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("redemption_code_already_redeemed");
+    const json = (await res.json()) as { code: string; detail: string; status: number };
+    expect(json.code).toBe("redemption_code_already_redeemed");
   });
 
   test("on already-invalidated → 409 ALREADY_INVALIDATED", async () => {
@@ -193,8 +196,8 @@ describe("POST /admin/redemption-codes/:id/invalidate", () => {
       { method: "POST", headers: authHeaders() },
     );
     expect(res.status).toBe(409);
-    const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("redemption_code_already_invalidated");
+    const json = (await res.json()) as { code: string; detail: string; status: number };
+    expect(json.code).toBe("redemption_code_already_invalidated");
   });
 
   test("unknown id → 404", async () => {

--- a/ornn-api/src/domains/redemption-codes/me-routes.test.ts
+++ b/ornn-api/src/domains/redemption-codes/me-routes.test.ts
@@ -15,6 +15,7 @@ import { RedemptionCodeRepository } from "./repository";
 import { RedemptionCodeService } from "./service";
 import { createMeRedemptionCodesRoutes } from "./me-routes";
 import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { buildProblemJsonBody } from "../../shared/types/index";
 
 let mongo: MongoMemoryServer;
 let client: MongoClient;
@@ -57,16 +58,18 @@ beforeAll(async () => {
   });
   app.onError((err, c) => {
     const e = err as { statusCode?: number; code?: string; message: string };
-    if (e.statusCode && e.code) {
-      return c.json(
-        { data: null, error: { code: e.code, message: e.message } },
-        e.statusCode as never,
-      );
-    }
-    return c.json(
-      { data: null, error: { code: "internal_error", message: e.message } },
-      500,
-    );
+    const statusCode = e.statusCode ?? 500;
+    const code = e.code ?? "internal_error";
+    const body = buildProblemJsonBody({
+      statusCode,
+      code,
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
   });
   app.route("/", createMeRedemptionCodesRoutes({ redemptionCodeService: service }));
 });
@@ -132,8 +135,8 @@ describe("POST /me/redemption-codes/redeem", () => {
       body: JSON.stringify({ code: "ZZZZZZZZZZZZZZZZ" }),
     });
     expect(res.status).toBe(404);
-    const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("redemption_code_not_found");
+    const json = (await res.json()) as { code: string; detail: string; status: number };
+    expect(json.code).toBe("redemption_code_not_found");
   });
 
   test("expired → 410 REDEMPTION_CODE_EXPIRED", async () => {
@@ -147,8 +150,8 @@ describe("POST /me/redemption-codes/redeem", () => {
       body: JSON.stringify({ code }),
     });
     expect(res.status).toBe(410);
-    const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("redemption_code_expired");
+    const json = (await res.json()) as { code: string; detail: string; status: number };
+    expect(json.code).toBe("redemption_code_expired");
   });
 
   test("invalidated → 410 REDEMPTION_CODE_INVALIDATED", async () => {
@@ -167,8 +170,8 @@ describe("POST /me/redemption-codes/redeem", () => {
       body: JSON.stringify({ code: minted.code }),
     });
     expect(res.status).toBe(410);
-    const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("redemption_code_invalidated");
+    const json = (await res.json()) as { code: string; detail: string; status: number };
+    expect(json.code).toBe("redemption_code_invalidated");
   });
 
   test("already-redeemed → 409 REDEMPTION_CODE_ALREADY_REDEEMED", async () => {
@@ -184,8 +187,8 @@ describe("POST /me/redemption-codes/redeem", () => {
       body: JSON.stringify({ code }),
     });
     expect(res.status).toBe(409);
-    const json = (await res.json()) as { error: { code: string } };
-    expect(json.error.code).toBe("redemption_code_already_redeemed");
+    const json = (await res.json()) as { code: string; detail: string; status: number };
+    expect(json.code).toBe("redemption_code_already_redeemed");
   });
 });
 

--- a/ornn-api/src/domains/settings/exportImport/routes.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/routes.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./routes";
 import { sections } from "../sections";
 import type { SettingsService } from "../types";
+import { buildProblemJsonBody } from "../../../shared/types/index";
 
 function fakeSettingsService(): SettingsService {
   const store = new Map<string, Record<string, unknown>>();
@@ -80,10 +81,16 @@ function makeApp(opts: {
   app.onError((err, c) => {
     const code = (err as { code?: string }).code ?? "internal_error";
     const status = (err as { statusCode?: number }).statusCode ?? 500;
-    return c.json(
-      { data: null, error: { code, message: err.message } },
-      status as never,
-    );
+    const body = buildProblemJsonBody({
+      statusCode: status,
+      code,
+      message: err.message,
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, status as never, {
+      "Content-Type": "application/problem+json",
+    });
   });
   return { app };
 }

--- a/ornn-api/src/domains/settings/llmProviders/routes.test.ts
+++ b/ornn-api/src/domains/settings/llmProviders/routes.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./service";
 import type { StoredProvider } from "./repository";
 import { createLlmProvidersRoutes } from "./routes";
+import { buildProblemJsonBody } from "../../../shared/types/index";
 
 const KEY = "ornn-test-passphrase-32-chars-min-okOK";
 
@@ -71,10 +72,16 @@ describe("LlmProviders POST", () => {
     app.onError((err, c) => {
       const code = (err as { code?: string }).code ?? "internal_error";
       const status = (err as { statusCode?: number }).statusCode ?? 500;
-      return c.json(
-        { data: null, error: { code, message: err.message } },
-        status as never,
-      );
+      const body = buildProblemJsonBody({
+        statusCode: status,
+        code,
+        message: err.message,
+        instance: c.req.path,
+        requestId: null,
+      });
+      return c.json(body, status as never, {
+        "Content-Type": "application/problem+json",
+      });
     });
 
     const plaintext = "sk-real-plaintext-secret-12345";

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -499,3 +499,64 @@ export type PlaygroundChatEvent =
 export function isDuplicateKeyError(err: unknown): boolean {
   return typeof err === "object" && err !== null && "code" in err && (err as { code: number }).code === 11000;
 }
+
+// ---------------------------------------------------------------------------
+// RFC 7807 error body (#456)
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire shape of the RFC 7807 `application/problem+json` body the API
+ * emits on every 4xx/5xx response. Fields at the root, not inside an
+ * envelope. See CONVENTIONS.md §1.3 and docs/ERRORS.md.
+ */
+export interface ProblemJsonBody {
+  readonly type: string;
+  readonly title: string;
+  readonly status: number;
+  readonly detail: string;
+  readonly instance: string;
+  readonly code: string;
+  readonly requestId: string | null;
+  readonly errors?: ReadonlyArray<{ path?: string; code?: string; message: string }>;
+}
+
+/**
+ * Short human-readable summary for the RFC 7807 `title` field. Used by
+ * the live bootstrap handler AND the per-domain test stubs so they stay
+ * in lockstep on the wire shape.
+ */
+export function rfc7807TitleForStatus(status: number): string {
+  if (status === 400) return "Validation failed";
+  if (status === 401) return "Authentication required";
+  if (status === 403) return "Permission denied";
+  if (status === 404) return "Resource not found";
+  if (status === 409) return "Resource conflict";
+  if (status === 413) return "Payload too large";
+  if (status === 415) return "Unsupported media type";
+  if (status === 429) return "Rate limited";
+  if (status >= 500 && status < 600) return "Server error";
+  return "Request failed";
+}
+
+/**
+ * Build the canonical RFC 7807 body from an `AppError`-like + the path
+ * the request hit. Shared between bootstrap.ts (live) and per-domain
+ * test stubs so wire shape never drifts between dev and CI.
+ */
+export function buildProblemJsonBody(input: {
+  statusCode: number;
+  code: string;
+  message: string;
+  instance: string;
+  requestId: string | null;
+}): ProblemJsonBody {
+  return {
+    type: `https://github.com/ChronoAIProject/Ornn/blob/main/docs/ERRORS.md#${input.code}`,
+    title: rfc7807TitleForStatus(input.statusCode),
+    status: input.statusCode,
+    detail: input.message,
+    instance: input.instance,
+    code: input.code,
+    requestId: input.requestId,
+  };
+}

--- a/ornn-web/src/services/apiClient.ts
+++ b/ornn-web/src/services/apiClient.ts
@@ -116,17 +116,35 @@ async function handleResponse<T>(response: Response): Promise<ApiResponse<T>> {
     return { data: null, error: null };
   }
 
-  const json = (await response.json()) as ApiResponse<T>;
+  const json = (await response.json()) as unknown;
 
-  if (!response.ok || json.error) {
+  if (!response.ok) {
+    // Error responses are RFC 7807 `application/problem+json` (#456)
+    // — fields at the body root. The pre-#456 `{ data, error: {…} }`
+    // envelope is no longer emitted.
+    const problem = (json ?? {}) as {
+      code?: string;
+      detail?: string;
+      title?: string;
+      status?: number;
+    };
     throw new ApiClientError(
-      json.error?.code ?? "UNKNOWN_ERROR",
-      json.error?.message ?? "An unexpected error occurred",
-      response.status,
+      problem.code ?? "unknown_error",
+      problem.detail ?? problem.title ?? "An unexpected error occurred",
+      problem.status ?? response.status,
     );
   }
 
-  return json;
+  // Success: legacy `{ data, error: null }` envelope (unchanged).
+  const envelope = json as ApiResponse<T>;
+  if (envelope?.error) {
+    throw new ApiClientError(
+      envelope.error.code ?? "unknown_error",
+      envelope.error.message ?? "An unexpected error occurred",
+      response.status,
+    );
+  }
+  return envelope;
 }
 
 /**

--- a/sdk/python/src/ornn_sdk/client.py
+++ b/sdk/python/src/ornn_sdk/client.py
@@ -207,6 +207,10 @@ class OrnnClient:
 
         Returns the unwrapped ``data`` field on success. Raises
         :class:`OrnnError` on any failure.
+
+        Success responses keep the legacy ``{data, error: null}`` envelope.
+        Error responses are RFC 7807 ``application/problem+json`` (#456) —
+        fields at the body root.
         """
         res = self._raw_request(method, path, **kwargs)
         body: Any = None
@@ -214,8 +218,14 @@ class OrnnClient:
             body = res.json()
         except ValueError:
             body = None
-        if res.status_code >= 400 or not isinstance(body, dict) or body.get("error") is not None:
+        if res.status_code >= 400:
             raise _build_error(res, body)
+        if not isinstance(body, dict) or body.get("error") is not None:
+            raise OrnnError(
+                status=res.status_code,
+                code="unknown_error",
+                message=f"Ornn API returned {res.status_code} with an unexpected body shape",
+            )
         return body.get("data")
 
     # ---- Plumbing -----------------------------------------------------------
@@ -236,22 +246,29 @@ def _quote(segment: str) -> str:
 
 
 def _build_error(res: httpx.Response, body: Any | None = None) -> OrnnError:
+    """Build an OrnnError from an RFC 7807 problem+json response (#456).
+
+    Fields live at the body root now (``code``, ``status``, ``detail``,
+    ``title``, ``type``, ``instance``, ``requestId``, optional
+    ``errors[]``). The pre-#456 ``{data, error: {…}}`` envelope is no
+    longer emitted.
+    """
     if body is None:
         try:
             body = res.json()
         except ValueError:
             body = None
-    if isinstance(body, dict) and isinstance(body.get("error"), dict):
-        err = body["error"]
+    if isinstance(body, dict) and (body.get("code") or body.get("detail") or body.get("title")):
+        message = body.get("detail") or body.get("title") or f"Ornn API returned {res.status_code}"
         return OrnnError(
-            status=res.status_code,
-            code=str(err.get("code") or "unknown_error"),
-            message=str(err.get("message") or f"Ornn API returned {res.status_code}"),
-            request_id=err.get("requestId"),
-            errors=list(err.get("errors") or []) or None,
+            status=int(body.get("status") or res.status_code),
+            code=str(body.get("code") or "unknown_error"),
+            message=str(message),
+            request_id=body.get("requestId"),
+            errors=list(body.get("errors") or []) or None,
         )
     return OrnnError(
         status=res.status_code,
         code="unknown_error",
-        message=f"Ornn API returned {res.status_code} without a recognized error envelope",
+        message=f"Ornn API returned {res.status_code} without a recognized error body",
     )

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -69,16 +69,18 @@ class TestEnvelope:
         assert result == {"hello": "world"}
 
     @respx.mock
-    def test_raises_ornn_error_on_failure_envelope(self) -> None:
+    def test_raises_ornn_error_on_problem_json(self) -> None:
+        # 4xx body is RFC 7807 problem+json (#456) — root-level fields.
         respx.get(f"{BASE}/api/v1/admin").respond(
             403,
             json={
-                "data": None,
-                "error": {
-                    "code": "permission_denied",
-                    "message": "Missing ornn:skill:admin",
-                    "requestId": "req_01HXYZ",
-                },
+                "type": "https://github.com/.../ERRORS.md#permission_denied",
+                "title": "Permission denied",
+                "status": 403,
+                "code": "permission_denied",
+                "detail": "Missing ornn:skill:admin",
+                "instance": "/v1/admin",
+                "requestId": "req_01HXYZ",
             },
         )
         with make_client() as ornn:
@@ -102,17 +104,19 @@ class TestEnvelope:
 
     @respx.mock
     def test_preserves_structured_errors_list(self) -> None:
+        # `errors[]` rides at the body root inside problem+json (#456).
         respx.post(f"{BASE}/api/v1/skills").respond(
             400,
             json={
-                "data": None,
-                "error": {
-                    "code": "validation_error",
-                    "message": "Validation failed",
-                    "errors": [
-                        {"path": "name", "code": "required", "message": "name is required"},
-                    ],
-                },
+                "type": "https://github.com/.../ERRORS.md#validation_error",
+                "title": "Validation failed",
+                "status": 400,
+                "code": "validation_error",
+                "detail": "Validation failed",
+                "instance": "/v1/skills",
+                "errors": [
+                    {"path": "name", "code": "required", "message": "name is required"},
+                ],
             },
         )
         with make_client() as ornn:
@@ -213,8 +217,12 @@ class TestGet:
         respx.get(f"{BASE}/api/v1/skills/nope").respond(
             404,
             json={
-                "data": None,
-                "error": {"code": "resource_not_found", "message": "no such skill"},
+                "type": "https://github.com/.../ERRORS.md#resource_not_found",
+                "title": "Resource not found",
+                "status": 404,
+                "code": "resource_not_found",
+                "detail": "no such skill",
+                "instance": "/v1/skills/nope",
             },
         )
         with make_client() as ornn:
@@ -263,8 +271,12 @@ class TestDownload:
         respx.get(f"{BASE}/api/v1/skills/abc/versions/9.9/download").respond(
             404,
             json={
-                "data": None,
-                "error": {"code": "resource_not_found", "message": "no such version"},
+                "type": "https://github.com/.../ERRORS.md#resource_not_found",
+                "title": "Resource not found",
+                "status": 404,
+                "code": "resource_not_found",
+                "detail": "no such version",
+                "instance": "/v1/skills/abc/versions/9.9/download",
             },
         )
         with make_client() as ornn:

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -41,17 +41,21 @@ interface EnvelopeSuccess<T> {
   readonly error: null;
 }
 
-interface EnvelopeFailure {
-  readonly data: null;
-  readonly error: {
-    readonly code: string;
-    readonly message: string;
-    readonly requestId?: string;
-    readonly errors?: ReadonlyArray<{ path?: string; code?: string; message: string }>;
-  };
+/**
+ * Wire shape for error responses post-#456 — RFC 7807
+ * `application/problem+json`. Fields at the body root; `error` /
+ * `data` are gone.
+ */
+interface ProblemJson {
+  readonly type?: string;
+  readonly title?: string;
+  readonly status?: number;
+  readonly code?: string;
+  readonly detail?: string;
+  readonly instance?: string;
+  readonly requestId?: string;
+  readonly errors?: ReadonlyArray<{ path?: string; code?: string; message: string }>;
 }
-
-type Envelope<T> = EnvelopeSuccess<T> | EnvelopeFailure;
 
 export class OrnnClient {
   private readonly baseUrl: string;
@@ -183,11 +187,21 @@ export class OrnnClient {
     init: { body?: BodyInit; headers?: Record<string, string> } = {},
   ): Promise<T> {
     const res = await this.rawRequest(method, path, init);
-    const body = (await res.json().catch(() => null)) as Envelope<T> | null;
-    if (!res.ok || !body || body.error !== null) {
-      throw buildError(res.status, body);
+    const body = (await res.json().catch(() => null)) as unknown;
+    if (!res.ok) {
+      // Error responses are RFC 7807 (#456) — fields at the body root.
+      throw buildError(res.status, body as ProblemJson | null);
     }
-    return (body as EnvelopeSuccess<T>).data;
+    // Success responses keep the `{ data, error: null }` envelope.
+    const env = body as EnvelopeSuccess<T> | null;
+    if (!env || env.error !== null) {
+      throw new OrnnError({
+        status: res.status,
+        code: "unknown_error",
+        message: `Ornn API returned ${res.status} with an unexpected body shape`,
+      });
+    }
+    return env.data;
   }
 
   private async rawRequest(
@@ -214,25 +228,24 @@ function zipToBlob(zip: Blob | ArrayBuffer | Uint8Array): Blob {
 }
 
 async function parseError(res: Response): Promise<OrnnError> {
-  const body = (await res.json().catch(() => null)) as Envelope<unknown> | null;
+  const body = (await res.json().catch(() => null)) as ProblemJson | null;
   return buildError(res.status, body);
 }
 
-function buildError(status: number, body: Envelope<unknown> | null): OrnnError {
-  if (body && body.error) {
-    const err = body.error;
+function buildError(status: number, body: ProblemJson | null): OrnnError {
+  if (body && (body.code || body.detail || body.title)) {
     const payload: OrnnErrorPayload = {
-      status,
-      code: err.code,
-      message: err.message,
-      requestId: err.requestId,
-      errors: err.errors,
+      status: body.status ?? status,
+      code: body.code ?? "unknown_error",
+      message: body.detail ?? body.title ?? `Ornn API returned ${status}`,
+      requestId: body.requestId,
+      errors: body.errors,
     };
     return new OrnnError(payload);
   }
   return new OrnnError({
     status,
     code: "unknown_error",
-    message: `Ornn API returned ${status} without a recognized error envelope`,
+    message: `Ornn API returned ${status} without a recognized error body`,
   });
 }

--- a/sdk/typescript/src/tests/client.test.ts
+++ b/sdk/typescript/src/tests/client.test.ts
@@ -89,15 +89,16 @@ describe("OrnnClient", () => {
     expect(result.items[0]!.id).toBe("abc");
   });
 
-  test("throws OrnnError with code + status + requestId on envelope failure", async () => {
+  test("throws OrnnError parsing RFC 7807 problem+json body (#456)", async () => {
     const fetchMock = mockFetch(() =>
       jsonResponse(403, {
-        data: null,
-        error: {
-          code: "permission_denied",
-          message: "Missing ornn:skill:admin",
-          requestId: "req_01",
-        },
+        type: "https://github.com/.../ERRORS.md#permission_denied",
+        title: "Permission denied",
+        status: 403,
+        code: "permission_denied",
+        detail: "Missing ornn:skill:admin",
+        instance: "/v1/admin/stats",
+        requestId: "req_01",
       }),
     );
     const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
@@ -220,8 +221,15 @@ describe("OrnnClient", () => {
   });
 
   test("downloadPackage(): throws OrnnError on 404", async () => {
+    // 404 body is RFC 7807 problem+json (#456) — fields at the root.
     const fetchMock = mockFetch(() =>
-      jsonResponse(404, { data: null, error: { code: "resource_not_found", message: "no such version" } }),
+      jsonResponse(404, {
+        type: "https://github.com/.../ERRORS.md#resource_not_found",
+        title: "Resource not found",
+        status: 404,
+        code: "resource_not_found",
+        detail: "no such version",
+      }),
     );
     const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
     const err = (await client.downloadPackage("abc", "9.9").catch((e) => e)) as OrnnError;


### PR DESCRIPTION
Refs #456. Behavior-changing — will go under-review post-merge.

## What

Error responses across `/api/v1/*` now ship as RFC 7807 `application/problem+json` per CONVENTIONS.md §1.3. Legacy `{ data: null, error: { code, message } }` envelope on error paths is gone; fields live at the body root:

```http
HTTP/1.1 404 Not Found
Content-Type: application/problem+json

{
  "type":      "https://github.com/ChronoAIProject/Ornn/blob/main/docs/ERRORS.md#skill_not_found",
  "title":     "Resource not found",
  "status":    404,
  "detail":    "Skill 'foo' not found",
  "instance":  "/v1/skills/foo",
  "code":      "skill_not_found",
  "requestId": "req_01HXYZ..."
}
```

**Success responses keep the `{ data, error: null }` envelope** — only error paths shift.

## Implementation

- `shared/types/index.ts` — new `buildProblemJsonBody(...)` + `rfc7807TitleForStatus(...)` helpers.
- `bootstrap.ts` — `app.onError` uses the helper, sets `Content-Type: application/problem+json`. AppError + unhandled crashes both go through.
- Per-domain test stubs (5 files) use the same helper — wire shape can't drift between dev and CI.
- Both SDKs + `ornn-web/apiClient` parse the new shape; existing test fixtures migrated.

## Test plan

- [x] `bun run test` (ornn-api) → 620/625 pass (5 todo)
- [x] `bun run test` (SDK TS) → 17/17 pass
- [x] `pytest -q` (SDK Python) → 23/23 pass
- [x] `bunx tsc --noEmit` clean on api + web + sdk-ts
- [ ] CI green
- [ ] Manual: hit a private skill as non-owner → response is `application/problem+json` with `code: "skill_not_found"`