### PR TITLE
feat(api): publish JSON Schema for SKILL.md frontmatter (#464)

### DIFF
--- a/.changeset/skill-manifest-jsonschema-464.md
+++ b/.changeset/skill-manifest-jsonschema-464.md
@@ -1,0 +1,17 @@
+---
+"ornn-api": minor
+---
+
+Publish JSON Schema for `SKILL.md` frontmatter (#464). New endpoint:
+
+```
+GET /api/v1/skill-manifest-schema.json
+```
+
+- Generated from the Zod source of truth (`shared/schemas/skillFrontmatter.ts`) so the published contract cannot drift from the runtime validator.
+- Output is JSON Schema **draft-2020-12**, served with `Content-Type: application/schema+json`.
+- Public, no auth, `Cache-Control: public, max-age=3600`.
+
+Lets VS Code / Cursor / JetBrains YAML language servers autocomplete + validate `SKILL.md` frontmatter directly against the live server contract. Schema-store registration (`schemastore.org`) is a separate, one-time external action.
+
+The OpenAPI spec at `GET /api/v1/openapi.json` lists the new path so contract tests pick it up. Documented in `docs/CONVENTIONS.md` §10.1.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -378,6 +378,22 @@ Every response carries:
 - CI contract test asserts every handler in code appears in the spec with complete metadata.
 - Error `type` URLs point to live documentation per § 1.6.
 
+### 10.1 Skill manifest JSON Schema
+
+The canonical JSON Schema for `SKILL.md` YAML frontmatter is published at:
+
+```
+GET /api/v1/skill-manifest-schema.json
+```
+
+- Generated from the Zod source of truth (`ornn-api/src/shared/schemas/skillFrontmatter.ts`) at server boot — the published schema cannot drift from the runtime validator.
+- Output is JSON Schema **draft-2020-12** (`$schema`) — what current IDEs (VS Code, Cursor, JetBrains) and `schemastore.org` consume.
+- Served with `Content-Type: application/schema+json` (IANA registration). No `{ data, error }` envelope — the body root is the schema document itself, because that's what schema-store tools expect.
+- Public, no auth required. `Cache-Control: public, max-age=3600`.
+- `SKILL_MANIFEST_SCHEMA_VERSION` (currently `"1"`) is bumped manually when the frontmatter contract changes in a way external tooling cares about. Out of an abundance of caution while we're pre-1.0, this version is not yet baked into the URL; consumers should re-fetch on a finite TTL.
+
+Skill authors and tooling SHOULD point their YAML language servers at this URL via `# yaml-language-server: $schema=...` so SKILL.md gets autocomplete + inline validation.
+
 ---
 
 ## 11. Architecture conventions

--- a/ornn-api/src/domains/skills/format/routes.test.ts
+++ b/ornn-api/src/domains/skills/format/routes.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the skill-format routes — focus on the JSON Schema
+ * publishing endpoint added in #464. The rules + validate endpoints
+ * are exercised end-to-end elsewhere; this file pins the wire shape
+ * IDEs and schemastore.org rely on.
+ *
+ * @module domains/skills/format/routes.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import {
+  createFormatRoutes,
+  SKILL_MANIFEST_JSON_SCHEMA,
+  SKILL_MANIFEST_SCHEMA_VERSION,
+} from "./routes";
+import type { SkillService } from "../crud/service";
+
+function fakeSkillService(): SkillService {
+  // Format routes only need `validateZipFormat`. The schema endpoint
+  // never touches the service, so a barely-populated stub is enough.
+  return {
+    validateZipFormat: async () => [],
+  } as unknown as SkillService;
+}
+
+function makeApp(): Hono {
+  const routes = createFormatRoutes({ skillService: fakeSkillService() });
+  const app = new Hono();
+  app.route("/api/v1", routes);
+  return app;
+}
+
+describe("GET /api/v1/skill-manifest-schema.json (#464)", () => {
+  test("returns the JSON Schema with application/schema+json content type", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/v1/skill-manifest-schema.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/schema+json");
+  });
+
+  test("body is a JSON Schema document at the root (no { data, error } envelope)", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/v1/skill-manifest-schema.json");
+    const body = (await res.json()) as Record<string, unknown>;
+    // Sniff for JSON Schema shape — at minimum it must declare a type
+    // and either properties or definitions. The legacy envelope would
+    // have `data` + `error` at the root; assert both are absent.
+    expect(body).not.toHaveProperty("data");
+    expect(body).not.toHaveProperty("error");
+    expect(body.type).toBe("object");
+    expect(body.properties).toBeDefined();
+  });
+
+  test("schema declares the canonical SKILL.md frontmatter properties", async () => {
+    // Use the in-process constant rather than re-fetching — same source,
+    // and keeps the test fast.
+    const props = (SKILL_MANIFEST_JSON_SCHEMA as { properties: Record<string, unknown> }).properties;
+    expect(props).toBeDefined();
+    // Required top-level fields per the canonical frontmatter spec.
+    expect(props.name).toBeDefined();
+    expect(props.description).toBeDefined();
+    expect(props.version).toBeDefined();
+    expect(props.metadata).toBeDefined();
+  });
+
+  test("schema is cacheable (long-lived Cache-Control)", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/v1/skill-manifest-schema.json");
+    const cc = res.headers.get("cache-control") ?? "";
+    // IDEs / schemastore.org refetch on expiry; the value isn't strict
+    // but it MUST be a public, finite-max-age cache directive. Anything
+    // missing or `no-store` would hammer the server.
+    expect(cc).toMatch(/public/);
+    expect(cc).toMatch(/max-age=\d+/);
+  });
+
+  test("SKILL_MANIFEST_SCHEMA_VERSION is set", () => {
+    // Schema version is a stable identifier for external tooling
+    // (schemastore.org pins to a specific revision). Just sanity-check
+    // it's a non-empty string — the value itself is bumped manually.
+    expect(typeof SKILL_MANIFEST_SCHEMA_VERSION).toBe("string");
+    expect(SKILL_MANIFEST_SCHEMA_VERSION.length).toBeGreaterThan(0);
+  });
+});

--- a/ornn-api/src/domains/skills/format/routes.ts
+++ b/ornn-api/src/domains/skills/format/routes.ts
@@ -1,11 +1,13 @@
 /**
  * Skill format rules and validation routes.
- * GET  /api/skill-format/rules    — public, returns format rules markdown
- * POST /api/skill-format/validate — authenticated, validates ZIP against rules
+ * GET  /api/skill-format/rules           — public, returns format rules markdown
+ * POST /api/skill-format/validate        — authenticated, validates ZIP against rules
+ * GET  /api/skill-manifest-schema.json   — public, JSON Schema for SKILL.md frontmatter (#464)
  * @module domains/skills/format/routes
  */
 
 import { Hono } from "hono";
+import { z } from "zod";
 import type { SkillService } from "../crud/service";
 import {
   type AuthVariables,
@@ -13,6 +15,7 @@ import {
   requirePermission,
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
+import { skillFrontmatterSchema } from "../../../shared/schemas/skillFrontmatter";
 
 /** Canonical skill format rules per the ornn platform spec. Updated with output-type. */
 export const SKILL_FORMAT_RULES = `# Ornn Skill Package Format Rules
@@ -64,6 +67,28 @@ export const SKILL_FORMAT_RULES = `# Ornn Skill Package Format Rules
 - **compatibility** (string, optional): must be under 500 characters.
 `;
 
+/**
+ * Stable version identifier for the published JSON Schema (#464). Bump
+ * this when the frontmatter contract changes in a way external tooling
+ * cares about. Embedded in the schema's `$id` so consumers can pin a
+ * specific revision and so IDE / linter caches invalidate on bumps.
+ */
+export const SKILL_MANIFEST_SCHEMA_VERSION = "1";
+
+/**
+ * JSON Schema for SKILL.md frontmatter, derived from the canonical Zod
+ * schema via zod 4's built-in `z.toJSONSchema()`. Computed once at
+ * module load — the source schema is static, so re-running the
+ * conversion per request is wasted work.
+ *
+ * The legacy `zod-to-json-schema` package emits empty schemas against
+ * zod 4 (the AST shape changed); the in-tree converter is the only
+ * working option until that package catches up. Output is JSON Schema
+ * draft-2020-12 — what `z.toJSONSchema` produces and what current IDEs
+ * + schemastore.org consume.
+ */
+export const SKILL_MANIFEST_JSON_SCHEMA = z.toJSONSchema(skillFrontmatterSchema);
+
 export interface FormatRoutesConfig {
   skillService: SkillService;
 }
@@ -79,6 +104,24 @@ export function createFormatRoutes(config: FormatRoutesConfig): Hono<{ Variables
    */
   app.get("/skill-format/rules", async (c) => {
     return c.json({ data: { rules: SKILL_FORMAT_RULES }, error: null });
+  });
+
+  /**
+   * GET /skill-manifest-schema.json — Public, IDE-friendly JSON Schema
+   * for `SKILL.md` frontmatter (#464). No auth, long-cacheable: the
+   * schema is static for a given build, and IDEs / schemastore.org
+   * consumers re-fetch on cache expiry.
+   *
+   * Content-Type is `application/schema+json` per IANA registration —
+   * not the generic `application/json` — so VS Code / Cursor and
+   * schema-store tools that sniff the response type pick it up
+   * correctly.
+   */
+  app.get("/skill-manifest-schema.json", async (c) => {
+    return c.json(SKILL_MANIFEST_JSON_SCHEMA, 200, {
+      "Content-Type": "application/schema+json",
+      "Cache-Control": "public, max-age=3600",
+    });
   });
 
   /**

--- a/ornn-api/src/openapi/specBuilder.ts
+++ b/ornn-api/src/openapi/specBuilder.ts
@@ -260,6 +260,33 @@ function formatValidatePath(): PathItem {
   };
 }
 
+/**
+ * JSON Schema for SKILL.md frontmatter (#464). Unlike the other format
+ * endpoints this one returns a raw JSON Schema document — no envelope —
+ * so external tooling (IDEs, schemastore.org) consumes it directly.
+ */
+function formatSchemaPath(): PathItem {
+  return {
+    get: {
+      summary: "JSON Schema for SKILL.md frontmatter",
+      description:
+        "Canonical JSON Schema (draft-7) for `SKILL.md` YAML frontmatter, generated from the server's Zod schema. Public, long-cacheable. Returns the schema document at the body root with `Content-Type: application/schema+json` — not the standard `{ data, error }` envelope, since consumers (VS Code, Cursor, schemastore.org) expect a raw JSON Schema.",
+      operationId: "getFormatSchema",
+      tags: ["Format"],
+      responses: {
+        200: {
+          description: "JSON Schema document",
+          content: {
+            "application/schema+json": {
+              schema: { type: "object" },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
 function playgroundChatPath(): PathItem {
   return {
     post: {
@@ -414,6 +441,7 @@ export function buildSpec(): OpenApiSpec {
       // Format
       [`${prefix}/skill-format/rules`]: formatRulesPath(),
       [`${prefix}/skill-format/validate`]: formatValidatePath(),
+      [`${prefix}/skill-manifest-schema.json`]: formatSchemaPath(),
       // Playground
       [`${prefix}/playground/chat`]: playgroundChatPath(),
       // Admin


### PR DESCRIPTION
## Summary

Publishes the canonical JSON Schema for `SKILL.md` YAML frontmatter at a stable, public endpoint so IDEs (VS Code, Cursor, JetBrains YAML LS) and schemastore.org-class tooling can hook in.

```http
GET /api/v1/skill-manifest-schema.json
Content-Type: application/schema+json
Cache-Control: public, max-age=3600
```

Body is a raw JSON Schema draft-2020-12 document at the root — not the `{ data, error }` envelope — because that's what every schema-store consumer expects.

## Why

- `package.json` has a canonical JSON Schema (schemastore.org). `pyproject.toml` is PEP-specified. HuggingFace publishes model-card schemas. Without one, skill authors get zero editor support and external linters have nothing to hook into.
- Generating from the Zod source of truth means the published schema cannot drift from the runtime validator.

## Implementation notes

- Used zod 4's built-in `z.toJSONSchema()` rather than `zod-to-json-schema`: the latter emits empty schemas against the zod 4 AST (confirmed locally — even a `z.object({ name: z.string() })` round-trips to `{}`).
- Pre-computed at module load — the source schema is static.
- Added to the OpenAPI spec so contract tests pick it up.
- New §10.1 in `docs/CONVENTIONS.md` documents the endpoint and the recommended `# yaml-language-server: $schema=...` pragma.

## Out of scope (deliberately deferred)

- Making `schemaVersion` a required frontmatter field — that's a breaking change to every existing skill.
- Registering the URL with schemastore.org — one-time external PR.

## Test plan

- [x] `bun test src/domains/skills/format/routes.test.ts` — 5 tests pass (content-type, body shape, properties present, cache headers, version constant)
- [x] `bun test` ornn-api full suite — 623 pass / 0 fail
- [x] `bun run typecheck` clean
- [ ] Manual: hit `GET /api/v1/skill-manifest-schema.json` from a local cluster, verify VS Code picks it up with `# yaml-language-server: $schema=...`

Refs #464