### PR TITLE
feat(api): Idempotency-Key middleware with 24h replay cache (#459)

### DIFF
--- a/.changeset/idempotency-key-middleware-459.md
+++ b/.changeset/idempotency-key-middleware-459.md
@@ -1,0 +1,15 @@
+---
+"ornn-api": minor
+---
+
+Implement the `Idempotency-Key` header documented in CONVENTIONS.md §3.4 (#459).
+
+State-changing requests (`POST` / `PUT` / `PATCH` / `DELETE`) that include an `Idempotency-Key` header now get retry-safe replay semantics: the server fingerprints `(userId, method, path, key)` and caches the response (body + status + headers) in a new `idempotency_keys` Mongo collection for 24h. Retries within that window get the cached response back with `Idempotency-Replay: true` and the handler is NOT re-executed.
+
+Matches the `Idempotency-Key` shape Stripe / Square / AWS / GitHub already expose. Closes a real reliability gap where an agent timing-out on a network blip and retrying could create duplicate skills / redemptions / notifications.
+
+Scope decisions:
+- Cache `2xx` + `4xx` responses (a validation error is deterministic for the same input); skip `5xx` (transient, retrying may succeed).
+- Keys are scoped per `userId` so two unrelated callers using the same string can't collide.
+- 24h TTL via a Mongo TTL index on `createdAt` — sweep cost is negligible at our request volume.
+- Keys longer than 255 chars are silently bypassed rather than rejected, to avoid breaking every existing caller as soon as the middleware ships.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -27,6 +27,13 @@ import { requestIdMiddleware, getRequestId } from "./middleware/requestId";
 // status, durationMs, sourceIp, requestId.
 import { apiRequestTrackingMiddleware } from "./middleware/apiRequestTracking";
 
+// Idempotency-Key middleware (#459). Caches state-changing-request
+// responses for 24h so retries don't create duplicates.
+import {
+  IdempotencyKeyRepository,
+  idempotencyMiddleware,
+} from "./middleware/idempotency";
+
 // Infrastructure
 import { connectMongo, type MongoConnection } from "./infra/db/mongodb";
 import { createAnalyticsEmitter } from "./infra/analytics";
@@ -314,6 +321,15 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const userDirectoryRepo = new UserDirectoryRepository(db);
   void userDirectoryRepo.ensureIndexes().catch((err) =>
     logger.warn({ err }, "users indexes ensureIndexes failed — proceeding anyway"),
+  );
+
+  // ---- Idempotency-Key cache (#459). 24h TTL on `idempotency_keys`;
+  // mongo's TTL monitor sweeps once a minute. Index creation is
+  // fire-and-forget so a single-replica boot still comes up if the
+  // monitor temporarily refuses (it'll be re-attempted on next boot).
+  const idempotencyKeyRepo = new IdempotencyKeyRepository(db);
+  void idempotencyKeyRepo.ensureIndexes().catch((err) =>
+    logger.warn({ err }, "idempotency_keys indexes ensureIndexes failed — proceeding anyway"),
   );
 
   // Convenience: resolve the LLM provider for a given surface in a
@@ -924,6 +940,13 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   // route sees the same cached result — avoids re-querying NyxID within a
   // single request even when multiple routes call `readUserOrgMemberships`.
   apiApp.use("*", nyxidOrgLookupMiddleware(nyxidOrgsClient));
+
+  // Idempotency-Key replay cache (#459). Mounted AFTER `proxyAuthSetup`
+  // so it can scope cache entries per `auth.userId` — without that, two
+  // unrelated callers using the same key would replay each other's
+  // response. Non-mutating methods (GET/HEAD/OPTIONS) and requests
+  // without an `Idempotency-Key` header are passed through untouched.
+  apiApp.use("*", idempotencyMiddleware({ repo: idempotencyKeyRepo }));
 
   // ---- Admin routes (engineer-1): dashboard, users, quota admin ----
   const adminDashboardService = new AdminDashboardService({

--- a/ornn-api/src/middleware/idempotency.test.ts
+++ b/ornn-api/src/middleware/idempotency.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for the Idempotency-Key middleware (#459).
+ *
+ * Uses an in-memory Mongo via `mongodb-memory-server` so the TTL index
+ * + duplicate-key behaviour matches production. The handler being
+ * wrapped is a counter that increments on every real execution — the
+ * counter is the canary that tells us whether replay actually
+ * short-circuited the handler (counter stays at 1) or re-ran it
+ * (counter goes to 2+).
+ *
+ * @module middleware/idempotency.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db } from "mongodb";
+import {
+  IdempotencyKeyRepository,
+  idempotencyMiddleware,
+  MAX_IDEMPOTENCY_KEY_LENGTH,
+} from "./idempotency";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: IdempotencyKeyRepository;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("idempotency_test");
+  repo = new IdempotencyKeyRepository(db);
+  await repo.ensureIndexes();
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("idempotency_keys").deleteMany({});
+});
+
+function makeApp(handler: (counter: { value: number }) => Promise<Response> | Response) {
+  const counter = { value: 0 };
+  const app = new Hono();
+  // Stub auth so the middleware can scope keys per user.
+  app.use("*", async (c, next) => {
+    const userHeader = c.req.header("x-test-user") ?? "u1";
+    c.set("auth" as never, { userId: userHeader } as never);
+    await next();
+  });
+  app.use("*", idempotencyMiddleware({ repo }));
+  app.all("/api/v1/skills", async (c) => {
+    counter.value += 1;
+    return handler(counter);
+  });
+  return { app, counter };
+}
+
+describe("idempotency middleware (#459)", () => {
+  test("GET requests bypass the cache entirely (no key required, no doc written)", async () => {
+    const { app, counter } = makeApp(() => new Response("ok", { status: 200 }));
+    await app.request("/api/v1/skills", { method: "GET" });
+    await app.request("/api/v1/skills", { method: "GET" });
+    expect(counter.value).toBe(2);
+    expect(await db.collection("idempotency_keys").countDocuments()).toBe(0);
+  });
+
+  test("POST without an Idempotency-Key header is uncached", async () => {
+    const { app, counter } = makeApp(() => new Response("ok", { status: 200 }));
+    await app.request("/api/v1/skills", { method: "POST" });
+    await app.request("/api/v1/skills", { method: "POST" });
+    expect(counter.value).toBe(2);
+    expect(await db.collection("idempotency_keys").countDocuments()).toBe(0);
+  });
+
+  test("identical POST + key returns the cached body and skips the handler (the core feature)", async () => {
+    const { app, counter } = makeApp((c) =>
+      new Response(JSON.stringify({ id: `skill-${c.value}` }), {
+        status: 201,
+        headers: { "Content-Type": "application/json", Location: "/v1/skills/abc" },
+      }),
+    );
+    const headers = { "Idempotency-Key": "key-abc-123" };
+    const first = await app.request("/api/v1/skills", { method: "POST", headers });
+    const second = await app.request("/api/v1/skills", { method: "POST", headers });
+
+    expect(counter.value).toBe(1);
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(await first.json()).toEqual({ id: "skill-1" });
+    expect(await second.json()).toEqual({ id: "skill-1" });
+    expect(second.headers.get("Idempotency-Replay")).toBe("true");
+    expect(first.headers.get("Idempotency-Replay")).toBe(null);
+    // Cached headers round-trip (Location was set by the handler).
+    expect(second.headers.get("Location")).toBe("/v1/skills/abc");
+  });
+
+  test("different users with the same key DON'T collide (per-user scoping)", async () => {
+    const { app, counter } = makeApp((c) =>
+      new Response(JSON.stringify({ id: c.value }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const key = "shared-key";
+    const a = await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "Idempotency-Key": key, "x-test-user": "alice" },
+    });
+    const b = await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "Idempotency-Key": key, "x-test-user": "bob" },
+    });
+    expect(counter.value).toBe(2);
+    expect(await a.json()).toEqual({ id: 1 });
+    expect(await b.json()).toEqual({ id: 2 });
+    expect(b.headers.get("Idempotency-Replay")).toBe(null);
+  });
+
+  test("different paths with the same key DON'T collide", async () => {
+    const counter = { value: 0 };
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("auth" as never, { userId: "u1" } as never);
+      await next();
+    });
+    app.use("*", idempotencyMiddleware({ repo }));
+    app.post("/api/v1/skills", async () => {
+      counter.value += 1;
+      return new Response(JSON.stringify({ kind: "skill", n: counter.value }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    app.post("/api/v1/tags", async () => {
+      counter.value += 1;
+      return new Response(JSON.stringify({ kind: "tag", n: counter.value }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const headers = { "Idempotency-Key": "k" };
+    const skill = await app.request("/api/v1/skills", { method: "POST", headers });
+    const tag = await app.request("/api/v1/tags", { method: "POST", headers });
+    expect(counter.value).toBe(2);
+    expect((await skill.json()) as { kind: string; n: number }).toEqual({ kind: "skill", n: 1 });
+    expect((await tag.json()) as { kind: string; n: number }).toEqual({ kind: "tag", n: 2 });
+  });
+
+  test("4xx responses ARE cached (the client should see the same validation error on retry)", async () => {
+    const { app, counter } = makeApp((c) =>
+      new Response(JSON.stringify({ code: "validation_error", n: c.value }), {
+        status: 400,
+        headers: { "Content-Type": "application/problem+json" },
+      }),
+    );
+    const headers = { "Idempotency-Key": "k" };
+    const first = await app.request("/api/v1/skills", { method: "POST", headers });
+    const second = await app.request("/api/v1/skills", { method: "POST", headers });
+    expect(counter.value).toBe(1);
+    expect(first.status).toBe(400);
+    expect(second.status).toBe(400);
+    expect(second.headers.get("Idempotency-Replay")).toBe("true");
+  });
+
+  test("5xx responses are NOT cached (transient — let the next retry hit the handler)", async () => {
+    const { app, counter } = makeApp((c) =>
+      new Response(JSON.stringify({ code: "internal_error", n: c.value }), {
+        status: 500,
+        headers: { "Content-Type": "application/problem+json" },
+      }),
+    );
+    const headers = { "Idempotency-Key": "k" };
+    await app.request("/api/v1/skills", { method: "POST", headers });
+    await app.request("/api/v1/skills", { method: "POST", headers });
+    expect(counter.value).toBe(2);
+    expect(await db.collection("idempotency_keys").countDocuments()).toBe(0);
+  });
+
+  test("204 No Content replays cleanly (empty body, no content-type)", async () => {
+    const { app, counter } = makeApp(() => new Response(null, { status: 204 }));
+    const headers = { "Idempotency-Key": "k" };
+    const first = await app.request("/api/v1/skills", { method: "DELETE", headers });
+    const second = await app.request("/api/v1/skills", { method: "DELETE", headers });
+    expect(counter.value).toBe(1);
+    expect(first.status).toBe(204);
+    expect(second.status).toBe(204);
+    expect(second.headers.get("Idempotency-Replay")).toBe("true");
+  });
+
+  test("oversize keys are silently bypassed (do not 400 every caller as soon as the middleware ships)", async () => {
+    const { app, counter } = makeApp(() => new Response("ok", { status: 200 }));
+    const oversize = "x".repeat(MAX_IDEMPOTENCY_KEY_LENGTH + 1);
+    await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "Idempotency-Key": oversize },
+    });
+    await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "Idempotency-Key": oversize },
+    });
+    expect(counter.value).toBe(2);
+    expect(await db.collection("idempotency_keys").countDocuments()).toBe(0);
+  });
+
+  test("TTL index is created with the documented 24h window", async () => {
+    const indexes = await db.collection("idempotency_keys").indexes();
+    const ttl = indexes.find((i) => i.name === "createdAt_ttl");
+    expect(ttl).toBeDefined();
+    expect(ttl?.expireAfterSeconds).toBe(24 * 60 * 60);
+  });
+
+  test("handler errors that don't produce a response don't pollute the cache", async () => {
+    // Hono catches thrown errors via `app.onError`. With no `onError`
+    // configured, a thrown error surfaces as a default 500 page — which
+    // is 5xx, which we already don't cache. Pin that explicitly so a
+    // future change to error handling can't sneak through.
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("auth" as never, { userId: "u1" } as never);
+      await next();
+    });
+    app.use("*", idempotencyMiddleware({ repo }));
+    app.post("/api/v1/skills", () => {
+      throw new Error("boom");
+    });
+    const headers = { "Idempotency-Key": "k" };
+    await app.request("/api/v1/skills", { method: "POST", headers });
+    expect(await db.collection("idempotency_keys").countDocuments()).toBe(0);
+  });
+});

--- a/ornn-api/src/middleware/idempotency.test.ts
+++ b/ornn-api/src/middleware/idempotency.test.ts
@@ -54,7 +54,7 @@ function makeApp(handler: (counter: { value: number }) => Promise<Response> | Re
     await next();
   });
   app.use("*", idempotencyMiddleware({ repo }));
-  app.all("/api/v1/skills", async (c) => {
+  app.all("/api/v1/skills", async () => {
     counter.value += 1;
     return handler(counter);
   });

--- a/ornn-api/src/middleware/idempotency.ts
+++ b/ornn-api/src/middleware/idempotency.ts
@@ -1,0 +1,249 @@
+/**
+ * Idempotency-Key middleware (CONVENTIONS.md §3.4, #459).
+ *
+ * On every state-changing request (`POST` / `PUT` / `PATCH` / `DELETE`)
+ * carrying an `Idempotency-Key` header, the middleware fingerprints
+ * `(userId, method, path, key)` and looks the fingerprint up in the
+ * `idempotency_keys` Mongo collection. If a prior response is cached
+ * within the 24 h TTL window, the cached body + status + headers are
+ * returned verbatim with `Idempotency-Replay: true`. Otherwise the
+ * handler executes and its response is persisted for the next retry.
+ *
+ * Industry parallels: Stripe, Square, AWS, GitHub all expose
+ * `Idempotency-Key` in the same shape. Without it, an agent that
+ * retries a POST after a transient network failure can create
+ * duplicate skills / redemptions / notifications — a class of bug that
+ * lands on the on-call to clean up manually.
+ *
+ * Mount order constraints:
+ * - MUST run AFTER `proxyAuthSetup` so `c.var.auth.userId` is set; the
+ *   fingerprint is per-user, otherwise two unrelated callers could
+ *   replay each other's response with the same key.
+ * - MUST run BEFORE per-route handlers so it can short-circuit on
+ *   cache hits and capture handler responses on cache misses.
+ *
+ * @module middleware/idempotency
+ */
+
+import type { MiddlewareHandler } from "hono";
+import type { Collection, Db } from "mongodb";
+import pino from "pino";
+
+const logger = pino({ level: "info" }).child({ module: "idempotency" });
+
+/** 24-hour TTL, per CONVENTIONS.md §3.4 — matches Stripe / GitHub. */
+export const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
+
+/** Methods that mutate state. GET / HEAD / OPTIONS are idempotent by definition. */
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Idempotency-Key values are arbitrary client strings. We refuse keys
+ * over this length to prevent unbounded growth of fingerprint indexes
+ * and to surface obvious bugs (e.g. an agent stuffing a full body into
+ * the header).
+ */
+export const MAX_IDEMPOTENCY_KEY_LENGTH = 255;
+
+/** 5xx responses are transient — replaying a server error doesn't help. */
+function shouldCache(status: number): boolean {
+  return status < 500;
+}
+
+export interface IdempotencyKeyDoc {
+  /** Composite fingerprint: `${userId}:${method}:${path}:${key}`. */
+  _id: string;
+  key: string;
+  userId: string;
+  method: string;
+  path: string;
+  responseStatus: number;
+  /**
+   * Response body as a UTF-8 string. Non-text payloads (e.g. ZIP
+   * downloads) get base64-encoded; `responseEncoding` tracks the form.
+   * The 16 MiB Mongo doc limit easily covers every JSON response we
+   * emit today and tomorrow.
+   */
+  responseBody: string;
+  responseEncoding: "utf-8" | "base64";
+  responseHeaders: Record<string, string>;
+  createdAt: Date;
+}
+
+export class IdempotencyKeyRepository {
+  private readonly col: Collection<IdempotencyKeyDoc>;
+
+  constructor(db: Db) {
+    this.col = db.collection<IdempotencyKeyDoc>("idempotency_keys");
+  }
+
+  async ensureIndexes(): Promise<void> {
+    // Mongo TTL monitor sweeps once per minute; documents are deleted
+    // when `createdAt + expireAfterSeconds < now`. The composite `_id`
+    // already gives unique-key replay protection.
+    await this.col.createIndex(
+      { createdAt: 1 },
+      { expireAfterSeconds: IDEMPOTENCY_TTL_SECONDS, name: "createdAt_ttl" },
+    );
+  }
+
+  async find(id: string): Promise<IdempotencyKeyDoc | null> {
+    return await this.col.findOne({ _id: id });
+  }
+
+  /**
+   * Insert with duplicate-key tolerance. Two concurrent requests with
+   * the same key race here — one wins, the other's identical handler
+   * output is silently discarded. Returns `false` on the loser's path
+   * so the caller knows it didn't persist.
+   */
+  async insert(doc: IdempotencyKeyDoc): Promise<{ inserted: boolean }> {
+    try {
+      await this.col.insertOne(doc);
+      return { inserted: true };
+    } catch (err: unknown) {
+      const code = (err as { code?: number } | null)?.code;
+      if (code === 11000) {
+        return { inserted: false };
+      }
+      throw err;
+    }
+  }
+}
+
+function fingerprint(userId: string, method: string, path: string, key: string): string {
+  return `${userId}:${method}:${path}:${key}`;
+}
+
+function captureHeaders(res: Response): Record<string, string> {
+  const headers: Record<string, string> = {};
+  res.headers.forEach((value, name) => {
+    headers[name] = value;
+  });
+  return headers;
+}
+
+/**
+ * Test seam: lets callers inject a custom date for deterministic TTL
+ * assertions. Production callers leave it as `Date.now()`.
+ */
+function nowProvider(): Date {
+  return new Date();
+}
+
+export interface IdempotencyConfig {
+  repo: IdempotencyKeyRepository;
+  /** Override for tests. */
+  now?: () => Date;
+}
+
+export function idempotencyMiddleware(config: IdempotencyConfig): MiddlewareHandler {
+  const { repo, now = nowProvider } = config;
+
+  return async (c, next) => {
+    const method = c.req.method.toUpperCase();
+    const rawKey = c.req.header("Idempotency-Key");
+
+    // Not applicable: safe method (GET / HEAD / OPTIONS) or no key.
+    if (!MUTATING_METHODS.has(method) || !rawKey) {
+      return next();
+    }
+
+    const key = rawKey.trim();
+    if (key.length === 0 || key.length > MAX_IDEMPOTENCY_KEY_LENGTH) {
+      // Malformed keys fall through and don't cache. Returning 400
+      // here would be more strict but creates a new failure mode for
+      // every existing caller as soon as the middleware ships.
+      logger.debug({ keyLength: key.length, path: c.req.path }, "Idempotency key rejected");
+      return next();
+    }
+
+    const auth = (c.get as unknown as (k: "auth") => { userId?: string } | undefined)("auth");
+    const userId = auth?.userId ?? "anonymous";
+    const path = c.req.path;
+    const id = fingerprint(userId, method, path, key);
+
+    const cached = await repo.find(id);
+    if (cached) {
+      logger.info({ id, userId, method, path, status: cached.responseStatus }, "Idempotency replay");
+      const replayHeaders = new Headers(cached.responseHeaders);
+      replayHeaders.set("Idempotency-Replay", "true");
+      const body =
+        cached.responseEncoding === "base64"
+          ? Uint8Array.from(atob(cached.responseBody), (ch) => ch.charCodeAt(0))
+          : cached.responseBody;
+      return new Response(body, {
+        status: cached.responseStatus,
+        headers: replayHeaders,
+      });
+    }
+
+    await next();
+
+    // Capture and persist the handler's response. The store happens
+    // BEFORE the function returns — synchronous persistence is the
+    // only way to guarantee that a retry arriving 10 ms later sees the
+    // cached entry, which is the entire point of the feature. (A
+    // fire-and-forget write would race the retry.)
+    const res: Response | undefined = c.res;
+    if (!res || !shouldCache(res.status)) {
+      return;
+    }
+
+    try {
+      const responseHeaders = captureHeaders(res);
+      const contentType = responseHeaders["content-type"] ?? "";
+      let body: string;
+      let encoding: "utf-8" | "base64";
+      if (contentType.startsWith("application/") || contentType.startsWith("text/")) {
+        // Clone before reading so the original response stream is
+        // still consumable by the actual client.
+        body = await res.clone().text();
+        encoding = "utf-8";
+      } else {
+        // Binary — base64-encode for storage. Empty bodies (e.g. 204)
+        // round-trip as empty strings either way.
+        const buffer = await res.clone().arrayBuffer();
+        body = bufferToBase64(new Uint8Array(buffer));
+        encoding = "base64";
+      }
+
+      const doc: IdempotencyKeyDoc = {
+        _id: id,
+        key,
+        userId,
+        method,
+        path,
+        responseStatus: res.status,
+        responseBody: body,
+        responseEncoding: encoding,
+        responseHeaders,
+        createdAt: now(),
+      };
+      const { inserted } = await repo.insert(doc);
+      if (!inserted) {
+        logger.debug({ id }, "Idempotency persist lost a race");
+      }
+    } catch (err) {
+      // Persistence failure must NEVER fail the request. The client
+      // gets a correct response; the only cost is no replay protection
+      // if the same retry happens before the TTL window.
+      logger.warn({ err, id }, "Idempotency persist failed");
+    }
+  };
+}
+
+/**
+ * Cross-runtime base64 encode for `Uint8Array`. Bun + Node have
+ * different globals available; this works in both without pulling in
+ * the `buffer` shim explicitly.
+ */
+function bufferToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = bytes[i];
+    if (byte === undefined) continue;
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}


### PR DESCRIPTION
## Summary

Implements the `Idempotency-Key` header documented in CONVENTIONS.md §3.4. Closes a real reliability gap: an agent that times out on a network blip and retries a `POST` can create duplicate skills / redemptions / notifications. With this PR, retries within 24h return the cached response with `Idempotency-Replay: true` and never re-execute the handler.

Wire shape matches Stripe / Square / AWS / GitHub.

```http
POST /api/v1/skills
Idempotency-Key: 8e5b...

# Second time, within 24h:
HTTP/1.1 201 Created
Idempotency-Replay: true
Location: /v1/skills/abc
{ "id": "abc", ... }   ← byte-for-byte identical to the first response
```

## Implementation

- New module: `ornn-api/src/middleware/idempotency.ts`.
- `IdempotencyKeyRepository` owns the `idempotency_keys` Mongo collection. Composite `_id` = `${userId}:${method}:${path}:${key}` enforces per-user + per-route scoping at the storage layer.
- `idempotencyMiddleware()` is a Hono middleware that short-circuits on cache hits and persists on cache misses. Mounted globally on `apiApp` after `proxyAuthSetup` (needs the userId).

## Design decisions

- **Cache 2xx + 4xx; never cache 5xx.** A validation error is deterministic and replayable; a transient server error isn't.
- **Per-user scoping** — two unrelated callers using the same key string can't collide.
- **24h TTL via a Mongo TTL index** on `createdAt`. Mongo's TTL monitor sweeps once a minute.
- **Race tolerance** — concurrent requests with the same key compete on the unique `_id`. The loser silently discards its identical output rather than failing.
- **Persistence failures never fail the request.** The client always sees the correct response; only cost is no replay protection within the window.
- **Oversize keys silently bypass** rather than 400 — ships safely without breaking any caller who happened to send a long header.

## Test plan

- [x] `bun test src/middleware/idempotency.test.ts` — 11 tests pass, covering: GET passthrough, no-key passthrough, basic replay, per-user scoping, per-path scoping, 4xx caching, 5xx bypass, 204 No Content replay, oversize key bypass, TTL index shape, handler-error no-pollution.
- [x] `bun test` full ornn-api suite — 626 pass / 0 fail.
- [x] `bun run typecheck` clean.
- [ ] Manual: send `POST /api/v1/skills/generate` with the same `Idempotency-Key` twice from a local cluster, verify second response carries `Idempotency-Replay: true` and the LLM call is NOT re-issued (`$$ saved`).

## Out of scope

- Per-endpoint `Idempotency-Key` parameter declaration in the OpenAPI spec — that's an ergonomic improvement for spec consumers; the middleware works regardless. Tracked separately if needed.

Refs #459