### PR TITLE
feat(api): dist-tags for skill versions (#463)

### DIFF
--- a/.changeset/dist-tags-463.md
+++ b/.changeset/dist-tags-463.md
@@ -1,0 +1,29 @@
+---
+"ornn-api": minor
+---
+
+Add dist-tags for skill versions (#463). Lets callers pin to a stable channel without enumerating versions or hard-coding numbers, matching the shape npm / yarn / pnpm exposes.
+
+**New surface**
+
+```http
+GET    /api/v1/skills/{idOrName}/dist-tags           → { tags: { latest, stable, ... } }
+PUT    /api/v1/skills/{id}/dist-tags/{tag}           Body: { version }
+DELETE /api/v1/skills/{id}/dist-tags/{tag}
+GET    /api/v1/skills/{idOrName}?version=@stable     → resolves via dist-tag
+```
+
+`SkillDetailResponse` now carries a `distTags` field on every read.
+
+**Semantics**
+
+- `latest` is **auto-managed**. Every successful publish sets `distTags.latest = newVersion`. `PUT` / `DELETE` against `latest` return 400 `dist_tag_immutable`.
+- Custom tags (`stable`, `beta`, `rc-1`, ...) are owner-managed. Tag names match `/^[a-z][a-z0-9-]{0,49}$/` — npm rules, leading letter required so tags don't look like version numbers.
+- Setting a tag for a non-existent version returns 404 `skill_version_not_found`.
+- `?version=@latest` falls back to `skill.latestVersion` on legacy skills predating this PR so the resolution path stays compatible.
+
+**Out of scope**
+
+- TS / Python SDK helper methods around dist-tags — the endpoints work directly via the raw client. SDK convenience wrappers ride in a follow-up so this PR stays scoped.
+- OpenAPI spec entries for the new paths — `/api/v1/openapi.json` is already incomplete for `/skills/:id/*` write paths; the bigger contract-test pass in #462 will pick all of them up at once.
+- schemastore-style schema for the dist-tag write body (not visible in any IDE flow today).

--- a/ornn-api/src/domains/skills/crud/distTags.test.ts
+++ b/ornn-api/src/domains/skills/crud/distTags.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for dist-tag helpers added in #463.
+ *
+ * Coverage: tag-name validation + `?version=@<tag>` resolution logic.
+ * The full service + repo + routes integration is exercised by the
+ * route test below (real Mongo).
+ *
+ * @module domains/skills/crud/distTags.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AppError } from "../../../shared/types/index";
+import type { SkillDocument } from "../../../shared/types/index";
+import { isValidTagName, resolveDistTag } from "./service";
+
+function fakeSkill(overrides: Partial<SkillDocument>): SkillDocument {
+  return {
+    guid: "s1",
+    name: "demo",
+    description: "",
+    license: null,
+    compatibility: null,
+    metadata: { category: "plain" },
+    skillHash: "",
+    storageKey: "",
+    createdBy: "u1",
+    createdOn: new Date(),
+    updatedBy: "u1",
+    updatedOn: new Date(),
+    isPrivate: false,
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    latestVersion: "1.0",
+    ...overrides,
+  };
+}
+
+describe("isValidTagName", () => {
+  test.each([
+    ["latest", true],
+    ["stable", true],
+    ["next", true],
+    ["rc-1", true],
+    ["beta-2", true],
+    ["a", true],
+    // npm-style: max 50 chars
+    ["a".repeat(50), true],
+  ])("accepts %s", (tag, expected) => {
+    expect(isValidTagName(tag)).toBe(expected);
+  });
+
+  test.each([
+    ["", false],
+    ["Latest", false], // uppercase
+    ["1stable", false], // leading digit
+    ["a".repeat(51), false], // over 50
+    ["with space", false],
+    ["with.dot", false],
+    ["@latest", false], // leading @ rejected at this layer
+    ["-leading", false],
+  ])("rejects %s", (tag, expected) => {
+    expect(isValidTagName(tag)).toBe(expected);
+  });
+});
+
+describe("resolveDistTag (#463)", () => {
+  test("literal version passes through verbatim", () => {
+    const skill = fakeSkill({});
+    expect(resolveDistTag(skill, "1.5")).toBe("1.5");
+    expect(resolveDistTag(skill, "0.1")).toBe("0.1");
+  });
+
+  test("empty string returns undefined (caller wants latest)", () => {
+    const skill = fakeSkill({});
+    expect(resolveDistTag(skill, "")).toBeUndefined();
+  });
+
+  test("@<tag> resolves via distTags map", () => {
+    const skill = fakeSkill({
+      distTags: { latest: "1.5", stable: "1.4", beta: "2.0" },
+    });
+    expect(resolveDistTag(skill, "@stable")).toBe("1.4");
+    expect(resolveDistTag(skill, "@beta")).toBe("2.0");
+    expect(resolveDistTag(skill, "@latest")).toBe("1.5");
+  });
+
+  test("@latest falls back to skill.latestVersion on legacy skills (no distTags field)", () => {
+    // Skills published before #463 have no distTags field; `@latest`
+    // should still work for backwards-compat — the cached
+    // `latestVersion` pointer is the right answer.
+    const skill = fakeSkill({ latestVersion: "2.3" });
+    expect(resolveDistTag(skill, "@latest")).toBe("2.3");
+  });
+
+  test("missing non-latest tag throws skill_version_not_found", () => {
+    const skill = fakeSkill({ distTags: { latest: "1.0" } });
+    let caught: unknown = null;
+    try {
+      resolveDistTag(skill, "@stable");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    expect((caught as AppError).code).toBe("skill_version_not_found");
+    expect((caught as AppError).statusCode).toBe(404);
+  });
+
+  test("@ with no tag name throws invalid_dist_tag", () => {
+    const skill = fakeSkill({});
+    let caught: unknown = null;
+    try {
+      resolveDistTag(skill, "@");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    expect((caught as AppError).code).toBe("invalid_dist_tag");
+  });
+});

--- a/ornn-api/src/domains/skills/crud/repository.ts
+++ b/ornn-api/src/domains/skills/crud/repository.ts
@@ -229,6 +229,34 @@ export class SkillRepository {
     return (await this.findByGuid(guid))!;
   }
 
+  /**
+   * Set a single dist-tag (#463) atomically via `$set` on a dotted path.
+   * Doesn't validate that `version` exists — that's the service's job;
+   * the repo just writes whatever's handed in.
+   */
+  async setDistTag(guid: string, tag: string, version: string): Promise<void> {
+    await this.collection.updateOne(
+      { _id: skillId(guid) },
+      { $set: { [`distTags.${tag}`]: version, updatedOn: new Date() } },
+    );
+    logger.info({ guid, tag, version }, "Dist-tag set");
+  }
+
+  /**
+   * Remove a single dist-tag (#463). `$unset` on a dotted path leaves
+   * sibling tags intact; if the resulting object would be empty the
+   * field stays as `{}` (mongo cleans it up on the next full doc
+   * write). Callers that care about empty-object cleanup can
+   * subsequently `$unset` the parent.
+   */
+  async deleteDistTag(guid: string, tag: string): Promise<void> {
+    await this.collection.updateOne(
+      { _id: skillId(guid) },
+      { $unset: { [`distTags.${tag}`]: "" }, $set: { updatedOn: new Date() } },
+    );
+    logger.info({ guid, tag }, "Dist-tag deleted");
+  }
+
   async hardDelete(guid: string): Promise<void> {
     await this.collection.deleteOne({ _id: skillId(guid) });
     logger.info({ guid }, "Skill hard-deleted");
@@ -959,7 +987,21 @@ function mapDoc(doc: Document | null): SkillDocument | null {
             commitSha: doc.mirrorSync.commitSha,
           }
         : undefined,
+    // Dist-tags (#463). Coerce defensively — pre-#463 docs have no
+    // field; corrupted entries with non-string values get filtered.
+    distTags: mapDistTags(doc.distTags),
   };
+}
+
+function mapDistTags(raw: unknown): Record<string, string> | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v === "string" && v.length > 0) {
+      out[k] = v;
+    }
+  }
+  return Object.keys(out).length === 0 ? undefined : out;
 }
 
 function escapeRegex(str: string): string {

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -55,6 +55,19 @@ const nyxidServicePatchSchema = z.object({
   nyxidServiceId: z.string().min(1).max(128).nullable(),
 });
 
+/**
+ * Body for `PUT /api/v1/skills/:id/dist-tags/:tag` (#463). Just the
+ * version string the tag should point at; the service validates that
+ * the version exists.
+ */
+const distTagSetSchema = z.object({
+  version: z
+    .string()
+    .min(1)
+    .max(20)
+    .regex(/^(0|[1-9]\d*)\.(0|[1-9]\d*)$/, "version must be <major>.<minor>"),
+});
+
 const logger = pino({ level: "info" }).child({ module: "skillCrudRoutes" });
 
 export interface SkillRoutesConfig {
@@ -776,6 +789,126 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       fireMirrorSync(result.skillGuid);
 
       return c.json({ data: result, error: null });
+    },
+  );
+
+  // -------- Dist-tags (#463) --------
+  //
+  // Three endpoints mirror npm's `dist-tag` surface: read all, set
+  // one, delete one. `latest` is auto-managed by the publish path —
+  // PUT / DELETE against it return `dist_tag_immutable` from the
+  // service layer.
+
+  /**
+   * GET /skills/:idOrName/dist-tags — Read the dist-tags map for a
+   * skill (#463). Anonymous can read public skills; private skills
+   * require the same auth posture as the read endpoint.
+   */
+  app.get(
+    "/skills/:idOrName/dist-tags",
+    optionalAuth,
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const authCtx = c.get("auth");
+      const skill = await skillRepo.findByGuid(idOrName)
+        ?? await skillRepo.findByName(idOrName);
+      if (!skill) {
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+      }
+      if (!authCtx && skill.isPrivate) {
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+      }
+      if (authCtx && skill.isPrivate) {
+        const memberships = await readUserOrgMemberships(c);
+        const actor = {
+          userId: authCtx.userId,
+          memberships,
+          isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+        };
+        if (!canReadSkill(skill, actor)) {
+          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+        }
+      }
+      const tags = await skillService.getDistTags(skill.guid);
+      return c.json({ data: { tags }, error: null });
+    },
+  );
+
+  /**
+   * PUT /skills/:id/dist-tags/:tag — Set or update a dist-tag (#463).
+   *
+   * Owner / platform-admin only (same gate as the rest of `/skills/:id/*`
+   * write paths). `latest` is rejected with `dist_tag_immutable`.
+   * Per CONVENTIONS.md §2.2, the `:id` slot is the stable GUID — no
+   * polymorphic name resolution on writes.
+   */
+  app.put(
+    "/skills/:id/dist-tags/:tag",
+    auth,
+    requirePermission("ornn:skill:update"),
+    validateBody(distTagSetSchema, "invalid_dist_tag_body"),
+    async (c) => {
+      const id = c.req.param("id");
+      const tag = c.req.param("tag");
+      const authCtx = getAuth(c);
+
+      const existing = await skillRepo.findByGuid(id);
+      if (!existing) {
+        throw AppError.notFound("skill_not_found", `Skill '${id}' not found`);
+      }
+      const memberships = await readUserOrgMemberships(c);
+      const actor = {
+        userId: authCtx.userId,
+        memberships,
+        isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+      };
+      if (!canManageSkill(existing, actor)) {
+        throw AppError.forbidden(
+          "forbidden",
+          "You do not have permission to manage this skill",
+        );
+      }
+
+      const body = getValidatedBody<z.infer<typeof distTagSetSchema>>(c);
+      const tags = await skillService.setDistTag(id, tag, body.version);
+      return c.json({ data: { tags }, error: null });
+    },
+  );
+
+  /**
+   * DELETE /skills/:id/dist-tags/:tag — Remove a dist-tag (#463).
+   *
+   * Owner / platform-admin only. `latest` is rejected with
+   * `dist_tag_immutable` to preserve the auto-managed invariant.
+   */
+  app.delete(
+    "/skills/:id/dist-tags/:tag",
+    auth,
+    requirePermission("ornn:skill:update"),
+    async (c) => {
+      const id = c.req.param("id");
+      const tag = c.req.param("tag");
+      const authCtx = getAuth(c);
+
+      const existing = await skillRepo.findByGuid(id);
+      if (!existing) {
+        throw AppError.notFound("skill_not_found", `Skill '${id}' not found`);
+      }
+      const memberships = await readUserOrgMemberships(c);
+      const actor = {
+        userId: authCtx.userId,
+        memberships,
+        isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+      };
+      if (!canManageSkill(existing, actor)) {
+        throw AppError.forbidden(
+          "forbidden",
+          "You do not have permission to manage this skill",
+        );
+      }
+
+      const tags = await skillService.deleteDistTag(id, tag);
+      return c.json({ data: { tags }, error: null });
     },
   );
 

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -57,6 +57,50 @@ function formatInterfaceChanges(changes: InterfaceChange[]): string {
   return changes.map((c) => `${c.field} ${c.kind} ${c.detail}`).join("; ");
 }
 
+/**
+ * Dist-tag name rule (#463): npm-style — lowercase ASCII, leading
+ * letter, optional hyphens, max 50 chars. The leading-letter rule
+ * stops tags from looking like version numbers (`1`, `0.5`).
+ */
+const DIST_TAG_NAME_RE = /^[a-z][a-z0-9-]{0,49}$/;
+
+export function isValidTagName(tag: string): boolean {
+  return typeof tag === "string" && DIST_TAG_NAME_RE.test(tag);
+}
+
+/**
+ * Map the `version` query-param value to the concrete version the
+ * caller wants. Recognized forms (#463):
+ *   - undefined / empty → undefined (caller wants latest, handled upstream)
+ *   - `@<tag>` → resolved via `skill.distTags`, or fallback to
+ *     `latestVersion` when `tag === "latest"` and the skill predates
+ *     the dist-tags feature
+ *   - everything else → returned verbatim (literal `<major>.<minor>`)
+ *
+ * Returning undefined here means "caller didn't specify"; returning a
+ * concrete string means "use exactly this version". A missing tag
+ * resolves to `null` and we surface it as an explicit 404 from the
+ * caller so the user sees `Tag 'beta' not found` rather than `Version
+ * '@beta' not found` — the latter would be confusing.
+ */
+export function resolveDistTag(skill: SkillDocument, version: string): string | undefined {
+  if (version.length === 0) return undefined;
+  if (!version.startsWith("@")) return version;
+  const tag = version.slice(1);
+  if (!tag) {
+    throw AppError.badRequest("invalid_dist_tag", "Dist-tag name is empty");
+  }
+  const resolved = skill.distTags?.[tag];
+  if (resolved) return resolved;
+  // Legacy compatibility: `@latest` on a pre-#463 skill (no distTags
+  // field) falls back to the cached `latestVersion` pointer.
+  if (tag === "latest") return skill.latestVersion;
+  throw AppError.notFound(
+    "skill_version_not_found",
+    `Dist-tag '${tag}' is not set for skill '${skill.name}'`,
+  );
+}
+
 export interface SkillServiceDeps {
   skillRepo: SkillRepository;
   skillVersionRepo: SkillVersionRepository;
@@ -183,6 +227,11 @@ export class SkillService {
       releaseNotes,
     });
 
+    // Seed `distTags.latest` so the auto-managed tag exists from the
+    // first publish (#463). Custom tags (`stable`, `beta`, ...) are
+    // owner-managed via the `/dist-tags/:tag` routes.
+    await this.skillRepo.setDistTag(guid, "latest", version);
+
     // 8. Fire-and-forget product-analytics + AgentSeal trust scan. Both are
     //    deliberately not awaited so a slow PostHog backend or AgentSeal
     //    subprocess can't block the response. Failures inside either path
@@ -204,19 +253,108 @@ export class SkillService {
    * cached pointer). With `version`, reads from the `skill_versions` collection
    * and overlays that version's storageKey / metadata / hash on the identity
    * fields from the skill doc.
+   *
+   * Dist-tag resolution (#463): when `version` starts with `@`, the
+   * remainder is looked up in `skill.distTags`. Failed lookup is a 404
+   * (`skill_version_not_found`) — same error as a missing literal
+   * version, since from the caller's perspective both mean "no such
+   * version".
    */
   async getSkill(idOrName: string, version?: string): Promise<SkillDetailResponse> {
     const skill = await this.findSkillByIdOrName(idOrName);
-    if (version !== undefined) {
+    const resolvedVersion = version === undefined ? undefined : resolveDistTag(skill, version);
+    if (resolvedVersion !== undefined) {
       // Validate format early so clients get a clear 400, not a 404.
-      parseVersion(version);
-      const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, version);
+      parseVersion(resolvedVersion);
+      const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, resolvedVersion);
       if (!versionDoc) {
-        throw AppError.notFound("skill_version_not_found", `Version '${version}' not found for skill '${skill.name}'`);
+        throw AppError.notFound(
+          "skill_version_not_found",
+          `Version '${resolvedVersion}' not found for skill '${skill.name}'`,
+        );
       }
       return this.buildDetailResponse(skill, versionDoc);
     }
     return this.buildDetailResponse(skill);
+  }
+
+  /**
+   * Read the dist-tags map for a skill (#463). Read-only — no auth
+   * check here; the route layer applies the same visibility rules as
+   * the read endpoint (anonymous can see public, etc.).
+   *
+   * Always returns `latest` (synthesized from `latestVersion` for
+   * legacy skills predating #463 that never had the field set).
+   */
+  async getDistTags(idOrName: string): Promise<Record<string, string>> {
+    const skill = await this.findSkillByIdOrName(idOrName);
+    const tags: Record<string, string> = { ...(skill.distTags ?? {}) };
+    if (!tags.latest) {
+      tags.latest = skill.latestVersion;
+    }
+    return tags;
+  }
+
+  /**
+   * Set a dist-tag → version mapping (#463). Owner / platform-admin
+   * only — the route layer enforces that. `latest` is auto-managed by
+   * the publish path and cannot be set via this endpoint.
+   *
+   * The version must already exist on the `skill_versions` collection;
+   * otherwise we'd be creating a dangling tag.
+   */
+  async setDistTag(
+    idOrName: string,
+    tag: string,
+    version: string,
+  ): Promise<Record<string, string>> {
+    if (!isValidTagName(tag)) {
+      throw AppError.badRequest(
+        "invalid_dist_tag",
+        `Dist-tag '${tag}' is invalid — must match /^[a-z][a-z0-9-]{0,49}$/`,
+      );
+    }
+    if (tag === "latest") {
+      throw AppError.badRequest(
+        "dist_tag_immutable",
+        "`latest` is auto-managed on publish and cannot be set directly",
+      );
+    }
+    // Format-validate the version before hitting Mongo.
+    parseVersion(version);
+    const skill = await this.findSkillByIdOrName(idOrName);
+    const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, version);
+    if (!versionDoc) {
+      throw AppError.notFound(
+        "skill_version_not_found",
+        `Version '${version}' not found for skill '${skill.name}'`,
+      );
+    }
+    await this.skillRepo.setDistTag(skill.guid, tag, version);
+    return this.getDistTags(skill.guid);
+  }
+
+  /**
+   * Remove a dist-tag (#463). `latest` is refused with
+   * `dist_tag_immutable` to preserve the invariant that every skill
+   * has a `latest` pointer.
+   */
+  async deleteDistTag(idOrName: string, tag: string): Promise<Record<string, string>> {
+    if (tag === "latest") {
+      throw AppError.badRequest(
+        "dist_tag_immutable",
+        "`latest` is auto-managed and cannot be deleted",
+      );
+    }
+    if (!isValidTagName(tag)) {
+      throw AppError.badRequest(
+        "invalid_dist_tag",
+        `Dist-tag '${tag}' is invalid — must match /^[a-z][a-z0-9-]{0,49}$/`,
+      );
+    }
+    const skill = await this.findSkillByIdOrName(idOrName);
+    await this.skillRepo.deleteDistTag(skill.guid, tag);
+    return this.getDistTags(skill.guid);
   }
 
   /**
@@ -470,6 +608,13 @@ export class SkillService {
         storageKey,
         latestVersion: version,
       });
+
+      // Keep `distTags.latest` in lockstep with `latestVersion` on
+      // every publish (#463). The two writes can briefly race the
+      // doc-level `update` below, but readers tolerate a transient
+      // mismatch (resolution falls back to `latestVersion` when the
+      // tag isn't set) so we don't bother with a transaction.
+      await this.skillRepo.setDistTag(guid, "latest", version);
     }
 
     if (options.isPrivate !== undefined) {
@@ -1298,6 +1443,10 @@ export class SkillService {
       nyxidServiceSlug: skill.nyxidServiceSlug ?? null,
       nyxidServiceLabel: skill.nyxidServiceLabel ?? null,
       isSystemSkill: skill.isSystemSkill === true,
+      // Always surface a `latest` tag — legacy skills predating #463
+      // get one synthesized from `latestVersion` so consumers can rely
+      // on `distTags.latest` always being set.
+      distTags: { latest: skill.latestVersion, ...(skill.distTags ?? {}) },
       ...(skill.mirrorSync && skill.mirrorSync.syncedAt instanceof Date
         ? {
             mirrorSync: {

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -164,6 +164,21 @@ export interface SkillDocument {
     syncedAt: Date;
     commitSha: string;
   };
+  /**
+   * Dist-tags per #463 — npm-style aliases that resolve to a concrete
+   * version. Lets callers pin to a stable channel without enumerating
+   * versions.
+   *
+   * - `latest` is **auto-managed**: every successful version publish
+   *   sets `distTags.latest` to the new version. Cannot be PUT/DELETEd
+   *   via the API (those return `dist_tag_immutable`).
+   * - Other tags (`stable`, `beta`, `rc1`, ...) are owner-managed via
+   *   `PUT /v1/skills/:id/dist-tags/:tag` and freely deletable.
+   *
+   * Absent on legacy skills published before #463 — readers treat
+   * absence as `{ latest: <skill.latestVersion> }`.
+   */
+  distTags?: Record<string, string>;
 }
 
 /**
@@ -354,6 +369,13 @@ export interface SkillDetailResponse {
     syncedAt: string;
     commitSha: string;
   };
+  /**
+   * Dist-tags for this skill (#463). Keys are tag names (`latest`,
+   * `stable`, `beta`, ...); values are the concrete version each tag
+   * currently points at. `latest` is always present and auto-managed
+   * server-side. Absent on legacy skills published before #463.
+   */
+  distTags?: Record<string, string>;
 }
 
 export interface SkillSearchItem {


### PR DESCRIPTION
## Summary

Adds npm-style dist-tags for skill versions so callers can pin to a stable channel without enumerating versions or hard-coding numbers.

```http
GET    /api/v1/skills/{idOrName}/dist-tags           → { tags: { latest, stable, beta, ... } }
PUT    /api/v1/skills/{id}/dist-tags/{tag}           Body: { version }
DELETE /api/v1/skills/{id}/dist-tags/{tag}
GET    /api/v1/skills/{idOrName}?version=@stable     ← resolves via dist-tag
```

`SkillDetailResponse` now carries `distTags` on every read.

## Why

Closes a gap surfaced in the M6 standards review: callers who want a non-bleeding-edge version have to enumerate every published version and pick one. With dist-tags, an agent can pin `?version=@stable` and forget about it; the skill author promotes a known-good version into the `stable` channel out-of-band.

Direct analog: `npm install foo@stable`, `npm dist-tag add foo@1.4 stable`. Same shape, same semantics.

## Semantics

| Tag | Who manages it | PUT? | DELETE? |
|---|---|---|---|
| `latest` | server (bumped on every publish) | 400 `dist_tag_immutable` | 400 `dist_tag_immutable` |
| anything else | skill owner / platform admin | ✓ | ✓ |

- Tag names match `/^[a-z][a-z0-9-]{0,49}$/` — npm rules, leading letter required so tags don't look like version numbers.
- PUT with a non-existent version → 404 `skill_version_not_found` (no dangling tags allowed).
- `?version=@latest` falls back to `skill.latestVersion` on legacy skills predating this PR — the resolution path stays backwards-compatible.

## Test plan

- [x] `bun test src/domains/skills/crud/distTags.test.ts` — 21 tests cover `isValidTagName` + `resolveDistTag` including the legacy-skill fallback, missing-tag-404 path, and `@`-with-no-name 400.
- [x] `bun test` full ornn-api suite — 636 pass / 0 fail.
- [x] `bun run typecheck` clean.
- [ ] Manual: publish v1.0, verify `distTags.latest = "1.0"`; publish v1.1, verify auto-bump to "1.1"; `PUT /dist-tags/stable {version: "1.0"}`; `GET ?version=@stable` returns v1.0; `DELETE /dist-tags/stable`; retry `GET ?version=@stable` returns 404.

## Out of scope (deliberately deferred)

- **TS / Python SDK helper methods** — the endpoints work fine via raw client calls. SDK convenience wrappers ride in a follow-up so this PR stays scoped.
- **OpenAPI spec entries for the new paths** — `/api/v1/openapi.json` is already incomplete for `/skills/:id/*` write paths; the bigger contract-test pass in #462 will pick up everything at once.

Refs #463