### PR TITLE
feat(api): backend zip-bomb caps mirroring #443 client guards (#633)

### DIFF
--- a/.changeset/zip-bomb-backend-caps-633.md
+++ b/.changeset/zip-bomb-backend-caps-633.md
@@ -1,0 +1,24 @@
+---
+"ornn-api": minor
+---
+
+Mirror the client-side `#443` zip-bomb defense on the backend (#633). Closes the gap surfaced during retrospective verification: an agent / SDK / `curl` client that bypasses the browser SPA could POST a 50 KB ZIP that uncompresses to 500 MB inside `validateZipFormat` or the AgentSeal subprocess.
+
+New `enforceZipLimits(zipBuffer)` in `shared/utils/zipLimits.ts` walks the ZIP central directory **without extracting** and throws RFC 7807 `413 Payload Too Large` (with stable `lowercase_snake_case` codes per CONVENTIONS.md §1.4) on any of:
+
+| Cap | Default | Error code |
+|---|---|---|
+| Cumulative uncompressed | 50 MiB | `uncompressed_too_large` |
+| Per-entry uncompressed | 25 MiB | `uncompressed_too_large` |
+| File count | 1000 | `too_many_files` |
+| Compression ratio | 50× (skipped for tiny ZIPs) | `uncompressed_too_large` |
+| Invalid ZIP | — | `invalid_zip` (400) |
+
+Wired into every authenticated upload path:
+- `POST /api/v1/skills` (create)
+- `PUT /api/v1/skills/:id` (update, only when a ZIP is actually replaced)
+- `POST /api/v1/skill-format/validate` (the standalone validator endpoint)
+
+Defaults match the client-side guard exactly so a ZIP that passes browser pre-flight also passes the server. Configurable via the function signature today (env-var hooks can ride in a follow-up if operators ask for them).
+
+8 unit tests cover the happy path, each cap, the invalid-ZIP fast-path, and the tiny-ZIP ratio-check carve-out.

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -27,6 +27,7 @@ import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import { AppError } from "../../../shared/types/index";
 import { canReadSkill, canManageSkill } from "./authorize";
 import { parseGithubUrl } from "./utils/githubPull";
+import { enforceZipLimits } from "../../../shared/utils/zipLimits";
 import pino from "pino";
 
 const deprecationPatchSchema = z.object({
@@ -233,6 +234,14 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       }
 
       const zipBuffer = new Uint8Array(body);
+
+      // Zip-bomb defense (#633). Walks the central directory without
+      // extracting; throws 413 (`uncompressed_too_large` / `too_many_files`
+      // / `invalid_zip`) before validateZipFormat / storage upload /
+      // AgentSeal subprocess. Cheap, runs ahead of every expensive
+      // side-effect.
+      await enforceZipLimits(zipBuffer);
+
       const userEmail = authCtx.email || undefined;
       const userDisplayName = authCtx.displayName || undefined;
 
@@ -977,6 +986,13 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       if (zipBuffer === undefined && isPrivate === undefined) {
         throw AppError.badRequest("no_update", "No update data provided. Send a ZIP file and/or isPrivate field.");
+      }
+
+      // Zip-bomb defense (#633) — same gate as the create path. Only
+      // when a ZIP is actually being replaced; a privacy-only PUT
+      // doesn't hit this.
+      if (zipBuffer !== undefined) {
+        await enforceZipLimits(zipBuffer);
       }
 
       logger.info({ guid, userId: authCtx.userId }, "Skill update via API");

--- a/ornn-api/src/domains/skills/format/routes.ts
+++ b/ornn-api/src/domains/skills/format/routes.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
 import { skillFrontmatterSchema } from "../../../shared/schemas/skillFrontmatter";
+import { enforceZipLimits } from "../../../shared/utils/zipLimits";
 
 /** Canonical skill format rules per the ornn platform spec. Updated with output-type. */
 export const SKILL_FORMAT_RULES = `# Ornn Skill Package Format Rules
@@ -144,6 +145,12 @@ export function createFormatRoutes(config: FormatRoutesConfig): Hono<{ Variables
       }
 
       const zipBuffer = new Uint8Array(body);
+
+      // Zip-bomb defense (#633) — same gate as the publish path. The
+      // /skill-format/validate endpoint is authenticated but otherwise
+      // unrestricted, so an attacker can still slow us down here with
+      // pathological ZIPs unless we cap before extraction.
+      await enforceZipLimits(zipBuffer);
 
       // `validateZipFormat` returns the full list of rule violations.
       // An empty array means the package is valid; anything non-empty is what

--- a/ornn-api/src/shared/utils/zipLimits.test.ts
+++ b/ornn-api/src/shared/utils/zipLimits.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for backend zip-bomb defense (#633).
+ *
+ * Each test builds a precisely-shaped ZIP via JSZip and asserts the
+ * cap's failure mode. The thresholds are passed via the config arg
+ * so we can use small, fast fixtures (a 100-byte payload tripping a
+ * 50-byte cap exercises the same code path as a 50 MB payload
+ * tripping the 50 MiB default).
+ *
+ * @module shared/utils/zipLimits.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+import { AppError } from "../types/index";
+import {
+  DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES,
+  enforceZipLimits,
+} from "./zipLimits";
+
+/**
+ * Build a deflate-compressed ZIP with the given entries. Real
+ * compression so the central-directory `uncompressedSize` field is
+ * actually populated — `STORE` mode would set compressed == uncompressed
+ * and make the ratio check meaningless.
+ */
+async function buildZip(entries: Record<string, Uint8Array | string>): Promise<Uint8Array> {
+  const z = new JSZip();
+  for (const [path, data] of Object.entries(entries)) {
+    z.file(path, data, { compression: "DEFLATE" });
+  }
+  return new Uint8Array(await z.generateAsync({ type: "uint8array", compression: "DEFLATE" }));
+}
+
+async function expectAppError(
+  promise: Promise<unknown>,
+  expected: { status: number; code: string; messagePattern?: RegExp },
+): Promise<AppError> {
+  let caught: unknown = null;
+  try {
+    await promise;
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(AppError);
+  const err = caught as AppError;
+  expect(err.statusCode).toBe(expected.status);
+  expect(err.code).toBe(expected.code);
+  if (expected.messagePattern) expect(err.message).toMatch(expected.messagePattern);
+  return err;
+}
+
+describe("enforceZipLimits (#633)", () => {
+  test("happy path: small valid ZIP passes through", async () => {
+    const zip = await buildZip({
+      "skill/SKILL.md": "---\nname: hello\n---\nbody",
+    });
+    await expect(enforceZipLimits(zip)).resolves.toBeUndefined();
+  });
+
+  test("rejects a non-ZIP buffer with 400 invalid_zip", async () => {
+    const garbage = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
+    await expectAppError(enforceZipLimits(garbage), {
+      status: 400,
+      code: "invalid_zip",
+      messagePattern: /not a valid ZIP/,
+    });
+  });
+
+  test("rejects when cumulative uncompressed exceeds the cap", async () => {
+    // Two entries each 600 bytes uncompressed; cap is 1000.
+    const payload = "x".repeat(600);
+    const zip = await buildZip({
+      "skill/SKILL.md": payload,
+      "skill/assets/big.txt": payload,
+    });
+    await expectAppError(
+      enforceZipLimits(zip, { maxTotalUncompressedBytes: 1000 }),
+      {
+        status: 413,
+        code: "uncompressed_too_large",
+        messagePattern: /uncompressed size exceeds/,
+      },
+    );
+  });
+
+  test("rejects when a single entry exceeds the per-entry cap", async () => {
+    const payload = "x".repeat(2000);
+    const zip = await buildZip({
+      "skill/SKILL.md": "ok",
+      "skill/assets/oversized.txt": payload,
+    });
+    await expectAppError(
+      enforceZipLimits(zip, {
+        maxTotalUncompressedBytes: 10_000, // total fits
+        maxEntryUncompressedBytes: 1000,   // but the entry doesn't
+      }),
+      {
+        status: 413,
+        code: "uncompressed_too_large",
+        messagePattern: /oversized\.txt.*per-entry limit/,
+      },
+    );
+  });
+
+  test("rejects when file count exceeds the cap", async () => {
+    const entries: Record<string, string> = {};
+    for (let i = 0; i < 50; i++) {
+      entries[`skill/assets/f${i}.txt`] = `content-${i}`;
+    }
+    const zip = await buildZip(entries);
+    await expectAppError(
+      enforceZipLimits(zip, { maxFileCount: 10 }),
+      {
+        status: 413,
+        code: "too_many_files",
+        messagePattern: /50 files; limit is 10/,
+      },
+    );
+  });
+
+  test("rejects on classic zip-bomb compression ratio", async () => {
+    // 80 KiB of zeros — deflates to <100 bytes (>1000× ratio).
+    // Compressed buffer must clear the 4 KB ratio-check floor.
+    const zeros = new Uint8Array(80 * 1024);
+    // Add filler so the compressed buffer crosses the 4 KB floor.
+    const filler = new Uint8Array(8 * 1024);
+    crypto.getRandomValues(filler);
+    const zip = await buildZip({
+      "skill/SKILL.md": "tiny",
+      "skill/assets/zeros.bin": zeros,
+      "skill/assets/filler.bin": filler,
+    });
+    await expectAppError(
+      enforceZipLimits(zip, {
+        // Generous cumulative + per-entry caps so the ratio is what fires.
+        maxTotalUncompressedBytes: 10 * 1024 * 1024,
+        maxEntryUncompressedBytes: 5 * 1024 * 1024,
+        maxFileCount: 100,
+        maxCompressionRatio: 5,
+      }),
+      {
+        status: 413,
+        code: "uncompressed_too_large",
+        messagePattern: /compression ratio.*exceeds.*zip-bomb signature/,
+      },
+    );
+  });
+
+  test("tiny ZIP skips the ratio check (header overhead would false-positive)", async () => {
+    // A few-byte ZIP has a high apparent ratio (header dominates) but
+    // poses zero risk. The ratio-check floor (4 KB compressed) means
+    // this passes — only the cumulative cap matters here.
+    const zip = await buildZip({
+      "skill/SKILL.md": "x".repeat(2000),
+    });
+    await expect(
+      enforceZipLimits(zip, {
+        maxTotalUncompressedBytes: 10_000,
+        maxCompressionRatio: 1.1, // would trip if the ratio check ran
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("defaults: 50 MiB / 25 MiB / 1000 files — sanity check the constants", async () => {
+    // Verify the exported constant is what the issue scope said.
+    expect(DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES).toBe(50 * 1024 * 1024);
+  });
+});

--- a/ornn-api/src/shared/utils/zipLimits.ts
+++ b/ornn-api/src/shared/utils/zipLimits.ts
@@ -1,0 +1,148 @@
+/**
+ * Backend zip-bomb defense (#633).
+ *
+ * `#443` shipped the same caps on the web client (`zipValidator.ts` in
+ * `ornn-web`), but every other client — SDK, MCP, raw `curl`, agents
+ * over HTTP — bypasses them. This module mirrors the protection on
+ * the server so the publish path can't be coerced into accepting a
+ * 50 KB ZIP that uncompresses to 500 MB inside an extraction loop or
+ * an AgentSeal subprocess.
+ *
+ * The guards walk entries WITHOUT extracting them — `_data.uncompressedSize`
+ * is parsed from the ZIP central directory at `loadAsync` time, so we
+ * decide whether to proceed before any expensive I/O.
+ *
+ * Three caps:
+ *   - cumulative uncompressed size (default 50 MiB)
+ *   - per-entry uncompressed size (default 25 MiB)
+ *   - file count (default 1000)
+ *
+ * Plus a compression-ratio sanity check (50:1) — the classic zip-bomb
+ * signature catches things the per-entry cap would miss when an
+ * attacker spreads payload across many entries.
+ *
+ * @module shared/utils/zipLimits
+ */
+
+import JSZip from "jszip";
+import { AppError } from "../types/index";
+
+/** Default 50 MiB cumulative cap — matches the client-side guard in `ornn-web`. */
+export const DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES = 50 * 1024 * 1024;
+
+/** Default 25 MiB per-entry cap — catches a single oversized file even if the total stays under the cap. */
+export const DEFAULT_MAX_ENTRY_UNCOMPRESSED_BYTES = 25 * 1024 * 1024;
+
+/** Default 1000 entries — a real skill package fits in ~50 files. */
+export const DEFAULT_MAX_FILE_COUNT = 1000;
+
+/**
+ * Compression-ratio sanity cap. `uncompressed / compressed > 50` is
+ * the classic zip-bomb signature — legitimate text/code packages
+ * compress around 3–10×, never 50×. Set high enough that a tiny
+ * package with one near-empty entry doesn't false-positive (the
+ * compressed lower bound below also gates this).
+ */
+export const DEFAULT_MAX_COMPRESSION_RATIO = 50;
+
+/**
+ * Don't bother running the ratio check when the compressed payload
+ * is tiny — ZIP header overhead dominates and ratio loses meaning.
+ * 4 KB is a safe lower bound (smaller than any plausible bomb).
+ */
+const RATIO_CHECK_MIN_COMPRESSED_BYTES = 4 * 1024;
+
+export interface ZipLimitsConfig {
+  maxTotalUncompressedBytes?: number;
+  maxEntryUncompressedBytes?: number;
+  maxFileCount?: number;
+  maxCompressionRatio?: number;
+}
+
+/**
+ * Throws `AppError.payloadTooLarge` with a stable lowercase_snake_case
+ * `code` on any cap violation. Reads from the JSZip central directory
+ * — does NOT extract any file. Safe to call before
+ * `validateZipFormat` / the AgentSeal scan.
+ *
+ * Codes (per CONVENTIONS.md §1.4):
+ *   - `uncompressed_too_large` — cumulative or per-entry cap exceeded
+ *   - `too_many_files` — entry count cap exceeded
+ *   - `invalid_zip` — the buffer isn't a parseable ZIP
+ */
+export async function enforceZipLimits(
+  zipBuffer: Uint8Array,
+  cfg: ZipLimitsConfig = {},
+): Promise<void> {
+  const maxTotal = cfg.maxTotalUncompressedBytes ?? DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES;
+  const maxEntry = cfg.maxEntryUncompressedBytes ?? DEFAULT_MAX_ENTRY_UNCOMPRESSED_BYTES;
+  const maxFiles = cfg.maxFileCount ?? DEFAULT_MAX_FILE_COUNT;
+  const maxRatio = cfg.maxCompressionRatio ?? DEFAULT_MAX_COMPRESSION_RATIO;
+
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(zipBuffer);
+  } catch (err) {
+    throw new AppError(
+      400,
+      "invalid_zip",
+      `Uploaded file is not a valid ZIP archive: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const entries = Object.values(zip.files).filter((f) => !f.dir);
+  if (entries.length > maxFiles) {
+    throw new AppError(413, "too_many_files",
+      `ZIP contains ${entries.length} files; limit is ${maxFiles}. Reduce file count or split into multiple skills.`,
+    );
+  }
+
+  let totalUncompressed = 0;
+  for (const entry of entries) {
+    // JSZip stashes the entry's uncompressed size on `_data.uncompressedSize`.
+    // Cast through `unknown` because the field is intentionally private
+    // and not part of the public type surface — the central-directory
+    // parser sets it at `loadAsync` time, so it's available without
+    // touching the entry payload.
+    const data = (entry as unknown as {
+      _data?: { uncompressedSize?: number };
+    })._data;
+    const size = data?.uncompressedSize ?? 0;
+
+    if (size > maxEntry) {
+      throw new AppError(413, "uncompressed_too_large",
+        `ZIP entry '${entry.name}' is ${formatBytes(size)} uncompressed; per-entry limit is ${formatBytes(maxEntry)}.`,
+      );
+    }
+    totalUncompressed += size;
+    if (totalUncompressed > maxTotal) {
+      throw new AppError(413, "uncompressed_too_large",
+        `ZIP uncompressed size exceeds ${formatBytes(maxTotal)} (would extract to at least ${formatBytes(totalUncompressed)}).`,
+      );
+    }
+  }
+
+  // Ratio check — only meaningful on payloads big enough that the
+  // ZIP header overhead doesn't dominate.
+  if (
+    zipBuffer.byteLength >= RATIO_CHECK_MIN_COMPRESSED_BYTES &&
+    totalUncompressed > 0
+  ) {
+    const ratio = totalUncompressed / zipBuffer.byteLength;
+    if (ratio > maxRatio) {
+      throw new AppError(413, "uncompressed_too_large",
+        `ZIP compression ratio ${ratio.toFixed(1)}× exceeds ${maxRatio}× — refuse to extract (classic zip-bomb signature).`,
+      );
+    }
+  }
+}
+
+/** Compact human-readable byte count: 1.5 MiB / 800 KiB / 42 B. */
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+/** Exported for direct testing. */
+export const __test__ = { formatBytes, RATIO_CHECK_MIN_COMPRESSED_BYTES };


### PR DESCRIPTION
Mirrors the client-side #443 zip-bomb defense on the backend. Closes the gap surfaced during retrospective verification: agents / SDK / curl bypass the SPA's pre-flight validator.

New `enforceZipLimits()` in `shared/utils/zipLimits.ts` walks the ZIP central directory (no extraction) and throws RFC 7807 413 on any of:

| Cap | Default | Code |
|---|---|---|
| Cumulative uncompressed | 50 MiB | `uncompressed_too_large` |
| Per-entry uncompressed | 25 MiB | `uncompressed_too_large` |
| File count | 1000 | `too_many_files` |
| Compression ratio | 50× | `uncompressed_too_large` |
| Invalid ZIP | — | `invalid_zip` (400) |

Wired into POST /skills, PUT /skills/:id, POST /skill-format/validate. Runs before validateZipFormat / storage upload / AgentSeal scan.

8 unit tests pass; full suite 668 pass / 0 fail; typecheck + lint clean.

Closes #633