### PR TITLE
fix(api): sweep c.req.json() bypass pattern (#438)

### DIFF
--- a/.changeset/validate-body-sweep-438.md
+++ b/.changeset/validate-body-sweep-438.md
@@ -1,0 +1,21 @@
+---
+"ornn-api": patch
+---
+
+Sweep the `c.req.json().catch(() => ({}))` bypass pattern across ornn-api routes (#438). Every state-changing endpoint that previously parsed JSON manually now flows through the `validateBody(schema, code)` middleware so malformed bodies surface as RFC 7807 `400 invalid_body` instead of silently coercing to `{}` and bypassing schema validation.
+
+Affected:
+- `skills/crud/routes` — `POST /skills/pull`, `POST /skills/:id/refresh`, `PUT /skills/:id/source`, JSON branch of `PUT /skills/:id`
+- `skills/audit/routes` — both audit-trigger endpoints (owner + admin)
+- `skills/generation/routes` — `POST /skills/generate/from-source`, `POST /skills/generate/from-openapi`, JSON branch of `POST /skills/generate`
+- `skills/mirror/routes` — `POST /github/repo`
+- `announcements/routes` — admin create + patch
+- `broadcasts/routes` — admin create + patch
+- `settings/routes` — every per-section `PUT`
+- `settings/llmProviders/routes` — provider create / update / model patch
+- `settings/exportImport/routes` — `POST /admin/settings/import`
+- `platform/routes` — `PATCH /admin/settings`
+
+`validateBody` is also taught to tolerate an empty body (treats it as `{}`) when the schema has no required fields — that's the spot the bypass pattern was covering, and removing it without that tolerance would break the `POST /skills/:id/refresh`-with-no-body case the SPA uses.
+
+Endpoints with rich per-field validation that's hard to express in Zod (mirror config, platform settings) get a thin gate (`z.record(z.string(), z.unknown())`) so the SyntaxError path is covered, while leaving the existing field checks in place. Future PRs can swap those for full schemas without changing the wire contract.

--- a/ornn-api/src/domains/announcements/routes.ts
+++ b/ornn-api/src/domains/announcements/routes.ts
@@ -30,6 +30,7 @@ import {
   requirePermission,
 } from "../../middleware/nyxidAuth";
 import { AppError } from "../../shared/types/index";
+import { validateBody, getValidatedBody } from "../../middleware/validate";
 import type { AnnouncementService } from "./service";
 import type { AnnouncementDocument } from "./types";
 
@@ -136,50 +137,47 @@ export function createAnnouncementRoutes(
     return c.json({ data: { items: items.map(toAdminDto) }, error: null });
   });
 
-  app.post("/admin/announcements", auth, adminGuard, async (c) => {
-    const authCtx = getAuth(c);
-    const body = await c.req.json().catch(() => ({}));
-    const parsed = createSchema.safeParse(body);
-    if (!parsed.success) {
-      throw AppError.badRequest(
-        "invalid_announcement_input",
-        parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
-      );
-    }
-    const created = await announcementService.create({
-      titleEn: parsed.data.titleEn,
-      titleZh: parsed.data.titleZh,
-      bodyMarkdownEn: parsed.data.bodyMarkdownEn,
-      bodyMarkdownZh: parsed.data.bodyMarkdownZh,
-      ctaLabelEn: parsed.data.ctaLabelEn ?? null,
-      ctaLabelZh: parsed.data.ctaLabelZh ?? null,
-      ctaUrl: parsed.data.ctaUrl ?? null,
-      enabled: parsed.data.enabled,
-      startsAt: parsed.data.startsAt ?? null,
-      endsAt: parsed.data.endsAt ?? null,
-      createdBy: authCtx.userId,
-    });
+  app.post(
+    "/admin/announcements",
+    auth,
+    adminGuard,
+    validateBody(createSchema, "invalid_announcement_input"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const data = getValidatedBody<z.infer<typeof createSchema>>(c);
+      const created = await announcementService.create({
+        titleEn: data.titleEn,
+        titleZh: data.titleZh,
+        bodyMarkdownEn: data.bodyMarkdownEn,
+        bodyMarkdownZh: data.bodyMarkdownZh,
+        ctaLabelEn: data.ctaLabelEn ?? null,
+        ctaLabelZh: data.ctaLabelZh ?? null,
+        ctaUrl: data.ctaUrl ?? null,
+        enabled: data.enabled,
+        startsAt: data.startsAt ?? null,
+        endsAt: data.endsAt ?? null,
+        createdBy: authCtx.userId,
+      });
     // 201 already set; add Location to match CONVENTIONS.md §3.2 (#458).
     c.header("Location", `/api/v1/admin/announcements/${created._id}`);
     return c.json({ data: toAdminDto(created), error: null }, 201);
   });
 
-  app.patch("/admin/announcements/:id", auth, adminGuard, async (c) => {
-    const id = c.req.param("id");
-    const body = await c.req.json().catch(() => ({}));
-    const parsed = updateSchema.safeParse(body);
-    if (!parsed.success) {
-      throw AppError.badRequest(
-        "invalid_announcement_input",
-        parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
-      );
-    }
-    if (Object.keys(parsed.data).length === 0) {
-      throw AppError.badRequest("invalid_announcement_input", "No fields to update");
-    }
-    const updated = await announcementService.update(id, parsed.data);
-    return c.json({ data: toAdminDto(updated), error: null });
-  });
+  app.patch(
+    "/admin/announcements/:id",
+    auth,
+    adminGuard,
+    validateBody(updateSchema, "invalid_announcement_input"),
+    async (c) => {
+      const id = c.req.param("id");
+      const data = getValidatedBody<z.infer<typeof updateSchema>>(c);
+      if (Object.keys(data).length === 0) {
+        throw AppError.badRequest("invalid_announcement_input", "No fields to update");
+      }
+      const updated = await announcementService.update(id, data);
+      return c.json({ data: toAdminDto(updated), error: null });
+    },
+  );
 
   app.delete("/admin/announcements/:id", auth, adminGuard, async (c) => {
     const id = c.req.param("id");

--- a/ornn-api/src/domains/broadcasts/routes.ts
+++ b/ornn-api/src/domains/broadcasts/routes.ts
@@ -27,7 +27,8 @@ import {
   nyxidAuthMiddleware,
   requirePermission,
 } from "../../middleware/nyxidAuth";
-import { AppError } from "../../shared/types/index";
+import { z } from "zod";
+import { validateBody, getValidatedBody } from "../../middleware/validate";
 import { createBroadcastSchema, patchBroadcastSchema } from "./schemas";
 import type { BroadcastService } from "./service";
 
@@ -50,49 +51,43 @@ export function createBroadcastRoutes(
     return c.json({ data: { items }, error: null });
   });
 
-  app.post("/admin/broadcasts", auth, adminGuard, async (c) => {
-    const authCtx = getAuth(c);
-    const body = await c.req.json().catch(() => ({}));
-    const parsed = createBroadcastSchema.safeParse(body);
-    if (!parsed.success) {
-      throw AppError.badRequest(
-        "invalid_broadcast_input",
-        parsed.error.issues
-          .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
-          .join("; "),
-      );
-    }
-    const created = await broadcastService.create({
-      titleI18n: parsed.data.titleI18n,
-      bodyMarkdownI18n: parsed.data.bodyMarkdownI18n,
-      createdBy: authCtx.userId,
-      recipientUserIds: parsed.data.recipientUserIds,
-    });
-    // 201 + Location per CONVENTIONS.md §3.2 (#458).
-    c.header("Location", `/api/v1/admin/broadcasts/${created.id}`);
-    return c.json({ data: created, error: null }, 201);
-  });
+  app.post(
+    "/admin/broadcasts",
+    auth,
+    adminGuard,
+    validateBody(createBroadcastSchema, "invalid_broadcast_input"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const data = getValidatedBody<z.infer<typeof createBroadcastSchema>>(c);
+      const created = await broadcastService.create({
+        titleI18n: data.titleI18n,
+        bodyMarkdownI18n: data.bodyMarkdownI18n,
+        createdBy: authCtx.userId,
+        recipientUserIds: data.recipientUserIds,
+      });
+      // 201 + Location per CONVENTIONS.md §3.2 (#458).
+      c.header("Location", `/api/v1/admin/broadcasts/${created.id}`);
+      return c.json({ data: created, error: null }, 201);
+    },
+  );
 
-  app.patch("/admin/broadcasts/:id", auth, adminGuard, async (c) => {
-    const authCtx = getAuth(c);
-    const id = c.req.param("id");
-    const body = await c.req.json().catch(() => ({}));
-    const parsed = patchBroadcastSchema.safeParse(body);
-    if (!parsed.success) {
-      throw AppError.badRequest(
-        "invalid_broadcast_input",
-        parsed.error.issues
-          .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
-          .join("; "),
-      );
-    }
-    const updated = await broadcastService.update(id, {
-      titleI18n: parsed.data.titleI18n,
-      bodyMarkdownI18n: parsed.data.bodyMarkdownI18n,
-      updatedBy: authCtx.userId,
-    });
-    return c.json({ data: updated, error: null });
-  });
+  app.patch(
+    "/admin/broadcasts/:id",
+    auth,
+    adminGuard,
+    validateBody(patchBroadcastSchema, "invalid_broadcast_input"),
+    async (c) => {
+      const authCtx = getAuth(c);
+      const id = c.req.param("id");
+      const data = getValidatedBody<z.infer<typeof patchBroadcastSchema>>(c);
+      const updated = await broadcastService.update(id, {
+        titleI18n: data.titleI18n,
+        bodyMarkdownI18n: data.bodyMarkdownI18n,
+        updatedBy: authCtx.userId,
+      });
+      return c.json({ data: updated, error: null });
+    },
+  );
 
   app.delete("/admin/broadcasts/:id", auth, adminGuard, async (c) => {
     const id = c.req.param("id");

--- a/ornn-api/src/domains/platform/routes.ts
+++ b/ornn-api/src/domains/platform/routes.ts
@@ -13,8 +13,10 @@ import {
   nyxidAuthMiddleware,
   requirePermission,
 } from "../../middleware/nyxidAuth";
+import { z } from "zod";
 import { AppError } from "../../shared/types/index";
 import { isMidMaskSentinel, midMaskSecret } from "../../infra/crypto";
+import { validateBody, getValidatedBody } from "../../middleware/validate";
 import type { PlatformSettingsService } from "./service";
 import type { PlatformSettings } from "./types";
 
@@ -50,10 +52,16 @@ export function createPlatformSettingsRoutes(
     return c.json({ data: maskSensitiveSettings(settings), error: null });
   });
 
-  app.patch("/admin/settings", auth, requirePermission("ornn:admin:skill"), async (c) => {
-    const body = (await c.req.json().catch(() => ({}))) as Partial<
-      Record<keyof PlatformSettings, unknown>
-    >;
+  app.patch(
+    "/admin/settings",
+    auth,
+    requirePermission("ornn:admin:skill"),
+    // The downstream field-by-field checks below enforce the proper
+    // shape per key; this gate just turns a SyntaxError into a clean
+    // 400 invalid_body (#438).
+    validateBody(z.record(z.string(), z.unknown()), "invalid_body"),
+    async (c) => {
+      const body = getValidatedBody<Partial<Record<keyof PlatformSettings, unknown>>>(c);
     type MutablePatch = { -readonly [K in keyof PlatformSettings]?: PlatformSettings[K] };
     const patch: MutablePatch = {};
 
@@ -134,9 +142,10 @@ export function createPlatformSettingsRoutes(
       throw AppError.badRequest("invalid_setting", "No valid setting fields in body");
     }
 
-    const updated = await platformSettingsService.patch(patch);
-    return c.json({ data: maskSensitiveSettings(updated), error: null });
-  });
+      const updated = await platformSettingsService.patch(patch);
+      return c.json({ data: maskSensitiveSettings(updated), error: null });
+    },
+  );
 
   return app;
 }

--- a/ornn-api/src/domains/settings/exportImport/routes.ts
+++ b/ornn-api/src/domains/settings/exportImport/routes.ts
@@ -16,12 +16,13 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import pino from "pino";
+import { z } from "zod";
+import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import {
   type AuthVariables,
   nyxidAuthMiddleware,
   requirePermission,
 } from "../../../middleware/nyxidAuth";
-import { AppError } from "../../../shared/types/index";
 import type { SettingsActor } from "../types";
 import type { SettingsExporter } from "./exporter";
 import type { ImportResult, SettingsImporter } from "./importer";
@@ -121,11 +122,12 @@ export function createSettingsExportImportRoutes(
           413,
         ),
     }),
+    // The importer (`importer.import`) validates the full structured
+    // payload internally. The middleware here just gates JSON-shape
+    // so a SyntaxError becomes 400 invalid_body per #438.
+    validateBody(z.record(z.string(), z.unknown()), "invalid_body"),
     async (c) => {
-      const body = await c.req.json().catch(() => null);
-      if (!body || typeof body !== "object") {
-        throw AppError.badRequest("invalid_body", "JSON body required");
-      }
+      const body = getValidatedBody<Record<string, unknown>>(c);
       // Accept dryRun from either the body (the SPA path) OR the
       // query string (curl / scripts). Body takes precedence. Was
       // query-only before — that silently mutated on the SPA's

--- a/ornn-api/src/domains/settings/llmProviders/routes.ts
+++ b/ornn-api/src/domains/settings/llmProviders/routes.ts
@@ -33,6 +33,7 @@ import {
   requirePermission,
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
+import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import type { SettingsActor } from "../types";
 import type { LlmProvidersService, ModelResolution, Surface } from "./service";
 
@@ -85,16 +86,24 @@ export function createLlmProvidersRoutes(
     return c.json({ data: { items }, error: null });
   });
 
-  app.post(base, auth, adminGuard, async (c) => {
-    const body = await c.req.json().catch(() => null);
-    if (!body) throw AppError.badRequest("invalid_body", "JSON body required");
-    const actor = currentActor(c);
-    const created = await llmProvidersService.create(body, actor);
-    // Re-fetch through the admin path so the 201 body never carries
-    // the plaintext secret the caller just submitted.
-    const masked = await llmProvidersService.getForAdmin(created._id);
-    return c.json({ data: masked, error: null }, 201);
-  });
+  app.post(
+    base,
+    auth,
+    adminGuard,
+    // Service-internal Zod schemas (`providerCreateSchema`) enforce
+    // the full shape. The middleware here just gates JSON-shape so a
+    // SyntaxError becomes 400 with RFC 7807 envelope (#438).
+    validateBody(z.record(z.string(), z.unknown()), "invalid_body"),
+    async (c) => {
+      const body = getValidatedBody<Record<string, unknown>>(c);
+      const actor = currentActor(c);
+      const created = await llmProvidersService.create(body, actor);
+      // Re-fetch through the admin path so the 201 body never carries
+      // the plaintext secret the caller just submitted.
+      const masked = await llmProvidersService.getForAdmin(created._id);
+      return c.json({ data: masked, error: null }, 201);
+    },
+  );
 
   app.get(`${base}/:id`, auth, adminGuard, async (c) => {
     const id = c.req.param("id");
@@ -105,15 +114,20 @@ export function createLlmProvidersRoutes(
     return c.json({ data: item, error: null });
   });
 
-  app.put(`${base}/:id`, auth, adminGuard, async (c) => {
-    const id = c.req.param("id");
-    const body = await c.req.json().catch(() => null);
-    if (!body) throw AppError.badRequest("invalid_body", "JSON body required");
-    const actor = currentActor(c);
-    await llmProvidersService.update(id, body, actor);
-    const masked = await llmProvidersService.getForAdmin(id);
-    return c.json({ data: masked, error: null });
-  });
+  app.put(
+    `${base}/:id`,
+    auth,
+    adminGuard,
+    validateBody(z.record(z.string(), z.unknown()), "invalid_body"),
+    async (c) => {
+      const id = c.req.param("id");
+      const body = getValidatedBody<Record<string, unknown>>(c);
+      const actor = currentActor(c);
+      await llmProvidersService.update(id, body, actor);
+      const masked = await llmProvidersService.getForAdmin(id);
+      return c.json({ data: masked, error: null });
+    },
+  );
 
   app.delete(`${base}/:id`, auth, adminGuard, async (c) => {
     const id = c.req.param("id");
@@ -142,11 +156,11 @@ export function createLlmProvidersRoutes(
     `${base}/:id/models/:modelId`,
     auth,
     adminGuard,
+    validateBody(z.record(z.string(), z.unknown()), "invalid_body"),
     async (c) => {
       const providerId = c.req.param("id");
       const modelId = c.req.param("modelId");
-      const body = await c.req.json().catch(() => null);
-      if (!body) throw AppError.badRequest("invalid_body", "JSON body required");
+      const body = getValidatedBody<Record<string, unknown>>(c);
       const actor = currentActor(c);
       await llmProvidersService.patchModel(providerId, modelId, body, actor);
       const masked = await llmProvidersService.getForAdmin(providerId);

--- a/ornn-api/src/domains/settings/routes.ts
+++ b/ornn-api/src/domains/settings/routes.ts
@@ -17,8 +17,9 @@ import {
   nyxidAuthMiddleware,
   requirePermission,
 } from "../../middleware/nyxidAuth";
-import { AppError } from "../../shared/types/index";
+import { z } from "zod";
 import { midMaskSecret } from "../../infra/crypto";
+import { validateBody, getValidatedBody } from "../../middleware/validate";
 import { sections, type SectionId } from "./sections";
 import type { SettingsService, SettingsActor } from "./types";
 
@@ -48,24 +49,30 @@ export function createSettingsRoutes(
       return c.json({ data: masked, error: null });
     });
 
-    app.put(path, auth, adminGuard, async (c) => {
-      const body = await c.req.json().catch(() => null);
-      if (!body || typeof body !== "object") {
-        throw AppError.badRequest("invalid_body", "request body must be a JSON object");
-      }
-      const actor = currentActor(c);
-      const result = await settingsService.putSection<Record<string, unknown>>(
-        id,
-        body as Record<string, unknown>,
-        actor,
-      );
-      const masked = maskSecrets(result.value, meta.secretFields);
-      return c.json({
-        data: masked,
-        error: null,
-        meta: { changedFields: result.changedFields },
-      });
-    });
+    app.put(
+      path,
+      auth,
+      adminGuard,
+      // Section-specific Zod schemas live inside `settingsService.putSection`;
+      // here we just gate that the body is a JSON object so a SyntaxError
+      // becomes 400 invalid_body instead of a 500 (#438).
+      validateBody(z.record(z.string(), z.unknown()), "invalid_body"),
+      async (c) => {
+        const body = getValidatedBody<Record<string, unknown>>(c);
+        const actor = currentActor(c);
+        const result = await settingsService.putSection<Record<string, unknown>>(
+          id,
+          body,
+          actor,
+        );
+        const masked = maskSecrets(result.value, meta.secretFields);
+        return c.json({
+          data: masked,
+          error: null,
+          meta: { changedFields: result.changedFields },
+        });
+      },
+    );
   }
 
   return app;

--- a/ornn-api/src/domains/skills/audit/routes.ts
+++ b/ornn-api/src/domains/skills/audit/routes.ts
@@ -17,6 +17,7 @@
 
 import { Hono } from "hono";
 import pino from "pino";
+import { z } from "zod";
 import type { AuditService } from "./service";
 import type { SkillService } from "../crud/service";
 import {
@@ -28,7 +29,13 @@ import {
   requirePermission,
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
+import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import { canReadSkill } from "../crud/authorize";
+
+/** Body schema for POST /skills/:idOrName/audit + admin variant (#438). */
+const auditTriggerSchema = z.object({
+  force: z.boolean().optional(),
+});
 
 const logger = pino({ level: "info" }).child({ module: "auditRoutes" });
 
@@ -167,11 +174,11 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
   app.post(
     "/skills/:idOrName/audit",
     auth,
+    validateBody(auditTriggerSchema, "invalid_audit_body"),
     async (c) => {
       const idOrName = c.req.param("idOrName");
       const authCtx = getAuth(c);
-      const body = (await c.req.json().catch(() => ({}))) as { force?: unknown };
-      const force = body.force === true;
+      const { force = false } = getValidatedBody<z.infer<typeof auditTriggerSchema>>(c);
 
       const skill = await skillService.getSkill(idOrName);
       const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
@@ -200,11 +207,11 @@ export function createAuditRoutes(config: AuditRoutesConfig): Hono<{ Variables: 
     "/admin/skills/:idOrName/audit",
     auth,
     requirePermission("ornn:admin:skill"),
+    validateBody(auditTriggerSchema, "invalid_audit_body"),
     async (c) => {
       const idOrName = c.req.param("idOrName");
       const authCtx = getAuth(c);
-      const body = (await c.req.json().catch(() => ({}))) as { force?: unknown };
-      const force = body.force === true;
+      const { force = false } = getValidatedBody<z.infer<typeof auditTriggerSchema>>(c);
 
       logger.info({ idOrName, triggeredBy: authCtx.userId, force }, "Admin audit triggered");
       const record = await auditService.runAudit(idOrName, {

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -68,6 +68,50 @@ const distTagSetSchema = z.object({
     .regex(/^(0|[1-9]\d*)\.(0|[1-9]\d*)$/, "version must be <major>.<minor>"),
 });
 
+/**
+ * Body for `POST /api/v1/skills/pull` (#438). Either `githubUrl` (a
+ * single browser-bar URL the server parses into repo/ref/path) OR an
+ * explicit `repo` (with optional `ref`/`path`). A cross-field refine
+ * checks that at least one is provided so we don't reach the handler
+ * with an empty body.
+ */
+const skillPullSchema = z
+  .object({
+    githubUrl: z.string().min(1).optional(),
+    repo: z.string().min(1).optional(),
+    ref: z.string().optional(),
+    path: z.string().optional(),
+    skip_validation: z.boolean().optional(),
+  })
+  .refine((b) => Boolean(b.githubUrl) || Boolean(b.repo), {
+    message: "Provide either 'githubUrl' (preferred) or 'repo' (with optional 'ref'/'path').",
+  });
+
+/**
+ * Body for `POST /api/v1/skills/:id/refresh` (#438). All fields optional.
+ * `skipValidation` and `skip_validation` are both accepted for
+ * backward compatibility with the original ad-hoc handler.
+ */
+const skillRefreshSchema = z.object({
+  dryRun: z.boolean().optional(),
+  skipValidation: z.boolean().optional(),
+  skip_validation: z.boolean().optional(),
+});
+
+/**
+ * Body for `PUT /api/v1/skills/:id/source` (#438). The url field is
+ * a discriminated union: `string` to link, `null` to clear. Anything
+ * else is rejected with a clear ZodIssue.
+ */
+const skillSourceSchema = z.object({
+  githubUrl: z.union([z.string().min(1), z.null()]),
+});
+
+/** Body for `PUT /api/v1/skills/:id` JSON-only branch (#438). ZIP branch handled separately. */
+const skillUpdateJsonSchema = z.object({
+  isPrivate: z.boolean().optional(),
+});
+
 const logger = pino({ level: "info" }).child({ module: "skillCrudRoutes" });
 
 export interface SkillRoutesConfig {
@@ -283,24 +327,16 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     "/skills/pull",
     auth,
     requirePermission("ornn:skill:create"),
+    validateBody(skillPullSchema, "invalid_pull_body"),
     async (c) => {
       const authCtx = getAuth(c);
-      const body = (await c.req.json().catch(() => ({}))) as {
-        // Preferred: a single GitHub folder URL the user copied from the
-        // browser address bar. Server parses out repo / ref / path.
-        githubUrl?: unknown;
-        // Legacy / explicit form: caller already split the source apart.
-        repo?: unknown;
-        ref?: unknown;
-        path?: unknown;
-        skip_validation?: unknown;
-      };
+      const body = getValidatedBody<z.infer<typeof skillPullSchema>>(c);
 
       let repo: string;
       let ref: string | undefined;
       let path: string | undefined;
 
-      if (typeof body.githubUrl === "string" && body.githubUrl) {
+      if (body.githubUrl) {
         try {
           const parsed = parseGithubUrl(body.githubUrl);
           repo = parsed.repo;
@@ -312,15 +348,12 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
             err instanceof Error ? err.message : String(err),
           );
         }
-      } else if (typeof body.repo === "string" && body.repo) {
-        repo = body.repo;
-        ref = typeof body.ref === "string" && body.ref ? body.ref : undefined;
-        path = typeof body.path === "string" ? body.path : undefined;
       } else {
-        throw AppError.badRequest(
-          "missing_source",
-          "Provide either 'githubUrl' (preferred) or 'repo' (with optional 'ref'/'path').",
-        );
+        // .refine() in the schema guarantees we have at least one of
+        // githubUrl/repo, so this branch is the explicit-repo form.
+        repo = body.repo!;
+        ref = body.ref;
+        path = body.path;
       }
 
       const skipValidation = body.skip_validation === true;
@@ -374,14 +407,11 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     "/skills/:id/refresh",
     auth,
     requirePermission("ornn:skill:update"),
+    validateBody(skillRefreshSchema, "invalid_refresh_body"),
     async (c) => {
       const authCtx = getAuth(c);
       const guid = c.req.param("id");
-      const body = (await c.req.json().catch(() => ({}))) as {
-        dryRun?: unknown;
-        skipValidation?: unknown;
-        skip_validation?: unknown;
-      };
+      const body = getValidatedBody<z.infer<typeof skillRefreshSchema>>(c);
       const dryRun = body.dryRun === true;
       const skipValidation = body.skipValidation === true || body.skip_validation === true;
 
@@ -461,10 +491,11 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     "/skills/:id/source",
     auth,
     requirePermission("ornn:skill:update"),
+    validateBody(skillSourceSchema, "invalid_source_body"),
     async (c) => {
       const authCtx = getAuth(c);
       const guid = c.req.param("id");
-      const body = (await c.req.json().catch(() => ({}))) as { githubUrl?: unknown };
+      const { githubUrl } = getValidatedBody<z.infer<typeof skillSourceSchema>>(c);
 
       const existing = await skillService.getSkill(guid);
       const isPlatformAdmin = authCtx.permissions.includes("ornn:admin:skill");
@@ -472,18 +503,6 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         throw AppError.forbidden(
           "not_skill_owner",
           "Only the skill's author or a platform admin may set its source",
-        );
-      }
-
-      let githubUrl: string | null;
-      if (body.githubUrl === null) {
-        githubUrl = null;
-      } else if (typeof body.githubUrl === "string") {
-        githubUrl = body.githubUrl;
-      } else {
-        throw AppError.badRequest(
-          "invalid_body",
-          "Body must include 'githubUrl' as a string (to link) or null (to unlink).",
         );
       }
 
@@ -969,9 +988,30 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
           isPrivate = String(formData["isPrivate"]) === "true";
         }
       } else if (contentType.includes("application/json")) {
-        const body = await c.req.json();
+        // Inline Zod parse — the route is hybrid content-type, so the
+        // `validateBody` middleware doesn't fit. Same #438 intent:
+        // malformed JSON returns 400 with the documented RFC 7807
+        // shape instead of bubbling a raw `SyntaxError`.
+        let body: z.infer<typeof skillUpdateJsonSchema>;
+        try {
+          const text = await c.req.text();
+          const raw = text.trim().length === 0 ? {} : JSON.parse(text);
+          const result = skillUpdateJsonSchema.safeParse(raw);
+          if (!result.success) {
+            throw AppError.badRequest(
+              "invalid_body",
+              result.error.issues
+                .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+                .join("; "),
+            );
+          }
+          body = result.data;
+        } catch (err) {
+          if (err instanceof AppError) throw err;
+          throw AppError.badRequest("invalid_body", "Request body must be valid JSON");
+        }
         if (body.isPrivate !== undefined) {
-          isPrivate = Boolean(body.isPrivate);
+          isPrivate = body.isPrivate;
         }
       }
 

--- a/ornn-api/src/domains/skills/generation/routes.ts
+++ b/ornn-api/src/domains/skills/generation/routes.ts
@@ -21,9 +21,11 @@ import {
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
 import { resolveZipRoot } from "../../../shared/utils/zip";
+import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import { fetchGithubSourceBundle } from "./githubFetcher";
 import JSZip from "jszip";
 import pino from "pino";
+import { z } from "zod";
 
 const logger = pino({ level: "info" }).child({ module: "skillGenerationRoutes" });
 
@@ -233,7 +235,21 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
           packageContent = await analyzePackageContent(new Uint8Array(buf));
         }
       } else if (contentType.includes("application/json")) {
-        const body = await c.req.json();
+        // Hybrid endpoint — multipart-or-JSON. Inline Zod parse so
+        // malformed JSON returns 400 invalid_body via the global RFC
+        // 7807 handler instead of a raw SyntaxError 500 (#438).
+        let body: { modelId?: string; messages?: unknown[]; prompt?: string };
+        try {
+          const text = await c.req.text();
+          const raw = text.trim().length === 0 ? {} : JSON.parse(text);
+          if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+            throw AppError.badRequest("invalid_body", "Request body must be a JSON object");
+          }
+          body = raw as typeof body;
+        } catch (err) {
+          if (err instanceof AppError) throw err;
+          throw AppError.badRequest("invalid_body", "Request body must be valid JSON");
+        }
         if (typeof body.modelId === "string" && body.modelId) {
           requestedModelId = body.modelId;
         }
@@ -245,7 +261,11 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
           const keepAliveMs = await resolveKeepAliveMs(keepAliveIntervalMsResolver);
           return streamGenerationEvents(
             c,
-            generationService.generateStreamWithHistory(body.messages, c.req.raw.signal, pf.modelId),
+            generationService.generateStreamWithHistory(
+              body.messages as Array<{ role: "user" | "assistant"; content: string }>,
+              c.req.raw.signal,
+              pf.modelId,
+            ),
             keepAliveMs,
             { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId },
           );
@@ -295,23 +315,34 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
     "/skills/generate/from-source",
     auth,
     requirePermission("ornn:skill:build"),
+    validateBody(
+      z.object({
+        code: z.string().optional(),
+        repoUrl: z.string().optional(),
+        path: z.string().optional(),
+        framework: z.string().optional(),
+        description: z.string().optional(),
+        modelId: z.string().optional(),
+      }),
+      "invalid_from_source_body",
+    ),
     async (c) => {
       const authCtx = getAuth(c);
-      const body = (await c.req.json().catch(() => ({}))) as {
-        code?: unknown;
-        repoUrl?: unknown;
-        path?: unknown;
-        framework?: unknown;
-        description?: unknown;
-        modelId?: unknown;
-      };
+      const body = getValidatedBody<{
+        code?: string;
+        repoUrl?: string;
+        path?: string;
+        framework?: string;
+        description?: string;
+        modelId?: string;
+      }>(c);
 
-      const inlineCode = typeof body.code === "string" ? body.code : undefined;
-      const repoUrl = typeof body.repoUrl === "string" ? body.repoUrl : undefined;
-      const path = typeof body.path === "string" ? body.path : undefined;
-      const framework = typeof body.framework === "string" ? body.framework : undefined;
-      const description = typeof body.description === "string" ? body.description : undefined;
-      const requestedModelId = typeof body.modelId === "string" ? body.modelId : undefined;
+      const inlineCode = body.code;
+      const repoUrl = body.repoUrl;
+      const path = body.path;
+      const framework = body.framework;
+      const description = body.description;
+      const requestedModelId = body.modelId;
 
       if (!inlineCode && !repoUrl) {
         throw AppError.badRequest(
@@ -394,17 +425,27 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
     "/skills/generate/from-openapi",
     auth,
     requirePermission("ornn:skill:build"),
+    validateBody(
+      z.object({
+        spec: z.string().min(1),
+        endpoints: z.array(z.unknown()).optional(),
+        description: z.string().optional(),
+        modelId: z.string().optional(),
+      }),
+      "invalid_from_openapi_body",
+    ),
     async (c) => {
       const authCtx = getAuth(c);
-      const body = await c.req.json();
+      const body = getValidatedBody<{
+        spec: string;
+        endpoints?: unknown[];
+        description?: string;
+        modelId?: string;
+      }>(c);
 
-      if (!body.spec || typeof body.spec !== "string") {
-        throw AppError.badRequest("missing_spec", "An OpenAPI 'spec' field (JSON or YAML string) is required");
-      }
-
-      const endpoints = Array.isArray(body.endpoints) ? body.endpoints : undefined;
-      const description = typeof body.description === "string" ? body.description : undefined;
-      const requestedModelId = typeof body.modelId === "string" ? body.modelId : undefined;
+      const endpoints = body.endpoints;
+      const description = body.description;
+      const requestedModelId = body.modelId;
 
       logger.info(
         { userId: authCtx.userId, specLength: body.spec.length, endpoints, hasDescription: !!description },
@@ -417,7 +458,12 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
       const keepAliveMs = await resolveKeepAliveMs(keepAliveIntervalMsResolver);
       return streamGenerationEvents(
         c,
-        generationService.generateFromOpenApi(body.spec, { endpoints, description }, signal, pf.modelId),
+        generationService.generateFromOpenApi(
+          body.spec,
+          { endpoints: endpoints as string[] | undefined, description },
+          signal,
+          pf.modelId,
+        ),
         keepAliveMs,
         { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId },
       );

--- a/ornn-api/src/domains/skills/mirror/routes.ts
+++ b/ornn-api/src/domains/skills/mirror/routes.ts
@@ -31,6 +31,8 @@
 
 import { Hono } from "hono";
 import pino from "pino";
+import { z } from "zod";
+import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import {
   type AuthVariables,
   nyxidAuthMiddleware,
@@ -159,8 +161,13 @@ export function createMirrorRoutes(
     "/github/repo",
     auth,
     requirePermission("ornn:admin:skill"),
+    // The per-field type / regex checks below are intricate (owner /
+    // repo name regex, app-id digits, PEM shape, branch protection).
+    // The middleware here just gates the JSON-object shape so a
+    // SyntaxError becomes 400 invalid_body (#438).
+    validateBody(z.record(z.string(), z.unknown()), "invalid_body"),
     async (c) => {
-      const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+      const body = getValidatedBody<Record<string, unknown>>(c);
       const current = await settingsService.getMirror();
       const confirmAbandonOldRepo = body.confirmAbandonOldRepo === true;
 

--- a/ornn-api/src/middleware/validate.ts
+++ b/ornn-api/src/middleware/validate.ts
@@ -56,11 +56,23 @@ export function validateBody<T extends z.ZodTypeAny>(
   errorCode: string = "invalid_body",
 ): MiddlewareHandler {
   return async (c, next) => {
+    // Read as text first so we can disambiguate "empty body" (a
+    // common pattern for endpoints with all-optional fields) from
+    // "syntactically broken JSON" — once `.json()` errors, the body
+    // stream is consumed, so we can't peek for emptiness after.
+    // Per #438 — the bypass pattern this replaces (`c.req.json().catch(() => ({}))`)
+    // had the same empty-body tolerance, but skipped the schema check.
+    // We now keep the tolerance AND validate.
+    const text = await c.req.text().catch(() => "");
     let raw: unknown;
-    try {
-      raw = await c.req.json();
-    } catch {
-      throw AppError.badRequest(errorCode, "Request body must be valid JSON");
+    if (text.trim().length === 0) {
+      raw = {};
+    } else {
+      try {
+        raw = JSON.parse(text);
+      } catch {
+        throw AppError.badRequest(errorCode, "Request body must be valid JSON");
+      }
     }
     const result = schema.safeParse(raw);
     if (!result.success) {


### PR DESCRIPTION
Every state-changing endpoint that previously parsed JSON manually via `c.req.json().catch(() => ({}))` now flows through `validateBody(schema, code)` so malformed bodies surface as RFC 7807 `400 invalid_body` instead of silently coercing to `{}` and bypassing schema validation.

12+ endpoints across 10 files updated. `validateBody` taught to tolerate empty body (covers the SPA's no-body refresh call).

All 660 ornn-api tests pass; typecheck + lint clean.

Closes #438