### PR TITLE
chore: enable noImplicitOverride across ornn-api/web/sdk (#450 part 1)

### DIFF
--- a/.changeset/stricter-ts-flags-450-part1.md
+++ b/.changeset/stricter-ts-flags-450-part1.md
@@ -1,0 +1,8 @@
+---
+"ornn-api": patch
+"@chronoai/ornn-sdk": patch
+---
+
+Enable `noImplicitOverride` in `ornn-api`, `ornn-web`, and `sdk/typescript` tsconfigs (#450 part 1). Catches accidental method-signature drift during class-inheritance refactors. Only one site needed the explicit `override` keyword (`ErrorBoundary` in `ornn-web`) — zero behavior change.
+
+The other two flags from #450 (`noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`) surface 68 and 75 type errors respectively across `ornn-api` alone. Per the issue's "Land in stages" guidance, those ride in their own follow-up PRs to keep the diff reviewable. Tracked as sub-tasks on #450.

--- a/ornn-api/tsconfig.json
+++ b/ornn-api/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,
+    "noImplicitOverride": true,
     "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/ornn-web/src/components/ErrorBoundary.tsx
+++ b/ornn-web/src/components/ErrorBoundary.tsx
@@ -38,7 +38,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     this.setState({ errorInfo });
     this.props.onError?.(error, errorInfo);
 
@@ -60,7 +60,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     window.location.href = "/";
   };
 
-  render(): ReactNode {
+  override render(): ReactNode {
     if (this.state.hasError) {
       if (this.props.fallback) {
         return this.props.fallback;

--- a/ornn-web/tsconfig.json
+++ b/ornn-web/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "noImplicitOverride": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM"],
     "strict": true,
+    "noImplicitOverride": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Lands the safe one of #450's three flags. Zero behavior change; one site (ErrorBoundary) needed explicit `override` on lifecycle methods.

The other two flags surface real type errors and ride in follow-up PRs per the issue's staging guidance:
- `noUncheckedIndexedAccess` → 68 errors in ornn-api
- `exactOptionalPropertyTypes` → 75 errors in ornn-api

Refs #450