### PR TITLE
feat: docker-compose for one-command local dev (#466)

### DIFF
--- a/.changeset/docker-compose-466.md
+++ b/.changeset/docker-compose-466.md
@@ -1,0 +1,14 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+Ship a `docker-compose.yml` for one-command local dev (#466). Brings up MongoDB, MinIO, `ornn-api`, and `ornn-web` in a single `docker compose up`. README's new "Run Ornn locally (5 minutes)" section and `CONTRIBUTING.md`'s rewritten "Getting set up" tier the prerequisites by what each contributor actually needs:
+
+- **Unit tests / lint / typecheck:** just Bun + Docker.
+- **Running the services:** `docker compose up`.
+- **Full integration with NyxID / chrono-storage / chrono-sandbox / opensandbox:** the existing K8s manifests under `deployment/`.
+
+NyxID stays out of compose deliberately — mocking the OAuth + JWT-signing path is non-trivial and would either ship a fake or pin to a real staging. Public endpoints (`/livez`, `/api/v1/skill-format/rules`, `/api/v1/skill-manifest-schema.json`, OpenAPI spec) work without auth, which is enough for most contributor flows. Auth-required endpoints need `NYXID_BASE_URL` pointed at your own NyxID instance — same model the existing `deployment/.env.ornn` uses.
+
+Includes a sample `.env.compose.sample` with the only knob a contributor typically overrides (`ENCRYPTION_KEY`).

--- a/.env.sample.compose
+++ b/.env.sample.compose
@@ -1,0 +1,14 @@
+# .env.compose.sample — copy to `.env` for `docker compose up`.
+#
+# Most knobs have safe dev defaults baked into docker-compose.yml.
+# Override here only when you need to override.
+
+# 32+ chars. The compose default is fine for dev; rotate for any
+# environment where the encrypted secrets actually matter.
+ENCRYPTION_KEY=dev-encryption-key-32-chars-min-12345
+
+# Bake the current commit into the SPA bundle's __APP_VERSION__ so
+# the version-check loop has a real identity. `git rev-parse --short HEAD`
+# is the canonical value; the compose file falls back to "compose-dev"
+# if unset.
+# GIT_COMMIT=$(git rev-parse --short HEAD)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ By participating you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md) (
 
 ## Getting set up
 
-Prerequisites: [Bun](https://bun.sh), Docker, a local Kubernetes cluster for full integration runs.
+**For unit tests, lint, typecheck (most PRs):** [Bun](https://bun.sh) + Docker.
 
 ```bash
 git clone https://github.com/ChronoAIProject/Ornn.git
@@ -40,7 +40,16 @@ bun run typecheck
 bun run build:web
 ```
 
-Full local-cluster setup (MongoDB, MinIO, OpenSandbox, NyxID, Ornn services) is documented in the project `CLAUDE.md` under "Local Deployment". You do not need the full cluster to land code changes — unit tests alone are sufficient for most PRs.
+**For running the services locally (`docker compose`):**
+
+```bash
+cp .env.compose.sample .env
+docker compose up --build
+```
+
+Brings up MongoDB, MinIO, `ornn-api`, and `ornn-web`. Auth layer (NyxID) stays external — point at your own NyxID instance via env, or stick to the public endpoints (`/livez`, `/api/v1/skill-format/rules`, etc.) which work without auth. Issue #466.
+
+**For full integration runs (incl. NyxID, chrono-storage, chrono-sandbox, opensandbox):** local Kubernetes cluster. Long-form setup is in `CLAUDE.md` under "Local Deployment". You do not need the full cluster to land most PRs — unit tests + the `docker compose` stack are sufficient for the vast majority.
 
 ## Issue-first workflow
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ nyxid proxy request ornn-api GET /api/v1/skills?q=summarize
 
 Full per-endpoint reference: [ornn.chrono-ai.fun/docs](https://ornn.chrono-ai.fun/docs).
 
+## Run Ornn locally (5 minutes)
+
+```bash
+git clone https://github.com/ChronoAIProject/Ornn.git
+cd Ornn
+cp .env.compose.sample .env
+docker compose up --build
+```
+
+- `ornn-api` on `http://localhost:3802`
+- `ornn-web` on `http://localhost:5173`
+- MongoDB on `27017`, MinIO console on `9001`
+
+This brings up the data + service layer (Mongo, MinIO, `ornn-api`, `ornn-web`). The auth layer (NyxID) stays external — for end-to-end use against authenticated endpoints, point the API at your own NyxID instance (or the staging instance via the team) by setting `NYXID_BASE_URL`. Public endpoints (`/livez`, `/api/v1/skill-format/rules`, `/api/v1/skill-manifest-schema.json`) work without auth out of the box.
+
+For full production parity (incl. NyxID, chrono-storage, chrono-sandbox, opensandbox), use the Kubernetes manifests under `deployment/` — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for the long-form setup.
+
 ## How Ornn compares
 
 The space of agent skill / tool registries is crowded. Quick orientation:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,127 @@
+# docker-compose.yml — one-command local dev (#466).
+#
+# Brings up the data layer (MongoDB + MinIO) plus the two ornn services
+# (`ornn-api` + `ornn-web`). The auth layer (NyxID) stays external — you
+# either run it separately via the existing `deployment/dependencies/`
+# Kubernetes manifests OR point at a hosted NyxID staging via env.
+#
+# Usage:
+#   cp .env.compose.sample .env
+#   docker compose up --build
+#   open https://localhost:5173    # ornn-web (proxies /api/v1/* → ornn-api)
+#
+# To stop:
+#   docker compose down
+#   docker compose down -v          # also removes persistent volumes
+#
+# Production parity is intentionally NOT a goal — that's what the K8s
+# manifests under `deployment/` are for. This compose is a fast,
+# zero-cluster path for contributors who want to run unit + integration
+# tests + a working ornn-api locally.
+
+services:
+  mongodb:
+    image: mongo:7
+    container_name: ornn-dev-mongodb
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ornn
+      MONGO_INITDB_ROOT_PASSWORD: ornn_dev_password
+    volumes:
+      - mongodb-data:/data/db
+    # Health check so dependents wait until Mongo is actually ready.
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+
+  minio:
+    image: minio/minio:latest
+    container_name: ornn-dev-minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000" # S3 API
+      - "9001:9001" # Web console
+    environment:
+      MINIO_ROOT_USER: ornn
+      MINIO_ROOT_PASSWORD: ornn_dev_password
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+
+  # ornn-api boots without an external NyxID. Auth-required endpoints
+  # return 401 — fine for running the test suite or hitting public
+  # /livez. For end-to-end use, set NYXID_BASE_URL via your local .env.
+  ornn-api:
+    build:
+      context: .
+      dockerfile: ornn-api/Dockerfile
+    image: ornn-api:dev
+    container_name: ornn-dev-api
+    restart: unless-stopped
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    ports:
+      - "3802:3802"
+    environment:
+      PORT: "3802"
+      LOG_LEVEL: "info"
+      LOG_PRETTY: "true"
+      MONGODB_URI: "mongodb://ornn:ornn_dev_password@mongodb:27017/ornn?authSource=admin"
+      MONGODB_DB: "ornn"
+      ALLOWED_ORIGINS: "http://localhost:5173,http://ornn-web:80"
+      # 32+ chars required (Zod gate at boot). Dev-only fixed value.
+      ENCRYPTION_KEY: "${ENCRYPTION_KEY:-dev-encryption-key-32-chars-min-12345}"
+      ORNN_PUBLIC_ORIGIN: "http://localhost:3802"
+      # No agentseal binary in this image — disable the scanner so the
+      # boot-time path validator from #442 doesn't fail.
+      AGENTSEAL_ENABLED: "false"
+      AGENTSEAL_PYTHON: "/usr/bin/env"
+      AGENTSEAL_SCRIPT: "/usr/bin/env"
+      # PostHog telemetry off by default in compose.
+      POSTHOG_ENABLED: "false"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3802/livez || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 20s
+
+  ornn-web:
+    build:
+      context: .
+      dockerfile: ornn-web/Dockerfile
+      args:
+        GIT_COMMIT: "${GIT_COMMIT:-compose-dev}"
+    image: ornn-web:dev
+    container_name: ornn-dev-web
+    restart: unless-stopped
+    depends_on:
+      ornn-api:
+        condition: service_healthy
+    ports:
+      - "5173:80"
+    environment:
+      # The web container's nginx serves the SPA + injects runtime
+      # config from this env at startup. ORNN_API_BASE_URL is what
+      # the SPA fetches from — point it at the host-side port.
+      ORNN_API_BASE_URL: "http://localhost:3802/api/v1"
+
+volumes:
+  mongodb-data:
+    name: ornn-dev-mongodb-data
+  minio-data:
+    name: ornn-dev-minio-data


### PR DESCRIPTION
`docker compose up --build` now stands up MongoDB + MinIO + ornn-api + ornn-web. README + CONTRIBUTING tier the prerequisites by what each contributor actually needs.

NyxID stays external — same model as the existing `deployment/.env.ornn` setup. Auth-required endpoints need `NYXID_BASE_URL` pointed at a real instance; public endpoints work out of the box.

Compose v1: infrastructure only. NyxID-mock + chrono-storage / sandbox in compose stay as follow-ups.

Closes #466