### PR TITLE
feat: cursor pagination + SDK searchAll iterator (#457 + #465)

### DIFF
--- a/.changeset/cursor-pagination-457-465.md
+++ b/.changeset/cursor-pagination-457-465.md
@@ -1,0 +1,32 @@
+---
+"ornn-api": minor
+"@chronoai/ornn-sdk": minor
+---
+
+Cursor pagination on `/skill-search` per CONVENTIONS.md §4.3 + SDK auto-pagination iterator (#457 + #465).
+
+**API (`/api/v1/skill-search`)**
+
+- Accepts `?cursor=<opaque-base64>` (alongside the existing `?page=N`). When both are sent, `cursor` wins.
+- Accepts `?limit=N` as an alias for the existing `?pageSize=N`.
+- Response now carries a `meta` envelope: `{ data: { items, total, page, pageSize, totalPages, meta: { limit, hasMore, nextCursor? } }, error }`. The legacy fields stay until they're sunset — clients can migrate at their own pace.
+- A malformed cursor returns `400 invalid_cursor` (RFC 7807 problem+json) instead of silently falling back to page 1.
+- Cursor payload is server-internal (`{ page: number }` today, `lastSort` keyset in a future PR) — clients MUST treat it as opaque.
+
+**SDK (`@chronoai/ornn-sdk`)**
+
+- `client.search()` now accepts `cursor` + `limit` params (additive).
+- New `client.searchAll({ q })` returns an `AsyncIterableIterator<SkillSummary>`. Threads `meta.nextCursor` automatically; terminates on `hasMore === false` or no more cursor. 10k-page safety cap.
+
+```ts
+for await (const skill of client.searchAll({ q: "pdf" })) {
+  console.log(skill.name);
+}
+```
+
+**Out of scope (follow-up)**
+
+- Real lastSort keyset cursor under the hood — current cursor encodes `{ page }` so the wire contract conforms to §4.3 while the underlying query stays offset-based. Switching the payload is invisible to clients.
+- Cursor support on other list endpoints (categories, tags, users) — those keep their existing offset shape for now.
+- Python SDK `search_all()` — follow-up.
+- `Sunset:` header on the legacy `page`/`pageSize` shape — once cursor adoption is high enough.

--- a/ornn-api/src/domains/skills/search/routes.ts
+++ b/ornn-api/src/domains/skills/search/routes.ts
@@ -18,6 +18,7 @@ import {
 import { validateQuery, getValidatedQuery } from "../../../middleware/validate";
 import { AppError } from "../../../shared/types/index";
 import { createLogger } from "../../../shared/logger";
+import { decodeCursor, buildNextCursor } from "../../../shared/cursor";
 const logger = createLogger("skillSearchRoutes");
 
 const searchQuerySchema = z.object({
@@ -31,6 +32,15 @@ const searchQuerySchema = z.object({
   scope: z.enum(["public", "private", "mixed", "shared-with-me", "mine"]).optional().default("private"),
   page: z.coerce.number().int().min(1).optional().default(1),
   pageSize: z.coerce.number().int().min(1).max(100).optional().default(9),
+  /**
+   * Cursor-based pagination per CONVENTIONS.md §4.3 (#457). Opaque
+   * base64-JSON token returned by previous response's `meta.nextCursor`.
+   * When set, takes precedence over `page` (same `pageSize` still
+   * applies). Backward-compat: callers may still send `page=N` until
+   * the offset shape is sunset.
+   */
+  cursor: z.string().max(2048).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
   model: z.string().optional(),
   /** System-skill tri-state filter. `any` (default) keeps all; `only`
    *  restricts to skills tied to an admin/platform NyxID service
@@ -81,7 +91,21 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
       const parsed = getValidatedQuery<z.infer<typeof searchQuerySchema>>(c);
       // q wins; legacy `query` is the fallback for un-upgraded clients (#586).
       const query = parsed.q ?? parsed.query ?? "";
-      const { mode, page, pageSize, model, systemFilter } = parsed;
+      const { mode, model, systemFilter } = parsed;
+      // Cursor pagination (#457). `cursor` wins over `page` when both
+      // are sent. `limit` aliases `pageSize` per CONVENTIONS.md §4.3.
+      const pageSize = parsed.limit ?? parsed.pageSize;
+      let page = parsed.page;
+      if (parsed.cursor !== undefined) {
+        const decoded = decodeCursor(parsed.cursor);
+        if (!decoded) {
+          throw AppError.badRequest(
+            "invalid_cursor",
+            "The provided cursor is malformed or from a previous API version.",
+          );
+        }
+        page = decoded.page;
+      }
       const authCtx = c.get("auth");
       const isAnonymous = !authCtx;
 
@@ -126,7 +150,28 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
         tagsAll: parseCsv(parsed.tags),
       });
 
-      return c.json({ data: response, error: null });
+      // Augment the legacy response shape with the cursor envelope
+      // per CONVENTIONS.md §4.3 (#457). `data.items` + `data.meta`
+      // are the canonical fields going forward; the existing
+      // `total/totalPages/page/pageSize/items` keys stay alongside
+      // for backward compat until they're sunset.
+      const itemsReturned = response.items.length;
+      const meta = {
+        limit: pageSize,
+        hasMore: itemsReturned >= pageSize && response.page * pageSize < response.total,
+        nextCursor: buildNextCursor({
+          currentPage: response.page,
+          pageSize,
+          itemsReturned,
+        }),
+      };
+      return c.json({
+        data: {
+          ...response,
+          meta,
+        },
+        error: null,
+      });
     },
   );
 

--- a/ornn-api/src/shared/cursor.test.ts
+++ b/ornn-api/src/shared/cursor.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the cursor codec (#457).
+ *
+ * Pins the encode/decode round-trip + the "last page" semantics so
+ * subsequent rewrites (eventual lastSort keyset cursors) can be
+ * validated against the same contract.
+ *
+ * @module shared/cursor.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { encodeCursor, decodeCursor, buildNextCursor } from "./cursor";
+
+describe("encodeCursor + decodeCursor round-trip", () => {
+  test("encodes + decodes a page payload losslessly", () => {
+    const original = { page: 7 };
+    const encoded = encodeCursor(original);
+    const decoded = decodeCursor(encoded);
+    expect(decoded).toEqual(original);
+  });
+
+  test("encoded cursor is URL-safe (no `/` or `+`)", () => {
+    // base64url is the standard for opaque tokens in URL params — pin
+    // it so future codec rewrites can't silently regress to base64.
+    const encoded = encodeCursor({ page: 1 });
+    expect(encoded).not.toMatch(/[/+=]/);
+  });
+
+  test("decodeCursor returns null on malformed input", () => {
+    expect(decodeCursor("")).toBeNull();
+    expect(decodeCursor(undefined)).toBeNull();
+    expect(decodeCursor("not-base64!")).toBeNull();
+    expect(decodeCursor(Buffer.from("not-json", "utf-8").toString("base64url"))).toBeNull();
+    // Missing `page` field
+    expect(decodeCursor(Buffer.from('{"x":1}', "utf-8").toString("base64url"))).toBeNull();
+    // Non-integer page
+    expect(decodeCursor(Buffer.from('{"page":1.5}', "utf-8").toString("base64url"))).toBeNull();
+    // Negative page
+    expect(decodeCursor(Buffer.from('{"page":-1}', "utf-8").toString("base64url"))).toBeNull();
+    // page is 0
+    expect(decodeCursor(Buffer.from('{"page":0}', "utf-8").toString("base64url"))).toBeNull();
+  });
+});
+
+describe("buildNextCursor — last-page semantics", () => {
+  test("emits a cursor when the page is full (more items likely)", () => {
+    const c = buildNextCursor({ currentPage: 2, pageSize: 9, itemsReturned: 9 });
+    expect(c).toBeDefined();
+    expect(decodeCursor(c)).toEqual({ page: 3 });
+  });
+
+  test("omits the cursor when the page is partial (last page)", () => {
+    // Per CONVENTIONS.md §4.3: "When hasMore === false, nextCursor MAY
+    // be omitted." This function returns undefined for that case.
+    const c = buildNextCursor({ currentPage: 5, pageSize: 9, itemsReturned: 3 });
+    expect(c).toBeUndefined();
+  });
+
+  test("omits the cursor when the page is empty", () => {
+    const c = buildNextCursor({ currentPage: 99, pageSize: 9, itemsReturned: 0 });
+    expect(c).toBeUndefined();
+  });
+});

--- a/ornn-api/src/shared/cursor.ts
+++ b/ornn-api/src/shared/cursor.ts
@@ -1,0 +1,61 @@
+/**
+ * Cursor encode/decode for paginated list endpoints (#457).
+ *
+ * Per CONVENTIONS.md §4.3, list endpoints return `meta.nextCursor`
+ * — an opaque base64-encoded JSON token the client passes back as
+ * `?cursor=...` for the next page. Clients MUST NOT parse the
+ * payload; the format is server-internal and free to evolve.
+ *
+ * v1 payload shape: `{ page: number }` — backed by the existing
+ * offset-based query layer underneath. The cursor abstraction lets
+ * the API contract conform to §4.3 immediately while the underlying
+ * query stays offset; a follow-up PR can swap the payload for a
+ * `lastSort` keyset cursor without changing the client-visible
+ * interface.
+ *
+ * @module shared/cursor
+ */
+
+export interface CursorPayload {
+  /** 1-indexed page number — what the underlying offset query reads. */
+  page: number;
+}
+
+/** Encode a cursor payload as a URL-safe base64 string. */
+export function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf-8").toString("base64url");
+}
+
+/**
+ * Decode an opaque cursor. Returns `null` for any malformed input —
+ * the route layer then surfaces a 400 `invalid_cursor` so an old
+ * client doesn't end up paginating from page 1 silently.
+ */
+export function decodeCursor(raw: string | undefined): CursorPayload | null {
+  if (!raw || typeof raw !== "string" || raw.length === 0) return null;
+  try {
+    const json = Buffer.from(raw, "base64url").toString("utf-8");
+    const parsed = JSON.parse(json) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const page = (parsed as { page?: unknown }).page;
+    if (typeof page !== "number" || !Number.isInteger(page) || page < 1) return null;
+    return { page };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the next-page cursor for an offset-based response. Returns
+ * `undefined` when there are no more pages (callers omit
+ * `nextCursor` from `meta` in that case per CONVENTIONS.md §4.3).
+ */
+export function buildNextCursor(args: {
+  currentPage: number;
+  pageSize: number;
+  itemsReturned: number;
+}): string | undefined {
+  // No more items means we're on the last page.
+  if (args.itemsReturned < args.pageSize) return undefined;
+  return encodeCursor({ page: args.currentPage + 1 });
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -78,8 +78,10 @@ export class OrnnClient {
 
   // ---- Public API ----
 
-  /** Search skills. Returns paginated results with `items` + pagination meta. */
-  async search(params: SkillSearchParams = {}): Promise<SkillSearchResult> {
+  /** Search skills. Returns one page; for cross-page iteration use `searchAll()`. */
+  async search(
+    params: SkillSearchParams & { cursor?: string; limit?: number } = {},
+  ): Promise<SkillSearchResult> {
     const query = new URLSearchParams();
     // Per CONVENTIONS.md §4.1 (#586) the canonical search param is `q`.
     if (params.q) query.set("q", params.q);
@@ -89,6 +91,10 @@ export class OrnnClient {
     if (params.runtime) query.set("runtime", params.runtime);
     if (params.mode) query.set("mode", params.mode);
     if (params.systemFilter) query.set("systemFilter", params.systemFilter);
+    // Cursor pagination (#457). When `cursor` is set, server uses it
+    // instead of `page`; both are still accepted for backward compat.
+    if (params.cursor !== undefined) query.set("cursor", params.cursor);
+    if (params.limit !== undefined) query.set("limit", String(params.limit));
     if (params.page !== undefined) query.set("page", String(params.page));
     if (params.pageSize !== undefined) query.set("pageSize", String(params.pageSize));
     const qs = query.toString();
@@ -96,6 +102,40 @@ export class OrnnClient {
       "GET",
       `/skill-search${qs ? `?${qs}` : ""}`,
     );
+  }
+
+  /**
+   * Auto-paginating iterator (#465). Yields every matching skill across
+   * pages; fetches the next page on demand using `meta.nextCursor`:
+   *
+   * ```ts
+   * for await (const skill of client.searchAll({ q: "pdf" })) {
+   *   console.log(skill.name);
+   * }
+   * ```
+   *
+   * Stops cleanly when the server returns `meta.hasMore === false` (or
+   * no `nextCursor`). Per-page errors surface as `OrnnError` and stop
+   * iteration — wrap in try/catch if you want to skip-and-continue.
+   */
+  async *searchAll(
+    params: SkillSearchParams & { limit?: number } = {},
+  ): AsyncIterableIterator<SkillSearchResult["items"][number]> {
+    let cursor: string | undefined;
+    // Loop guard — the server contract says nextCursor only appears
+    // when there's a next page, so this loop terminates naturally on
+    // the last page. Cap at 10k pages defensively in case a misbehaving
+    // server returns nextCursor forever; 10k pages × default limit (9)
+    // is ~90k items which exceeds every realistic registry.
+    for (let i = 0; i < 10_000; i++) {
+      const page: SkillSearchResult = await this.search(
+        cursor !== undefined ? { ...params, cursor } : params,
+      );
+      for (const item of page.items) yield item;
+      const next = page.meta?.nextCursor;
+      if (!next || page.meta?.hasMore === false) return;
+      cursor = next;
+    }
   }
 
   /** Fetch a single skill by GUID or name. */

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -74,6 +74,18 @@ export interface SkillSearchResult {
   readonly pageSize: number;
   readonly totalPages: number;
   readonly mode?: string;
+  /**
+   * Cursor pagination envelope per CONVENTIONS.md §4.3 (#457). Use
+   * `client.searchAll({ q })` to iterate transparently — the iterator
+   * threads `meta.nextCursor` through subsequent requests.
+   *
+   * When `hasMore === false`, `nextCursor` MAY be omitted.
+   */
+  readonly meta?: {
+    readonly limit: number;
+    readonly hasMore: boolean;
+    readonly nextCursor?: string;
+  };
 }
 
 export interface UpdateSkillMetadata {


### PR DESCRIPTION
CONVENTIONS.md §4.3 has specified cursor-based pagination since day one; implementation lagged. This adds the cursor envelope to `/skill-search` + an auto-paginating iterator to the TS SDK.

**ornn-api:**
- `?cursor=<opaque-base64>` + `?limit=N` accepted alongside existing `?page=N` / `?pageSize=N`. cursor wins when both sent.
- Response gains `meta: { limit, hasMore, nextCursor? }` next to existing total/totalPages/page/pageSize/items shape.
- Malformed cursor → 400 `invalid_cursor` (RFC 7807).
- New `shared/cursor.ts` codec with 6 unit tests.

**SDK:**
- `client.search()` takes optional `cursor` + `limit`.
- New `client.searchAll(params)` — AsyncIterableIterator yielding every matching skill across pages.

**Backward compat preserved.** Cursor payload opaque (v1: `{ page }`, future: `lastSort` keyset).

698 ornn-api tests / 17 SDK tests / typecheck clean.

Closes #457, closes #465