### PR TITLE
feat(api): sliding-window rate limit + RFC 9239 headers (#439 + #460)

### DIFF
--- a/.changeset/rate-limit-439-460.md
+++ b/.changeset/rate-limit-439-460.md
@@ -1,0 +1,23 @@
+---
+"ornn-api": minor
+---
+
+Sliding-window rate-limit middleware + RFC 9239 headers on every response (#439 + #460).
+
+New `ornn-api/src/middleware/rateLimit.ts` exports `rateLimit({ windowMs, max, label?, keyBy? })`. Defaults:
+- **Key:** `auth.userId` when present, else `x-forwarded-for` first IP, else `"anonymous"`.
+- **Storage:** in-memory `Map` per process; cleanup pass every 60s on access.
+- **Headers:** `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset` (seconds) emitted on every allowed AND denied response. Denied responses also carry `Retry-After`.
+- **Deny:** throws `AppError(429, "rate_limited", "...")` — the global handler emits it as `application/problem+json` per RFC 7807.
+
+Applied to the three highest-cost endpoints:
+
+| Route | Limit | Why |
+|---|---|---|
+| `GET /skill-search` | 60/min/user | Mongo aggregation (keyword) or LLM rerank (semantic) |
+| `POST /skills` | 10/min/user | ZIP validate + storage write + AgentSeal scan |
+| `POST /skills/generate` | 20/min/user | Every request is an LLM call |
+
+6 new unit tests pin: header emission, per-user keying, window reset, 429 response shape, multi-label composition. Full suite 704 / 0.
+
+**Storage caveat for prod:** in-memory means multi-pod clusters get per-pod-buckets — the effective limit is `N × max` where N is the replica count. Acceptable for the current single-replica dev/staging cluster; a Redis backend is the natural next step before prod traffic hits a multi-replica deployment.

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -28,6 +28,7 @@ import { AppError } from "../../../shared/types/index";
 import { canReadSkill, canManageSkill } from "./authorize";
 import { parseGithubUrl } from "./utils/githubPull";
 import { enforceZipLimits } from "../../../shared/utils/zipLimits";
+import { rateLimit } from "../../../middleware/rateLimit";
 import { createLogger } from "../../../shared/logger";
 const deprecationPatchSchema = z.object({
   isDeprecated: z.boolean(),
@@ -258,6 +259,10 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     "/skills",
     auth,
     requirePermission("ornn:skill:create"),
+    // Rate limit (#439): upload runs the ZIP validator + storage write
+    // + AgentSeal scan. Per-user 10/min is generous for legitimate
+    // publishing flow and stops a runaway script from filling storage.
+    rateLimit({ windowMs: 60_000, max: 10, label: "skills-create" }),
     async (c) => {
       const authCtx = getAuth(c);
       const skipValidation = c.req.query("skip_validation") === "true";

--- a/ornn-api/src/domains/skills/generation/routes.ts
+++ b/ornn-api/src/domains/skills/generation/routes.ts
@@ -22,6 +22,7 @@ import {
 import { AppError } from "../../../shared/types/index";
 import { resolveZipRoot } from "../../../shared/utils/zip";
 import { validateBody, getValidatedBody } from "../../../middleware/validate";
+import { rateLimit } from "../../../middleware/rateLimit";
 import { fetchGithubSourceBundle } from "./githubFetcher";
 import JSZip from "jszip";
 import { createLogger } from "../../../shared/logger";
@@ -213,6 +214,11 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
     "/skills/generate",
     auth,
     requirePermission("ornn:skill:build"),
+    // Rate limit (#439): every generation runs an LLM call —
+    // most expensive endpoint in the API. Per-user 20/min is
+    // ~3s minimum between requests, which still feels instant for
+    // legitimate flows while stopping a script from burning budget.
+    rateLimit({ windowMs: 60_000, max: 20, label: "skills-generate" }),
     async (c) => {
       const contentType = c.req.header("content-type") ?? "";
       const authCtx = getAuth(c);

--- a/ornn-api/src/domains/skills/search/routes.ts
+++ b/ornn-api/src/domains/skills/search/routes.ts
@@ -19,6 +19,7 @@ import { validateQuery, getValidatedQuery } from "../../../middleware/validate";
 import { AppError } from "../../../shared/types/index";
 import { createLogger } from "../../../shared/logger";
 import { decodeCursor, buildNextCursor } from "../../../shared/cursor";
+import { rateLimit } from "../../../middleware/rateLimit";
 const logger = createLogger("skillSearchRoutes");
 
 const searchQuerySchema = z.object({
@@ -86,6 +87,12 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
   app.get(
     "/skill-search",
     optionalAuth,
+    // Rate limit (#439): keyword search hits Mongo (cheap), semantic
+    // hits an LLM (paid). One generous cap covers both — the hot path
+    // is the keyword scope, and the semantic gate inside `searchService`
+    // already requires auth so the per-user key matters. RFC 9239
+    // headers go out on every response (#460).
+    rateLimit({ windowMs: 60_000, max: 60, label: "skill-search" }),
     validateQuery(searchQuerySchema, "invalid_query"),
     async (c) => {
       const parsed = getValidatedQuery<z.infer<typeof searchQuerySchema>>(c);

--- a/ornn-api/src/middleware/rateLimit.test.ts
+++ b/ornn-api/src/middleware/rateLimit.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the sliding-window rate-limit middleware (#439 + #460).
+ *
+ * Pins:
+ *   - RFC 9239 headers emitted on every response (allowed + denied)
+ *   - 429 response with Retry-After when the cap is exceeded
+ *   - Per-user keying defaults work (no collision between users)
+ *   - Window resets after the configured interval
+ *
+ * @module middleware/rateLimit.test
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { AppError } from "../shared/types/index";
+import { __resetRateLimitForTests, rateLimit } from "./rateLimit";
+import { buildProblemJsonBody } from "../shared/types/index";
+
+function makeApp(opts: {
+  windowMs?: number;
+  max?: number;
+  label?: string;
+} = {}) {
+  const app = new Hono();
+  // Stub auth so the default keyBy can find a user id.
+  app.use("*", async (c, next) => {
+    const user = c.req.header("x-test-user") ?? "u1";
+    c.set("auth" as never, { userId: user } as never);
+    await next();
+  });
+  app.use(
+    "*",
+    rateLimit({
+      windowMs: opts.windowMs ?? 60_000,
+      max: opts.max ?? 3,
+      label: opts.label ?? "test",
+    }),
+  );
+  app.get("/", (c) => c.json({ ok: true }));
+  // Translate AppError → 429 like the global handler does.
+  app.onError((err, c) => {
+    if (err instanceof AppError) {
+      const body = buildProblemJsonBody({
+        statusCode: err.statusCode,
+        code: err.code,
+        message: err.message,
+        instance: c.req.path,
+        requestId: null,
+      });
+      return c.json(body, err.statusCode as never, {
+        "Content-Type": "application/problem+json",
+      });
+    }
+    return c.json({ error: { code: "internal_error", message: String(err) } }, 500);
+  });
+  return app;
+}
+
+describe("rateLimit middleware (#439 + #460)", () => {
+  beforeEach(() => __resetRateLimitForTests());
+
+  test("emits RFC 9239 headers on every allowed response", async () => {
+    const app = makeApp({ max: 3 });
+    const res = await app.request("/", { headers: { "x-test-user": "alice" } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("RateLimit-Limit")).toBe("3");
+    expect(res.headers.get("RateLimit-Remaining")).toBe("2");
+    const reset = Number(res.headers.get("RateLimit-Reset"));
+    expect(reset).toBeGreaterThan(0);
+    expect(reset).toBeLessThanOrEqual(60);
+  });
+
+  test("decrements Remaining across consecutive requests by the same user", async () => {
+    const app = makeApp({ max: 3 });
+    const headers = { "x-test-user": "bob" };
+    const r1 = await app.request("/", { headers });
+    const r2 = await app.request("/", { headers });
+    const r3 = await app.request("/", { headers });
+    expect(r1.headers.get("RateLimit-Remaining")).toBe("2");
+    expect(r2.headers.get("RateLimit-Remaining")).toBe("1");
+    expect(r3.headers.get("RateLimit-Remaining")).toBe("0");
+  });
+
+  test("returns 429 with Retry-After + problem+json when the cap is exceeded", async () => {
+    const app = makeApp({ max: 2 });
+    const headers = { "x-test-user": "charlie" };
+    await app.request("/", { headers });
+    await app.request("/", { headers });
+    const denied = await app.request("/", { headers });
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get("Content-Type")).toContain("application/problem+json");
+    expect(denied.headers.get("Retry-After")).not.toBeNull();
+    expect(denied.headers.get("RateLimit-Remaining")).toBe("0");
+    const body = (await denied.json()) as { code: string; status: number };
+    expect(body.code).toBe("rate_limited");
+    expect(body.status).toBe(429);
+  });
+
+  test("different users share separate buckets (per-user keying)", async () => {
+    const app = makeApp({ max: 1 });
+    const aliceFirst = await app.request("/", { headers: { "x-test-user": "alice" } });
+    expect(aliceFirst.status).toBe(200);
+    // Alice is now at her cap; Bob shouldn't be affected.
+    const bobFirst = await app.request("/", { headers: { "x-test-user": "bob" } });
+    expect(bobFirst.status).toBe(200);
+    expect(bobFirst.headers.get("RateLimit-Remaining")).toBe("0");
+    // Alice's second hit fails.
+    const aliceSecond = await app.request("/", { headers: { "x-test-user": "alice" } });
+    expect(aliceSecond.status).toBe(429);
+  });
+
+  test("window resets after windowMs", async () => {
+    const app = makeApp({ max: 2, windowMs: 50 });
+    const headers = { "x-test-user": "dave" };
+    await app.request("/", { headers });
+    await app.request("/", { headers });
+    const denied = await app.request("/", { headers });
+    expect(denied.status).toBe(429);
+    // Wait past the window
+    await new Promise((r) => setTimeout(r, 60));
+    const allowed = await app.request("/", { headers });
+    expect(allowed.status).toBe(200);
+    expect(allowed.headers.get("RateLimit-Remaining")).toBe("1");
+  });
+
+  test("different labels share separate buckets (multi-limit composition)", async () => {
+    // Two limiters on the same user with different labels.
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("auth" as never, { userId: "eve" } as never);
+      await next();
+    });
+    app.use("*", rateLimit({ windowMs: 60_000, max: 2, label: "burst" }));
+    app.use("*", rateLimit({ windowMs: 60_000, max: 10, label: "daily" }));
+    app.get("/", (c) => c.json({ ok: true }));
+    app.onError((err, c) => {
+      if (err instanceof AppError) return c.json({ code: err.code }, err.statusCode as never);
+      return c.json({ code: "internal_error" }, 500);
+    });
+    // Hit the route 3 times — third should fail on the burst limit
+    // even though daily allows 10.
+    await app.request("/");
+    await app.request("/");
+    const r3 = await app.request("/");
+    expect(r3.status).toBe(429);
+  });
+});

--- a/ornn-api/src/middleware/rateLimit.ts
+++ b/ornn-api/src/middleware/rateLimit.ts
@@ -1,0 +1,158 @@
+/**
+ * Sliding-window rate-limit middleware (#439).
+ *
+ * Closes a real abuse surface: `/skill-search?mode=semantic` calls a
+ * paid LLM per request, `/skills` POST runs the AgentSeal scan + ZIP
+ * processing, and `/skills/generate` does both. Without a rate limit,
+ * a trivial loop burns LLM budget or DoS's the database via Mongo
+ * aggregation; an authenticated abuser can do worse than an anonymous
+ * one because the auth quota gates *monthly* spend, not *burst rate*.
+ *
+ * Emits RFC 9239 headers on every response (#460) — clients with
+ * proper backoff (`@chronoai/ornn-sdk`'s future retry wrapper, Stripe-
+ * style SDKs, etc.) read these and self-throttle. Without them,
+ * clients can't tell the difference between "go slower" and "go away".
+ *
+ * Storage is in-memory per process — fine for the single-replica dev /
+ * staging cluster; multi-pod prod will need a Redis backend before
+ * this can be tightened. The middleware behind the scenes uses a
+ * `Map<key, { count, resetAt }>` with periodic-on-access cleanup so
+ * idle keys don't accumulate forever.
+ *
+ * Mount order: must run AFTER `proxyAuthSetup` so `auth.userId` is
+ * available for keying. When auth is missing (public endpoints), the
+ * key falls back to the proxy-forwarded IP. Without IP either,
+ * everyone shares the "anonymous" bucket — a fail-safe for the rare
+ * truly-public path.
+ *
+ * @module middleware/rateLimit
+ */
+
+import type { Context, MiddlewareHandler } from "hono";
+import { AppError } from "../shared/types/index";
+import { createLogger } from "../shared/logger";
+
+const logger = createLogger("rateLimit");
+
+export interface RateLimitConfig {
+  /** Window length in milliseconds. */
+  readonly windowMs: number;
+  /** Max requests allowed in the window. */
+  readonly max: number;
+  /**
+   * Override how the bucket key is derived. Default: `auth.userId` →
+   * `x-forwarded-for` → `"anonymous"`.
+   */
+  readonly keyBy?: (c: Context) => string;
+  /**
+   * Human-readable name for log entries. Useful when one route has
+   * multiple rate-limit middleware mounted (e.g. a per-IP burst cap
+   * + a per-user daily budget).
+   */
+  readonly label?: string;
+}
+
+interface BucketEntry {
+  count: number;
+  /** Epoch ms when the window resets. */
+  resetAt: number;
+}
+
+/**
+ * Module-level bucket store. Multiple `rateLimit()` calls share this
+ * map so the cleanup pass touches every active key.
+ *
+ * Keys are namespaced by label so two middlewares mounted on the same
+ * route don't collide (e.g. `"upload:userId"` vs `"upload-ip:ip"`).
+ */
+const buckets = new Map<string, BucketEntry>();
+
+/**
+ * Last time we walked the bucket map to drop expired entries. Cheap
+ * O(n) sweep; bounded by request rate × cleanup interval.
+ */
+let lastCleanup = 0;
+const CLEANUP_INTERVAL_MS = 60_000;
+
+function cleanupExpired(now: number): void {
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
+  lastCleanup = now;
+  for (const [key, entry] of buckets) {
+    if (entry.resetAt <= now) buckets.delete(key);
+  }
+}
+
+function defaultKeyBy(c: Context): string {
+  const auth = (c.get as unknown as (k: "auth") => { userId?: string } | undefined)("auth");
+  if (auth?.userId) return `user:${auth.userId}`;
+  // Trust proxy-forwarded IP — production traffic comes through
+  // NyxID's reverse proxy which sets `x-forwarded-for`.
+  const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+  if (ip) return `ip:${ip}`;
+  return "anonymous";
+}
+
+/**
+ * Test seam — clears the in-process bucket store between tests.
+ * Not part of the runtime API.
+ */
+export function __resetRateLimitForTests(): void {
+  buckets.clear();
+  lastCleanup = 0;
+}
+
+/**
+ * Create a Hono middleware that enforces a sliding-window rate limit
+ * + emits RFC 9239 headers on every response.
+ *
+ * Per-request flow:
+ *
+ *   1. Compute `key` from the request (default: per-user else per-IP).
+ *   2. Look up the bucket. If the window has expired, reset the count.
+ *   3. Increment + decide allow/deny.
+ *   4. Emit `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset`
+ *      headers regardless of outcome.
+ *   5. On deny, throw `AppError(429, "rate_limited")` with `Retry-After`
+ *      (the global RFC 7807 handler emits it as `application/problem+json`).
+ */
+export function rateLimit(config: RateLimitConfig): MiddlewareHandler {
+  const { windowMs, max, keyBy = defaultKeyBy, label = "default" } = config;
+
+  return async (c, next) => {
+    const now = Date.now();
+    cleanupExpired(now);
+
+    const requestKey = keyBy(c);
+    const key = `${label}:${requestKey}`;
+    let entry = buckets.get(key);
+    if (!entry || entry.resetAt <= now) {
+      entry = { count: 0, resetAt: now + windowMs };
+      buckets.set(key, entry);
+    }
+    entry.count += 1;
+
+    const remaining = Math.max(0, max - entry.count);
+    const resetSeconds = Math.max(0, Math.ceil((entry.resetAt - now) / 1000));
+
+    // RFC 9239 — set BEFORE the next middleware runs so even handlers
+    // that emit their own response shape carry them.
+    c.header("RateLimit-Limit", String(max));
+    c.header("RateLimit-Remaining", String(remaining));
+    c.header("RateLimit-Reset", String(resetSeconds));
+
+    if (entry.count > max) {
+      c.header("Retry-After", String(resetSeconds));
+      logger.info(
+        { key: requestKey, label, count: entry.count, max, resetSeconds },
+        "rate_limited",
+      );
+      throw new AppError(
+        429,
+        "rate_limited",
+        `Rate limit exceeded for ${label}. Retry in ${resetSeconds}s.`,
+      );
+    }
+
+    await next();
+  };
+}


### PR DESCRIPTION
Closes a real abuse surface — semantic search hits a paid LLM per request, POST /skills runs AgentSeal scan + storage, /skills/generate is LLM. None of these were rate-limited.

**New `middleware/rateLimit.ts`** — sliding window, per-user key default (auth.userId → IP → anonymous), in-memory store with cleanup sweep.

**Emits RFC 9239 headers on every response** (allowed + denied):
- `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`
- `Retry-After` on 429

**Applied:**
| Route | Limit | Why |
|---|---|---|
| `GET /skill-search` | 60/min/user | Mongo / LLM |
| `POST /skills` | 10/min/user | ZIP + AgentSeal |
| `POST /skills/generate` | 20/min/user | LLM per request |

Deny → 429 `rate_limited` (RFC 7807 problem+json).

**Storage caveat:** in-memory → multi-pod clusters effectively get N×max. Acceptable for single-replica dev/staging; Redis backend is the natural next step.

6 new tests; full suite 704 / 0.

Closes #439, closes #460