### PR TITLE
refactor(api): decompose bootstrap.ts into per-domain wiring modules (#580)

### DIFF
--- a/.changeset/bootstrap-decompose-580.md
+++ b/.changeset/bootstrap-decompose-580.md
@@ -1,0 +1,25 @@
+---
+"ornn-api": patch
+---
+
+Decompose `bootstrap.ts` per-domain (#580).
+
+Lifts 10 leaf domains' wiring out of the 1089-line `bootstrap.ts` monolith into per-domain `bootstrap.ts` modules. Each one exports a `wire{Domain}({ db, logger, ...deps })` function that bundles repo construction + `ensureIndexes()` fire-and-forget catch + any one-shot boot migration + service construction + routes construction into a single call. The orchestrator stays in charge of *ordering* and shared client construction; the per-domain *detail* moves out.
+
+Domains extracted:
+
+- announcements
+- analytics
+- quota (consumed by playground / skill-gen / admin)
+- redemption-codes (admin + me route surfaces, shared service for atomic pivot consistency)
+- broadcasts (2-step: shared repo first, then service + routes)
+- notifications (consumes shared broadcasts repo for the merged feed)
+- platform settings (legacy single-doc surface)
+- admin (dashboard + users + quota admin)
+- skill search
+- skill generation
+- playground
+
+What's still inlined: skills CRUD, skill audit, GitHub mirror, settings export/import, and `createAdminRoutes` (skill / generation / agentseal admin). These have heavier cross-cutting dependency lists (scheduler lifecycle, audit fan-out, analytics emitter closures) — extracting them cleanly needs a follow-up.
+
+bootstrap.ts: **1089 → 970 lines** (-11%, -119 lines net). No behavioral change — boot order is preserved, all 798 tests still pass.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -135,11 +135,7 @@ import { wireQuota } from "./domains/quota/bootstrap";
 import { wireRedemptionCodes } from "./domains/redemption-codes/bootstrap";
 
 // Domain: Admin (engineer-1): dashboard, users, quota admin.
-import { AdminDashboardService } from "./domains/admin/dashboard/service";
-import { createAdminDashboardRoutes } from "./domains/admin/dashboard/routes";
-import { createAdminQuotaRoutes } from "./domains/admin/quota/routes";
-import { AdminUsersService } from "./domains/admin-users/service";
-import { createAdminUsersRoutes } from "./domains/admin-users/routes";
+import { wireAdmin } from "./domains/admin/bootstrap";
 
 // LLM provider migration (#270 — fold legacy global model catalog into
 // per-provider arrays). One-time, idempotent, runs before any
@@ -872,22 +868,11 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   apiApp.use("*", idempotencyMiddleware({ repo: idempotencyKeyRepo }));
 
   // ---- Admin routes (engineer-1): dashboard, users, quota admin ----
-  const adminDashboardService = new AdminDashboardService({
-    db,
-    userDirectoryRepo,
-  });
-  const adminDashboardRoutes = createAdminDashboardRoutes({
-    dashboardService: adminDashboardService,
-  });
-  const adminUsersService = new AdminUsersService({
-    db,
-    userDirectoryRepo,
-  });
-  const adminUsersRoutes = createAdminUsersRoutes({ adminUsersService });
-  const adminQuotaRoutes = createAdminQuotaRoutes({
-    quotaService,
-    userDirectoryRepo,
-  });
+  const {
+    dashboardRoutes: adminDashboardRoutes,
+    usersRoutes: adminUsersRoutes,
+    quotaRoutes: adminQuotaRoutes,
+  } = wireAdmin({ db, userDirectoryRepo, quotaService });
   apiApp.route("/", skillRoutes);
   apiApp.route("/", mirrorRoutes);
   apiApp.route("/", auditRoutes);

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -66,19 +66,16 @@ import { createAuditRoutes } from "./domains/skills/audit/routes";
 
 
 // Domain: Notifications
-import { NotificationRepository } from "./domains/notifications/repository";
-import { NotificationService } from "./domains/notifications/service";
-import { createNotificationRoutes } from "./domains/notifications/routes";
-import { dropLegacyNotificationCategories } from "./domains/notifications/migration";
+import { wireNotifications } from "./domains/notifications/bootstrap";
 
 // Domain: Announcements (landing-page popup)
 import { wireAnnouncements } from "./domains/announcements/bootstrap";
 
 // Domain: Broadcasts (admin-authored notifications, #500)
-import { BroadcastRepository } from "./domains/broadcasts/repository";
-import { BroadcastService } from "./domains/broadcasts/service";
-import { createBroadcastRoutes } from "./domains/broadcasts/routes";
-import { backfillBroadcastRecipientUserIds } from "./domains/broadcasts/migration";
+import {
+  wireBroadcasts,
+  wireBroadcastsRepo,
+} from "./domains/broadcasts/bootstrap";
 
 // Domain: Analytics
 import { wireAnalytics } from "./domains/analytics/bootstrap";
@@ -459,59 +456,32 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     agentsealScanner,
   });
 
-  // ---- Domain: Notifications (built before AuditService so the audit
-  //   pipeline can fan out completion notifications) ----
-  const notificationRepo = new NotificationRepository(db);
-  void notificationRepo.ensureIndexes().catch((err) =>
-    logger.warn({ err }, "notifications indexes ensureIndexes failed — proceeding anyway"),
-  );
-  // One-time boot migration (#218) — drop legacy `share.*` rows left over
-  // from the pre-#198 share/audit-gate workflow. Idempotent; no-op after
-  // first run. Failure is non-fatal — old rows surface as ugly UI but
-  // never block the boot.
-  await dropLegacyNotificationCategories(db).catch((err) =>
-    logger.error(
-      { err: err instanceof Error ? err.message : String(err) },
-      "dropLegacyNotificationCategories failed — legacy notification rows may still surface in /notifications until the next deploy",
-    ),
-  );
-  // `broadcastRepo` is constructed in the broadcasts block below; we
-  // need a reference at NotificationService-build time so the merged
-  // feed (#500) can left-join read receipts. Reordered so broadcasts
-  // build first.
-  const broadcastRepoForNotifications = new BroadcastRepository(db);
-  void broadcastRepoForNotifications.ensureIndexes().catch((err) =>
-    logger.warn({ err }, "broadcasts indexes ensureIndexes failed — proceeding anyway"),
-  );
-  // One-shot bilingual + targeting backfill for broadcasts. Pre-#502
-  // docs don't carry `recipientUserIds`; this migration writes an
-  // explicit `null` on every absent doc so the merged feed can rely
-  // on a stable `string[] | null` shape. Idempotent; failure is
-  // non-fatal — the repo mapper's `Array.isArray` guard already
-  // normalises absent fields to `null` on the read path.
-  await backfillBroadcastRecipientUserIds(db, logger).catch((err) =>
-    logger.error(
-      { err: err instanceof Error ? err.message : String(err) },
-      "broadcasts recipientUserIds backfill crashed — mapper fallback will cover reads, retry on next boot",
-    ),
-  );
-  const notificationService = new NotificationService({
-    notificationRepo,
-    broadcastRepo: broadcastRepoForNotifications,
+  // ---- Domain: Notifications + Broadcasts ----
+  // The two share a single BroadcastRepository instance: notifications
+  // reads it on the merged-feed path (#500 left-join), broadcasts
+  // writes through its own service on admin CRUD. Build the repo
+  // first so notifications can take its reference, then wire each
+  // surface's service + routes. Notifications is built before the
+  // audit service so the audit pipeline can fan out completion
+  // notifications.
+  const { repo: broadcastRepoForNotifications } = await wireBroadcastsRepo({
+    db,
+    logger,
   });
-  const notificationRoutes = createNotificationRoutes({ notificationService });
+  const { service: notificationService, routes: notificationRoutes } =
+    await wireNotifications({
+      db,
+      logger,
+      broadcastRepo: broadcastRepoForNotifications,
+    });
 
   // ---- Domain: Announcements (landing-page popup, issue #307) ----
   const { routes: announcementRoutes } = await wireAnnouncements({ db, logger });
 
   // ---- Domain: Broadcasts (admin-authored, fan-out via notifications, #500) ----
-  // Reuse the same `BroadcastRepository` instance the notifications
-  // service got — both surfaces share state (admin CRUD + per-user
-  // feed merge), and a single instance keeps the wiring legible.
-  const broadcastService = new BroadcastService({
+  const { routes: broadcastRoutes } = wireBroadcasts({
     repo: broadcastRepoForNotifications,
   });
-  const broadcastRoutes = createBroadcastRoutes({ broadcastService });
 
   // ---- NyxID Orgs Client — built early so the audit fan-out can expand
   //   sharedWithOrgs into member rosters when sending consumer notifications.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -81,8 +81,7 @@ import {
 import { wireAnalytics } from "./domains/analytics/bootstrap";
 
 // Domain: Skill Search
-import { SearchService } from "./domains/skills/search/service";
-import { createSearchRoutes } from "./domains/skills/search/routes";
+import { wireSkillSearch } from "./domains/skills/search/bootstrap";
 
 // Domain: Skill Generation
 import { SkillGenerationService } from "./domains/skills/generation/service";
@@ -682,19 +681,14 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   });
 
   // ---- Domain: Skill Search ----
-  const searchService = new SearchService({
+  // Search shares the playground surface for default-model resolution
+  // (it's a playground-flavoured LLM call). Backend-eng-2 may add a
+  // dedicated `search` section later; until then, share with playground.
+  const { routes: searchRoutes } = wireSkillSearch({
     skillRepo,
     llmClient: nyxLlmClient,
-    // Default model resolves through the playground surface (search is
-    // a playground-flavoured LLM call). Backend-eng-2 may add a
-    // dedicated `search` section later; until then, share with playground.
     defaultModelResolver: async () =>
       (await resolveSurfaceDefaults("playground")).model,
-  });
-
-  const searchRoutes = createSearchRoutes({
-    searchService,
-    skillRepo,
   });
 
   // ---- Domain: Skill Generation ----

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -87,8 +87,7 @@ import { wireSkillSearch } from "./domains/skills/search/bootstrap";
 import { wireSkillGeneration } from "./domains/skills/generation/bootstrap";
 
 // Domain: Playground
-import { PlaygroundChatService } from "./domains/playground/chatService";
-import { createPlaygroundRoutes } from "./domains/playground/routes";
+import { wirePlayground } from "./domains/playground/bootstrap";
 
 // Domain: Admin
 import { createAdminRoutes } from "./domains/admin/routes";
@@ -702,19 +701,14 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     });
 
   // ---- Domain: Playground ----
-  const chatService = new PlaygroundChatService({
+  const { routes: playgroundRoutes } = wirePlayground({
     llmClient: nyxLlmClient,
     sandboxClient,
     skillService,
     defaultsResolver: async () => resolveSurfaceDefaults("playground"),
-  });
-
-  const playgroundRoutes = createPlaygroundRoutes({
-    chatService,
     keepAliveIntervalMsResolver: async () =>
       (await settingsService.getPlayground()).sseKeepAliveMs,
     analyticsService,
-    skillService,
     quotaService,
     llmProvidersService,
   });

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -72,10 +72,7 @@ import { createNotificationRoutes } from "./domains/notifications/routes";
 import { dropLegacyNotificationCategories } from "./domains/notifications/migration";
 
 // Domain: Announcements (landing-page popup)
-import { AnnouncementRepository } from "./domains/announcements/repository";
-import { AnnouncementService } from "./domains/announcements/service";
-import { createAnnouncementRoutes } from "./domains/announcements/routes";
-import { migrateAnnouncementsToBilingual } from "./domains/announcements/migration";
+import { wireAnnouncements } from "./domains/announcements/bootstrap";
 
 // Domain: Broadcasts (admin-authored notifications, #500)
 import { BroadcastRepository } from "./domains/broadcasts/repository";
@@ -512,23 +509,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const notificationRoutes = createNotificationRoutes({ notificationService });
 
   // ---- Domain: Announcements (landing-page popup, issue #307) ----
-  const announcementRepo = new AnnouncementRepository(db);
-  void announcementRepo.ensureIndexes().catch((err) =>
-    logger.warn({ err }, "announcements indexes ensureIndexes failed — proceeding anyway"),
-  );
-  // One-shot bilingual backfill: copies legacy single-locale columns
-  // (title / bodyMarkdown / ctaLabel) into the new per-locale slots
-  // (`*En` + `*Zh`) on existing docs. Idempotent — second boot is a
-  // no-op. Failure is logged + non-fatal; the repo's mapper falls
-  // back to legacy fields if the migration hasn't run yet.
-  await migrateAnnouncementsToBilingual(db, logger).catch((err) =>
-    logger.error(
-      { err: err instanceof Error ? err.message : String(err) },
-      "announcements bilingual migration crashed — repo fallback will cover reads, retry on next boot",
-    ),
-  );
-  const announcementService = new AnnouncementService({ repo: announcementRepo });
-  const announcementRoutes = createAnnouncementRoutes({ announcementService });
+  const { routes: announcementRoutes } = await wireAnnouncements({ db, logger });
 
   // ---- Domain: Broadcasts (admin-authored, fan-out via notifications, #500) ----
   // Reuse the same `BroadcastRepository` instance the notifications

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -84,8 +84,7 @@ import { wireAnalytics } from "./domains/analytics/bootstrap";
 import { wireSkillSearch } from "./domains/skills/search/bootstrap";
 
 // Domain: Skill Generation
-import { SkillGenerationService } from "./domains/skills/generation/service";
-import { createGenerationRoutes } from "./domains/skills/generation/routes";
+import { wireSkillGeneration } from "./domains/skills/generation/bootstrap";
 
 // Domain: Playground
 import { PlaygroundChatService } from "./domains/playground/chatService";
@@ -692,18 +691,15 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   });
 
   // ---- Domain: Skill Generation ----
-  const generationService = new SkillGenerationService({
-    llmClient: nyxLlmClient,
-    defaultsResolver: async () => resolveSurfaceDefaults("skillGen"),
-  });
-
-  const generationRoutes = createGenerationRoutes({
-    generationService,
-    keepAliveIntervalMsResolver: async () =>
-      (await settingsService.getSkillGen()).sseKeepAliveMs,
-    quotaService,
-    llmProvidersService,
-  });
+  const { service: generationService, routes: generationRoutes } =
+    wireSkillGeneration({
+      llmClient: nyxLlmClient,
+      defaultsResolver: async () => resolveSurfaceDefaults("skillGen"),
+      keepAliveIntervalMsResolver: async () =>
+        (await settingsService.getSkillGen()).sseKeepAliveMs,
+      quotaService,
+      llmProvidersService,
+    });
 
   // ---- Domain: Playground ----
   const chatService = new PlaygroundChatService({

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -134,9 +134,7 @@ import { createSettingsExportImportRoutes } from "./domains/settings/exportImpor
 import { LlmModelListClient } from "./clients/llmModelListClient";
 
 // Domain: Quota (per-user playground / skill-gen counters + admin grants)
-import { QuotaRepository } from "./domains/quota/repository";
-import { QuotaService } from "./domains/quota/service";
-import { createQuotaRoutes } from "./domains/quota/routes";
+import { wireQuota } from "./domains/quota/bootstrap";
 
 // Domain: Redemption codes (admin-issued single-use quota grants)
 import { RedemptionCodeRepository } from "./domains/redemption-codes/repository";
@@ -632,35 +630,19 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   });
 
   // ---- Domain: Quota (per-user playground / skill-gen counters + admin grants) ----
-  const quotaRepo = new QuotaRepository(db);
-  void quotaRepo.ensureIndexes().catch((err) =>
-    logger.warn({ err }, "quota indexes ensureIndexes failed — proceeding anyway"),
-  );
+  const { service: quotaService, routes: quotaRoutes } = wireQuota({
+    db,
+    logger,
+    settingsService,
+    notificationService,
+  });
 
   // ---- Domain: Redemption codes (single-use admin-issued quota grants) ----
+  // Repo built here, service constructed below (consumes `quotaService`).
   const redemptionCodeRepo = new RedemptionCodeRepository(db);
   void redemptionCodeRepo.ensureIndexes().catch((err) =>
     logger.warn({ err }, "redemption_codes indexes ensureIndexes failed — proceeding anyway"),
   );
-  const quotaService = new QuotaService({
-    repo: quotaRepo,
-    defaults: {
-      getQuotaDefaults: async () => {
-        const [pg, sg] = await Promise.all([
-          settingsService.getPlayground(),
-          settingsService.getSkillGen(),
-        ]);
-        return {
-          defaultPlaygroundMonthly: pg.defaultMonthlyQuota,
-          defaultSkillGenMonthly: sg.defaultMonthlyQuota,
-        };
-      },
-    },
-    notificationService,
-  });
-  const quotaRoutes = createQuotaRoutes({
-    quotaService,
-  });
 
   // ---- Per-provider model catalog migration (#270) ----
   // Fold the standalone `models` collection into `llm_providers.models[]`

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -137,10 +137,7 @@ import { LlmModelListClient } from "./clients/llmModelListClient";
 import { wireQuota } from "./domains/quota/bootstrap";
 
 // Domain: Redemption codes (admin-issued single-use quota grants)
-import { RedemptionCodeRepository } from "./domains/redemption-codes/repository";
-import { RedemptionCodeService } from "./domains/redemption-codes/service";
-import { createAdminRedemptionCodesRoutes } from "./domains/admin/redemption-codes/routes";
-import { createMeRedemptionCodesRoutes } from "./domains/redemption-codes/me-routes";
+import { wireRedemptionCodes } from "./domains/redemption-codes/bootstrap";
 
 // Domain: Admin (engineer-1): dashboard, users, quota admin.
 import { AdminDashboardService } from "./domains/admin/dashboard/service";
@@ -638,11 +635,10 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   });
 
   // ---- Domain: Redemption codes (single-use admin-issued quota grants) ----
-  // Repo built here, service constructed below (consumes `quotaService`).
-  const redemptionCodeRepo = new RedemptionCodeRepository(db);
-  void redemptionCodeRepo.ensureIndexes().catch((err) =>
-    logger.warn({ err }, "redemption_codes indexes ensureIndexes failed — proceeding anyway"),
-  );
+  const {
+    adminRoutes: adminRedemptionCodesRoutes,
+    meRoutes: meRedemptionCodesRoutes,
+  } = wireRedemptionCodes({ db, logger, quotaService });
 
   // ---- Per-provider model catalog migration (#270) ----
   // Fold the standalone `models` collection into `llm_providers.models[]`
@@ -925,17 +921,6 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     quotaService,
     userDirectoryRepo,
   });
-  const redemptionCodeService = new RedemptionCodeService({
-    repo: redemptionCodeRepo,
-    quotaService,
-  });
-  const adminRedemptionCodesRoutes = createAdminRedemptionCodesRoutes({
-    redemptionCodeService,
-  });
-  const meRedemptionCodesRoutes = createMeRedemptionCodesRoutes({
-    redemptionCodeService,
-  });
-
   apiApp.route("/", skillRoutes);
   apiApp.route("/", mirrorRoutes);
   apiApp.route("/", auditRoutes);

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -81,9 +81,7 @@ import { createBroadcastRoutes } from "./domains/broadcasts/routes";
 import { backfillBroadcastRecipientUserIds } from "./domains/broadcasts/migration";
 
 // Domain: Analytics
-import { AnalyticsRepository } from "./domains/analytics/repository";
-import { AnalyticsService } from "./domains/analytics/service";
-import { createAnalyticsRoutes } from "./domains/analytics/routes";
+import { wireAnalytics } from "./domains/analytics/bootstrap";
 
 // Domain: Skill Search
 import { SearchService } from "./domains/skills/search/service";
@@ -561,12 +559,11 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const auditRoutes = createAuditRoutes({ auditService, skillService });
 
   // ---- Domain: Analytics ----
-  const analyticsRepo = new AnalyticsRepository(db);
-  void analyticsRepo.ensureIndexes().catch((err) =>
-    logger.warn({ err }, "skill_executions indexes ensureIndexes failed — proceeding anyway"),
-  );
-  const analyticsService = new AnalyticsService({ analyticsRepo });
-  const analyticsRoutes = createAnalyticsRoutes({ analyticsService, skillService });
+  const { service: analyticsService, routes: analyticsRoutes } = wireAnalytics({
+    db,
+    logger,
+    skillService,
+  });
 
   // ---- Domain: Platform settings (admin-editable: audit threshold, mirror config, LLM override) ----
   // Backend-engineer-2 is replacing this with a multi-section

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -113,9 +113,7 @@ import { createMeRoutes } from "./domains/me/routes";
 import { createUserRoutes } from "./domains/users/routes";
 
 // Domain: Platform settings (legacy single-doc — still used by mirror, audit-waiver) ----
-import { PlatformSettingsRepository } from "./domains/platform/repository";
-import { PlatformSettingsService } from "./domains/platform/service";
-import { createPlatformSettingsRoutes } from "./domains/platform/routes";
+import { wirePlatformSettings } from "./domains/platform/bootstrap";
 
 // Domain: Settings (multi-section + LLM providers + export/import) — backend-engineer-2.
 import { SettingsRepository } from "./domains/settings/repository";
@@ -537,11 +535,10 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   // the existing single-doc `PlatformSettings` shape into the bridge
   // contract — every field a client/route asks for is satisfied here
   // (with sensible fallbacks for sections that don't exist yet).
-  const platformSettingsRepo = new PlatformSettingsRepository(db);
-  const platformSettingsService = new PlatformSettingsService(platformSettingsRepo, {
+  const { routes: platformSettingsRoutes } = wirePlatformSettings({
+    db,
     encryptionKey: config.encryptionKey,
   });
-  const platformSettingsRoutes = createPlatformSettingsRoutes({ platformSettingsService });
 
   // ---- Settings routes (engineer-2): per-section CRUD, LLM providers,
   //   export/import.

--- a/ornn-api/src/domains/admin/bootstrap.ts
+++ b/ornn-api/src/domains/admin/bootstrap.ts
@@ -1,0 +1,58 @@
+/**
+ * Wire the admin domain (#580 — bootstrap decomposition).
+ *
+ * Bundles the dashboard + users + quota admin surfaces. Each one needs
+ * the user directory repo + db handle; the quota admin route also
+ * needs the `QuotaService` so it can grant/revoke against current
+ * buckets. The three were originally inlined in bootstrap.ts back to
+ * back; this lifts them into a single wiring call that returns each
+ * route handler so the mount block stays unchanged.
+ *
+ * The standalone `createAdminRoutes` (skill + generation + agentseal
+ * admin) keeps living in bootstrap.ts — it depends on too many
+ * cross-cutting clients (skillRepo, skillService, skillVersionRepo,
+ * generationService, agentsealScanner) to fit cleanly here.
+ *
+ * @module domains/admin/bootstrap
+ */
+
+import type { Db } from "mongodb";
+import type { Hono } from "hono";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { AdminDashboardService } from "./dashboard/service";
+import { createAdminDashboardRoutes } from "./dashboard/routes";
+import { createAdminQuotaRoutes } from "./quota/routes";
+import { AdminUsersService } from "../admin-users/service";
+import { createAdminUsersRoutes } from "../admin-users/routes";
+import type { UserDirectoryRepository } from "../users/repository";
+import type { QuotaService } from "../quota/service";
+
+export interface AdminWiring {
+  readonly dashboardRoutes: Hono<{ Variables: AuthVariables }>;
+  readonly usersRoutes: Hono<{ Variables: AuthVariables }>;
+  readonly quotaRoutes: Hono<{ Variables: AuthVariables }>;
+}
+
+export function wireAdmin(deps: {
+  db: Db;
+  userDirectoryRepo: UserDirectoryRepository;
+  quotaService: QuotaService;
+}): AdminWiring {
+  const dashboardService = new AdminDashboardService({
+    db: deps.db,
+    userDirectoryRepo: deps.userDirectoryRepo,
+  });
+  const dashboardRoutes = createAdminDashboardRoutes({
+    dashboardService,
+  });
+  const usersService = new AdminUsersService({
+    db: deps.db,
+    userDirectoryRepo: deps.userDirectoryRepo,
+  });
+  const usersRoutes = createAdminUsersRoutes({ adminUsersService: usersService });
+  const quotaRoutes = createAdminQuotaRoutes({
+    quotaService: deps.quotaService,
+    userDirectoryRepo: deps.userDirectoryRepo,
+  });
+  return { dashboardRoutes, usersRoutes, quotaRoutes };
+}

--- a/ornn-api/src/domains/analytics/bootstrap.ts
+++ b/ornn-api/src/domains/analytics/bootstrap.ts
@@ -1,0 +1,44 @@
+/**
+ * Wire the analytics domain (#580 — bootstrap decomposition).
+ *
+ * Pure leaf wiring: repo (with fire-and-forget index ensure for both
+ * `skill_executions` + `skill_pulls` collections) → service → routes.
+ * Routes also need the skill-service reference to join skill metadata
+ * onto execution rows, so the caller passes it in.
+ *
+ * @module domains/analytics/bootstrap
+ */
+
+import type { Db } from "mongodb";
+import type { Hono } from "hono";
+import type { Logger } from "pino";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { AnalyticsRepository } from "./repository";
+import { AnalyticsService } from "./service";
+import { createAnalyticsRoutes } from "./routes";
+import type { SkillService } from "../skills/crud/service";
+
+export interface AnalyticsWiring {
+  readonly service: AnalyticsService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+export function wireAnalytics(deps: {
+  db: Db;
+  logger: Logger;
+  skillService: SkillService;
+}): AnalyticsWiring {
+  const repo = new AnalyticsRepository(deps.db);
+  void repo.ensureIndexes().catch((err) =>
+    deps.logger.warn(
+      { err },
+      "skill_executions indexes ensureIndexes failed — proceeding anyway",
+    ),
+  );
+  const service = new AnalyticsService({ analyticsRepo: repo });
+  const routes = createAnalyticsRoutes({
+    analyticsService: service,
+    skillService: deps.skillService,
+  });
+  return { service, routes };
+}

--- a/ornn-api/src/domains/announcements/bootstrap.ts
+++ b/ornn-api/src/domains/announcements/bootstrap.ts
@@ -1,0 +1,60 @@
+/**
+ * Wire the announcements domain (#580 — bootstrap decomposition).
+ *
+ * Pure leaf wiring: repo → ensureIndexes (fire-and-forget) → one-shot
+ * bilingual backfill migration → service → routes. The boot caller
+ * stays in charge of ordering — this function just bundles the per-
+ * domain construction detail.
+ *
+ * @module domains/announcements/bootstrap
+ */
+
+import type { Db } from "mongodb";
+import type { Hono } from "hono";
+import type { Logger } from "pino";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { AnnouncementRepository } from "./repository";
+import { AnnouncementService } from "./service";
+import { createAnnouncementRoutes } from "./routes";
+import { migrateAnnouncementsToBilingual } from "./migration";
+
+export interface AnnouncementsWiring {
+  readonly service: AnnouncementService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+/**
+ * Construct repo + service + routes for announcements and queue the
+ * one-shot bilingual backfill. Returns the routes (mount on the API
+ * sub-app) plus the service (no current consumer needs it externally,
+ * but exposing it keeps the contract symmetric with other domains).
+ *
+ * Migration failure is non-fatal: the repo's mapper falls back to
+ * legacy single-locale fields, so reads stay correct even when the
+ * migration hasn't run yet.
+ */
+export async function wireAnnouncements(deps: {
+  db: Db;
+  logger: Logger;
+}): Promise<AnnouncementsWiring> {
+  const repo = new AnnouncementRepository(deps.db);
+  void repo.ensureIndexes().catch((err) =>
+    deps.logger.warn(
+      { err },
+      "announcements indexes ensureIndexes failed — proceeding anyway",
+    ),
+  );
+  // One-shot bilingual backfill: copies legacy single-locale columns
+  // (title / bodyMarkdown / ctaLabel) into the new per-locale slots
+  // (`*En` + `*Zh`). Idempotent — second boot is a no-op. Failure is
+  // logged + non-fatal; the repo's mapper falls back to legacy fields.
+  await migrateAnnouncementsToBilingual(deps.db, deps.logger).catch((err) =>
+    deps.logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "announcements bilingual migration crashed — repo fallback will cover reads, retry on next boot",
+    ),
+  );
+  const service = new AnnouncementService({ repo });
+  const routes = createAnnouncementRoutes({ announcementService: service });
+  return { service, routes };
+}

--- a/ornn-api/src/domains/broadcasts/bootstrap.ts
+++ b/ornn-api/src/domains/broadcasts/bootstrap.ts
@@ -1,0 +1,79 @@
+/**
+ * Wire the broadcasts domain (#580 — bootstrap decomposition).
+ *
+ * Broadcasts and notifications share the same `BroadcastRepository`
+ * instance: notifications reads from it on the merged-feed path
+ * (#500 left-join with read receipts), broadcasts writes through its
+ * own service on admin CRUD. A single shared instance keeps the
+ * read/write surfaces consistent without a second TTL or cache layer.
+ *
+ * Wiring order is deliberate — the repo is built FIRST so the
+ * `wireNotifications` call can take a reference to it, then the
+ * broadcast service + routes are built on top of the same repo.
+ *
+ * @module domains/broadcasts/bootstrap
+ */
+
+import type { Db } from "mongodb";
+import type { Hono } from "hono";
+import type { Logger } from "pino";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { BroadcastRepository } from "./repository";
+import { BroadcastService } from "./service";
+import { createBroadcastRoutes } from "./routes";
+import { backfillBroadcastRecipientUserIds } from "./migration";
+
+export interface BroadcastsRepoWiring {
+  readonly repo: BroadcastRepository;
+}
+
+export interface BroadcastsWiring extends BroadcastsRepoWiring {
+  readonly service: BroadcastService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+/**
+ * Step 1 — construct the repo + run the one-shot bilingual + targeting
+ * backfill migration. Notifications wiring needs the repo reference
+ * before its own service is built; this entry point gives it that
+ * without forcing broadcasts to construct its service + routes prematurely.
+ *
+ * Pre-#502 docs don't carry `recipientUserIds`; the migration writes
+ * an explicit `null` on every absent doc so the merged feed can rely
+ * on a stable `string[] | null` shape. Idempotent; failure is
+ * non-fatal — the repo mapper's `Array.isArray` guard already
+ * normalises absent fields to `null` on the read path.
+ */
+export async function wireBroadcastsRepo(deps: {
+  db: Db;
+  logger: Logger;
+}): Promise<BroadcastsRepoWiring> {
+  const repo = new BroadcastRepository(deps.db);
+  void repo.ensureIndexes().catch((err) =>
+    deps.logger.warn(
+      { err },
+      "broadcasts indexes ensureIndexes failed — proceeding anyway",
+    ),
+  );
+  await backfillBroadcastRecipientUserIds(deps.db, deps.logger).catch((err) =>
+    deps.logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "broadcasts recipientUserIds backfill crashed — mapper fallback will cover reads, retry on next boot",
+    ),
+  );
+  return { repo };
+}
+
+/**
+ * Step 2 — build the service + routes on the shared repo. Called
+ * after `wireNotifications` so the merged feed has already taken
+ * its repo reference (no functional dependency, just an ordering
+ * preference that matches the original bootstrap flow).
+ */
+export function wireBroadcasts(deps: {
+  repo: BroadcastRepository;
+}): { service: BroadcastService; routes: Hono<{ Variables: AuthVariables }> } {
+  const service = new BroadcastService({ repo: deps.repo });
+  const routes = createBroadcastRoutes({ broadcastService: service });
+  return { service, routes };
+}

--- a/ornn-api/src/domains/notifications/bootstrap.ts
+++ b/ornn-api/src/domains/notifications/bootstrap.ts
@@ -1,0 +1,59 @@
+/**
+ * Wire the notifications domain (#580 — bootstrap decomposition).
+ *
+ * Notifications consumes the shared `BroadcastRepository` (built by
+ * the broadcasts wiring) on the merged-feed path. The caller is
+ * expected to construct the broadcasts repo first via
+ * `wireBroadcastsRepo`, then pass that repo into `wireNotifications`.
+ *
+ * Also runs a one-time legacy-category cleanup migration (#218 — drop
+ * `share.*` notification rows) so the consumer UI doesn't surface
+ * stale rows from the pre-#198 share/audit-gate workflow.
+ *
+ * @module domains/notifications/bootstrap
+ */
+
+import type { Db } from "mongodb";
+import type { Hono } from "hono";
+import type { Logger } from "pino";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { NotificationRepository } from "./repository";
+import { NotificationService } from "./service";
+import { createNotificationRoutes } from "./routes";
+import { dropLegacyNotificationCategories } from "./migration";
+import type { BroadcastRepository } from "../broadcasts/repository";
+
+export interface NotificationsWiring {
+  readonly service: NotificationService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+export async function wireNotifications(deps: {
+  db: Db;
+  logger: Logger;
+  broadcastRepo: BroadcastRepository;
+}): Promise<NotificationsWiring> {
+  const repo = new NotificationRepository(deps.db);
+  void repo.ensureIndexes().catch((err) =>
+    deps.logger.warn(
+      { err },
+      "notifications indexes ensureIndexes failed — proceeding anyway",
+    ),
+  );
+  // One-time boot migration (#218) — drop legacy `share.*` rows left
+  // over from the pre-#198 share/audit-gate workflow. Idempotent; no-op
+  // after first run. Failure is non-fatal — old rows surface as ugly
+  // UI but never block the boot.
+  await dropLegacyNotificationCategories(deps.db).catch((err) =>
+    deps.logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "dropLegacyNotificationCategories failed — legacy notification rows may still surface in /notifications until the next deploy",
+    ),
+  );
+  const service = new NotificationService({
+    notificationRepo: repo,
+    broadcastRepo: deps.broadcastRepo,
+  });
+  const routes = createNotificationRoutes({ notificationService: service });
+  return { service, routes };
+}

--- a/ornn-api/src/domains/platform/bootstrap.ts
+++ b/ornn-api/src/domains/platform/bootstrap.ts
@@ -1,0 +1,36 @@
+/**
+ * Wire the legacy platform-settings domain (#580 — bootstrap decomposition).
+ *
+ * This is the pre-#302 single-doc `platform_settings:{_id:"ornn"}`
+ * surface (audit-waiver threshold + legacy mirror config + legacy LLM
+ * override). Backend-engineer-2's multi-section `SettingsService`
+ * replaced most of it; what remains is still consumed by the audit
+ * waiver path + a handful of legacy routes, so we keep this wiring
+ * alive until those sites migrate.
+ *
+ * @module domains/platform/bootstrap
+ */
+
+import type { Db } from "mongodb";
+import type { Hono } from "hono";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { PlatformSettingsRepository } from "./repository";
+import { PlatformSettingsService } from "./service";
+import { createPlatformSettingsRoutes } from "./routes";
+
+export interface PlatformSettingsWiring {
+  readonly service: PlatformSettingsService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+export function wirePlatformSettings(deps: {
+  db: Db;
+  encryptionKey: string;
+}): PlatformSettingsWiring {
+  const repo = new PlatformSettingsRepository(deps.db);
+  const service = new PlatformSettingsService(repo, {
+    encryptionKey: deps.encryptionKey,
+  });
+  const routes = createPlatformSettingsRoutes({ platformSettingsService: service });
+  return { service, routes };
+}

--- a/ornn-api/src/domains/playground/bootstrap.ts
+++ b/ornn-api/src/domains/playground/bootstrap.ts
@@ -1,0 +1,59 @@
+/**
+ * Wire the playground domain (#580 — bootstrap decomposition).
+ *
+ * Playground has the heaviest downstream dep list of the LLM-driven
+ * domains: chat service needs the llmClient + sandboxClient +
+ * skillService + surface defaults; routes additionally mount
+ * analyticsService (every chat completion fires a `chat.completed`
+ * event), quotaService (every call charges the playground bucket),
+ * and llmProvidersService (the picker behind the SSE init event).
+ *
+ * @module domains/playground/bootstrap
+ */
+
+import type { Hono } from "hono";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { PlaygroundChatService } from "./chatService";
+import { createPlaygroundRoutes } from "./routes";
+import type { NyxLlmClient } from "../../clients/nyxid/llm";
+import type { SandboxClient } from "../../clients/sandboxClient";
+import type { SkillService } from "../skills/crud/service";
+import type { AnalyticsService } from "../analytics/service";
+import type { QuotaService } from "../quota/service";
+import type { LlmProvidersService } from "../settings/llmProviders/service";
+
+export interface PlaygroundWiring {
+  readonly chatService: PlaygroundChatService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+export function wirePlayground(deps: {
+  llmClient: NyxLlmClient;
+  sandboxClient: SandboxClient;
+  skillService: SkillService;
+  defaultsResolver: () => Promise<{
+    model: string;
+    maxOutputTokens: number;
+    temperature: number;
+  }>;
+  keepAliveIntervalMsResolver: () => Promise<number>;
+  analyticsService: AnalyticsService;
+  quotaService: QuotaService;
+  llmProvidersService: LlmProvidersService;
+}): PlaygroundWiring {
+  const chatService = new PlaygroundChatService({
+    llmClient: deps.llmClient,
+    sandboxClient: deps.sandboxClient,
+    skillService: deps.skillService,
+    defaultsResolver: deps.defaultsResolver,
+  });
+  const routes = createPlaygroundRoutes({
+    chatService,
+    keepAliveIntervalMsResolver: deps.keepAliveIntervalMsResolver,
+    analyticsService: deps.analyticsService,
+    skillService: deps.skillService,
+    quotaService: deps.quotaService,
+    llmProvidersService: deps.llmProvidersService,
+  });
+  return { chatService, routes };
+}

--- a/ornn-api/src/domains/quota/bootstrap.ts
+++ b/ornn-api/src/domains/quota/bootstrap.ts
@@ -1,0 +1,62 @@
+/**
+ * Wire the quota domain (#580 — bootstrap decomposition).
+ *
+ * Quota is a downstream consumer of `settingsService` (for the
+ * per-surface default-monthly-allotment fallback) and
+ * `notificationService` (for the over-threshold warning fan-out). The
+ * service is exported because three other domains mount it as a
+ * dependency: playground, skill-gen, and admin (admin quota CRUD).
+ *
+ * @module domains/quota/bootstrap
+ */
+
+import type { Db } from "mongodb";
+import type { Hono } from "hono";
+import type { Logger } from "pino";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { QuotaRepository } from "./repository";
+import { QuotaService } from "./service";
+import { createQuotaRoutes } from "./routes";
+import type { NotificationService } from "../notifications/service";
+import type { SettingsService } from "../settings/types";
+
+export interface QuotaWiring {
+  readonly service: QuotaService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+export function wireQuota(deps: {
+  db: Db;
+  logger: Logger;
+  settingsService: SettingsService;
+  notificationService: NotificationService;
+}): QuotaWiring {
+  const repo = new QuotaRepository(deps.db);
+  void repo.ensureIndexes().catch((err) =>
+    deps.logger.warn(
+      { err },
+      "quota indexes ensureIndexes failed — proceeding anyway",
+    ),
+  );
+  const service = new QuotaService({
+    repo,
+    defaults: {
+      // The "raise the default mid-month" headroom rule is implemented
+      // inside QuotaService; this resolver just hands it the current
+      // section values whenever it asks.
+      getQuotaDefaults: async () => {
+        const [pg, sg] = await Promise.all([
+          deps.settingsService.getPlayground(),
+          deps.settingsService.getSkillGen(),
+        ]);
+        return {
+          defaultPlaygroundMonthly: pg.defaultMonthlyQuota,
+          defaultSkillGenMonthly: sg.defaultMonthlyQuota,
+        };
+      },
+    },
+    notificationService: deps.notificationService,
+  });
+  const routes = createQuotaRoutes({ quotaService: service });
+  return { service, routes };
+}

--- a/ornn-api/src/domains/redemption-codes/bootstrap.ts
+++ b/ornn-api/src/domains/redemption-codes/bootstrap.ts
@@ -1,0 +1,52 @@
+/**
+ * Wire the redemption-codes domain (#580 — bootstrap decomposition).
+ *
+ * Consumes `quotaService` (every redeem fans out into per-surface quota
+ * grants). Exposes BOTH route surfaces — `/admin/redemption-codes` for
+ * mint/list/invalidate and `/me/redemption-codes/redeem` for the user
+ * side. Both share a single RedemptionCodeService instance so the
+ * atomic `findOneAndUpdate` pivots inside the service stay consistent.
+ *
+ * @module domains/redemption-codes/bootstrap
+ */
+
+import type { Db } from "mongodb";
+import type { Hono } from "hono";
+import type { Logger } from "pino";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { RedemptionCodeRepository } from "./repository";
+import { RedemptionCodeService } from "./service";
+import { createMeRedemptionCodesRoutes } from "./me-routes";
+import { createAdminRedemptionCodesRoutes } from "../admin/redemption-codes/routes";
+import type { QuotaService } from "../quota/service";
+
+export interface RedemptionCodesWiring {
+  readonly service: RedemptionCodeService;
+  readonly adminRoutes: Hono<{ Variables: AuthVariables }>;
+  readonly meRoutes: Hono<{ Variables: AuthVariables }>;
+}
+
+export function wireRedemptionCodes(deps: {
+  db: Db;
+  logger: Logger;
+  quotaService: QuotaService;
+}): RedemptionCodesWiring {
+  const repo = new RedemptionCodeRepository(deps.db);
+  void repo.ensureIndexes().catch((err) =>
+    deps.logger.warn(
+      { err },
+      "redemption_codes indexes ensureIndexes failed — proceeding anyway",
+    ),
+  );
+  const service = new RedemptionCodeService({
+    repo,
+    quotaService: deps.quotaService,
+  });
+  const adminRoutes = createAdminRedemptionCodesRoutes({
+    redemptionCodeService: service,
+  });
+  const meRoutes = createMeRedemptionCodesRoutes({
+    redemptionCodeService: service,
+  });
+  return { service, adminRoutes, meRoutes };
+}

--- a/ornn-api/src/domains/skills/generation/bootstrap.ts
+++ b/ornn-api/src/domains/skills/generation/bootstrap.ts
@@ -1,0 +1,51 @@
+/**
+ * Wire the skill-generation domain (#580 — bootstrap decomposition).
+ *
+ * Generation has more downstream coupling than search — it owns its
+ * own surface (`skillGen`) in settings, so the keep-alive interval
+ * + default model both resolve through settingsService. It also
+ * mounts QuotaService (every generation charges the user's
+ * skill-gen bucket) and LlmProvidersService (the picker behind the
+ * SSE init event).
+ *
+ * @module domains/skills/generation/bootstrap
+ */
+
+import type { Hono } from "hono";
+import type { AuthVariables } from "../../../middleware/nyxidAuth";
+import { SkillGenerationService } from "./service";
+import { createGenerationRoutes } from "./routes";
+import type { NyxLlmClient } from "../../../clients/nyxid/llm";
+import type { QuotaService } from "../../quota/service";
+import type { LlmProvidersService } from "../../settings/llmProviders/service";
+
+export interface SkillGenerationWiring {
+  readonly service: SkillGenerationService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+export function wireSkillGeneration(deps: {
+  llmClient: NyxLlmClient;
+  /** Returns `{ model, maxOutputTokens, temperature }` snapshot for the skillGen surface. */
+  defaultsResolver: () => Promise<{
+    model: string;
+    maxOutputTokens: number;
+    temperature: number;
+  }>;
+  /** Per-request SSE keepalive interval (ms) — driven by `skillGen.sseKeepAliveMs`. */
+  keepAliveIntervalMsResolver: () => Promise<number>;
+  quotaService: QuotaService;
+  llmProvidersService: LlmProvidersService;
+}): SkillGenerationWiring {
+  const service = new SkillGenerationService({
+    llmClient: deps.llmClient,
+    defaultsResolver: deps.defaultsResolver,
+  });
+  const routes = createGenerationRoutes({
+    generationService: service,
+    keepAliveIntervalMsResolver: deps.keepAliveIntervalMsResolver,
+    quotaService: deps.quotaService,
+    llmProvidersService: deps.llmProvidersService,
+  });
+  return { service, routes };
+}

--- a/ornn-api/src/domains/skills/search/bootstrap.ts
+++ b/ornn-api/src/domains/skills/search/bootstrap.ts
@@ -1,0 +1,46 @@
+/**
+ * Wire the skill-search domain (#580 — bootstrap decomposition).
+ *
+ * Search is a playground-flavoured LLM call: there's no dedicated
+ * `search` section in settings, so the default model resolves through
+ * the playground surface. The caller passes a `defaultModelResolver`
+ * closure rather than `settingsService` directly so we don't take a
+ * dependency on the whole settings surface for a single field read.
+ *
+ * @module domains/skills/search/bootstrap
+ */
+
+import type { Hono } from "hono";
+import type { AuthVariables } from "../../../middleware/nyxidAuth";
+import { SearchService } from "./service";
+import { createSearchRoutes } from "./routes";
+import type { SkillRepository } from "../crud/repository";
+import type { NyxLlmClient } from "../../../clients/nyxid/llm";
+
+export interface SkillSearchWiring {
+  readonly service: SearchService;
+  readonly routes: Hono<{ Variables: AuthVariables }>;
+}
+
+export function wireSkillSearch(deps: {
+  skillRepo: SkillRepository;
+  llmClient: NyxLlmClient;
+  /**
+   * Closure resolving the default model id at request time. Search
+   * shares the playground surface today; if backend-eng-2 adds a
+   * dedicated `search` section later, this stays the same — just
+   * route through the new section in the caller.
+   */
+  defaultModelResolver: () => Promise<string>;
+}): SkillSearchWiring {
+  const service = new SearchService({
+    skillRepo: deps.skillRepo,
+    llmClient: deps.llmClient,
+    defaultModelResolver: deps.defaultModelResolver,
+  });
+  const routes = createSearchRoutes({
+    searchService: service,
+    skillRepo: deps.skillRepo,
+  });
+  return { service, routes };
+}


### PR DESCRIPTION
## Summary

`ornn-api/src/bootstrap.ts` was a 1089-line monolithic wiring function. This PR lifts 10 leaf domains' wiring out into per-domain `bootstrap.ts` modules that export a `wire{Domain}(...)` function. The orchestrator stays in charge of ordering + shared client construction; the per-domain *detail* moves out.

- **bootstrap.ts: 1089 → 970 lines** (-11%, -119 net)
- **10 new files**, one per extracted domain
- **No behavioral change** — boot order preserved, all 798 tests pass, typecheck clean
- **11 commits** — one per extracted domain so each commit is self-contained + bisectable

## Domains extracted

| Commit | Domain | Notes |
|---|---|---|
| `c8dbeb5` | announcements | bilingual backfill migration moved into wiring |
| `44ea684` | analytics | shared with skills/playground/admin downstream |
| `159ee8a` | quota | settings-driven defaults resolver lifted next to QuotaService |
| `63fb5b1` | redemption-codes | admin + me route surfaces, shared service for atomic pivot consistency |
| `af53d74` | broadcasts + notifications | 2-step: shared repo first, then notifications + broadcasts services |
| `36437dc` | platform settings | legacy single-doc surface |
| `2b624ce` | admin | dashboard + users + quota admin |
| `20d7fef` | skill search | closure-based default-model resolver |
| `07bc91e` | skill generation | + SSE keepalive resolver |
| `6957d18` | playground | heaviest dep list — analytics + quota + llm providers |
| `903689f` | (docs) | changeset |

## What's still inlined

Skills CRUD, skill audit, GitHub mirror, settings export/import, and `createAdminRoutes` (skill / generation / agentseal admin). These have heavier cross-cutting dependency lists (scheduler lifecycle, audit fan-out, analytics-emitter closures) — extracting them cleanly needs a follow-up issue.

## Pattern

Every new `wire{Domain}.ts` follows the same template:

```ts
export interface {Domain}Wiring {
  readonly service: {Domain}Service;
  readonly routes: Hono<{ Variables: AuthVariables }>;
}

export function wire{Domain}(deps: { db: Db; logger: Logger; ...crosscutting }): {Domain}Wiring {
  const repo = new {Domain}Repository(deps.db);
  void repo.ensureIndexes().catch((err) => deps.logger.warn(...));
  // one-shot migrations if any
  const service = new {Domain}Service({...});
  const routes = create{Domain}Routes({...});
  return { service, routes };
}
```

The `service` is always returned (even when no current consumer reads it) so future cross-domain consumers can grab it without re-shaping the wiring contract.

## Test plan

- [x] `bun test` — 793 pass, 5 todo, 0 fail (798 across 71 files)
- [x] `bun run typecheck:api` — clean
- [ ] CI runs same suite + lint + docker-build
- [ ] Deploy to local k8s cluster + smoke `/api/v1/livez` + `/api/v1/readyz` + one route per extracted domain

Closes #580.