### PR TITLE
refactor(web): decompose SkillDetailPage into 9 colocated components (#453)

### DIFF
--- a/.changeset/skill-detail-decompose-453.md
+++ b/.changeset/skill-detail-decompose-453.md
@@ -1,0 +1,21 @@
+---
+"ornn-web": patch
+---
+
+First-pass decomposition of `SkillDetailPage` (#453).
+
+`SkillDetailPage.tsx` was 1133 lines — well over the 300-line target the issue sets. This PR pulls 7 self-contained chunks into colocated components under `components/skill/`:
+
+- `SkillSaveConfirmModal` — save-with-skip-validation toggle
+- `SkillDeleteConfirmModal` — whole-skill delete confirmation
+- `SkillAuditStartedModal` — post-audit-kickoff acknowledgement
+- `SkillVersionsBrowserModal` — all-versions list + Compare button + per-row delete toast
+- `AuditVerdictPill` — right-rail audit verdict tile (3 visual states)
+- `SkillDetailStates` — loading skeleton + 404 not-found shells
+- `SkillVersionsCard` + `SkillVisibilityCard` — right-rail cards
+
+Net: `SkillDetailPage.tsx` from **1133 → 868 lines** (-23%). 9 new component files at 41-124 lines each.
+
+Behavior unchanged. Each new component is stateless except for the toast-emitting delete handler inside the versions browser (kept colocated so the parent doesn't need to thread it through). All 110 frontend tests still pass; typecheck clean.
+
+Per the issue's "one PR per page" guidance, DocsPage (901L) and PlaygroundPage (813L) get their own PRs. A follow-up will also extract the `useSkillDetail()` hook to pull the queries / mutations / derived state out of the page entirely — that's the biggest remaining lever, but the data flow is too entangled with the JSX layout to bisect cleanly in this PR.

--- a/ornn-web/src/components/skill/AuditVerdictPill.tsx
+++ b/ornn-web/src/components/skill/AuditVerdictPill.tsx
@@ -1,0 +1,95 @@
+/**
+ * Audit-verdict tile shown inside the right-rail Audit card on SkillDetailPage (#453).
+ *
+ * Three visual states:
+ *   - running (in-flight audit takes precedence even when a previous
+ *     completed verdict exists for this version — the spinner wins)
+ *   - never audited (the unknown / empty state — render a neutral pill)
+ *   - completed (green / yellow / red tone driven by `audit.verdict`,
+ *     with the numeric score + label)
+ *
+ * Stateless. Owner is `SkillDetailPage` (and any future page that wants
+ * the same widget without re-implementing it).
+ *
+ * @module components/skill/AuditVerdictPill
+ */
+
+import { useTranslation } from "react-i18next";
+import type { AuditRecord } from "@/types/audit";
+
+export interface AuditVerdictPillProps {
+  audit?: AuditRecord;
+  running?: boolean;
+}
+
+export function AuditVerdictPill({ audit, running }: AuditVerdictPillProps) {
+  const { t } = useTranslation();
+
+  // In-flight audit takes precedence over the cached completed result —
+  // even if there's a previous completed verdict on this version, surface
+  // the spinner while a new run is scoring.
+  if (running) {
+    return (
+      <div className="mb-3.5 flex items-center gap-3 rounded-sm border border-accent/30 bg-accent/5 p-3 font-mono text-[11px] uppercase tracking-wider text-accent">
+        <div
+          className="flex h-8 w-8 items-center justify-center rounded-sm border border-accent/30"
+          aria-hidden
+        >
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-accent/30 border-t-accent" />
+        </div>
+        <span>{t("skillDetail.auditRunning", "Audit in progress")}</span>
+      </div>
+    );
+  }
+
+  if (!audit || audit.status !== "completed") {
+    return (
+      <div className="mb-3.5 flex items-center gap-3 rounded-sm border border-strong-edge bg-elevated/60 p-3 font-mono text-[11px] uppercase tracking-wider text-meta">
+        <div
+          className="flex h-8 w-8 items-center justify-center rounded-sm border border-strong-edge text-meta"
+          aria-hidden
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="9" />
+          </svg>
+        </div>
+        <span>{t("skillDetail.auditNone", "Not audited")}</span>
+      </div>
+    );
+  }
+
+  const tone =
+    audit.verdict === "green"
+      ? "border-success/30 bg-success-soft text-success"
+      : audit.verdict === "yellow"
+        ? "border-warning/30 bg-warning-soft text-warning"
+        : "border-danger/30 bg-danger-soft text-danger";
+  const label =
+    audit.verdict === "green"
+      ? t("skillDetail.auditPassLabel", "Pass · low risk")
+      : audit.verdict === "yellow"
+        ? t("skillDetail.auditWarnLabel", "Caution")
+        : t("skillDetail.auditFailLabel", "Risk");
+
+  return (
+    <div className={`mb-3.5 flex items-center gap-3 rounded-sm border p-3 ${tone}`}>
+      <div
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-current text-page"
+        aria-hidden
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      </div>
+      <div className="flex flex-col gap-0.5">
+        <div>
+          <span className="font-display text-2xl font-semibold leading-none">
+            {audit.overallScore.toFixed(1)}
+          </span>
+          <span className="ml-1 font-mono text-[11px] tracking-wide text-meta">/ 10</span>
+        </div>
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em]">{label}</span>
+      </div>
+    </div>
+  );
+}

--- a/ornn-web/src/components/skill/SkillAuditStartedModal.tsx
+++ b/ornn-web/src/components/skill/SkillAuditStartedModal.tsx
@@ -1,0 +1,41 @@
+/**
+ * Audit-started modal extracted from SkillDetailPage (#453).
+ *
+ * Shown right after the user kicks off a manual audit — explains that
+ * the run is now happening in the background and they can keep working
+ * while it finishes. A new audit history row materializes when it lands.
+ *
+ * @module components/skill/SkillAuditStartedModal
+ */
+
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+
+export interface SkillAuditStartedModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SkillAuditStartedModal({ isOpen, onClose }: SkillAuditStartedModalProps) {
+  const { t } = useTranslation();
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t("skillDetail.auditStartedTitle", "Audit started") as string}
+    >
+      <p className="font-text text-sm text-meta">
+        {t(
+          "skillDetail.auditStartedBody",
+          "We're running the audit in the background. It takes around 20-30 seconds — when it's done, a new entry will appear in the Audit history. You can close this dialog and keep working.",
+        )}
+      </p>
+      <div className="mt-6 flex justify-end">
+        <Button size="sm" onClick={onClose}>
+          {t("common.gotIt", "Got it")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/ornn-web/src/components/skill/SkillDeleteConfirmModal.tsx
+++ b/ornn-web/src/components/skill/SkillDeleteConfirmModal.tsx
@@ -1,0 +1,45 @@
+/**
+ * Delete-confirmation modal extracted from SkillDetailPage (#453).
+ *
+ * Confirms the user intends to delete the whole skill (not just a
+ * version — version deletion is inside the All-versions browser).
+ *
+ * @module components/skill/SkillDeleteConfirmModal
+ */
+
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+
+export interface SkillDeleteConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  skillName: string;
+  onConfirm: () => void;
+  deleting: boolean;
+}
+
+export function SkillDeleteConfirmModal({
+  isOpen,
+  onClose,
+  skillName,
+  onConfirm,
+  deleting,
+}: SkillDeleteConfirmModalProps) {
+  const { t } = useTranslation();
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t("skillDetail.deleteTitle")}>
+      <p className="font-text text-sm text-meta">
+        {t("skillDetail.deleteConfirm", { name: skillName }).replace(/<\/?strong>/g, "")}
+      </p>
+      <div className="mt-6 flex justify-end gap-3">
+        <Button variant="secondary" size="sm" onClick={onClose}>
+          {t("common.cancel")}
+        </Button>
+        <Button variant="danger" size="sm" onClick={onConfirm} loading={deleting}>
+          {t("common.delete")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/ornn-web/src/components/skill/SkillDetailStates.tsx
+++ b/ornn-web/src/components/skill/SkillDetailStates.tsx
@@ -1,0 +1,45 @@
+/**
+ * Loading + not-found shell states for SkillDetailPage (#453).
+ *
+ * Pulled out so the page file only carries the happy-path render. Each
+ * state component owns its own PageTransition wrapper so the route
+ * still feels animated even when the data isn't there yet.
+ *
+ * @module components/skill/SkillDetailStates
+ */
+
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { Button } from "@/components/ui/Button";
+import { Skeleton } from "@/components/ui/Skeleton";
+
+export function SkillDetailLoading() {
+  return (
+    <PageTransition>
+      <div className="flex h-full items-center justify-center">
+        <Skeleton lines={10} />
+      </div>
+    </PageTransition>
+  );
+}
+
+export function SkillDetailNotFound() {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  return (
+    <PageTransition>
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center">
+          <h2 className="mb-2 font-display text-2xl text-danger">
+            {t("skillDetail.notFound")}
+          </h2>
+          <p className="text-meta">{t("skillDetail.notFoundDesc")}</p>
+          <Button onClick={() => navigate("/registry")} className="mt-6">
+            {t("skillDetail.backToExplore")}
+          </Button>
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/components/skill/SkillSaveConfirmModal.tsx
+++ b/ornn-web/src/components/skill/SkillSaveConfirmModal.tsx
@@ -1,0 +1,72 @@
+/**
+ * Save-confirmation modal extracted from SkillDetailPage (#453).
+ *
+ * Confirms the user intends to save uncommitted changes back to the
+ * skill package + offers the `skipValidation` opt-out for the trust
+ * scanner. Stateless wrapper — the parent owns the toggle, the parent
+ * triggers the save mutation, the parent passes loading state in.
+ *
+ * @module components/skill/SkillSaveConfirmModal
+ */
+
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+
+export interface SkillSaveConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  skillName: string;
+  skipValidation: boolean;
+  onSkipValidationChange: (next: boolean) => void;
+  onConfirm: () => void;
+  saving: boolean;
+}
+
+export function SkillSaveConfirmModal({
+  isOpen,
+  onClose,
+  skillName,
+  skipValidation,
+  onSkipValidationChange,
+  onConfirm,
+  saving,
+}: SkillSaveConfirmModalProps) {
+  const { t } = useTranslation();
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t("skillDetail.saveChanges")}>
+      <p className="mb-4 font-text text-sm text-meta">
+        {t("skillDetail.saveConfirm", { name: skillName })}
+      </p>
+      <label className="flex cursor-pointer items-center gap-3 rounded-sm border border-subtle bg-elevated p-3 select-none">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={skipValidation}
+          onClick={() => onSkipValidationChange(!skipValidation)}
+          className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+            skipValidation ? "bg-accent" : "bg-elevated"
+          }`}
+        >
+          <span
+            className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${
+              skipValidation ? "translate-x-4" : "translate-x-0"
+            }`}
+          />
+        </button>
+        <div>
+          <p className="font-text text-sm text-strong">{t("skillDetail.skipValidation")}</p>
+          <p className="font-text text-xs text-meta">{t("skillDetail.skipDescription")}</p>
+        </div>
+      </label>
+      <div className="mt-6 flex justify-end gap-3">
+        <Button variant="secondary" size="sm" onClick={onClose}>
+          {t("common.cancel")}
+        </Button>
+        <Button size="sm" onClick={onConfirm} loading={saving}>
+          {t("common.save")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/ornn-web/src/components/skill/SkillVersionsBrowserModal.tsx
+++ b/ornn-web/src/components/skill/SkillVersionsBrowserModal.tsx
@@ -1,0 +1,124 @@
+/**
+ * All-versions browser modal extracted from SkillDetailPage (#453).
+ *
+ * Lists every version of a skill in a scrollable list, lets the user
+ * jump to a different version (or back to "latest" by passing null
+ * for the latest version id), and offers a "Compare versions" button
+ * that opens the diff modal. Owners + admins can also deprecate /
+ * undeprecate / delete individual versions inline via the embedded
+ * `SkillVersionList`.
+ *
+ * The version-delete handler stays inline here because it shows a
+ * success/failure toast — the parent doesn't need to own that flow,
+ * so wrapping it lets the modal swallow the per-row interaction.
+ *
+ * @module components/skill/SkillVersionsBrowserModal
+ */
+
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+import { SkillVersionList } from "@/components/skill/SkillVersionList";
+import { useToastStore } from "@/stores/toastStore";
+import { translateError } from "@/utils/translateError";
+import type { AuditRecord } from "@/types/audit";
+import type { SkillVersionEntry } from "@/types/domain";
+
+export interface SkillVersionsBrowserModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  versions: SkillVersionEntry[];
+  currentVersion: string;
+  latestVersion: string;
+  canManage: boolean;
+  /**
+   * Per-version audit summary keyed by version string. Versions absent
+   * render a "not audited" pill in the list. `undefined` suppresses
+   * audit pills entirely.
+   */
+  auditSummary?: Record<string, AuditRecord>;
+  /** Fire when the user picks a version. Null = jump back to latest. */
+  onSelectVersion: (versionOrNull: string | null) => void;
+  onToggleDeprecation?: (args: {
+    version: string;
+    isDeprecated: boolean;
+    deprecationNote?: string;
+  }) => Promise<void> | void;
+  deprecationPending: boolean;
+  deleteVersionPending: boolean;
+  deleteVersionAsync: (version: string) => Promise<unknown>;
+  /** Hooked when the user clicks "Compare versions". */
+  onOpenDiff: () => void;
+}
+
+export function SkillVersionsBrowserModal({
+  isOpen,
+  onClose,
+  versions,
+  currentVersion,
+  latestVersion,
+  canManage,
+  auditSummary,
+  onSelectVersion,
+  onToggleDeprecation,
+  deprecationPending,
+  deleteVersionPending,
+  deleteVersionAsync,
+  onOpenDiff,
+}: SkillVersionsBrowserModalProps) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t("skillDetail.versionsTitle", "All versions") as string}
+      className="!max-w-3xl"
+    >
+      {versions.length >= 2 && (
+        <div className="mb-4 flex justify-end">
+          <Button variant="secondary" size="sm" onClick={onOpenDiff}>
+            {t("versionDiff.openButton", "Compare versions")}
+          </Button>
+        </div>
+      )}
+      <SkillVersionList
+        versions={versions}
+        currentVersion={currentVersion}
+        onSelect={(v) => {
+          onSelectVersion(v === latestVersion ? null : v);
+          onClose();
+        }}
+        canManage={canManage}
+        onToggleDeprecation={onToggleDeprecation}
+        isMutating={deprecationPending}
+        isDeleting={deleteVersionPending}
+        auditSummary={auditSummary}
+        onDeleteVersion={async (version) => {
+          try {
+            await deleteVersionAsync(version);
+            // If the version the user just deleted was the one
+            // currently being viewed, reset to latest so the page
+            // doesn't 404 on the next render.
+            if (currentVersion === version) onSelectVersion(null);
+            addToast({
+              type: "success",
+              message: t("skillDetail.versionDeleted", "Version v{{version}} deleted", {
+                version,
+              }),
+            });
+          } catch (err) {
+            addToast({
+              type: "error",
+              message: translateError(
+                err,
+                t("skillDetail.versionDeleteFailed", "Failed to delete version"),
+              ),
+            });
+          }
+        }}
+      />
+    </Modal>
+  );
+}

--- a/ornn-web/src/components/skill/SkillVersionsCard.tsx
+++ b/ornn-web/src/components/skill/SkillVersionsCard.tsx
@@ -1,0 +1,70 @@
+/**
+ * Right-rail "Versions" card extracted from SkillDetailPage (#453).
+ *
+ * Shows the current version (with a "latest" eyebrow when the user is
+ * viewing the head), publish date, total version count, and a CTA that
+ * opens the all-versions browser modal owned by the parent page. Pure
+ * presentation — every interactive bit calls back to the parent.
+ *
+ * @module components/skill/SkillVersionsCard
+ */
+
+import { useTranslation } from "react-i18next";
+
+export interface SkillVersionsCardProps {
+  currentVersion: string;
+  publishedOnSGT: string;
+  totalVersions: number;
+  viewingLatest: boolean;
+  onBrowseAll: () => void;
+}
+
+export function SkillVersionsCard({
+  currentVersion,
+  publishedOnSGT,
+  totalVersions,
+  viewingLatest,
+  onBrowseAll,
+}: SkillVersionsCardProps) {
+  const { t } = useTranslation();
+  return (
+    <section className="rounded-md border border-subtle bg-card p-5 card-impression">
+      <h3 className="mb-3.5 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4a2 2 0 0 0 1-1.7z" />
+          <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+          <line x1="12" y1="22.08" x2="12" y2="12" />
+        </svg>
+        {t("skillDetail.cardVersions", "Versions")}
+      </h3>
+      <div className="mb-1.5 flex items-baseline gap-2">
+        <span className="font-display text-2xl font-semibold tracking-tight text-strong">
+          {currentVersion}
+        </span>
+        {viewingLatest && (
+          <span className="rounded-sm border border-accent/40 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-accent">
+            {t("skillDetail.latest", "latest")}
+          </span>
+        )}
+      </div>
+      <p className="font-mono text-[11px] leading-relaxed tracking-wide text-meta">
+        {t("skillDetail.heroPublishedOn", "Published {{date}}", { date: publishedOnSGT })}
+        {totalVersions > 1 && (
+          <>
+            {" · "}
+            {t("skillDetail.versionsTotal", "{{n}} versions total", { n: totalVersions })}
+          </>
+        )}
+      </p>
+      <div className="mt-3.5 flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={onBrowseAll}
+          className="inline-flex items-center gap-1 self-start py-1 font-mono text-[10px] uppercase tracking-widest text-accent transition-all hover:text-accent-muted hover:gap-2"
+        >
+          {t("skillDetail.browseVersions", "Browse all versions")} →
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/ornn-web/src/components/skill/SkillVisibilityCard.tsx
+++ b/ornn-web/src/components/skill/SkillVisibilityCard.tsx
@@ -1,0 +1,113 @@
+/**
+ * Right-rail "Visibility" card extracted from SkillDetailPage (#453).
+ *
+ * Renders the three-tier visibility ladder:
+ *   public  — `isPrivate: false`
+ *   limited — `isPrivate: true` AND at least one explicit grant
+ *   private — `isPrivate: true` AND no grants — only the author +
+ *             platform admins can see it.
+ *
+ * Plus a per-tier-colored pill, user/org grant counts, and a "Manage
+ * permissions" button for the owner. The actual permissions editor
+ * lives in `PermissionsModal`; this card just opens it.
+ *
+ * @module components/skill/SkillVisibilityCard
+ */
+
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/Button";
+
+type Tier = "public" | "limited" | "private";
+
+export interface SkillVisibilityCardProps {
+  isPrivate: boolean;
+  sharedWithUsersCount: number;
+  sharedWithOrgsCount: number;
+  isOwner: boolean;
+  onManagePermissions: () => void;
+}
+
+export function SkillVisibilityCard({
+  isPrivate,
+  sharedWithUsersCount,
+  sharedWithOrgsCount,
+  isOwner,
+  onManagePermissions,
+}: SkillVisibilityCardProps) {
+  const { t } = useTranslation();
+  const hasGrants = sharedWithUsersCount > 0 || sharedWithOrgsCount > 0;
+  const tier: Tier = !isPrivate ? "public" : hasGrants ? "limited" : "private";
+
+  const tierClass: Record<Tier, string> = {
+    public: "border-success/40 bg-success-soft text-success",
+    limited: "border-warning/40 bg-warning-soft text-warning",
+    private: "border-info/40 bg-info-soft text-info",
+  };
+  const tierLabel: Record<Tier, string> = {
+    public: t("common.public", "Public"),
+    limited: t("common.limited", "Limited access"),
+    private: t("common.private", "Private"),
+  };
+
+  return (
+    <section className="rounded-md border border-subtle bg-card p-5 card-impression">
+      <h3 className="mb-3.5 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <circle cx="12" cy="12" r="9" /><line x1="3" y1="12" x2="21" y2="12" />
+          <path d="M12 3a14 14 0 0 1 4 9 14 14 0 0 1-4 9 14 14 0 0 1-4-9 14 14 0 0 1 4-9z" />
+        </svg>
+        {t("skillDetail.cardVisibility", "Visibility")}
+      </h3>
+      <span
+        className={`mb-3 inline-flex items-center gap-1.5 rounded-sm border px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider ${tierClass[tier]}`}
+      >
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          {tier === "public" ? (
+            <>
+              <circle cx="12" cy="12" r="9" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+            </>
+          ) : tier === "limited" ? (
+            <>
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+            </>
+          ) : (
+            <path d="M12 2a5 5 0 0 0-5 5v3H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-8a2 2 0 0 0-2-2h-2V7a5 5 0 0 0-5-5z" />
+          )}
+        </svg>
+        {tierLabel[tier]}
+      </span>
+      <ul className="space-y-1.5 font-text text-sm text-body">
+        <li className="flex items-baseline gap-2.5">
+          <span className="min-w-[18px] text-right font-mono text-sm font-semibold text-strong">
+            {sharedWithUsersCount}
+          </span>
+          <span className="text-xs text-meta">{t("skillDetail.shareUsers", "users")}</span>
+        </li>
+        <li className="flex items-baseline gap-2.5">
+          <span className="min-w-[18px] text-right font-mono text-sm font-semibold text-strong">
+            {sharedWithOrgsCount}
+          </span>
+          <span className="text-xs text-meta">
+            {t("skillDetail.shareOrgs", "organizations")}
+          </span>
+        </li>
+      </ul>
+      {isOwner && (
+        <div className="mt-3.5">
+          <Button
+            variant="secondary"
+            size="sm"
+            className="w-full"
+            onClick={onManagePermissions}
+          >
+            {t("skillDetail.managePermissions", "Manage permissions")}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -43,6 +43,8 @@ import {
   SkillDetailLoading,
   SkillDetailNotFound,
 } from "@/components/skill/SkillDetailStates";
+import { SkillVersionsCard } from "@/components/skill/SkillVersionsCard";
+import { SkillVisibilityCard } from "@/components/skill/SkillVisibilityCard";
 import {
   useSkill,
   useDeleteSkill,
@@ -603,131 +605,23 @@ export function SkillDetailPage() {
 
             {/* ── Versions card ── */}
             {versionList.length > 0 && (
-              <section className="rounded-md border border-subtle bg-card p-5 card-impression">
-                <h3 className="mb-3.5 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-                    <path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4a2 2 0 0 0 1-1.7z" />
-                    <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
-                    <line x1="12" y1="22.08" x2="12" y2="12" />
-                  </svg>
-                  {t("skillDetail.cardVersions", "Versions")}
-                </h3>
-                <div className="mb-1.5 flex items-baseline gap-2">
-                  <span className="font-display text-2xl font-semibold tracking-tight text-strong">
-                    {skill.version}
-                  </span>
-                  {viewingLatest && (
-                    <span className="rounded-sm border border-accent/40 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-accent">
-                      {t("skillDetail.latest", "latest")}
-                    </span>
-                  )}
-                </div>
-                <p className="font-mono text-[11px] leading-relaxed tracking-wide text-meta">
-                  {t("skillDetail.heroPublishedOn", "Published {{date}}", { date: formatDateSGT(skill.createdOn) })}
-                  {versionList.length > 1 && (
-                    <>
-                      {" · "}
-                      {t("skillDetail.versionsTotal", "{{n}} versions total", { n: versionList.length })}
-                    </>
-                  )}
-                </p>
-                <div className="mt-3.5 flex flex-col gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setShowVersions(true)}
-                    className="inline-flex items-center gap-1 self-start py-1 font-mono text-[10px] uppercase tracking-widest text-accent transition-all hover:text-accent-muted hover:gap-2"
-                  >
-                    {t("skillDetail.browseVersions", "Browse all versions")} →
-                  </button>
-                </div>
-              </section>
+              <SkillVersionsCard
+                currentVersion={skill.version}
+                publishedOnSGT={formatDateSGT(skill.createdOn)}
+                totalVersions={versionList.length}
+                viewingLatest={Boolean(viewingLatest)}
+                onBrowseAll={() => setShowVersions(true)}
+              />
             )}
 
             {/* ── Visibility card ── */}
-            <section className="rounded-md border border-subtle bg-card p-5 card-impression">
-              <h3 className="mb-3.5 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-                  <circle cx="12" cy="12" r="9" /><line x1="3" y1="12" x2="21" y2="12" />
-                  <path d="M12 3a14 14 0 0 1 4 9 14 14 0 0 1-4 9 14 14 0 0 1-4-9 14 14 0 0 1 4-9z" />
-                </svg>
-                {t("skillDetail.cardVisibility", "Visibility")}
-              </h3>
-              {(() => {
-                // Visibility ladder:
-                //   public  — `isPrivate: false`
-                //   limited — `isPrivate: true` AND at least one explicit
-                //             grant (user or org)
-                //   private — `isPrivate: true` AND no grants — only the
-                //             author + platform admins can see it.
-                const hasGrants =
-                  skill.sharedWithUsers.length > 0 || skill.sharedWithOrgs.length > 0;
-                const tier: "public" | "limited" | "private" = !skill.isPrivate
-                  ? "public"
-                  : hasGrants
-                    ? "limited"
-                    : "private";
-                const tierClass: Record<typeof tier, string> = {
-                  public: "border-success/40 bg-success-soft text-success",
-                  limited: "border-warning/40 bg-warning-soft text-warning",
-                  private: "border-info/40 bg-info-soft text-info",
-                };
-                const tierLabel: Record<typeof tier, string> = {
-                  public: t("common.public", "Public"),
-                  limited: t("common.limited", "Limited access"),
-                  private: t("common.private", "Private"),
-                };
-                return (
-                  <span
-                    className={`mb-3 inline-flex items-center gap-1.5 rounded-sm border px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider ${tierClass[tier]}`}
-                  >
-                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                      {tier === "public" ? (
-                        <>
-                          <circle cx="12" cy="12" r="9" />
-                          <line x1="3" y1="12" x2="21" y2="12" />
-                        </>
-                      ) : tier === "limited" ? (
-                        <>
-                          <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-                          <circle cx="9" cy="7" r="4" />
-                          <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
-                          <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-                        </>
-                      ) : (
-                        <path d="M12 2a5 5 0 0 0-5 5v3H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-8a2 2 0 0 0-2-2h-2V7a5 5 0 0 0-5-5z" />
-                      )}
-                    </svg>
-                    {tierLabel[tier]}
-                  </span>
-                );
-              })()}
-              <ul className="space-y-1.5 font-text text-sm text-body">
-                <li className="flex items-baseline gap-2.5">
-                  <span className="min-w-[18px] text-right font-mono text-sm font-semibold text-strong">
-                    {skill.sharedWithUsers.length}
-                  </span>
-                  <span className="text-xs text-meta">{t("skillDetail.shareUsers", "users")}</span>
-                </li>
-                <li className="flex items-baseline gap-2.5">
-                  <span className="min-w-[18px] text-right font-mono text-sm font-semibold text-strong">
-                    {skill.sharedWithOrgs.length}
-                  </span>
-                  <span className="text-xs text-meta">{t("skillDetail.shareOrgs", "organizations")}</span>
-                </li>
-              </ul>
-              {isOwner && (
-                <div className="mt-3.5">
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="w-full"
-                    onClick={() => setShowPermissionsModal(true)}
-                  >
-                    {t("skillDetail.managePermissions", "Manage permissions")}
-                  </Button>
-                </div>
-              )}
-            </section>
+            <SkillVisibilityCard
+              isPrivate={skill.isPrivate}
+              sharedWithUsersCount={skill.sharedWithUsers.length}
+              sharedWithOrgsCount={skill.sharedWithOrgs.length}
+              isOwner={isOwner}
+              onManagePermissions={() => setShowPermissionsModal(true)}
+            />
 
             {/* ── Advanced options ── click-to-open card. Settings UI
                 lives in `AdvancedOptionsModal` (settings-page-style:

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -40,6 +40,10 @@ import { SkillAuditStartedModal } from "@/components/skill/SkillAuditStartedModa
 import { SkillVersionsBrowserModal } from "@/components/skill/SkillVersionsBrowserModal";
 import { AuditVerdictPill } from "@/components/skill/AuditVerdictPill";
 import {
+  SkillDetailLoading,
+  SkillDetailNotFound,
+} from "@/components/skill/SkillDetailStates";
+import {
   useSkill,
   useDeleteSkill,
   useDeleteSkillVersion,
@@ -356,31 +360,8 @@ export function SkillDetailPage() {
     );
   }, [skill, startAuditMutation, addToast, t]);
 
-  if (isLoading) {
-    return (
-      <PageTransition>
-        <div className="flex h-full items-center justify-center">
-          <Skeleton lines={10} />
-        </div>
-      </PageTransition>
-    );
-  }
-
-  if (error || !skill) {
-    return (
-      <PageTransition>
-        <div className="flex h-full items-center justify-center">
-          <div className="text-center">
-            <h2 className="mb-2 font-display text-2xl text-danger">{t("skillDetail.notFound")}</h2>
-            <p className="text-meta">{t("skillDetail.notFoundDesc")}</p>
-            <Button onClick={() => navigate("/registry")} className="mt-6">
-              {t("skillDetail.backToExplore")}
-            </Button>
-          </div>
-        </div>
-      </PageTransition>
-    );
-  }
+  if (isLoading) return <SkillDetailLoading />;
+  if (error || !skill) return <SkillDetailNotFound />;
 
   const versionAudit = auditSummaryByVersion?.[skill.version];
   // Detect an in-flight audit on the current version so the right-rail

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -18,7 +18,6 @@ import { Link, useParams, useNavigate, useSearchParams } from "react-router-dom"
 import JSZip from "jszip";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { Button } from "@/components/ui/Button";
-import { Modal } from "@/components/ui/Modal";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { VersionPicker } from "@/components/skill/VersionPicker";
@@ -31,11 +30,15 @@ import { BackLink } from "@/components/layout/BackLink";
 import { useRefreshSkillFromSource } from "@/hooks/useSkills";
 import { useStartAudit, useAuditSummaryByVersion, useSkillAuditHistory } from "@/hooks/useAudit";
 import { useSkillPulls } from "@/hooks/useAnalytics";
-import { SkillVersionList } from "@/components/skill/SkillVersionList";
 import { AgentSealTrustBadge } from "@/components/agentseal/AgentSealTrustBadge";
 import { PermissionsModal } from "@/components/skill/PermissionsModal";
 import { AdvancedOptionsModal } from "@/components/skill/AdvancedOptionsModal";
 import { VersionDiffModal } from "@/components/skill/VersionDiffModal";
+import { SkillSaveConfirmModal } from "@/components/skill/SkillSaveConfirmModal";
+import { SkillDeleteConfirmModal } from "@/components/skill/SkillDeleteConfirmModal";
+import { SkillAuditStartedModal } from "@/components/skill/SkillAuditStartedModal";
+import { SkillVersionsBrowserModal } from "@/components/skill/SkillVersionsBrowserModal";
+import { AuditVerdictPill } from "@/components/skill/AuditVerdictPill";
 import {
   useSkill,
   useDeleteSkill,
@@ -52,7 +55,6 @@ import { translateError } from "@/utils/translateError";
 import { track } from "@/lib/analytics";
 import { useTranslation } from "react-i18next";
 import type { FileNode } from "@/components/editor/FileTree";
-import type { AuditRecord } from "@/types/audit";
 
 /** Format a date string to exact SGT (Asia/Singapore) timestamp. */
 function formatDateSGT(dateStr: string): string {
@@ -916,95 +918,32 @@ export function SkillDetailPage() {
       </div>
 
       {/* ── Save confirmation modal ── */}
-      <Modal
+      <SkillSaveConfirmModal
         isOpen={showSaveConfirm}
         onClose={() => setShowSaveConfirm(false)}
-        title={t("skillDetail.saveChanges")}
-      >
-        <p className="mb-4 font-text text-sm text-meta">
-          {t("skillDetail.saveConfirm", { name: skill.name })}
-        </p>
-        <label className="flex cursor-pointer items-center gap-3 rounded-sm border border-subtle bg-elevated p-3 select-none">
-          <button
-            type="button"
-            role="switch"
-            aria-checked={skipValidation}
-            onClick={() => setSkipValidation((v) => !v)}
-            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
-              skipValidation ? "bg-accent" : "bg-elevated"
-            }`}
-          >
-            <span
-              className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${
-                skipValidation ? "translate-x-4" : "translate-x-0"
-              }`}
-            />
-          </button>
-          <div>
-            <p className="font-text text-sm text-strong">{t("skillDetail.skipValidation")}</p>
-            <p className="font-text text-xs text-meta">{t("skillDetail.skipDescription")}</p>
-          </div>
-        </label>
-        <div className="mt-6 flex justify-end gap-3">
-          <Button variant="secondary" size="sm" onClick={() => setShowSaveConfirm(false)}>
-            {t("common.cancel")}
-          </Button>
-          <Button size="sm" onClick={() => handleSave(skipValidation)} loading={updatePackageMutation.isPending}>
-            {t("common.save")}
-          </Button>
-        </div>
-      </Modal>
+        skillName={skill.name}
+        skipValidation={skipValidation}
+        onSkipValidationChange={setSkipValidation}
+        onConfirm={() => handleSave(skipValidation)}
+        saving={updatePackageMutation.isPending}
+      />
 
       {/* ── All versions browser ── */}
-      <Modal
+      <SkillVersionsBrowserModal
         isOpen={showVersions}
         onClose={() => setShowVersions(false)}
-        title={t("skillDetail.versionsTitle", "All versions") as string}
-        className="!max-w-3xl"
-      >
-        {versionList.length >= 2 && (
-          <div className="mb-4 flex justify-end">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setShowVersionDiff(true)}
-            >
-              {t("versionDiff.openButton", "Compare versions")}
-            </Button>
-          </div>
-        )}
-        <SkillVersionList
-          versions={versionList}
-          currentVersion={skill.version}
-          onSelect={(v) => {
-            handleVersionChange(v === latestVersion ? null : v);
-            setShowVersions(false);
-          }}
-          canManage={canManageVersions}
-          onToggleDeprecation={handleToggleDeprecation}
-          isMutating={deprecationMutation.isPending}
-          isDeleting={deleteVersionMutation.isPending}
-          auditSummary={auditSummaryByVersion}
-          onDeleteVersion={async (version) => {
-            try {
-              await deleteVersionMutation.mutateAsync(version);
-              if (skill.version === version) handleVersionChange(null);
-              addToast({
-                type: "success",
-                message: t("skillDetail.versionDeleted", "Version v{{version}} deleted", { version }),
-              });
-            } catch (err) {
-              addToast({
-                type: "error",
-                message: translateError(
-                  err,
-                  t("skillDetail.versionDeleteFailed", "Failed to delete version"),
-                ),
-              });
-            }
-          }}
-        />
-      </Modal>
+        versions={versionList}
+        currentVersion={skill.version}
+        latestVersion={latestVersion}
+        canManage={canManageVersions}
+        auditSummary={auditSummaryByVersion}
+        onSelectVersion={handleVersionChange}
+        onToggleDeprecation={handleToggleDeprecation}
+        deprecationPending={deprecationMutation.isPending}
+        deleteVersionPending={deleteVersionMutation.isPending}
+        deleteVersionAsync={(v) => deleteVersionMutation.mutateAsync(v)}
+        onOpenDiff={() => setShowVersionDiff(true)}
+      />
 
       {/* ── Version diff modal ── */}
       <VersionDiffModal
@@ -1016,23 +955,13 @@ export function SkillDetailPage() {
       />
 
       {/* ── Delete confirmation modal ── */}
-      <Modal
+      <SkillDeleteConfirmModal
         isOpen={showDeleteConfirm}
         onClose={() => setShowDeleteConfirm(false)}
-        title={t("skillDetail.deleteTitle")}
-      >
-        <p className="font-text text-sm text-meta">
-          {t("skillDetail.deleteConfirm", { name: skill.name }).replace(/<\/?strong>/g, "")}
-        </p>
-        <div className="mt-6 flex justify-end gap-3">
-          <Button variant="secondary" size="sm" onClick={() => setShowDeleteConfirm(false)}>
-            {t("common.cancel")}
-          </Button>
-          <Button variant="danger" size="sm" onClick={handleDeleteConfirm} loading={deleteMutation.isPending}>
-            {t("common.delete")}
-          </Button>
-        </div>
-      </Modal>
+        skillName={skill.name}
+        onConfirm={handleDeleteConfirm}
+        deleting={deleteMutation.isPending}
+      />
 
       {/* ── Permissions editor ── */}
       {isOwner && (
@@ -1053,81 +982,12 @@ export function SkillDetailPage() {
       )}
 
       {/* ── Audit started modal ── */}
-      <Modal
+      <SkillAuditStartedModal
         isOpen={showAuditStartedModal}
         onClose={() => setShowAuditStartedModal(false)}
-        title={t("skillDetail.auditStartedTitle", "Audit started") as string}
-      >
-        <p className="font-text text-sm text-meta">
-          {t(
-            "skillDetail.auditStartedBody",
-            "We're running the audit in the background. It takes around 20-30 seconds — when it's done, a new entry will appear in the Audit history. You can close this dialog and keep working.",
-          )}
-        </p>
-        <div className="mt-6 flex justify-end">
-          <Button size="sm" onClick={() => setShowAuditStartedModal(false)}>
-            {t("common.gotIt", "Got it")}
-          </Button>
-        </div>
-      </Modal>
+      />
 
       </div>
     </PageTransition>
-  );
-}
-
-/** Audit verdict tile rendered inside the right-rail Audit card. */
-function AuditVerdictPill({ audit, running }: { audit?: AuditRecord; running?: boolean }) {
-  const { t } = useTranslation();
-  // In-flight audit takes precedence over the cached completed result —
-  // even if there's a previous completed verdict on this version, surface
-  // the spinner while a new run is scoring.
-  if (running) {
-    return (
-      <div className="mb-3.5 flex items-center gap-3 rounded-sm border border-accent/30 bg-accent/5 p-3 font-mono text-[11px] uppercase tracking-wider text-accent">
-        <div className="flex h-8 w-8 items-center justify-center rounded-sm border border-accent/30" aria-hidden>
-          <span className="h-4 w-4 animate-spin rounded-full border-2 border-accent/30 border-t-accent" />
-        </div>
-        <span>{t("skillDetail.auditRunning", "Audit in progress")}</span>
-      </div>
-    );
-  }
-  if (!audit || audit.status !== "completed") {
-    return (
-      <div className="mb-3.5 flex items-center gap-3 rounded-sm border border-strong-edge bg-elevated/60 p-3 font-mono text-[11px] uppercase tracking-wider text-meta">
-        <div className="flex h-8 w-8 items-center justify-center rounded-sm border border-strong-edge text-meta" aria-hidden>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="9" /></svg>
-        </div>
-        <span>{t("skillDetail.auditNone", "Not audited")}</span>
-      </div>
-    );
-  }
-  const tone =
-    audit.verdict === "green"
-      ? "border-success/30 bg-success-soft text-success"
-      : audit.verdict === "yellow"
-        ? "border-warning/30 bg-warning-soft text-warning"
-        : "border-danger/30 bg-danger-soft text-danger";
-  const label =
-    audit.verdict === "green"
-      ? t("skillDetail.auditPassLabel", "Pass · low risk")
-      : audit.verdict === "yellow"
-        ? t("skillDetail.auditWarnLabel", "Caution")
-        : t("skillDetail.auditFailLabel", "Risk");
-  return (
-    <div className={`mb-3.5 flex items-center gap-3 rounded-sm border p-3 ${tone}`}>
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-current text-page" aria-hidden>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3"><polyline points="20 6 9 17 4 12" /></svg>
-      </div>
-      <div className="flex flex-col gap-0.5">
-        <div>
-          <span className="font-display text-2xl font-semibold leading-none">
-            {audit.overallScore.toFixed(1)}
-          </span>
-          <span className="ml-1 font-mono text-[11px] tracking-wide text-meta">/ 10</span>
-        </div>
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em]">{label}</span>
-      </div>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary

\`SkillDetailPage.tsx\` was 1133 lines — well over the 300-line target #453 sets for page components. This PR pulls 7 self-contained chunks into 9 new colocated components under \`components/skill/\`:

- **Modals (4):** \`SkillSaveConfirmModal\`, \`SkillDeleteConfirmModal\`, \`SkillAuditStartedModal\`, \`SkillVersionsBrowserModal\`
- **Right-rail (3):** \`AuditVerdictPill\`, \`SkillVersionsCard\`, \`SkillVisibilityCard\`
- **States (2):** \`SkillDetailLoading\`, \`SkillDetailNotFound\` (both in \`SkillDetailStates.tsx\`)

Net: \`SkillDetailPage.tsx\` **1133 → 868 lines** (-23%). 9 new files at 41-124 lines each.

## Per the issue's "one PR per page" guidance

\`DocsPage\` (901L) and \`PlaygroundPage\` (813L) get their own PRs.

## What's still inline

\`SkillDetailPage\` is still 868 lines — not at the <300 target yet. The biggest remaining lever is extracting \`useSkillDetail()\` to pull the queries / mutations / derived state out of the page entirely. That's a non-trivial refactor because the data flow is woven through the entire JSX layout; bisecting it cleanly needs a separate PR.

## Behavior

Unchanged. Each new component is stateless except for the toast-emitting delete handler inside the versions browser (kept colocated so the parent doesn't have to thread it through).

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run test\` — 793 backend + 110 web + 17 sdk tests pass
- [ ] CI runs same suite
- [ ] Deploy to local k8s — N/A (web-only change; ornn-web image rebuild needed for browser verification)

Partial progress on #453 — full closure requires DocsPage + PlaygroundPage decomposition PRs.