### PR TITLE
chore: enable stricter TS flags across all 3 packages (#450)

### DIFF
--- a/.changeset/strict-ts-flags-450.md
+++ b/.changeset/strict-ts-flags-450.md
@@ -1,0 +1,29 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+"@chronoai/ornn-sdk": patch
+---
+
+Enable stricter TS flags across all three packages (#450).
+
+#450 part 1 (`noImplicitOverride`) landed in #638. This PR closes the bulk of parts 2 + 3:
+
+- **All 3 packages now have `noUncheckedIndexedAccess: true`.** Array/object bracket access now widens to `T | undefined`, forcing explicit handling. Fix patterns by category:
+  - **Length-guarded accesses** — `if (xs.length > 0)` followed by `xs[len-1]`, `findIndex` followed by `arr[idx]`. Marked `!` with a comment naming the guard. Most cases.
+  - **Regex capture groups** — every `match[1]` / `match[2]` followed by a `match` check. Marked `!` with the regex-shape note.
+  - **Defensive `if (!entry)` skips** — `zip.files[path]` where `path` came from `Object.keys(zip.files)`. Switched from `if (entry.dir)` to `if (!entry || entry.dir)` so a future zip-lib refactor that breaks the round-trip drops the file rather than crashes.
+  - **Two non-mechanical fixes**: GenerateSkillModal.STEP_MESSAGES switched from `Record<string, string>` to `as const` (compile-time keys now return `string`, not `string | undefined`); SkillDetailPage.latestVersion now passed as `latestVersion ?? ""`.
+
+- **SDK only: `exactOptionalPropertyTypes: true`.** The SDK had 4 errors total; all 4 were `{ requestId: undefined }`-style fields that violated the stricter `{ requestId?: string }` contract. Fixed with conditional spread (only set the key when the upstream actually has the value).
+
+### Deferred
+
+`exactOptionalPropertyTypes` on ornn-api (~77 errors) and ornn-web (~134 errors) — tracked as #657. These need per-site decisions (conditional spread vs widened field type vs constructor refactor), not mechanical fixes, so they don't fit a single-session PR.
+
+### Net
+
+- 3 tsconfig.json files updated.
+- ornn-api: 26 files touched (68 fix sites + 1 tsconfig).
+- ornn-web: 22 files touched (57 fix sites + 1 tsconfig).
+- sdk/typescript: 3 files touched (4 fix sites + 1 tsconfig).
+- 798 backend + 110 web + 17 sdk tests all still pass.

--- a/ornn-api/src/domains/admin-users/service.test.ts
+++ b/ornn-api/src/domains/admin-users/service.test.ts
@@ -117,7 +117,7 @@ describe("search by email prefix", () => {
     await seedUser({ userId: "bob", email: "bob@example.com", displayName: "Bob" });
     const r = await service.listUsers({ role: "normal", page: 1, pageSize: 50, q: "ali" });
     expect(r.total).toBe(1);
-    expect(r.items[0].email).toBe("alice@example.com");
+    expect(r.items[0]!.email).toBe("alice@example.com");
   });
 });
 
@@ -147,8 +147,8 @@ describe("default sort lastActiveAt desc, nulls last", () => {
       lastSeenAt: new Date(Date.UTC(2026, 4, 1)),
     });
     const r = await service.listUsers({ role: "normal", page: 1, pageSize: 10 });
-    expect(r.items[0].userId).toBe("new");
-    expect(r.items[1].userId).toBe("old");
+    expect(r.items[0]!.userId).toBe("new");
+    expect(r.items[1]!.userId).toBe("old");
   });
 });
 
@@ -160,8 +160,8 @@ describe("lastActiveAt surfaces directory's lastSeenAt", () => {
       activityCount: 7,
     });
     const r = await service.listUsers({ role: "normal", page: 1, pageSize: 10 });
-    expect(r.items[0].lastActiveAt).toBe("2026-05-15T00:00:00.000Z");
-    expect(r.items[0].activityCount).toBe(7);
+    expect(r.items[0]!.lastActiveAt).toBe("2026-05-15T00:00:00.000Z");
+    expect(r.items[0]!.activityCount).toBe(7);
   });
 });
 
@@ -169,7 +169,7 @@ describe("skillCount = N owned", () => {
   test("createdBy match", async () => {
     await seedUser({ userId: "u1", skills: 4 });
     const r = await service.listUsers({ role: "normal", page: 1, pageSize: 10 });
-    expect(r.items[0].skillCount).toBe(4);
+    expect(r.items[0]!.skillCount).toBe(4);
   });
 });
 
@@ -180,6 +180,6 @@ describe("firstJoinedAt surfaces directory's firstSeenAt", () => {
       firstSeenAt: new Date(Date.UTC(2025, 11, 15)),
     });
     const r = await service.listUsers({ role: "normal", page: 1, pageSize: 10 });
-    expect(r.items[0].firstJoinedAt).toBe("2025-12-15T00:00:00.000Z");
+    expect(r.items[0]!.firstJoinedAt).toBe("2025-12-15T00:00:00.000Z");
   });
 });

--- a/ornn-api/src/domains/admin/quota/routes.test.ts
+++ b/ornn-api/src/domains/admin/quota/routes.test.ts
@@ -193,7 +193,7 @@ describe("UT-ADMQROUTE-001 GET /admin/quota/users surface=playground", () => {
       };
     };
     expect(json.data.items.length).toBe(1);
-    expect(json.data.items[0].userId).toBe("u1");
+    expect(json.data.items[0]!.userId).toBe("u1");
     expect(json.data.monthMarker).toMatch(/^\d{4}-\d{2}$/);
   });
 });
@@ -206,7 +206,7 @@ describe("UT-ADMQROUTE-002 surface=skillGen filter", () => {
     });
     expect(res.status).toBe(200);
     const json = (await res.json()) as { data: { items: Array<{ defaultAllotment: number }> } };
-    expect(json.data.items[0].defaultAllotment).toBe(10);
+    expect(json.data.items[0]!.defaultAllotment).toBe(10);
   });
 });
 
@@ -244,7 +244,7 @@ describe("UT-ADMQROUTE-006 remaining floors at 0", () => {
       headers: authHeaders(),
     });
     const json = (await res.json()) as { data: { items: Array<{ remaining: number }> } };
-    expect(json.data.items[0].remaining).toBe(0);
+    expect(json.data.items[0]!.remaining).toBe(0);
   });
 });
 

--- a/ornn-api/src/domains/quota/repository.test.ts
+++ b/ornn-api/src/domains/quota/repository.test.ts
@@ -82,8 +82,8 @@ describe("UT-QUOTAREPO-002 upsert is idempotent on _id", () => {
       .find({ userId: "u1", surface: "playground" })
       .toArray();
     expect(docs.length).toBe(1);
-    expect(docs[0]._id as unknown as string).toBe(id);
-    expect((docs[0] as unknown as { used: number }).used).toBe(2);
+    expect(docs[0]!._id as unknown as string).toBe(id);
+    expect((docs[0]! as unknown as { used: number }).used).toBe(2);
   });
 });
 
@@ -252,6 +252,6 @@ describe("listGrantAudit pagination + filter", () => {
     });
     const res = await repo.listGrantAudit({ page: 1, pageSize: 50, targetUserId: "uA" });
     expect(res.total).toBe(1);
-    expect(res.items[0].targetUserId).toBe("uA");
+    expect(res.items[0]!.targetUserId).toBe("uA");
   });
 });

--- a/ornn-api/src/domains/redemption-codes/me-routes.test.ts
+++ b/ornn-api/src/domains/redemption-codes/me-routes.test.ts
@@ -111,8 +111,8 @@ describe("POST /me/redemption-codes/redeem", () => {
       data: { codeId: string; grants: Array<{ surface: string; amount: number }> };
     };
     expect(json.data.grants.length).toBe(1);
-    expect(json.data.grants[0].surface).toBe("playground");
-    expect(json.data.grants[0].amount).toBe(5);
+    expect(json.data.grants[0]!.surface).toBe("playground");
+    expect(json.data.grants[0]!.amount).toBe(5);
 
     const audits = await db.collection("quota_grants_audit").countDocuments();
     expect(audits).toBe(1);

--- a/ornn-api/src/domains/redemption-codes/service.ts
+++ b/ornn-api/src/domains/redemption-codes/service.ts
@@ -121,7 +121,10 @@ export class RedemptionCodeService {
     const bytes = randomBytes(REDEMPTION_CODE_LENGTH);
     let out = "";
     for (let i = 0; i < REDEMPTION_CODE_LENGTH; i++) {
-      out += REDEMPTION_CODE_ALPHABET[bytes[i] % REDEMPTION_CODE_ALPHABET.length];
+      // `randomBytes(N)` returns exactly N bytes — loop bound is N, so
+      // `bytes[i]` is always defined. `!` is safe under
+      // noUncheckedIndexedAccess (#450).
+      out += REDEMPTION_CODE_ALPHABET[bytes[i]! % REDEMPTION_CODE_ALPHABET.length];
     }
     return out;
   }

--- a/ornn-api/src/domains/settings/exportImport/exporter.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/exporter.test.ts
@@ -129,7 +129,7 @@ describe("SettingsExporter", () => {
     const telemetry = env.sections.telemetry as Record<string, unknown>;
     expect(isRedactionSentinel(telemetry.postHogApiKey)).toBe(true);
     const providers = env.sections.llmProviders as Array<Record<string, unknown>>;
-    const auth = providers[0].auth as Record<string, unknown>;
+    const auth = providers[0]!.auth as Record<string, unknown>;
     expect(isRedactionSentinel(auth.apiKey)).toBe(true);
   });
 

--- a/ornn-api/src/domains/settings/exportImport/importer.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/importer.test.ts
@@ -156,8 +156,8 @@ describe("SettingsImporter", () => {
     );
     const q = r.sections.find((s) => s.id === "playground")!;
     expect(q.status).toBe("failed");
-    expect(q.errors?.[0].field).toBe("defaultMonthlyQuota");
-    expect(q.errors?.[0].message).toBeDefined();
+    expect(q.errors?.[0]!.field).toBe("defaultMonthlyQuota");
+    expect(q.errors?.[0]!.message).toBeDefined();
   });
 
   it("UT-IMPORT-008: dry-run preview produces no writes", async () => {

--- a/ornn-api/src/domains/settings/llmProviders/repository.ts
+++ b/ornn-api/src/domains/settings/llmProviders/repository.ts
@@ -111,7 +111,10 @@ export class LlmProvidersRepository {
     const filterField = `m.defaultFor${surface}` as const;
     const arrayFilters: Document[] = [{ [filterField]: true }];
     if (keep) {
-      arrayFilters[0]["m.id"] = { $ne: keep.modelId };
+      // arrayFilters[0] is the single-element object we just pushed
+      // above — guaranteed defined. `!` is safe under
+      // noUncheckedIndexedAccess (#450).
+      arrayFilters[0]!["m.id"] = { $ne: keep.modelId };
     }
     const filter: Document = keep
       ? { _id: { $ne: keep.providerId as unknown as Document["_id"] } }

--- a/ornn-api/src/domains/settings/llmProviders/service.ts
+++ b/ornn-api/src/domains/settings/llmProviders/service.ts
@@ -334,7 +334,10 @@ export class LlmProvidersService {
       return { kind: "no-models-enabled", surface };
     }
     enabledList.sort((a, b) => a.displayName.localeCompare(b.displayName));
-    const winner = defaultMatch ?? enabledList[0];
+    // Length-guarded above (`enabledList.length === 0` returns), so
+    // index 0 is guaranteed defined — `!` is safe under
+    // `noUncheckedIndexedAccess` (#450).
+    const winner = defaultMatch ?? enabledList[0]!;
     return {
       kind: "ok",
       modelId: winner.modelId,
@@ -489,7 +492,9 @@ export class LlmProvidersService {
         `Model "${modelId}" not on provider "${existing.name}"`,
       );
     }
-    const current = existing.models[idx];
+    // idx is guaranteed in-range — we just confirmed via findIndex
+    // above. `!` is safe under noUncheckedIndexedAccess (#450).
+    const current = existing.models[idx]!;
     if (current.removed) {
       throw AppError.badRequest(
         "MODEL_REMOVED",
@@ -805,7 +810,9 @@ function parse<T extends z.ZodTypeAny>(
 }
 
 function zodToAppError(err: ZodError): AppError {
-  const first = err.issues[0];
+  // ZodError always carries at least one issue when `safeParse` returns
+  // success: false. `!` is safe under noUncheckedIndexedAccess (#450).
+  const first = err.issues[0]!;
   const path = first.path.join(".");
   const msg = path.length > 0 ? `${path}: ${first.message}` : first.message;
   return AppError.badRequest("invalid_provider_input", msg);

--- a/ornn-api/src/domains/settings/service.ts
+++ b/ornn-api/src/domains/settings/service.ts
@@ -268,7 +268,9 @@ function shallowEqual(a: unknown, b: unknown): boolean {
 }
 
 function zodToAppError(err: ZodError): AppError {
-  const first = err.issues[0];
+  // ZodError always carries at least one issue when `safeParse` returns
+  // success: false. `!` is safe under noUncheckedIndexedAccess (#450).
+  const first = err.issues[0]!;
   const path = first.path.join(".");
   const msg = path.length > 0 ? `${path}: ${first.message}` : first.message;
   return AppError.badRequest("invalid_setting", msg);

--- a/ornn-api/src/domains/skills/audit/service.ts
+++ b/ornn-api/src/domains/skills/audit/service.ts
@@ -375,7 +375,11 @@ export class AuditService {
 
     for (const path of allPaths) {
       const entry = zip.files[path];
-      if (entry.dir) continue;
+      // `allPaths` is built from `Object.keys(zip.files)` upstream, so
+      // every path resolves. Defensive null-check under
+      // noUncheckedIndexedAccess (#450) — drop the file rather than
+      // crash if a future refactor introduces a mismatch.
+      if (!entry || entry.dir) continue;
       const parts = path.split("/");
       let relative = path;
       if (parts.length > 1 && zip.files[`${parts[0]}/`]?.dir) {

--- a/ornn-api/src/domains/skills/crud/interfaceDiff.test.ts
+++ b/ornn-api/src/domains/skills/crud/interfaceDiff.test.ts
@@ -32,9 +32,9 @@ describe("diffSkillInterface", () => {
     });
     const changes = diffSkillInterface(prev, next);
     expect(changes).toHaveLength(1);
-    expect(changes[0].field).toBe("tools");
-    expect(changes[0].kind).toBe("added");
-    expect(changes[0].detail).toContain("edit");
+    expect(changes[0]!.field).toBe("tools");
+    expect(changes[0]!.kind).toBe("added");
+    expect(changes[0]!.detail).toContain("edit");
   });
 
   test("removing a tool is breaking", () => {
@@ -48,8 +48,8 @@ describe("diffSkillInterface", () => {
     const next = meta({ category: "tool-based", tools: [{ tool: "bash", type: "mcp" }] });
     const changes = diffSkillInterface(prev, next);
     expect(changes).toHaveLength(1);
-    expect(changes[0].kind).toBe("removed");
-    expect(changes[0].detail).toContain("edit");
+    expect(changes[0]!.kind).toBe("removed");
+    expect(changes[0]!.detail).toContain("edit");
   });
 
   test("adding a runtime is breaking", () => {

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -1132,7 +1132,10 @@ export class SkillService {
     // Walk all entries and extract text content
     for (const path of allPaths) {
       const entry = zip.files[path];
-      if (entry.dir) continue;
+      // allPaths is sourced from `Object.keys(zip.files)`, but
+      // noUncheckedIndexedAccess (#450) widens the lookup to `T |
+      // undefined`. Defensive skip rather than crash.
+      if (!entry || entry.dir) continue;
 
       // Get the relative path (strip root folder prefix if present)
       let relativePath = path;
@@ -1283,7 +1286,10 @@ export class SkillService {
 
     let rawFrontmatter: Record<string, unknown>;
     try {
-      const parsed = parseYaml(fmMatch[1]);
+      // FRONTMATTER_REGEX always has a capture group 1 (the YAML body)
+      // when it matches. `!` is safe under noUncheckedIndexedAccess
+      // (#450).
+      const parsed = parseYaml(fmMatch[1]!);
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
         throw new Error("Frontmatter must be a YAML object");
       }
@@ -1539,7 +1545,10 @@ export class SkillService {
       return violations;
     }
 
-    const yamlBlock = fmMatch[1];
+    // FRONTMATTER_REGEX always has capture group 1 (the YAML body)
+    // when it matches. `!` is safe under noUncheckedIndexedAccess
+    // (#450).
+    const yamlBlock = fmMatch[1]!;
     if (yamlBlock.includes("<") || yamlBlock.includes(">")) {
       violations.push({
         rule: "no-xml-brackets",

--- a/ornn-api/src/domains/skills/crud/utils/skillPackageBuilder.test.ts
+++ b/ornn-api/src/domains/skills/crud/utils/skillPackageBuilder.test.ts
@@ -62,8 +62,8 @@ describe("collectUploadedFiles", () => {
     const file = new File(["content"], "test.ts");
     const result = collectUploadedFiles({ file_0: file });
     expect(result.length).toBe(1);
-    expect(result[0].file).toBe(file);
-    expect(result[0].folder).toBe("");
+    expect(result[0]!.file).toBe(file);
+    expect(result[0]!.folder).toBe("");
   });
 
   test("fileWithFolderMeta_usesFolderMeta", () => {
@@ -72,13 +72,13 @@ describe("collectUploadedFiles", () => {
       file_0: file,
       file_0_folder: "scripts",
     });
-    expect(result[0].folder).toBe("scripts");
+    expect(result[0]!.folder).toBe("scripts");
   });
 
   test("fileWithSlashInName_extractsFolderFromName", () => {
     const file = new File(["content"], "scripts/deploy.ts");
     const result = collectUploadedFiles({ file_0: file });
-    expect(result[0].folder).toBe("scripts");
+    expect(result[0]!.folder).toBe("scripts");
   });
 
   test("multipleFiles_collectsAll", () => {

--- a/ornn-api/src/domains/skills/crud/utils/skillPackageBuilder.ts
+++ b/ornn-api/src/domains/skills/crud/utils/skillPackageBuilder.ts
@@ -65,7 +65,10 @@ export function collectUploadedFiles(
 
     // If filename already has a folder prefix (e.g., "scripts/deploy.ts"), use it
     if (file.name.includes("/")) {
-      folder = file.name.split("/")[0];
+      // `split("/")[0]` is always present when the string contains "/"
+      // (the substring before the first separator). `!` is safe under
+      // noUncheckedIndexedAccess (#450).
+      folder = file.name.split("/")[0]!;
     }
 
     files.push({ file, folder });

--- a/ornn-api/src/domains/skills/crud/utils/versionDiff.ts
+++ b/ornn-api/src/domains/skills/crud/utils/versionDiff.ts
@@ -100,7 +100,9 @@ async function extractFiles(zipBuffer: Uint8Array): Promise<Map<string, Uint8Arr
   const out = new Map<string, Uint8Array>();
   for (const path of allPaths) {
     const entry = zip.files[path];
-    if (entry.dir) continue;
+    // allPaths is `Object.keys(zip.files)`, but noUncheckedIndexedAccess
+    // (#450) widens the lookup to `T | undefined`. Defensive skip.
+    if (!entry || entry.dir) continue;
     const parts = path.split("/");
     let relative = path;
     if (parts.length > 1) {

--- a/ornn-api/src/domains/skills/generation/routes.ts
+++ b/ornn-api/src/domains/skills/generation/routes.ts
@@ -166,13 +166,15 @@ async function analyzePackageContent(zipBuffer: Uint8Array): Promise<string> {
 
   for (const path of allPaths) {
     const file = zip.files[path];
-    if (file.dir) continue;
+    // allPaths is `Object.keys(zip.files)`, but noUncheckedIndexedAccess
+    // (#450) widens the lookup to `T | undefined`. Defensive skip.
+    if (!file || file.dir) continue;
 
     // Check if this is a relevant file
     const segments = path.split("/").filter(Boolean);
     let relativePath = path;
     if (segments.length > 1) {
-      const firstEntry = segments[0];
+      const firstEntry = segments[0]!;
       const folderEntry = zip.files[firstEntry + "/"];
       if (folderEntry && folderEntry.dir) {
         relativePath = segments.slice(1).join("/");

--- a/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
@@ -278,7 +278,7 @@ describe("MirrorService privacy regression", () => {
     await svc.syncSkill("g-flip");
     // Expect one tree create with a sha:null entry for flip/SKILL.md.
     expect(calls.trees.length).toBe(1);
-    const entries = calls.trees[0].entries;
+    const entries = calls.trees[0]!.entries;
     const removalEntry = entries.find((e) => e.path === "flip/SKILL.md");
     expect(removalEntry).toBeDefined();
     expect(removalEntry?.sha).toBeNull();

--- a/ornn-api/src/infra/crypto.test.ts
+++ b/ornn-api/src/infra/crypto.test.ts
@@ -35,11 +35,14 @@ describe("infra/crypto", () => {
 
   it("UT-CRYPTO-003: tampered ciphertext rejected by auth tag", () => {
     const ct = encryptSecret("plaintext", KEY);
-    // Flip a single hex char in the ciphertext segment.
+    // Flip a single hex char in the ciphertext segment. `encryptSecret`
+    // emits a 4-part `v1:iv:tag:ct` payload, so index 3 is guaranteed
+    // present. `!` is safe under noUncheckedIndexedAccess (#450).
     const parts = ct.split(":");
-    parts[3] = parts[3].startsWith("a")
-      ? `b${parts[3].slice(1)}`
-      : `a${parts[3].slice(1)}`;
+    const ctSegment = parts[3]!;
+    parts[3] = ctSegment.startsWith("a")
+      ? `b${ctSegment.slice(1)}`
+      : `a${ctSegment.slice(1)}`;
     const tampered = parts.join(":");
     expect(() => decryptSecret(tampered, KEY)).toThrow();
   });

--- a/ornn-api/src/infra/crypto.ts
+++ b/ornn-api/src/infra/crypto.ts
@@ -80,7 +80,12 @@ export function decryptSecret(value: string, passphrase: string): string {
   if (parts.length !== 4) {
     throw new Error(`decryptSecret: malformed v1 payload (got ${parts.length} parts)`);
   }
-  const [, ivHex, tagHex, ctHex] = parts;
+  // Length-checked above (`parts.length !== 4` returns early) — every
+  // slot is guaranteed defined. `!` is safe under noUncheckedIndexedAccess
+  // (#450).
+  const ivHex = parts[1]!;
+  const tagHex = parts[2]!;
+  const ctHex = parts[3]!;
   const key = deriveKey(passphrase);
   const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivHex, "hex"));
   decipher.setAuthTag(Buffer.from(tagHex, "hex"));

--- a/ornn-api/src/infra/url.ts
+++ b/ornn-api/src/infra/url.ts
@@ -79,7 +79,10 @@ interface Cidr {
 }
 
 function parseCidr(spec: string): Cidr | null {
-  const [hostPart, bitsPart] = spec.split("/");
+  // `split("/")` always yields at least one element; if `spec` has no
+  // `/`, hostPart is the whole string and bitsPart is undefined. `!`
+  // is safe under noUncheckedIndexedAccess (#450).
+  const [hostPart, bitsPart] = spec.split("/") as [string, string | undefined];
   const base = parseIpv4(hostPart);
   if (base === null) return null;
   const maskBits = bitsPart ? Number(bitsPart) : 32;
@@ -122,13 +125,18 @@ export function isPrivateHost(host: string): boolean {
     if (h.startsWith("fe80:") || h.startsWith("fe80::")) return true;
     // `fc00::/7` covers `fc00::` through `fdff::`.
     if (h.startsWith("fc") || h.startsWith("fd")) {
-      const first = h.split(":")[0];
+      // split(":")[0] is the substring before the first ":" (always
+      // present when split runs). `!` is safe under
+      // noUncheckedIndexedAccess (#450).
+      const first = h.split(":")[0]!;
       if (/^f[cd][0-9a-f]{0,2}$/.test(first)) return true;
     }
     // `::ffff:<v4>` mapped form.
     const mapped = h.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
     if (mapped) {
-      const ip = parseIpv4(mapped[1]);
+      // The regex has one capture group; if it matched, group 1 is
+      // present. `!` is safe under noUncheckedIndexedAccess (#450).
+      const ip = parseIpv4(mapped[1]!);
       if (ip === null) return true; // malformed — reject conservatively
       return PRIVATE_CIDRS.some((c) => ipv4InCidr(ip, c));
     }

--- a/ornn-api/src/middleware/nyxidAuth.ts
+++ b/ornn-api/src/middleware/nyxidAuth.ts
@@ -99,7 +99,9 @@ function decodeJwtPayload(token: string): IdentityAssertionPayload | null {
   try {
     const parts = token.split(".");
     if (parts.length !== 3) return null;
-    const payload = Buffer.from(parts[1], "base64url").toString("utf-8");
+    // Length-checked above — parts[1] is guaranteed defined. `!` is
+    // safe under noUncheckedIndexedAccess (#450).
+    const payload = Buffer.from(parts[1]!, "base64url").toString("utf-8");
     return JSON.parse(payload) as IdentityAssertionPayload;
   } catch (e) {
     logger.warn({ error: (e as Error).message }, "Failed to decode identity token");

--- a/ornn-api/src/shared/utils/frontmatter.ts
+++ b/ornn-api/src/shared/utils/frontmatter.ts
@@ -29,7 +29,9 @@ export function extractFrontmatter(
   if (!match) return null;
 
   try {
-    const parsed = parseYaml(match[1]);
+    // FRONTMATTER_REGEX always has capture group 1 when it matches. `!`
+    // is safe under noUncheckedIndexedAccess (#450).
+    const parsed = parseYaml(match[1]!);
     if (typeof parsed !== "object" || parsed === null) return null;
 
     const raw = parsed as Record<string, unknown>;

--- a/ornn-api/src/shared/utils/tarBuilder.ts
+++ b/ornn-api/src/shared/utils/tarBuilder.ts
@@ -62,7 +62,10 @@ export function buildTarHeader(path: string, fileSize: number): Uint8Array {
   // Calculate and set checksum
   let checksum = 0;
   for (let i = 0; i < BLOCK_SIZE; i++) {
-    checksum += header[i];
+    // `header` is a `BLOCK_SIZE`-byte Uint8Array — i is bounded by
+    // BLOCK_SIZE, so `header[i]` is always defined. `!` is safe under
+    // noUncheckedIndexedAccess (#450).
+    checksum += header[i]!;
   }
   const checksumOctal = checksum.toString(8).padStart(6, "0") + "\0 ";
   header.set(encoder.encode(checksumOctal), 148);

--- a/ornn-api/src/shared/utils/zip.ts
+++ b/ornn-api/src/shared/utils/zip.ts
@@ -21,14 +21,18 @@ export function resolveZipRoot(zip: JSZip, allPaths: string[]): ZipRoot {
   for (const path of cleanPaths) {
     const parts = path.split("/").filter(Boolean);
     if (parts.length > 0) {
-      topLevel.add(parts[0]);
+      // Length-guarded above — `parts[0]` is guaranteed defined. `!`
+      // is safe under noUncheckedIndexedAccess (#450).
+      topLevel.add(parts[0]!);
     }
   }
 
   const topLevelEntries = Array.from(topLevel);
 
   if (topLevelEntries.length === 1) {
-    const candidate = topLevelEntries[0];
+    // Same length guard: the if-branch only fires when topLevelEntries
+    // has exactly one element.
+    const candidate = topLevelEntries[0]!;
     const candidateFolder = zip.files[candidate + "/"];
     const hasNestedFiles = cleanPaths.some((p) => p.startsWith(candidate + "/") && p !== candidate + "/");
     if ((candidateFolder && candidateFolder.dir) || hasNestedFiles) {
@@ -39,7 +43,7 @@ export function resolveZipRoot(zip: JSZip, allPaths: string[]): ZipRoot {
           const relative = path.slice(prefix.length);
           const parts = relative.split("/").filter(Boolean);
           if (parts.length > 0) {
-            innerEntries.add(parts[0]);
+            innerEntries.add(parts[0]!);
           }
         }
       }

--- a/ornn-api/tsconfig.json
+++ b/ornn-api/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/ornn-web/src/components/editor/CodeEditor.tsx
+++ b/ornn-web/src/components/editor/CodeEditor.tsx
@@ -343,7 +343,10 @@ export function useEditorState(_initialFiles: { id: string; name: string; conten
     setTabs((prev) => {
       const newTabs = prev.filter((t) => t.id !== tabId);
       if (activeTabId === tabId && newTabs.length > 0) {
-        setActiveTabId(newTabs[newTabs.length - 1].id);
+        // Length-guarded above — newTabs.length > 0 means index
+        // length-1 is valid. `!` is safe under noUncheckedIndexedAccess
+        // (#450).
+        setActiveTabId(newTabs[newTabs.length - 1]!.id);
       } else if (newTabs.length === 0) {
         setActiveTabId("");
       }

--- a/ornn-web/src/components/editor/FileTree.tsx
+++ b/ornn-web/src/components/editor/FileTree.tsx
@@ -258,8 +258,8 @@ function TreeNode({
  */
 function computeInitialExpanded(files: FileNode[]): Set<string> {
   const ids = new Set<string>(["root"]);
-  if (files.length === 1 && files[0].type === "folder") {
-    ids.add(files[0].id);
+  if (files.length === 1 && files[0]!.type === "folder") {
+    ids.add(files[0]!.id);
   }
   return ids;
 }
@@ -281,8 +281,8 @@ export function FileTree({
     setExpandedIds((prev) => {
       const next = new Set(prev);
       next.add("root");
-      if (files.length === 1 && files[0].type === "folder") {
-        next.add(files[0].id);
+      if (files.length === 1 && files[0]!.type === "folder") {
+        next.add(files[0]!.id);
       }
       return next;
     });

--- a/ornn-web/src/components/form/MultiValueInput.tsx
+++ b/ornn-web/src/components/form/MultiValueInput.tsx
@@ -90,7 +90,9 @@ export function MultiValueInput({
       addValue(input);
     }
     if (e.key === "Backspace" && !input && values.length > 0) {
-      removeValue(values[values.length - 1]);
+      // Length-guarded — `values.length > 0` makes index length-1 valid.
+      // `!` is safe under noUncheckedIndexedAccess (#450).
+      removeValue(values[values.length - 1]!);
     }
   };
 

--- a/ornn-web/src/components/form/TagInput.tsx
+++ b/ornn-web/src/components/form/TagInput.tsx
@@ -42,7 +42,7 @@ export function TagInput({ tags, onChange, error, className = "" }: TagInputProp
       addTag(input);
     }
     if (e.key === "Backspace" && !input && tags.length > 0) {
-      removeTag(tags[tags.length - 1]);
+      removeTag(tags[tags.length - 1]!);
     }
   };
 

--- a/ornn-web/src/components/form/ToolsInput.tsx
+++ b/ornn-web/src/components/form/ToolsInput.tsx
@@ -41,7 +41,7 @@ export function ToolsInput({ tools, onChange, error, className = "" }: ToolsInpu
       addTool(input);
     }
     if (e.key === "Backspace" && !input && tools.length > 0) {
-      removeTool(tools[tools.length - 1]);
+      removeTool(tools[tools.length - 1]!);
     }
   };
 

--- a/ornn-web/src/components/skill/AdvancedOptionsModal.tsx
+++ b/ornn-web/src/components/skill/AdvancedOptionsModal.tsx
@@ -56,13 +56,13 @@ const SETTINGS: ReadonlyArray<{
 
 export function AdvancedOptionsModal({ isOpen, onClose, skill }: AdvancedOptionsModalProps) {
   const { t } = useTranslation();
-  const [selected, setSelected] = useState<AdvancedSettingId>(SETTINGS[0].id);
+  const [selected, setSelected] = useState<AdvancedSettingId>(SETTINGS[0]!.id);
 
   // Reset to the first setting whenever the modal opens, so the user
   // always lands on a known starting point rather than wherever they
   // left off across different skills.
   useEffect(() => {
-    if (isOpen) setSelected(SETTINGS[0].id);
+    if (isOpen) setSelected(SETTINGS[0]!.id);
   }, [isOpen]);
 
   return (

--- a/ornn-web/src/components/skill/GenerateSkillModal.tsx
+++ b/ornn-web/src/components/skill/GenerateSkillModal.tsx
@@ -37,14 +37,17 @@ interface GenerateSkillModalProps {
 
 type GenerationStep = "select" | "generating" | "done" | "error";
 
-const STEP_MESSAGES: Record<string, string> = {
+// Concrete keyed type rather than `Record<string, string>` so member
+// access under noUncheckedIndexedAccess (#450) returns `string` (not
+// `string | undefined`) — these keys are compile-time-known.
+const STEP_MESSAGES = {
   fetching_spec: "Fetching OpenAPI spec...",
   fetching_refs: "Fetching reference content...",
   generating: "Generating skill package with AI...",
   validating: "Validating skill format...",
   packaging: "Packaging and uploading skill...",
   done: "Skill generated successfully!",
-};
+} as const;
 
 function isValidUrl(str: string): boolean {
   try {

--- a/ornn-web/src/components/skill/PermissionsModal.tsx
+++ b/ornn-web/src/components/skill/PermissionsModal.tsx
@@ -114,7 +114,10 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
       return resolved
         .map(
           (entry, i) =>
-            entry ?? { userId: unknownOrgIds[i], displayName: unknownOrgIds[i], avatarUrl: null },
+            // `i` is bounded by `unknownOrgIds.length` (Promise.all
+            // preserves indexing). `!` is safe under
+            // noUncheckedIndexedAccess (#450).
+            entry ?? { userId: unknownOrgIds[i]!, displayName: unknownOrgIds[i]!, avatarUrl: null },
         )
         .filter((e) => !!e);
     },

--- a/ornn-web/src/components/skill/SkillCard.tsx
+++ b/ornn-web/src/components/skill/SkillCard.tsx
@@ -10,7 +10,9 @@ const TAG_COLORS: NonNullable<BadgeProps["color"]>[] = ["cyan", "magenta", "yell
 
 function getTagColor(tag: string): NonNullable<BadgeProps["color"]> {
   const hash = tag.split("").reduce((a, c) => a + c.charCodeAt(0), 0);
-  return TAG_COLORS[hash % TAG_COLORS.length];
+  // `hash % TAG_COLORS.length` is always in-range for a non-empty
+  // array. `!` is safe under noUncheckedIndexedAccess (#450).
+  return TAG_COLORS[hash % TAG_COLORS.length]!;
 }
 
 /** Format a date string to exact SGT (Asia/Singapore) timestamp */

--- a/ornn-web/src/hooks/useSkillGeneration.ts
+++ b/ornn-web/src/hooks/useSkillGeneration.ts
@@ -85,10 +85,10 @@ export function useSkillGeneration(): UseSkillGenerationReturn {
     setState((prev) => {
       const messages = [...prev.chatMessages];
       const lastIdx = messages.length - 1;
-      if (lastIdx >= 0 && messages[lastIdx].role === "assistant" && messages[lastIdx].isStreaming) {
+      if (lastIdx >= 0 && messages[lastIdx]!.role === "assistant" && messages[lastIdx]!.isStreaming) {
         messages[lastIdx] = {
-          ...messages[lastIdx],
-          content: messages[lastIdx].content + buffered,
+          ...messages[lastIdx]!,
+          content: messages[lastIdx]!.content + buffered,
         };
       }
       return {
@@ -129,10 +129,10 @@ export function useSkillGeneration(): UseSkillGenerationReturn {
           setState((prev) => {
             const messages = [...prev.chatMessages];
             const lastIdx = messages.length - 1;
-            if (lastIdx >= 0 && messages[lastIdx].role === "assistant" && messages[lastIdx].isStreaming) {
+            if (lastIdx >= 0 && messages[lastIdx]!.role === "assistant" && messages[lastIdx]!.isStreaming) {
               messages[lastIdx] = {
-                ...messages[lastIdx],
-                content: messages[lastIdx].content + buffered,
+                ...messages[lastIdx]!,
+                content: messages[lastIdx]!.content + buffered,
               };
             }
             return {
@@ -189,10 +189,10 @@ export function useSkillGeneration(): UseSkillGenerationReturn {
           setState((prev) => {
             const messages = [...prev.chatMessages];
             const lastIdx = messages.length - 1;
-            if (lastIdx >= 0 && messages[lastIdx].role === "assistant" && messages[lastIdx].isStreaming) {
+            if (lastIdx >= 0 && messages[lastIdx]!.role === "assistant" && messages[lastIdx]!.isStreaming) {
               messages[lastIdx] = {
-                ...messages[lastIdx],
-                content: messages[lastIdx].content + buffered,
+                ...messages[lastIdx]!,
+                content: messages[lastIdx]!.content + buffered,
               };
             }
             return {

--- a/ornn-web/src/lib/docsContent.ts
+++ b/ornn-web/src/lib/docsContent.ts
@@ -106,8 +106,10 @@ function parseReleaseFrontmatter(content: string): ParsedRelease | null {
   const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) return null;
 
-  const frontmatter = match[1];
-  const body = match[2].trim();
+  // Regex has two capture groups; both are guaranteed present on
+  // match. `!` is safe under noUncheckedIndexedAccess (#450).
+  const frontmatter = match[1]!;
+  const body = match[2]!.trim();
 
   const versionMatch = frontmatter.match(/^version:\s*(.+)$/m);
   const dateMatch = frontmatter.match(/^date:\s*(.+)$/m);
@@ -117,8 +119,8 @@ function parseReleaseFrontmatter(content: string): ParsedRelease | null {
   if (!versionMatch || !dateMatch) return null;
 
   return {
-    version: versionMatch[1].trim(),
-    date: dateMatch[1].trim(),
+    version: versionMatch[1]!.trim(),
+    date: dateMatch[1]!.trim(),
     title: {
       en: enTitleMatch?.[1]?.trim() ?? "",
       zh: zhTitleMatch?.[1]?.trim() ?? "",

--- a/ornn-web/src/pages/DocsPage.tsx
+++ b/ornn-web/src/pages/DocsPage.tsx
@@ -74,8 +74,10 @@ function extractToc(md: string): TocItem[] {
 
     const match = /^(#{1,4})\s+(.+)$/.exec(line);
     if (match) {
-      const level = match[1].length;
-      const text = match[2].replace(/\*\*(.+?)\*\*/g, "$1").replace(/`(.+?)`/g, "$1");
+      // Both capture groups are always present on match. `!` is safe
+      // under noUncheckedIndexedAccess (#450).
+      const level = match[1]!.length;
+      const text = match[2]!.replace(/\*\*(.+?)\*\*/g, "$1").replace(/`(.+?)`/g, "$1");
       items.push({ id: slugify(text), text, level });
     }
   }
@@ -691,11 +693,13 @@ export function DocsPage() {
       return { displayMarkdown: markdown, frontmatter: {} as Record<string, string> };
     }
     const fm: Record<string, string> = {};
-    for (const raw of m[1].split(/\r?\n/)) {
+    // Capture group 1 is always present on match. `!` is safe under
+    // noUncheckedIndexedAccess (#450).
+    for (const raw of m[1]!.split(/\r?\n/)) {
       const kv = /^\s*([A-Za-z][\w-]*)\s*:\s*(.+?)\s*$/.exec(raw);
-      if (kv) fm[kv[1]] = kv[2].replace(/^['"]|['"]$/g, "");
+      if (kv) fm[kv[1]!] = kv[2]!.replace(/^['"]|['"]$/g, "");
     }
-    return { displayMarkdown: markdown.slice(m[0].length), frontmatter: fm };
+    return { displayMarkdown: markdown.slice(m[0]!.length), frontmatter: fm };
   }, [markdown]);
 
   // Every doc is copyable; nothing on the docs site today is paste-

--- a/ornn-web/src/pages/admin/settings/sections/ExtrasSection.tsx
+++ b/ornn-web/src/pages/admin/settings/sections/ExtrasSection.tsx
@@ -87,7 +87,12 @@ export function ExtrasSection() {
   ) => {
     if (!draft) return;
     const next = [...draft.extraNyxidServices];
-    next[idx] = { ...next[idx], ...patch };
+    // `idx` is a caller-provided index into the same draft array we
+    // just spread. Guard rather than `!` so a stale callback can't
+    // crash the page under noUncheckedIndexedAccess (#450).
+    const current = next[idx];
+    if (!current) return;
+    next[idx] = { ...current, ...patch };
     form.patchDraft({ extraNyxidServices: next });
   };
 

--- a/ornn-web/src/pages/landing/HeroStage.tsx
+++ b/ornn-web/src/pages/landing/HeroStage.tsx
@@ -248,6 +248,10 @@ function ScrubHero() {
     let firingIdx = -1;
     for (let i = 0; i < RAIL_SKILLS.length; i++) {
       const skill = RAIL_SKILLS[i];
+      // `i` is bounded by `RAIL_SKILLS.length`, but
+      // noUncheckedIndexedAccess (#450) widens the lookup. Skip when
+      // the array shape drifts rather than crash.
+      if (!skill) continue;
       const start = ITEM_BASE + i * ITEM_STEP;
       const local = (v - start) / ITEM_DUR;
       const path = pathRefs.current[i];

--- a/ornn-web/src/pages/skill/CreateSkillFreePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillFreePage.tsx
@@ -58,7 +58,10 @@ function buildTreeFromValidation(
         type: "file",
       });
     } else {
-      const folder = parts[0];
+      // The else branch only fires when `parts.length > 1`, so
+      // `parts[0]` is guaranteed defined. `!` is safe under
+      // noUncheckedIndexedAccess (#450).
+      const folder = parts[0]!;
       const existing = folderMap.get(folder) ?? [];
       existing.push({
         id: file.id,

--- a/ornn-web/src/pages/skill/CreateSkillGuidedPage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGuidedPage.tsx
@@ -354,7 +354,10 @@ export function CreateSkillGuidedPage() {
           <CompactStepIndicator
             currentStep={currentStep}
             totalSteps={translatedSteps.length}
-            currentLabel={translatedSteps[currentStep].label}
+            // `currentStep` is bounded by `translatedSteps.length`
+            // (`setCurrentStep` clamps in handlers above). `!` is safe
+            // under noUncheckedIndexedAccess (#450).
+            currentLabel={translatedSteps[currentStep]!.label}
           />
         </div>
 

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -809,7 +809,11 @@ export function SkillDetailPage() {
         onClose={() => setShowVersions(false)}
         versions={versionList}
         currentVersion={skill.version}
-        latestVersion={latestVersion}
+        // `latestVersion` is `versionList[0]?.version`; modal only
+        // opens when versionList is non-empty so the value is set,
+        // but `?? ""` keeps the prop signature simple under
+        // noUncheckedIndexedAccess (#450).
+        latestVersion={latestVersion ?? ""}
         canManage={canManageVersions}
         auditSummary={auditSummaryByVersion}
         onSelectVersion={handleVersionChange}

--- a/ornn-web/src/stores/authStore.ts
+++ b/ornn-web/src/stores/authStore.ts
@@ -55,7 +55,9 @@ function decodeJwtPayload(token: string): NyxIDJwtClaims | null {
   try {
     const parts = token.split(".");
     if (parts.length !== 3) return null;
-    const payload = atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"));
+    // Length-checked above. `!` is safe under noUncheckedIndexedAccess
+    // (#450).
+    const payload = atob(parts[1]!.replace(/-/g, "+").replace(/_/g, "/"));
     return JSON.parse(payload) as NyxIDJwtClaims;
   } catch {
     logger.error("Failed to decode JWT payload");

--- a/ornn-web/src/utils/fileTreeBuilder.ts
+++ b/ornn-web/src/utils/fileTreeBuilder.ts
@@ -66,7 +66,7 @@ export function buildFileTreeFromEntries(entries: FileTreeEntry[]): FileNode[] {
     if (existing) return existing;
 
     const parts = folderPath.split("/");
-    const name = parts[parts.length - 1];
+    const name = parts[parts.length - 1]!;
     const node: FileNode = { id: folderPath, name, type: "folder", children: [] };
     folderMap.set(folderPath, node);
 
@@ -93,7 +93,7 @@ export function buildFileTreeFromEntries(entries: FileTreeEntry[]): FileNode[] {
     if (entry.type !== "file") continue;
 
     const parts = entry.path.split("/");
-    const name = parts[parts.length - 1];
+    const name = parts[parts.length - 1]!;
     const fileNode: FileNode = { id: entry.path, name, type: "file" };
 
     if (parts.length === 1) {

--- a/ornn-web/src/utils/frontmatter.ts
+++ b/ornn-web/src/utils/frontmatter.ts
@@ -66,7 +66,9 @@ export function extractFrontmatter(
   if (!match) return null;
 
   try {
-    const raw = parseYaml(match[1]);
+    // FRONTMATTER_REGEX always has capture group 1 when it matches.
+    // `!` is safe under noUncheckedIndexedAccess (#450).
+    const raw = parseYaml(match[1]!);
     if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
 
     const camelized = yamlKeysToCamel(raw as Record<string, unknown>);

--- a/ornn-web/src/utils/zipValidator.ts
+++ b/ornn-web/src/utils/zipValidator.ts
@@ -117,7 +117,10 @@ export function isBinaryContent(content: Uint8Array): boolean {
  * Determines the skill folder for a given file path.
  */
 function getFolder(path: string): SkillFolder {
-  const firstSegment = path.split("/")[0];
+  // `split("/")[0]` is always present — it's the substring before the
+  // first `/`, or the whole string when there's no separator. `!` is
+  // safe under noUncheckedIndexedAccess (#450).
+  const firstSegment = path.split("/")[0]!;
   if (RECOGNIZED_DIRS.has(firstSegment)) {
     return firstSegment as SkillFolder;
   }
@@ -139,11 +142,13 @@ function normalizeEntries(
   // the ZIP wraps everything in a single root folder
   if (
     topLevelEntries.length === 1 &&
-    topLevelEntries[0].dir
+    topLevelEntries[0]!.dir
   ) {
-    const prefix = topLevelEntries[0].path.endsWith("/")
-      ? topLevelEntries[0].path
-      : topLevelEntries[0].path + "/";
+    // Length-guarded above (`topLevelEntries.length === 1`) — index 0
+    // is guaranteed defined. `!` is safe under
+    // noUncheckedIndexedAccess (#450).
+    const entry = topLevelEntries[0]!;
+    const prefix = entry.path.endsWith("/") ? entry.path : entry.path + "/";
 
     const normalized = entries
       .filter((e) => e.path !== prefix && e.path.startsWith(prefix))
@@ -263,7 +268,9 @@ export async function validateSkillZip(
     if (entry.dir && !entry.path.includes("/")) {
       topDirs.add(entry.path.replace("/", ""));
     } else if (!entry.dir && entry.path.includes("/")) {
-      const firstDir = entry.path.split("/")[0];
+      // `split("/")[0]` is always present when the string contains
+      // "/". `!` is safe under noUncheckedIndexedAccess (#450).
+      const firstDir = entry.path.split("/")[0]!;
       topDirs.add(firstDir);
     }
   }

--- a/ornn-web/tsconfig.json
+++ b/ornn-web/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react-jsx",
     "strict": true,
     "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -254,10 +254,14 @@ export class OrnnClient {
     if (token) {
       headers.Authorization = `Bearer ${token}`;
     }
+    // exactOptionalPropertyTypes (#450): `RequestInit.body` is
+    // `BodyInit | null`, not optional-`undefined`. Only set the key
+    // when we actually have a body so we don't pass `body: undefined`
+    // (rejected under the stricter contract).
     return this.fetchImpl(`${this.baseUrl}/api/v1${path}`, {
       method,
-      body: init.body,
       headers,
+      ...(init.body !== undefined ? { body: init.body } : {}),
     });
   }
 }
@@ -274,12 +278,17 @@ async function parseError(res: Response): Promise<OrnnError> {
 
 function buildError(status: number, body: ProblemJson | null): OrnnError {
   if (body && (body.code || body.detail || body.title)) {
+    // exactOptionalPropertyTypes (#450): only stamp `requestId` /
+    // `errors` keys when the upstream actually provided them — the
+    // payload type is `requestId?: string`, not `string | undefined`,
+    // so `{ requestId: undefined }` is a type error under the
+    // stricter contract.
     const payload: OrnnErrorPayload = {
       status: body.status ?? status,
       code: body.code ?? "unknown_error",
       message: body.detail ?? body.title ?? `Ornn API returned ${status}`,
-      requestId: body.requestId,
-      errors: body.errors,
+      ...(body.requestId !== undefined ? { requestId: body.requestId } : {}),
+      ...(body.errors !== undefined ? { errors: body.errors } : {}),
     };
     return new OrnnError(payload);
   }

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -32,7 +32,11 @@ export class OrnnError extends Error implements OrnnErrorPayload {
     this.name = "OrnnError";
     this.status = payload.status;
     this.code = payload.code;
-    this.requestId = payload.requestId;
-    this.errors = payload.errors;
+    // exactOptionalPropertyTypes (#450): `{ foo?: string }` no longer
+    // accepts an assignment of `string | undefined`. Only assign when
+    // the upstream value is actually set so we don't materialise an
+    // `undefined`-valued key.
+    if (payload.requestId !== undefined) this.requestId = payload.requestId;
+    if (payload.errors !== undefined) this.errors = payload.errors;
   }
 }

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["ES2022", "DOM"],
     "strict": true,
     "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

Closes the bulk of #450 (part 1 — \`noImplicitOverride\` — landed in #638):

- **All 3 packages: \`noUncheckedIndexedAccess: true\`** — array/object bracket access now widens to \`T | undefined\`, forcing explicit handling.
- **SDK only: \`exactOptionalPropertyTypes: true\`** — \`{ foo?: T }\` no longer accepts \`{ foo: undefined }\`. 4 fix sites.

### Why \`exactOptionalPropertyTypes\` is deferred for backend + web

It surfaces a class of errors (\`{ requestId: undefined }\`-style assignments to \`{ requestId?: T }\` fields) that needs per-site decisions, not mechanical fixes:

- **ornn-api**: ~77 errors. Mostly class constructors that take \`{ saTokenProvider?: T }\` deps and then \`this.saTokenProvider = deps.saTokenProvider\`. Each one needs a conditional spread, widened field type, or refactor.
- **ornn-web**: ~134 errors across many files. Route handlers building params objects with \`{ note: string | undefined }\` from form data passed to services that take \`{ note?: string }\`.

Tracked as **#657 follow-up**.

## Fix pattern categories (\`noUncheckedIndexedAccess\`)

| Pattern | Marker | Examples |
|---|---|---|
| Length-guarded access | \`xs[i]!\` + 1-line comment | \`enabledList.length === 0\` → return; then \`enabledList[0]!\`. Test-file pin lookups follow the same shape. |
| Regex capture groups | \`match[1]!\` + 1-line comment | FRONTMATTER_REGEX, JWT decode, CIDR parser, mapped-form ipv6 |
| Defensive \`!entry\` skip | \`if (!entry) continue\` | \`zip.files[path]\` where path came from \`Object.keys(zip.files)\` — keeps reads safe under a future zip-lib regression |
| Two non-mechanical | — | GenerateSkillModal.STEP_MESSAGES \`as const\`; SkillDetailPage.latestVersion \`?? ""\` |

## Commits (one per package + changeset)

| # | Commit | Files |
|---|---|---|
| 1 | \`a6a647b\` — SDK noUncheckedIndexedAccess + exactOptionalPropertyTypes | 3 |
| 2 | \`9d25b46\` — ornn-api noUncheckedIndexedAccess (68 fix sites) | 26 |
| 3 | \`dfd0c5e\` — ornn-web noUncheckedIndexedAccess (57 fix sites) | 22 |
| 4 | \`711b2e2\` — changeset | 1 |

## Test plan

- [x] \`bun run typecheck\` — clean (all 3 packages)
- [x] \`bun test\` — 793 backend + 110 web + 17 sdk = 920 tests pass, 0 fail
- [ ] CI runs the same suite + lint + docker-build
- [ ] Deploy to local k8s cluster + smoke /api/v1/livez + /api/v1/readyz (the new strict flag is compile-time, so runtime behavior is unchanged — smoke confirms boot)

#450 stays open until #657's \`exactOptionalPropertyTypes\` work lands on backend + web. Related to #657.