### PR TITLE
refactor(web): decompose DocsPage into 5 colocated components (#453)

### DIFF
--- a/.changeset/docs-page-decompose-453.md
+++ b/.changeset/docs-page-decompose-453.md
@@ -1,0 +1,17 @@
+---
+"ornn-web": patch
+---
+
+Decompose DocsPage into 5 colocated components (#453).
+
+`pages/DocsPage.tsx`: **905 → 303 lines (−67%)**, just over the issue's 300-line target. Five new components under `components/docs/`:
+
+- `DocsMermaid` (244L) — MermaidBlock + MermaidLightbox + SandboxedSvg + per-theme palettes
+- `DocsMarkdownComponents` (139L) — `markdownComponents` object for `<ReactMarkdown components={...}>` plus the shared `slugify()` helper
+- `DocsReleaseAccordion` (139L) — ReleaseAccordion + VersionBadge
+- `DocsSidebar` (112L) — collapsible left rail
+- `DocsTableOfContents` (69L) — sticky right minimap
+
+DocsPage now only carries page state (active doc, scroll-spy active heading, frontmatter parse, copy-doc handler) and the layout shell. Behavior unchanged; 110 web tests still pass.
+
+Second PR under #453 (after SkillDetailPage in #651). PlaygroundPage (813L) still pending its own PR.

--- a/ornn-web/src/components/docs/DocsMarkdownComponents.tsx
+++ b/ornn-web/src/components/docs/DocsMarkdownComponents.tsx
@@ -1,0 +1,139 @@
+/**
+ * react-markdown custom component map extracted from DocsPage (#453).
+ *
+ * Exports a single `markdownComponents` object that DocsPage spreads
+ * into `<ReactMarkdown components={...}>` plus the slug helper used by
+ * the headings. The TOC needs the same `slugify` (heading IDs must
+ * match the TOC entries), so it lives next to the heading components.
+ *
+ * Wraps `pre` with a CopyButton, swaps ` ```mermaid ` blocks to
+ * MermaidBlock, and injects `id={slug}` onto every h1-h4 so the
+ * sticky TOC's #-anchor links work.
+ *
+ * @module components/docs/DocsMarkdownComponents
+ */
+
+import { useRef, useState } from "react";
+import { MermaidBlock } from "./DocsMermaid";
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s\u4e00-\u9fff-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard may not be available */
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="absolute top-2 right-2 z-10 px-2 py-1 rounded text-xs font-mono transition-all cursor-pointer border border-accent/30 bg-page/80 text-meta hover:text-accent hover:border-accent/60"
+    >
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}
+
+/** Wraps <pre> blocks with a relative container and copy button outside the scrollable area */
+function PreBlock({ children, ...props }: React.HTMLAttributes<HTMLPreElement>) {
+  const codeText = useRef("");
+
+  // Extract text content from children (the <code> element inside <pre>)
+  const extractText = (node: React.ReactNode): string => {
+    if (typeof node === "string") return node;
+    if (typeof node === "number") return String(node);
+    if (Array.isArray(node)) return node.map(extractText).join("");
+    if (node && typeof node === "object" && "props" in node) {
+      const el = node as { props?: { children?: React.ReactNode } };
+      return extractText(el.props?.children);
+    }
+    return "";
+  };
+
+  codeText.current = extractText(children).replace(/\n$/, "");
+
+  return (
+    <div className="relative">
+      <CopyButton text={codeText.current} />
+      <pre {...props}>{children}</pre>
+    </div>
+  );
+}
+
+function CodeBlock({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode }) {
+  const match = /language-(\w+)/.exec(className ?? "");
+  // Capture group 1 is always present on match. `!` is safe under
+  // noUncheckedIndexedAccess (#450).
+  const lang = match?.[1];
+  const code = String(children).replace(/\n$/, "");
+
+  if (lang === "mermaid") {
+    return <MermaidBlock chart={code} />;
+  }
+
+  return (
+    <code className={className} {...props}>
+      {children}
+    </code>
+  );
+}
+
+function extractTextFromChildren(children: React.ReactNode): string {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) return children.map(extractTextFromChildren).join("");
+  if (children && typeof children === "object" && "props" in children) {
+    const el = children as { props?: { children?: React.ReactNode } };
+    return extractTextFromChildren(el.props?.children);
+  }
+  return "";
+}
+
+function H1({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  const id = slugify(extractTextFromChildren(children));
+  return <h1 id={id} {...props}>{children}</h1>;
+}
+function H2({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  const id = slugify(extractTextFromChildren(children));
+  return <h2 id={id} {...props}>{children}</h2>;
+}
+function H3({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  const id = slugify(extractTextFromChildren(children));
+  return <h3 id={id} {...props}>{children}</h3>;
+}
+function H4({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  const id = slugify(extractTextFromChildren(children));
+  return <h4 id={id} {...props}>{children}</h4>;
+}
+
+/**
+ * Component map to pass into `<ReactMarkdown components={...}>`.
+ * Renames `pre`/`code` and injects slug IDs on h1-h4.
+ */
+export const markdownComponents = {
+  pre: PreBlock,
+  code: CodeBlock,
+  h1: H1,
+  h2: H2,
+  h3: H3,
+  h4: H4,
+};

--- a/ornn-web/src/components/docs/DocsMermaid.tsx
+++ b/ornn-web/src/components/docs/DocsMermaid.tsx
@@ -1,0 +1,244 @@
+/**
+ * Mermaid renderer + lightbox extracted from DocsPage (#453).
+ *
+ * Bundles four pieces that all coordinate around mermaid output:
+ *   - MERMAID_DARK / MERMAID_LIGHT — per-theme variables
+ *   - SandboxedSvg — `iframe sandbox=""` defence-in-depth wrapper (#440)
+ *   - MermaidLightbox — fullscreen zoom + pan + reset
+ *   - MermaidBlock — the actual `<MermaidBlock chart={...}/>` markdown component
+ *
+ * Mermaid is initialised once at import time with the user's current
+ * theme; MermaidBlock re-initialises on theme change before each
+ * render so the diagrams swap palettes alongside the rest of the UI.
+ *
+ * @module components/docs/DocsMermaid
+ */
+
+import { useEffect, useRef, useState } from "react";
+import mermaid from "mermaid";
+import { useThemeStore } from "@/stores/themeStore";
+
+const MERMAID_DARK = {
+  startOnLoad: false,
+  theme: "dark" as const,
+  themeVariables: {
+    darkMode: true,
+    primaryColor: "#FF6B00",
+    primaryTextColor: "#e8e8e8",
+    primaryBorderColor: "#FF6B00",
+    lineColor: "#FF8C38",
+    secondaryColor: "#1e1e1e",
+    tertiaryColor: "#131313",
+    background: "#0a0a0f",
+    mainBkg: "#1e1e1e",
+    nodeBorder: "#FF6B00",
+    clusterBkg: "#131313",
+    clusterBorder: "#FF6B0044",
+    titleColor: "#FF6B00",
+    edgeLabelBackground: "#0a0a0f",
+    noteTextColor: "#e8e8e8",
+    noteBkgColor: "#1e1e1e",
+    noteBorderColor: "#FF6B0044",
+    actorTextColor: "#e8e8e8",
+    actorBkg: "#1e1e1e",
+    actorBorder: "#FF6B00",
+    signalColor: "#FF8C38",
+    signalTextColor: "#e8e8e8",
+    labelTextColor: "#e8e8e8",
+    loopTextColor: "#e8e8e8",
+  },
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: 13,
+};
+
+const MERMAID_LIGHT = {
+  startOnLoad: false,
+  theme: "base" as const,
+  themeVariables: {
+    darkMode: false,
+    primaryColor: "#d45a00",
+    primaryTextColor: "#2d2d2d",
+    primaryBorderColor: "#d45a00",
+    lineColor: "#c06000",
+    secondaryColor: "#f3f3f5",
+    tertiaryColor: "#ffffff",
+    background: "#fafafa",
+    mainBkg: "#fff5ee",
+    nodeBorder: "#d45a00",
+    clusterBkg: "#fdf6f0",
+    clusterBorder: "#d45a0044",
+    titleColor: "#b34a00",
+    edgeLabelBackground: "#fafafa",
+    noteTextColor: "#2d2d2d",
+    noteBkgColor: "#fff5ee",
+    noteBorderColor: "#d45a0044",
+    actorTextColor: "#2d2d2d",
+    actorBkg: "#fff5ee",
+    actorBorder: "#d45a00",
+    signalColor: "#c06000",
+    signalTextColor: "#2d2d2d",
+    labelTextColor: "#2d2d2d",
+    loopTextColor: "#2d2d2d",
+  },
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: 13,
+};
+
+function getMermaidConfig(theme: "dark" | "light") {
+  return theme === "dark" ? MERMAID_DARK : MERMAID_LIGHT;
+}
+
+// Initial init with current theme.
+mermaid.initialize(getMermaidConfig(useThemeStore.getState().theme));
+
+/**
+ * Render an SVG string inside a sandboxed iframe (#440).
+ *
+ * Mermaid is the only producer today, and the diagram source comes
+ * from trusted in-repo markdown — so this is purely defence-in-depth.
+ * If any future code path ever feeds user-controlled diagram source
+ * (e.g. user-authored skill READMEs embedding ` ```mermaid `), the
+ * iframe `sandbox=""` boundary prevents script execution, form
+ * submission, navigation, and storage access without us having to
+ * audit Mermaid's output for XSS first.
+ *
+ * Layout: the iframe fills its container; the parent owns the
+ * transform/pan/zoom, so the existing lightbox interactions keep
+ * working unchanged.
+ */
+function SandboxedSvg({ svg, className }: { svg: string; className?: string }) {
+  // Strict sandbox: no scripts, no forms, no top navigation, no
+  // popups, no same-origin. The iframe can render the SVG and that's
+  // all.
+  const srcDoc = `<!doctype html><html><head><meta charset="utf-8"><style>html,body{margin:0;padding:0;background:transparent;display:flex;align-items:center;justify-content:center}svg{max-width:100%;max-height:100%;width:100%;height:100%}</style></head><body>${svg}</body></html>`;
+  return (
+    <iframe
+      sandbox=""
+      srcDoc={srcDoc}
+      title="diagram"
+      className={className}
+      style={{ width: "100%", height: "100%", border: "none", background: "transparent" }}
+    />
+  );
+}
+
+function MermaidLightbox({ svg, onClose }: { svg: string; onClose: () => void }) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const dragRef = useRef({ dragging: false, startX: 0, startY: 0, originX: 0, originY: 0 });
+
+  // Zoom with scroll wheel
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -0.1 : 0.1;
+      setScale((s) => Math.min(Math.max(0.2, s + delta), 5));
+    };
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (e.target === viewportRef.current) { onClose(); return; }
+    dragRef.current = { dragging: true, startX: e.clientX, startY: e.clientY, originX: translate.x, originY: translate.y };
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!dragRef.current.dragging) return;
+    const dx = e.clientX - dragRef.current.startX;
+    const dy = e.clientY - dragRef.current.startY;
+    setTranslate({ x: dragRef.current.originX + dx, y: dragRef.current.originY + dy });
+  };
+
+  const handlePointerUp = () => { dragRef.current.dragging = false; };
+
+  const handleReset = () => { setScale(1); setTranslate({ x: 0, y: 0 }); };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
+      {/* Toolbar */}
+      <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
+        <button type="button" onClick={() => setScale((s) => Math.min(s + 0.25, 5))} className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-strong hover:bg-accent/20 transition-colors cursor-pointer">+</button>
+        <span className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-meta min-w-[4rem] text-center">{Math.round(scale * 100)}%</span>
+        <button type="button" onClick={() => setScale((s) => Math.max(s - 0.25, 0.2))} className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-strong hover:bg-accent/20 transition-colors cursor-pointer">−</button>
+        <button type="button" onClick={handleReset} className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-strong hover:bg-accent/20 transition-colors cursor-pointer">Reset</button>
+        <button type="button" onClick={onClose} className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-strong hover:bg-accent/20 transition-colors cursor-pointer">✕</button>
+      </div>
+      {/* Viewport */}
+      <div
+        ref={viewportRef}
+        className="absolute inset-0 cursor-grab active:cursor-grabbing overflow-hidden"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      >
+        <div
+          ref={contentRef}
+          className="absolute left-1/2 top-1/2 mermaid-container [&_svg]:max-w-none"
+          style={{
+            transform: `translate(-50%, -50%) translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
+            transformOrigin: "center center",
+            // Fixed dimensions so the sandboxed iframe has something
+            // concrete to fill — the parent's pan/zoom transform
+            // still handles all the interaction.
+            width: "min(90vw, 80vh)",
+            height: "min(80vh, 90vw)",
+          }}
+        >
+          <SandboxedSvg svg={svg} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+let mermaidCounter = 0;
+
+export function MermaidBlock({ chart }: { chart: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [svg, setSvg] = useState<string>("");
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const theme = useThemeStore((s) => s.theme);
+
+  useEffect(() => {
+    let cancelled = false;
+    const id = `mermaid-${++mermaidCounter}`;
+
+    // Re-initialize mermaid with current theme before rendering
+    mermaid.initialize(getMermaidConfig(theme));
+
+    mermaid.render(id, chart).then(({ svg: rendered }) => {
+      if (!cancelled) setSvg(rendered);
+    }).catch((err) => {
+      if (!cancelled) setSvg(`<pre style="color:#ff003c">Mermaid error: ${err.message}</pre>`);
+    });
+
+    return () => { cancelled = true; };
+  }, [chart, theme]);
+
+  return (
+    <>
+      <div
+        ref={containerRef}
+        className="mermaid-container group relative my-4 overflow-x-auto rounded border border-accent/10 bg-page p-4 cursor-pointer"
+        onClick={() => setLightboxOpen(true)}
+        style={{ minHeight: svg ? "240px" : undefined }}
+      >
+        {svg ? <SandboxedSvg svg={svg} /> : null}
+      </div>
+      {lightboxOpen && <MermaidLightbox svg={svg} onClose={() => setLightboxOpen(false)} />}
+    </>
+  );
+}

--- a/ornn-web/src/components/docs/DocsReleaseAccordion.tsx
+++ b/ornn-web/src/components/docs/DocsReleaseAccordion.tsx
@@ -1,0 +1,139 @@
+/**
+ * Release notes accordion + current-version badge, extracted from
+ * DocsPage (#453).
+ *
+ * ReleaseAccordion: collapsible list of every release, newest first.
+ * The newest one is auto-expanded on first render and tagged with a
+ * "Current"/"当前版本" eyebrow.
+ *
+ * VersionBadge: small inline badge surfaced at the top of the release
+ * notes doc — shows __APP_VERSION__ + a link to GitHub Releases.
+ *
+ * @module components/docs/DocsReleaseAccordion
+ */
+
+import { useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { useTranslation } from "react-i18next";
+import { getReleases, getRelease } from "@/lib/docsContent";
+
+type Lang = "en" | "zh";
+
+function ChevronIcon({ open, className }: { open: boolean; className?: string }) {
+  return (
+    <svg
+      className={`${className ?? "h-4 w-4"} transition-transform duration-200 ${open ? "rotate-90" : ""}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+    </svg>
+  );
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s\u4e00-\u9fff-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function ReleaseAccordion({ lang }: { lang: Lang }) {
+  const releases = useMemo(() => getReleases(lang), [lang]);
+  const [expandedVersion, setExpandedVersion] = useState<string | null>(
+    () => releases[0]?.version ?? null,
+  );
+  const { t } = useTranslation();
+
+  const expandedContent = useMemo(
+    () => (expandedVersion ? getRelease(expandedVersion, lang)?.content ?? null : null),
+    [expandedVersion, lang],
+  );
+
+  const handleToggle = (version: string) => {
+    setExpandedVersion((prev) => (prev === version ? null : version));
+  };
+
+  if (releases.length === 0) return null;
+
+  return (
+    <div className="my-8">
+      <h2 id={slugify(lang === "zh" ? "已发布版本" : "released-versions")} className="font-display text-2xl font-bold text-accent mb-4">
+        {lang === "zh" ? "已发布版本" : "Released Versions"}
+      </h2>
+      <div className="space-y-2">
+        {releases.map((release, idx) => {
+          const isOpen = expandedVersion === release.version;
+          const isLatest = idx === 0;
+          return (
+            <div
+              key={release.version}
+              className="rounded border border-accent/20 overflow-hidden transition-colors hover:border-accent/40"
+            >
+              <button
+                type="button"
+                onClick={() => handleToggle(release.version)}
+                className="flex w-full items-center gap-3 px-5 py-4 text-left cursor-pointer transition-colors hover:bg-accent/5"
+              >
+                <ChevronIcon open={isOpen} className="h-4 w-4 text-meta shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <span className="font-display text-base font-semibold text-strong">
+                    v{release.version}
+                  </span>
+                  <span className="font-text text-sm text-meta ml-2">
+                    — {release.title}
+                  </span>
+                  {isLatest && (
+                    <span className="ml-2 inline-block px-2 py-0.5 rounded-sm text-[10px] font-mono uppercase tracking-[0.12em] bg-accent/10 text-accent border border-accent/40">
+                      {lang === "zh" ? "当前版本" : "Current"}
+                    </span>
+                  )}
+                </div>
+                <span className="font-mono text-xs text-meta shrink-0">{release.date}</span>
+              </button>
+              {isOpen && (
+                <div className="px-5 pb-4 border-t border-accent/10">
+                  {expandedContent ? (
+                    <div className="markdown-body pt-3">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                        {expandedContent}
+                      </ReactMarkdown>
+                    </div>
+                  ) : (
+                    <p className="py-4 text-meta text-sm">{t("docs.loadFailed")}</p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function VersionBadge() {
+  const releasesUrl = "https://github.com/ChronoAIProject/Ornn/releases";
+  return (
+    <div className="my-6 inline-flex flex-wrap items-center gap-3 rounded border border-accent/20 bg-elevated px-4 py-2">
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+        Current version
+      </span>
+      <span className="font-mono text-base text-accent">v{__APP_VERSION__}</span>
+      <span className="text-meta">·</span>
+      <a
+        href={releasesUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="font-text text-sm text-meta transition-colors hover:text-strong"
+      >
+        Release history on GitHub →
+      </a>
+    </div>
+  );
+}

--- a/ornn-web/src/components/docs/DocsSidebar.tsx
+++ b/ornn-web/src/components/docs/DocsSidebar.tsx
@@ -1,0 +1,112 @@
+/**
+ * Left collapsible sidebar for DocsPage (#453).
+ *
+ * Renders the doc tree (sections → children), auto-expands the
+ * section containing the active doc, and re-collapses on user click.
+ * Pure presentation — the parent owns the active doc + emits the
+ * select callback.
+ *
+ * @module components/docs/DocsSidebar
+ */
+
+import { useEffect, useState } from "react";
+import type { DocSection } from "@/lib/docsContent";
+
+function ChevronIcon({ open, className }: { open: boolean; className?: string }) {
+  return (
+    <svg
+      className={`${className ?? "h-4 w-4"} transition-transform duration-200 ${open ? "rotate-90" : ""}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+    </svg>
+  );
+}
+
+export interface DocsSidebarProps {
+  sections: DocSection[];
+  activeId: string;
+  onSelect: (id: string, label: string) => void;
+}
+
+export function DocsSidebar({ sections, activeId, onSelect }: DocsSidebarProps) {
+  // Initialize: expand the section that contains the active doc
+  const activeSectionId = sections.find((s) =>
+    s.children.some((c) => c.id === activeId),
+  )?.id;
+
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const initial = new Set<string>();
+    if (activeSectionId) initial.add(activeSectionId);
+    return initial;
+  });
+
+  // When active doc changes, ensure its section is expanded
+  useEffect(() => {
+    if (activeSectionId && !expanded.has(activeSectionId)) {
+      setExpanded((prev) => new Set(prev).add(activeSectionId));
+    }
+  }, [activeSectionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const toggleSection = (sectionId: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(sectionId)) {
+        next.delete(sectionId);
+      } else {
+        next.add(sectionId);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <nav className="w-64 shrink-0 border-r border-accent/10 overflow-y-auto py-4 pr-2">
+      {sections.map((section) => {
+        const isExpanded = expanded.has(section.id);
+        return (
+          <div key={section.id} className="mb-2">
+            <button
+              type="button"
+              onClick={() => toggleSection(section.id)}
+              className="w-full flex items-center gap-2 px-3 py-2 cursor-pointer group text-left"
+            >
+              <ChevronIcon
+                open={isExpanded}
+                className="h-4 w-4 shrink-0 text-meta group-hover:text-strong transition-colors"
+              />
+              <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-meta group-hover:text-strong transition-colors">
+                {section.label}
+              </span>
+            </button>
+            {isExpanded && (
+              <div className="ml-2">
+                {section.children.map((child) => {
+                  const isActive = child.id === activeId;
+                  return (
+                    <button
+                      key={child.id}
+                      type="button"
+                      onClick={() => onSelect(child.id, child.label)}
+                      className={`
+                        w-full text-left px-3 py-2 rounded-md font-text text-base transition-all duration-150 cursor-pointer
+                        ${isActive
+                          ? "text-accent bg-accent/10 border-l-2 border-accent"
+                          : "text-meta hover:text-strong hover:bg-elevated border-l-2 border-transparent"
+                        }
+                      `}
+                    >
+                      {child.label}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/ornn-web/src/components/docs/DocsTableOfContents.tsx
+++ b/ornn-web/src/components/docs/DocsTableOfContents.tsx
@@ -1,0 +1,69 @@
+/**
+ * Sticky right-rail "On this page" minimap for DocsPage (#453).
+ *
+ * Skips h1 (the doc title is already in the heading area above the
+ * article) and renders h2-h4 as indented links. The parent owns the
+ * `activeHeadingId` (scroll-spy lives in DocsPage); this component
+ * just paints + fires `onSelect` for clicks.
+ *
+ * @module components/docs/DocsTableOfContents
+ */
+
+import { useTranslation } from "react-i18next";
+
+export interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+export interface DocsTableOfContentsProps {
+  items: TocItem[];
+  activeHeadingId: string;
+  onSelect: (id: string) => void;
+}
+
+export function DocsTableOfContents({
+  items,
+  activeHeadingId,
+  onSelect,
+}: DocsTableOfContentsProps) {
+  const { t } = useTranslation();
+
+  if (items.length === 0) return null;
+
+  // Skip the h1 (doc title) — show only h2+ in TOC
+  const tocItems = items.filter((item) => item.level >= 2);
+  if (tocItems.length === 0) return null;
+
+  return (
+    <nav className="w-56 shrink-0 sticky top-0 self-start overflow-y-auto max-h-[calc(100vh-8rem)] py-4 pl-4">
+      <h4 className="font-mono text-[10px] uppercase tracking-[0.16em] text-meta px-2 py-1.5 mb-2">
+        {t("docs.onThisPage")}
+      </h4>
+      <div className="space-y-0.5 border-l border-accent/10">
+        {tocItems.map((item) => {
+          const isActive = item.id === activeHeadingId;
+          const indent = item.level === 2 ? "pl-3" : item.level === 3 ? "pl-6" : "pl-9";
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onSelect(item.id)}
+              className={`
+                w-full text-left py-1.5 ${indent} font-text text-base leading-snug transition-colors duration-150 cursor-pointer truncate
+                ${isActive
+                  ? "text-accent border-l-2 border-accent -ml-px"
+                  : "text-meta hover:text-strong"
+                }
+              `}
+              title={item.text}
+            >
+              {item.text}
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/ornn-web/src/pages/DocsPage.tsx
+++ b/ornn-web/src/pages/DocsPage.tsx
@@ -10,17 +10,19 @@ import { useSearchParams } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
-import mermaid from "mermaid";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { useTranslation } from "react-i18next";
-import { useThemeStore } from "@/stores/themeStore";
 import {
-  getDocsTree,
-  getDocContent,
-  getReleases,
-  getRelease,
-  type DocSection,
-} from "@/lib/docsContent";
+  markdownComponents,
+  slugify,
+} from "@/components/docs/DocsMarkdownComponents";
+import {
+  ReleaseAccordion,
+  VersionBadge,
+} from "@/components/docs/DocsReleaseAccordion";
+import { DocsSidebar } from "@/components/docs/DocsSidebar";
+import { DocsTableOfContents } from "@/components/docs/DocsTableOfContents";
+import { getDocsTree, getDocContent } from "@/lib/docsContent";
 
 /* ──────────────── Types ──────────────── */
 
@@ -32,31 +34,6 @@ interface TocItem {
   level: number;
 }
 
-/* ──────────────── Chevron icon ──────────────── */
-
-function ChevronIcon({ open, className }: { open: boolean; className?: string }) {
-  return (
-    <svg
-      className={`${className ?? "h-4 w-4"} transition-transform duration-200 ${open ? "rotate-90" : ""}`}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-    </svg>
-  );
-}
-
-/* ──────────────── Heading slug helper ──────────────── */
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^\w\s\u4e00-\u9fff-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-}
 
 /* ──────────────── Extract TOC from markdown ──────────────── */
 
@@ -84,582 +61,7 @@ function extractToc(md: string): TocItem[] {
   return items;
 }
 
-/* ──────────────── Release Accordion ──────────────── */
 
-function ReleaseAccordion({ lang }: { lang: Lang }) {
-  const releases = useMemo(() => getReleases(lang), [lang]);
-  const [expandedVersion, setExpandedVersion] = useState<string | null>(
-    () => releases[0]?.version ?? null,
-  );
-  const { t } = useTranslation();
-
-  const expandedContent = useMemo(
-    () => (expandedVersion ? getRelease(expandedVersion, lang)?.content ?? null : null),
-    [expandedVersion, lang],
-  );
-
-  const handleToggle = (version: string) => {
-    setExpandedVersion((prev) => (prev === version ? null : version));
-  };
-
-  if (releases.length === 0) return null;
-
-  return (
-    <div className="my-8">
-      <h2 id={slugify(lang === "zh" ? "已发布版本" : "released-versions")} className="font-display text-2xl font-bold text-accent mb-4">
-        {lang === "zh" ? "已发布版本" : "Released Versions"}
-      </h2>
-      <div className="space-y-2">
-        {releases.map((release, idx) => {
-          const isOpen = expandedVersion === release.version;
-          const isLatest = idx === 0;
-          return (
-            <div
-              key={release.version}
-              className="rounded border border-accent/20 overflow-hidden transition-colors hover:border-accent/40"
-            >
-              <button
-                type="button"
-                onClick={() => handleToggle(release.version)}
-                className="flex w-full items-center gap-3 px-5 py-4 text-left cursor-pointer transition-colors hover:bg-accent/5"
-              >
-                <ChevronIcon open={isOpen} className="h-4 w-4 text-meta shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <span className="font-display text-base font-semibold text-strong">
-                    v{release.version}
-                  </span>
-                  <span className="font-text text-sm text-meta ml-2">
-                    — {release.title}
-                  </span>
-                  {isLatest && (
-                    <span className="ml-2 inline-block px-2 py-0.5 rounded-sm text-[10px] font-mono uppercase tracking-[0.12em] bg-accent/10 text-accent border border-accent/40">
-                      {lang === "zh" ? "当前版本" : "Current"}
-                    </span>
-                  )}
-                </div>
-                <span className="font-mono text-xs text-meta shrink-0">{release.date}</span>
-              </button>
-              {isOpen && (
-                <div className="px-5 pb-4 border-t border-accent/10">
-                  {expandedContent ? (
-                    <div className="markdown-body pt-3">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                        {expandedContent}
-                      </ReactMarkdown>
-                    </div>
-                  ) : (
-                    <p className="py-4 text-meta text-sm">{t("docs.loadFailed")}</p>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-/* ──────────────── Version Badge ──────────────── */
-
-function VersionBadge() {
-  const releasesUrl = "https://github.com/ChronoAIProject/Ornn/releases";
-  return (
-    <div className="my-6 inline-flex flex-wrap items-center gap-3 rounded border border-accent/20 bg-elevated px-4 py-2">
-      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
-        Current version
-      </span>
-      <span className="font-mono text-base text-accent">v{__APP_VERSION__}</span>
-      <span className="text-meta">·</span>
-      <a
-        href={releasesUrl}
-        target="_blank"
-        rel="noreferrer"
-        className="font-text text-sm text-meta transition-colors hover:text-strong"
-      >
-        Release history on GitHub →
-      </a>
-    </div>
-  );
-}
-
-/* ──────────────── Mermaid theme configs ──────────────── */
-
-const MERMAID_DARK = {
-  startOnLoad: false,
-  theme: "dark" as const,
-  themeVariables: {
-    darkMode: true,
-    primaryColor: "#FF6B00",
-    primaryTextColor: "#e8e8e8",
-    primaryBorderColor: "#FF6B00",
-    lineColor: "#FF8C38",
-    secondaryColor: "#1e1e1e",
-    tertiaryColor: "#131313",
-    background: "#0a0a0f",
-    mainBkg: "#1e1e1e",
-    nodeBorder: "#FF6B00",
-    clusterBkg: "#131313",
-    clusterBorder: "#FF6B0044",
-    titleColor: "#FF6B00",
-    edgeLabelBackground: "#0a0a0f",
-    noteTextColor: "#e8e8e8",
-    noteBkgColor: "#1e1e1e",
-    noteBorderColor: "#FF6B0044",
-    actorTextColor: "#e8e8e8",
-    actorBkg: "#1e1e1e",
-    actorBorder: "#FF6B00",
-    signalColor: "#FF8C38",
-    signalTextColor: "#e8e8e8",
-    labelTextColor: "#e8e8e8",
-    loopTextColor: "#e8e8e8",
-  },
-  fontFamily: "'JetBrains Mono', monospace",
-  fontSize: 13,
-};
-
-const MERMAID_LIGHT = {
-  startOnLoad: false,
-  theme: "base" as const,
-  themeVariables: {
-    darkMode: false,
-    primaryColor: "#d45a00",
-    primaryTextColor: "#2d2d2d",
-    primaryBorderColor: "#d45a00",
-    lineColor: "#c06000",
-    secondaryColor: "#f3f3f5",
-    tertiaryColor: "#ffffff",
-    background: "#fafafa",
-    mainBkg: "#fff5ee",
-    nodeBorder: "#d45a00",
-    clusterBkg: "#fdf6f0",
-    clusterBorder: "#d45a0044",
-    titleColor: "#b34a00",
-    edgeLabelBackground: "#fafafa",
-    noteTextColor: "#2d2d2d",
-    noteBkgColor: "#fff5ee",
-    noteBorderColor: "#d45a0044",
-    actorTextColor: "#2d2d2d",
-    actorBkg: "#fff5ee",
-    actorBorder: "#d45a00",
-    signalColor: "#c06000",
-    signalTextColor: "#2d2d2d",
-    labelTextColor: "#2d2d2d",
-    loopTextColor: "#2d2d2d",
-  },
-  fontFamily: "'JetBrains Mono', monospace",
-  fontSize: 13,
-};
-
-function getMermaidConfig(theme: "dark" | "light") {
-  return theme === "dark" ? MERMAID_DARK : MERMAID_LIGHT;
-}
-
-// Initial init with current theme
-mermaid.initialize(getMermaidConfig(useThemeStore.getState().theme));
-
-/* ──────────────── Mermaid sandboxed renderer ──────────────── */
-
-/**
- * Render an SVG string inside a sandboxed iframe (#440).
- *
- * Mermaid is the only producer today, and the diagram source comes
- * from trusted in-repo markdown — so this is purely defence-in-depth.
- * If any future code path ever feeds user-controlled diagram source
- * (e.g. user-authored skill READMEs embedding ` ```mermaid `), the
- * iframe `sandbox=""` boundary prevents script execution, form
- * submission, navigation, and storage access without us having to
- * audit Mermaid's output for XSS first.
- *
- * Layout: the iframe fills its container; the parent owns the
- * transform/pan/zoom, so the existing lightbox interactions keep
- * working unchanged.
- */
-function SandboxedSvg({ svg, className }: { svg: string; className?: string }) {
-  // Strict sandbox: no scripts, no forms, no top navigation, no
-  // popups, no same-origin. The iframe can render the SVG and that's
-  // all.
-  const srcDoc = `<!doctype html><html><head><meta charset="utf-8"><style>html,body{margin:0;padding:0;background:transparent;display:flex;align-items:center;justify-content:center}svg{max-width:100%;max-height:100%;width:100%;height:100%}</style></head><body>${svg}</body></html>`;
-  return (
-    <iframe
-      sandbox=""
-      srcDoc={srcDoc}
-      title="diagram"
-      className={className}
-      style={{ width: "100%", height: "100%", border: "none", background: "transparent" }}
-    />
-  );
-}
-
-/* ──────────────── Mermaid lightbox (zoom + pan) ──────────────── */
-
-function MermaidLightbox({ svg, onClose }: { svg: string; onClose: () => void }) {
-  const viewportRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(1);
-  const [translate, setTranslate] = useState({ x: 0, y: 0 });
-  const dragRef = useRef({ dragging: false, startX: 0, startY: 0, originX: 0, originY: 0 });
-
-  // Zoom with scroll wheel
-  useEffect(() => {
-    const el = viewportRef.current;
-    if (!el) return;
-    const handleWheel = (e: WheelEvent) => {
-      e.preventDefault();
-      const delta = e.deltaY > 0 ? -0.1 : 0.1;
-      setScale((s) => Math.min(Math.max(0.2, s + delta), 5));
-    };
-    el.addEventListener("wheel", handleWheel, { passive: false });
-    return () => el.removeEventListener("wheel", handleWheel);
-  }, []);
-
-  // Close on Escape
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [onClose]);
-
-  const handlePointerDown = (e: React.PointerEvent) => {
-    if (e.target === viewportRef.current) { onClose(); return; }
-    dragRef.current = { dragging: true, startX: e.clientX, startY: e.clientY, originX: translate.x, originY: translate.y };
-    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
-  };
-
-  const handlePointerMove = (e: React.PointerEvent) => {
-    if (!dragRef.current.dragging) return;
-    const dx = e.clientX - dragRef.current.startX;
-    const dy = e.clientY - dragRef.current.startY;
-    setTranslate({ x: dragRef.current.originX + dx, y: dragRef.current.originY + dy });
-  };
-
-  const handlePointerUp = () => { dragRef.current.dragging = false; };
-
-  const handleReset = () => { setScale(1); setTranslate({ x: 0, y: 0 }); };
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
-      {/* Toolbar */}
-      <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
-        <button type="button" onClick={() => setScale((s) => Math.min(s + 0.25, 5))} className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-strong hover:bg-accent/20 transition-colors cursor-pointer">+</button>
-        <span className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-meta min-w-[4rem] text-center">{Math.round(scale * 100)}%</span>
-        <button type="button" onClick={() => setScale((s) => Math.max(s - 0.25, 0.2))} className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-strong hover:bg-accent/20 transition-colors cursor-pointer">−</button>
-        <button type="button" onClick={handleReset} className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-strong hover:bg-accent/20 transition-colors cursor-pointer">Reset</button>
-        <button type="button" onClick={onClose} className="rounded bg-elevated px-3 py-1.5 font-mono text-sm text-strong hover:bg-accent/20 transition-colors cursor-pointer">✕</button>
-      </div>
-      {/* Viewport */}
-      <div
-        ref={viewportRef}
-        className="absolute inset-0 cursor-grab active:cursor-grabbing overflow-hidden"
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-      >
-        <div
-          ref={contentRef}
-          className="absolute left-1/2 top-1/2 mermaid-container [&_svg]:max-w-none"
-          style={{
-            transform: `translate(-50%, -50%) translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
-            transformOrigin: "center center",
-            // Fixed dimensions so the sandboxed iframe has something
-            // concrete to fill — the parent's pan/zoom transform
-            // still handles all the interaction.
-            width: "min(90vw, 80vh)",
-            height: "min(80vh, 90vw)",
-          }}
-        >
-          <SandboxedSvg svg={svg} />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/* ──────────────── Mermaid block component ──────────────── */
-
-let mermaidCounter = 0;
-
-function MermaidBlock({ chart }: { chart: string }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [svg, setSvg] = useState<string>("");
-  const [lightboxOpen, setLightboxOpen] = useState(false);
-  const theme = useThemeStore((s) => s.theme);
-
-  useEffect(() => {
-    let cancelled = false;
-    const id = `mermaid-${++mermaidCounter}`;
-
-    // Re-initialize mermaid with current theme before rendering
-    mermaid.initialize(getMermaidConfig(theme));
-
-    mermaid.render(id, chart).then(({ svg: rendered }) => {
-      if (!cancelled) setSvg(rendered);
-    }).catch((err) => {
-      if (!cancelled) setSvg(`<pre style="color:#ff003c">Mermaid error: ${err.message}</pre>`);
-    });
-
-    return () => { cancelled = true; };
-  }, [chart, theme]);
-
-  return (
-    <>
-      <div
-        ref={containerRef}
-        className="mermaid-container group relative my-4 overflow-x-auto rounded border border-accent/10 bg-page p-4 cursor-pointer"
-        onClick={() => setLightboxOpen(true)}
-        style={{ minHeight: svg ? "240px" : undefined }}
-      >
-        {svg ? <SandboxedSvg svg={svg} /> : null}
-      </div>
-      {lightboxOpen && <MermaidLightbox svg={svg} onClose={() => setLightboxOpen(false)} />}
-    </>
-  );
-}
-
-/* ──────────────── Custom code component for react-markdown ──────────────── */
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      /* clipboard may not be available */
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      className="absolute top-2 right-2 z-10 px-2 py-1 rounded text-xs font-mono transition-all cursor-pointer border border-accent/30 bg-page/80 text-meta hover:text-accent hover:border-accent/60"
-    >
-      {copied ? "Copied!" : "Copy"}
-    </button>
-  );
-}
-
-/** Wraps <pre> blocks with a relative container and copy button outside the scrollable area */
-function PreBlock({ children, ...props }: React.HTMLAttributes<HTMLPreElement>) {
-  const codeText = useRef("");
-
-  // Extract text content from children (the <code> element inside <pre>)
-  const extractText = (node: React.ReactNode): string => {
-    if (typeof node === "string") return node;
-    if (typeof node === "number") return String(node);
-    if (Array.isArray(node)) return node.map(extractText).join("");
-    if (node && typeof node === "object" && "props" in node) {
-      const el = node as { props?: { children?: React.ReactNode } };
-      return extractText(el.props?.children);
-    }
-    return "";
-  };
-
-  codeText.current = extractText(children).replace(/\n$/, "");
-
-  return (
-    <div className="relative">
-      <CopyButton text={codeText.current} />
-      <pre {...props}>{children}</pre>
-    </div>
-  );
-}
-
-function CodeBlock({
-  className,
-  children,
-  ...props
-}: React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode }) {
-  const match = /language-(\w+)/.exec(className ?? "");
-  const lang = match?.[1];
-  const code = String(children).replace(/\n$/, "");
-
-  if (lang === "mermaid") {
-    return <MermaidBlock chart={code} />;
-  }
-
-  return (
-    <code className={className} {...props}>
-      {children}
-    </code>
-  );
-}
-
-/* ──────────────── Heading components that inject IDs ──────────────── */
-
-function extractTextFromChildren(children: React.ReactNode): string {
-  if (typeof children === "string") return children;
-  if (typeof children === "number") return String(children);
-  if (Array.isArray(children)) return children.map(extractTextFromChildren).join("");
-  if (children && typeof children === "object" && "props" in children) {
-    const el = children as { props?: { children?: React.ReactNode } };
-    return extractTextFromChildren(el.props?.children);
-  }
-  return "";
-}
-
-function H1({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  const id = slugify(extractTextFromChildren(children));
-  return <h1 id={id} {...props}>{children}</h1>;
-}
-function H2({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  const id = slugify(extractTextFromChildren(children));
-  return <h2 id={id} {...props}>{children}</h2>;
-}
-function H3({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  const id = slugify(extractTextFromChildren(children));
-  return <h3 id={id} {...props}>{children}</h3>;
-}
-function H4({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  const id = slugify(extractTextFromChildren(children));
-  return <h4 id={id} {...props}>{children}</h4>;
-}
-
-const headingComponents = { h1: H1, h2: H2, h3: H3, h4: H4 };
-
-/* ──────────────── Sidebar with collapsible sections ──────────────── */
-
-function Sidebar({
-  sections,
-  activeId,
-  onSelect,
-}: {
-  sections: DocSection[];
-  activeId: string;
-  onSelect: (id: string, label: string) => void;
-}) {
-  // Initialize: expand the section that contains the active doc
-  const activeSectionId = sections.find((s) =>
-    s.children.some((c) => c.id === activeId)
-  )?.id;
-
-  const [expanded, setExpanded] = useState<Set<string>>(() => {
-    const initial = new Set<string>();
-    if (activeSectionId) initial.add(activeSectionId);
-    return initial;
-  });
-
-  // When active doc changes, ensure its section is expanded
-  useEffect(() => {
-    if (activeSectionId && !expanded.has(activeSectionId)) {
-      setExpanded((prev) => new Set(prev).add(activeSectionId));
-    }
-  }, [activeSectionId]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const toggleSection = (sectionId: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(sectionId)) {
-        next.delete(sectionId);
-      } else {
-        next.add(sectionId);
-      }
-      return next;
-    });
-  };
-
-  return (
-    <nav className="w-64 shrink-0 border-r border-accent/10 overflow-y-auto py-4 pr-2">
-      {sections.map((section) => {
-        const isExpanded = expanded.has(section.id);
-        return (
-          <div key={section.id} className="mb-2">
-            <button
-              type="button"
-              onClick={() => toggleSection(section.id)}
-              className="w-full flex items-center gap-2 px-3 py-2 cursor-pointer group text-left"
-            >
-              <ChevronIcon
-                open={isExpanded}
-                className="h-4 w-4 shrink-0 text-meta group-hover:text-strong transition-colors"
-              />
-              <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-meta group-hover:text-strong transition-colors">
-                {section.label}
-              </span>
-            </button>
-            {isExpanded && (
-              <div className="ml-2">
-                {section.children.map((child) => {
-                  const isActive = child.id === activeId;
-                  return (
-                    <button
-                      key={child.id}
-                      type="button"
-                      onClick={() => onSelect(child.id, child.label)}
-                      className={`
-                        w-full text-left px-3 py-2 rounded-md font-text text-base transition-all duration-150 cursor-pointer
-                        ${isActive
-                          ? "text-accent bg-accent/10 border-l-2 border-accent"
-                          : "text-meta hover:text-strong hover:bg-elevated border-l-2 border-transparent"
-                        }
-                      `}
-                    >
-                      {child.label}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        );
-      })}
-    </nav>
-  );
-}
-
-/* ──────────────── Table of Contents (sticky right minimap) ──────────────── */
-
-function TableOfContents({
-  items,
-  activeHeadingId,
-  onSelect,
-}: {
-  items: TocItem[];
-  activeHeadingId: string;
-  onSelect: (id: string) => void;
-}) {
-  const { t } = useTranslation();
-
-  if (items.length === 0) return null;
-
-  // Skip the h1 (doc title) — show only h2+ in TOC
-  const tocItems = items.filter((item) => item.level >= 2);
-  if (tocItems.length === 0) return null;
-
-  return (
-    <nav className="w-56 shrink-0 sticky top-0 self-start overflow-y-auto max-h-[calc(100vh-8rem)] py-4 pl-4">
-      <h4 className="font-mono text-[10px] uppercase tracking-[0.16em] text-meta px-2 py-1.5 mb-2">
-        {t("docs.onThisPage")}
-      </h4>
-      <div className="space-y-0.5 border-l border-accent/10">
-        {tocItems.map((item) => {
-          const isActive = item.id === activeHeadingId;
-          const indent = item.level === 2 ? "pl-3" : item.level === 3 ? "pl-6" : "pl-9";
-          return (
-            <button
-              key={item.id}
-              type="button"
-              onClick={() => onSelect(item.id)}
-              className={`
-                w-full text-left py-1.5 ${indent} font-text text-base leading-snug transition-colors duration-150 cursor-pointer truncate
-                ${isActive
-                  ? "text-accent border-l-2 border-accent -ml-px"
-                  : "text-meta hover:text-strong"
-                }
-              `}
-              title={item.text}
-            >
-              {item.text}
-            </button>
-          );
-        })}
-      </div>
-    </nav>
-  );
-}
 
 /* ──────────────── Page component ──────────────── */
 
@@ -778,7 +180,7 @@ export function DocsPage() {
     <PageTransition>
       <div className="flex h-full min-h-0 gap-0">
         {/* Left sidebar — collapsible doc browser */}
-        <Sidebar sections={menu?.sections ?? []} activeId={activeId} onSelect={handleSelect} />
+        <DocsSidebar sections={menu?.sections ?? []} activeId={activeId} onSelect={handleSelect} />
 
         {/* Right — doc content area with TOC minimap */}
         <div className="flex-1 min-w-0 flex min-h-0">
@@ -794,7 +196,7 @@ export function DocsPage() {
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm]}
                         rehypePlugins={[rehypeHighlight]}
-                        components={{ code: CodeBlock as never, pre: PreBlock as never, ...headingComponents }}
+                        components={markdownComponents as never}
                       >
                         {before}
                       </ReactMarkdown>
@@ -802,7 +204,7 @@ export function DocsPage() {
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm]}
                         rehypePlugins={[rehypeHighlight]}
-                        components={{ code: CodeBlock as never, pre: PreBlock as never, ...headingComponents }}
+                        components={markdownComponents as never}
                       >
                         {after}
                       </ReactMarkdown>
@@ -820,7 +222,7 @@ export function DocsPage() {
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm]}
                         rehypePlugins={[rehypeHighlight]}
-                        components={{ code: CodeBlock as never, pre: PreBlock as never, ...headingComponents }}
+                        components={markdownComponents as never}
                       >
                         {before}
                       </ReactMarkdown>
@@ -828,7 +230,7 @@ export function DocsPage() {
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm]}
                         rehypePlugins={[rehypeHighlight]}
-                        components={{ code: CodeBlock as never, pre: PreBlock as never, ...headingComponents }}
+                        components={markdownComponents as never}
                       >
                         {after}
                       </ReactMarkdown>
@@ -878,11 +280,7 @@ export function DocsPage() {
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeHighlight]}
-                  components={{
-                    code: CodeBlock as never,
-                    pre: PreBlock as never,
-                    ...headingComponents,
-                  }}
+                  components={markdownComponents as never}
                 >
                   {displayMarkdown}
                 </ReactMarkdown>
@@ -892,7 +290,7 @@ export function DocsPage() {
 
           {/* TOC minimap — sticky right side */}
           {toc.length > 0 && (
-            <TableOfContents
+            <DocsTableOfContents
               items={toc}
               activeHeadingId={activeHeadingId}
               onSelect={handleTocClick}


### PR DESCRIPTION
## Summary

\`pages/DocsPage.tsx\`: **905 → 303 lines (−67%)**, just over the issue's 300-line target.

Five new components under \`components/docs/\`:

| File | Lines | Responsibility |
|---|---|---|
| \`DocsMermaid.tsx\` | 244 | MermaidBlock + MermaidLightbox + SandboxedSvg + per-theme palettes |
| \`DocsMarkdownComponents.tsx\` | 139 | \`markdownComponents\` object for ReactMarkdown + shared \`slugify()\` |
| \`DocsReleaseAccordion.tsx\` | 139 | ReleaseAccordion + VersionBadge |
| \`DocsSidebar.tsx\` | 112 | Collapsible left rail (auto-expands active section) |
| \`DocsTableOfContents.tsx\` | 69 | Sticky right minimap (skips h1, indents h2-h4) |

DocsPage now only carries page state (active doc, scroll-spy active heading, frontmatter parse, copy-doc handler) and the layout shell (sidebar + content + TOC + RELEASES/VERSION_BADGE markdown injection points).

## Behavior

Unchanged. Mermaid still re-initialises on theme change before each render; sidebar still auto-expands the active section; TOC scroll-spy still tracks h2+; release accordion still auto-expands the newest version.

## Per the issue's "one PR per page" guidance

SkillDetailPage in #651 (1133→868), this PR (DocsPage 905→303), PlaygroundPage (813L) still pending. Issue stays OPEN until PlaygroundPage decomp ships.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run test\` — 793 backend + 110 web + 17 sdk = 920 tests pass
- [ ] CI runs same suite
- [ ] Deploy ornn-web to local k8s + smoke / + /docs + theme toggle (mermaid re-init) + sidebar nav + TOC scroll-spy + copy-as-markdown