### PR TITLE
refactor(web): decompose PlaygroundPage into 6 colocated components (#453)

### DIFF
--- a/.changeset/playground-page-decompose-453.md
+++ b/.changeset/playground-page-decompose-453.md
@@ -1,0 +1,18 @@
+---
+"ornn-web": patch
+---
+
+Decompose PlaygroundPage into 6 colocated components (#453).
+
+`pages/PlaygroundPage.tsx`: **813 → 518 lines (−36%)**. Six new components under `components/playground/`:
+
+- `PlaygroundHelpers` (101L) — pure helpers + `ThinkingBubble` indicator
+- `PlaygroundEmptyHero` (86L) — centered welcome flag + 3 suggestion chips
+- `PlaygroundConversation` (109L) — forwardRef: turns + streaming buffer + file outputs + error banner + scroll anchor
+- `PlaygroundRail` (101L) — fixed right-edge rail with hover-peek + click-to-pin
+- `PlaygroundEnvDrawerBody` (81L) — per-key input list + lock hint
+- `PlaygroundPackageDrawerBody` (79L) — SkillPackagePreview + registry-link footer
+
+PlaygroundPage now carries state plumbing (hooks for skill / package / chat / quota), the drawer outer container, the composer (ChatInput + ModelPicker + QuotaInline), and the early-return states (no-skill / loading / 404 / over-limit). The suggested `usePlaygroundSession()` hook extraction is deferred — would pull queries / chat state / handlers out and likely bring the page under 300L, but the data flow doesn't bisect into a small commit.
+
+Closes the page-component portion of #453 (SkillDetailPage in #651, DocsPage in #659, this PR). Issue stays open for the deferred hook-extraction work.

--- a/ornn-web/src/components/playground/PlaygroundConversation.tsx
+++ b/ornn-web/src/components/playground/PlaygroundConversation.tsx
@@ -1,0 +1,109 @@
+/**
+ * Active-conversation message stream for PlaygroundPage (#453).
+ *
+ * Layout: rendered turns + the currently-streaming assistant buffer +
+ * ThinkingBubble (between submit and the first streamed token) + file
+ * outputs (image inline, others as download links) + error banner +
+ * the bottom anchor div the parent scrolls into view.
+ *
+ * Stateless — the parent owns chat state via `usePlaygroundChat()`
+ * and the scroll-anchor ref.
+ *
+ * @module components/playground/PlaygroundConversation
+ */
+
+import { forwardRef } from "react";
+import { ChatMessage } from "@/components/playground/ChatMessage";
+import { ThinkingBubble } from "@/components/playground/PlaygroundHelpers";
+import type { PlaygroundMessage, ToolCallStatus, FileOutput } from "@/types/playground";
+
+export interface PlaygroundConversationProps {
+  messages: PlaygroundMessage[];
+  isStreaming: boolean;
+  toolCallStatuses: Record<string, ToolCallStatus>;
+  currentAssistantContent: string;
+  fileOutputs: FileOutput[];
+  error: string | null;
+}
+
+export const PlaygroundConversation = forwardRef<HTMLDivElement, PlaygroundConversationProps>(
+  function PlaygroundConversation(
+    {
+      messages,
+      isStreaming,
+      toolCallStatuses,
+      currentAssistantContent,
+      fileOutputs,
+      error,
+    },
+    anchorRef,
+  ) {
+    return (
+      <div className="space-y-3 py-3">
+        {messages.map((msg, idx) => {
+          const isLastAssistant =
+            msg.role === "assistant" &&
+            idx === messages.length - 1 &&
+            isStreaming;
+          return (
+            <ChatMessage
+              key={msg.id}
+              message={msg}
+              toolCallStatuses={toolCallStatuses}
+              isStreaming={isLastAssistant}
+            />
+          );
+        })}
+
+        {currentAssistantContent && (
+          <ChatMessage
+            message={{
+              id: "streaming-buffer",
+              role: "assistant",
+              content: currentAssistantContent,
+            }}
+            toolCallStatuses={toolCallStatuses}
+            isStreaming
+          />
+        )}
+
+        {isStreaming && !currentAssistantContent && <ThinkingBubble />}
+
+        {fileOutputs.map((file, idx) => (
+          <div key={`file-${idx}`} className="flex justify-start">
+            <div className="max-w-[88%] rounded-sm border border-subtle bg-card p-2.5">
+              {file.mimeType.startsWith("image/") ? (
+                <div>
+                  <img
+                    src={`data:${file.mimeType};base64,${file.content}`}
+                    alt={file.path}
+                    className="max-w-full rounded-sm"
+                  />
+                  <p className="mt-1.5 font-mono text-[10px] text-meta">
+                    {file.path} ({Math.round(file.size / 1024)}KB)
+                  </p>
+                </div>
+              ) : (
+                <a
+                  href={`data:${file.mimeType};base64,${file.content}`}
+                  download={file.path.split("/").pop()}
+                  className="font-mono text-xs text-accent hover:underline"
+                >
+                  {file.path} ({Math.round(file.size / 1024)}KB)
+                </a>
+              )}
+            </div>
+          </div>
+        ))}
+
+        {error && (
+          <div className="rounded-sm border border-danger/30 bg-danger/5 px-3 py-2.5">
+            <p className="font-text text-xs text-danger">{error}</p>
+          </div>
+        )}
+
+        <div ref={anchorRef} />
+      </div>
+    );
+  },
+);

--- a/ornn-web/src/components/playground/PlaygroundEmptyHero.tsx
+++ b/ornn-web/src/components/playground/PlaygroundEmptyHero.tsx
@@ -1,0 +1,86 @@
+/**
+ * Empty-state hero for PlaygroundPage (#453).
+ *
+ * ChatGPT-style centered welcome flag: skill name eyebrow + headline +
+ * lead sentence (swaps to an env-vars-first message when the skill
+ * needs runtime vars that aren't filled yet) + three suggestion chips
+ * + a drawer-discovery footer note. Disabled state on the chips
+ * mirrors the chat-input lock so users see the same gate from both
+ * surfaces.
+ *
+ * Stateless — the parent owns the starters list + click handler +
+ * envIncomplete flag.
+ *
+ * @module components/playground/PlaygroundEmptyHero
+ */
+
+import { useTranslation } from "react-i18next";
+import type { PromptStarter } from "./PlaygroundHelpers";
+
+export interface PlaygroundEmptyHeroProps {
+  skillName: string | null;
+  envIncomplete: boolean;
+  starters: PromptStarter[];
+  onStarterClick: (body: string) => void;
+}
+
+export function PlaygroundEmptyHero({
+  skillName,
+  envIncomplete,
+  starters,
+  onStarterClick,
+}: PlaygroundEmptyHeroProps) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex h-full flex-col items-center justify-center py-8">
+      <div className="w-full space-y-6 text-center">
+        <div className="space-y-2">
+          <div className="font-mono text-[10px] uppercase tracking-[0.20em] text-meta">
+            {skillName}
+          </div>
+          <h2 className="font-display text-3xl font-semibold leading-[1.15] tracking-tight text-strong">
+            {t("playground.heroTitle", "Probe the skill.")}
+          </h2>
+          <p className="font-text text-[15px] leading-relaxed text-body">
+            {envIncomplete
+              ? t(
+                  "playground.heroEnvFirst",
+                  "Set the runtime env vars in the Env drawer on the right, then start chatting.",
+                )
+              : t(
+                  "playground.heroSubtitle",
+                  "Ask anything about {{name}}, or have it run with sample input.",
+                  { name: skillName },
+                )}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          {starters.map((s) => (
+            <button
+              key={s.label}
+              type="button"
+              onClick={() => onStarterClick(s.body)}
+              disabled={envIncomplete}
+              className="group flex flex-col items-start gap-1 rounded-xl border border-subtle bg-card/60 px-3.5 py-3 text-left transition-all hover:border-accent/60 hover:bg-card disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent">
+                {s.label}
+              </span>
+              <span className="line-clamp-2 font-text text-[13px] leading-snug text-body">
+                {s.body}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta/70">
+          {t(
+            "playground.drawerHint",
+            "Skill · Env · Package on the right edge",
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ornn-web/src/components/playground/PlaygroundEnvDrawerBody.tsx
+++ b/ornn-web/src/components/playground/PlaygroundEnvDrawerBody.tsx
@@ -1,0 +1,81 @@
+/**
+ * Env-vars drawer body extracted from PlaygroundPage (#453).
+ *
+ * Per-key input list with a "Set"/"Required" pill on each row + a
+ * one-line lock hint when any required key is empty. Stateless — the
+ * parent owns the values dict and the change handler.
+ *
+ * @module components/playground/PlaygroundEnvDrawerBody
+ */
+
+import { useTranslation } from "react-i18next";
+
+export interface PlaygroundEnvDrawerBodyProps {
+  envVarKeys: string[];
+  envVars: Record<string, string>;
+  allEnvVarsFilled: boolean;
+  onEnvVarChange: (key: string, value: string) => void;
+}
+
+export function PlaygroundEnvDrawerBody({
+  envVarKeys,
+  envVars,
+  allEnvVarsFilled,
+  onEnvVarChange,
+}: PlaygroundEnvDrawerBodyProps) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Header strip — same flat voice as the skill drawer. */}
+      <div className="shrink-0 border-b border-subtle bg-elevated/30 px-5 py-4">
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+          [§&nbsp;{t("playground.envVars")}]
+        </div>
+        <p className="mt-2 font-text text-sm leading-relaxed text-body">
+          {t("playground.envVarsDesc")}
+        </p>
+      </div>
+
+      {/* Form */}
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-4">
+        {envVarKeys.map((key) => {
+          const filled = !!envVars[key]?.trim();
+          return (
+            <div key={key} className="space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <label
+                  className="block min-w-0 flex-1 truncate font-mono text-[11px] text-strong"
+                  title={key}
+                >
+                  {key}
+                </label>
+                <span
+                  className={`shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] ${
+                    filled ? "text-success" : "text-meta"
+                  }`}
+                >
+                  {filled ? t("common.set") : t("common.required")}
+                </span>
+              </div>
+              <input
+                type="text"
+                value={envVars[key] ?? ""}
+                onChange={(e) => onEnvVarChange(key, e.target.value)}
+                placeholder={t("playground.enterValue")}
+                className="w-full rounded-sm border border-subtle bg-page px-2.5 py-1.5 font-mono text-xs text-strong placeholder:text-meta/50 focus:border-accent/60 focus:outline-none"
+              />
+            </div>
+          );
+        })}
+        {!allEnvVarsFilled && (
+          <p className="pt-2 font-text text-[11px] leading-relaxed text-meta">
+            {t(
+              "playground.envVarsLockHint",
+              "Chat is locked until every required env var has a value.",
+            )}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ornn-web/src/components/playground/PlaygroundHelpers.tsx
+++ b/ornn-web/src/components/playground/PlaygroundHelpers.tsx
@@ -1,0 +1,101 @@
+/**
+ * Small helpers + ThinkingBubble extracted from PlaygroundPage (#453).
+ *
+ * - `extractEnvVarKeys(metadata)` — pulls the unique `env.var` keys
+ *   out of every runtime in a skill's metadata.
+ * - `isRuntimeBased(metadata)` — true when the skill needs the
+ *   sandbox (category "runtime-based" or "mixed"). Drives whether the
+ *   Env drawer is offered + locks chat until vars are filled.
+ * - `defaultPromptStarters(skillName, t)` — the three suggestion chips
+ *   shown in the empty-state hero.
+ * - `ThinkingBubble` — pre-token streaming indicator.
+ *
+ * @module components/playground/PlaygroundHelpers
+ */
+
+import { motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+
+export type TFunc = ReturnType<typeof import("react-i18next").useTranslation>["t"];
+
+export interface PromptStarter {
+  label: string;
+  body: string;
+}
+
+/** Extract env var keys from skill metadata. */
+export function extractEnvVarKeys(metadata: Record<string, unknown> | null): string[] {
+  if (!metadata) return [];
+  const runtimes = metadata.runtimes as Array<{ envs?: Array<{ var: string }> }> | undefined;
+  if (!runtimes?.length) return [];
+  const keys: string[] = [];
+  for (const rt of runtimes) {
+    if (rt.envs) {
+      for (const env of rt.envs) {
+        if (env.var && !keys.includes(env.var)) {
+          keys.push(env.var);
+        }
+      }
+    }
+  }
+  return keys;
+}
+
+/** Check if skill is runtime-based. */
+export function isRuntimeBased(metadata: Record<string, unknown> | null): boolean {
+  if (!metadata) return false;
+  const category = metadata.category as string;
+  return category === "runtime-based" || category === "mixed";
+}
+
+/** Default suggestion chips on the empty-state hero. */
+export function defaultPromptStarters(skillName: string, t: TFunc): PromptStarter[] {
+  return [
+    {
+      label: t("playground.starter1Label", "Walk me through it"),
+      body: t(
+        "playground.starter1Body",
+        "Walk me through what `{{name}}` does and the main ways I'd use it.",
+        { name: skillName },
+      ),
+    },
+    {
+      label: t("playground.starter2Label", "Show an example"),
+      body: t(
+        "playground.starter2Body",
+        "Give me a concrete usage example for `{{name}}` — make up sample input and run it.",
+        { name: skillName },
+      ),
+    },
+    {
+      label: t("playground.starter3Label", "List capabilities"),
+      body: t(
+        "playground.starter3Body",
+        "List every capability `{{name}}` exposes, with a one-line description for each.",
+        { name: skillName },
+      ),
+    },
+  ];
+}
+
+/** Pre-token streaming indicator — three pulsing ember dots, spring-in. */
+export function ThinkingBubble() {
+  const { t } = useTranslation();
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.96 }}
+      transition={{ type: "spring", stiffness: 320, damping: 28, mass: 0.6 }}
+      className="flex justify-start"
+    >
+      <div className="rounded-2xl border border-subtle bg-card px-4 py-3">
+        <div className="flex items-center gap-1.5" aria-label={t("aria.generating")}>
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "0ms" }} />
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "150ms" }} />
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "300ms" }} />
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/ornn-web/src/components/playground/PlaygroundPackageDrawerBody.tsx
+++ b/ornn-web/src/components/playground/PlaygroundPackageDrawerBody.tsx
@@ -1,0 +1,79 @@
+/**
+ * Package drawer body extracted from PlaygroundPage (#453).
+ *
+ * Renders the skill package preview (file tree + viewer) inside the
+ * drawer, with a footer that pins a registry link to the bottom. The
+ * preview is read-only; the parent owns the files + contents +
+ * metadata and the package-loading flag.
+ *
+ * @module components/playground/PlaygroundPackageDrawerBody
+ */
+
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
+import type { FileNode } from "@/components/editor/FileTree";
+import type { SkillMetadata } from "@/types/skillPackage";
+
+export interface PlaygroundPackageDrawerBodyProps {
+  packageLoading: boolean;
+  packageFiles: FileNode[];
+  /** Matches `useSkillPackage().fileContents` shape (path → text). */
+  packageContents: Map<string, string>;
+  /** `null` while the skill is still loading; SkillPackagePreview tolerates either. */
+  previewMetadata: SkillMetadata | null;
+  /** When present, the footer shows `name@vversion` + a link to the registry. */
+  skill: { name: string; version: string } | null | undefined;
+}
+
+export function PlaygroundPackageDrawerBody({
+  packageLoading,
+  packageFiles,
+  packageContents,
+  previewMetadata,
+  skill,
+}: PlaygroundPackageDrawerBodyProps) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Padded content area — must itself be a flex column so the
+          preview's `flex-1 min-h-0` actually claims the remaining
+          height and the file viewer scrolls internally instead of
+          bleeding past the footer. */}
+      <div className="flex min-h-0 flex-1 flex-col p-4">
+        {packageLoading ? (
+          <Skeleton lines={8} />
+        ) : packageFiles.length > 0 ? (
+          <SkillPackagePreview
+            files={packageFiles}
+            fileContents={packageContents}
+            metadata={previewMetadata}
+            editable={false}
+            className="min-h-0 flex-1"
+          />
+        ) : (
+          <div className="flex h-32 items-center justify-center">
+            <p className="font-text text-xs text-meta">{t("playground.noPackage")}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Footer — registry link pinned at the bottom, matching the
+          Skill drawer's pattern. */}
+      {skill && (
+        <div className="flex shrink-0 items-center justify-between border-t border-subtle bg-elevated/30 px-5 py-3">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
+            {skill.name}@v{skill.version}
+          </span>
+          <Link
+            to={`/skills/${encodeURIComponent(skill.name)}`}
+            className="font-mono text-[11px] text-accent hover:underline"
+          >
+            {t("playground.openInRegistry", "Open in registry →")}
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ornn-web/src/components/playground/PlaygroundRail.tsx
+++ b/ornn-web/src/components/playground/PlaygroundRail.tsx
@@ -1,0 +1,101 @@
+/**
+ * Right-edge drawer rail extracted from PlaygroundPage (#453).
+ *
+ * Always-visible vertical strip with one tab per drawer. Each tab has:
+ *   - hover-peek: opens its drawer until the cursor leaves the rail
+ *   - click: pins the drawer until the user clicks elsewhere
+ *   - tooltip on the LEFT side that fades in on hover when the drawer
+ *     isn't already open
+ *   - optional warning dot (e.g. env vars incomplete)
+ *   - active-pin marker (a 1px vertical line on the rail edge)
+ *
+ * Stateless — the parent owns activeDrawer + pinnedDrawer + the
+ * open/close handlers.
+ *
+ * @module components/playground/PlaygroundRail
+ */
+
+import type { ComponentType } from "react";
+import type { IconProps } from "@/components/icons";
+
+export type DrawerKey = "package" | "env";
+
+export interface PlaygroundRailTab {
+  key: DrawerKey;
+  ariaLabel: string;
+  tip: string;
+  Icon: ComponentType<IconProps>;
+  /** Render a small warning dot to the left of the icon. */
+  warn?: boolean;
+}
+
+export interface PlaygroundRailProps {
+  tabs: PlaygroundRailTab[];
+  activeDrawer: DrawerKey | null;
+  pinnedDrawer: DrawerKey | null;
+  onHoverOpen: (key: DrawerKey) => void;
+  onHoverCloseScheduled: () => void;
+  onTogglePin: (key: DrawerKey) => void;
+}
+
+export function PlaygroundRail({
+  tabs,
+  activeDrawer,
+  pinnedDrawer,
+  onHoverOpen,
+  onHoverCloseScheduled,
+  onTogglePin,
+}: PlaygroundRailProps) {
+  return (
+    <div
+      className="fixed right-0 top-1/2 z-40 flex -translate-y-1/2 flex-col gap-1"
+      onMouseLeave={onHoverCloseScheduled}
+    >
+      {tabs.map((tab) => {
+        const active = activeDrawer === tab.key;
+        const Icon = tab.Icon;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            onMouseEnter={() => onHoverOpen(tab.key)}
+            onClick={() => onTogglePin(tab.key)}
+            className={`group relative flex h-11 w-9 items-center justify-center rounded-l-sm border-y border-l transition-colors ${
+              active
+                ? "border-accent/60 bg-card text-accent"
+                : "border-subtle bg-card/80 text-meta hover:border-accent/40 hover:text-strong"
+            }`}
+            aria-label={tab.ariaLabel}
+          >
+            <Icon className="h-4 w-4" />
+
+            {/* Horizontal tooltip — fades in on hover when the drawer
+                for this tab is not already open. Matches the drawer
+                header voice `[§ NAME]`. */}
+            {!active && (
+              <span
+                className="pointer-events-none absolute right-full top-1/2 mr-2 -translate-y-1/2 whitespace-nowrap rounded-sm border border-subtle bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-strong opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+                aria-hidden
+              >
+                [§&nbsp;{tab.tip}]
+              </span>
+            )}
+
+            {tab.warn && (
+              <span
+                className="absolute -left-1 top-1.5 h-1.5 w-1.5 rounded-full bg-warning"
+                aria-hidden
+              />
+            )}
+            {pinnedDrawer === tab.key && (
+              <span
+                className="absolute -left-px inset-y-2 w-px bg-accent"
+                aria-hidden
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -18,18 +18,16 @@
  * @module pages/PlaygroundPage
  */
 
-import { useState, useRef, useEffect, useMemo, useCallback, type ComponentType } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { useSearchParams, Link } from "react-router-dom";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { motion, AnimatePresence } from "framer-motion";
 import { PageTransition } from "@/components/layout/PageTransition";
-import { Skeleton } from "@/components/ui/Skeleton";
 import { ChatInput, type ChatInputHandle } from "@/components/playground/ChatInput";
-import { ChatMessage } from "@/components/playground/ChatMessage";
-import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { ModelPicker } from "@/components/models/ModelPicker";
 import { OverLimitPage } from "@/components/quota/OverLimitPage";
 import { QuotaInline } from "@/components/quota/QuotaInline";
-import { EnvIcon, PackageIcon, type IconProps } from "@/components/icons";
+import { EnvIcon, PackageIcon } from "@/components/icons";
 import {
   createDefaultSkillMetadata,
   type SkillMetadata,
@@ -40,85 +38,21 @@ import { useSkillPackage } from "@/hooks/useSkillPackage";
 import { usePlaygroundChat } from "@/hooks/usePlaygroundChat";
 import { useMyQuota } from "@/hooks/useQuota";
 import { useTranslation } from "react-i18next";
+import {
+  extractEnvVarKeys,
+  isRuntimeBased,
+  defaultPromptStarters,
+} from "@/components/playground/PlaygroundHelpers";
+import { PlaygroundEmptyHero } from "@/components/playground/PlaygroundEmptyHero";
+import { PlaygroundEnvDrawerBody } from "@/components/playground/PlaygroundEnvDrawerBody";
+import { PlaygroundPackageDrawerBody } from "@/components/playground/PlaygroundPackageDrawerBody";
+import {
+  PlaygroundRail,
+  type DrawerKey,
+  type PlaygroundRailTab,
+} from "@/components/playground/PlaygroundRail";
+import { PlaygroundConversation } from "@/components/playground/PlaygroundConversation";
 
-/** Extract env var keys from skill metadata */
-function extractEnvVarKeys(metadata: Record<string, unknown> | null): string[] {
-  if (!metadata) return [];
-  const runtimes = metadata.runtimes as Array<{ envs?: Array<{ var: string }> }> | undefined;
-  if (!runtimes?.length) return [];
-  const keys: string[] = [];
-  for (const rt of runtimes) {
-    if (rt.envs) {
-      for (const env of rt.envs) {
-        if (env.var && !keys.includes(env.var)) {
-          keys.push(env.var);
-        }
-      }
-    }
-  }
-  return keys;
-}
-
-/** Check if skill is runtime-based */
-function isRuntimeBased(metadata: Record<string, unknown> | null): boolean {
-  if (!metadata) return false;
-  const category = metadata.category as string;
-  return category === "runtime-based" || category === "mixed";
-}
-
-/** Pre-token streaming indicator — three pulsing ember dots, spring-in. */
-function ThinkingBubble() {
-  const { t } = useTranslation();
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 8, scale: 0.98 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      exit={{ opacity: 0, scale: 0.96 }}
-      transition={{ type: "spring", stiffness: 320, damping: 28, mass: 0.6 }}
-      className="flex justify-start"
-    >
-      <div className="rounded-2xl border border-subtle bg-card px-4 py-3">
-        <div className="flex items-center gap-1.5" aria-label={t("aria.generating")}>
-          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "0ms" }} />
-          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "150ms" }} />
-          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent/70" style={{ animationDelay: "300ms" }} />
-        </div>
-      </div>
-    </motion.div>
-  );
-}
-
-interface PromptStarter {
-  label: string;
-  body: string;
-}
-
-type TFunc = ReturnType<typeof import("react-i18next").useTranslation>["t"];
-
-function defaultPromptStarters(skillName: string, t: TFunc): PromptStarter[] {
-  return [
-    {
-      label: t("playground.starter1Label", "Walk me through it"),
-      body: t("playground.starter1Body", "Walk me through what `{{name}}` does and the main ways I'd use it.", {
-        name: skillName,
-      }),
-    },
-    {
-      label: t("playground.starter2Label", "Show an example"),
-      body: t("playground.starter2Body", "Give me a concrete usage example for `{{name}}` — make up sample input and run it.", {
-        name: skillName,
-      }),
-    },
-    {
-      label: t("playground.starter3Label", "List capabilities"),
-      body: t("playground.starter3Body", "List every capability `{{name}}` exposes, with a one-line description for each.", {
-        name: skillName,
-      }),
-    },
-  ];
-}
-
-type DrawerKey = "package" | "env";
 
 export function PlaygroundPage() {
   const { t } = useTranslation();
@@ -373,13 +307,7 @@ export function PlaygroundPage() {
   // the drawer header `[§ NAME]` voice). The Package drawer now hosts the
   // skill identity (name + category + tags + description) at the top of
   // `SkillPackagePreview`, so a separate Skill tab would be redundant.
-  const railTabs: Array<{
-    key: DrawerKey;
-    ariaLabel: string;
-    tip: string;
-    Icon: ComponentType<IconProps>;
-    warn?: boolean;
-  }> = [
+  const railTabs: PlaygroundRailTab[] = [
     ...(needsEnvVars
       ? [
           {
@@ -434,125 +362,22 @@ export function PlaygroundPage() {
             {/* Messages scroll area */}
             <div ref={messagesScrollRef} className="min-h-0 flex-1 overflow-y-auto pr-1">
               {!conversationActive ? (
-                /* ─── Empty-state hero ─── ChatGPT-style centered prompt
-                    flag with skill identity, single-line lede, and three
-                    starters as soft chips below. Vertical-centered so
-                    the cursor lands ~middle of the screen at rest. */
-                <div className="flex h-full flex-col items-center justify-center py-8">
-                  <div className="w-full space-y-6 text-center">
-                    <div className="space-y-2">
-                      <div className="font-mono text-[10px] uppercase tracking-[0.20em] text-meta">
-                        {skillName}
-                      </div>
-                      <h2 className="font-display text-3xl font-semibold leading-[1.15] tracking-tight text-strong">
-                        {t("playground.heroTitle", "Probe the skill.")}
-                      </h2>
-                      <p className="font-text text-[15px] leading-relaxed text-body">
-                        {envIncomplete
-                          ? t(
-                              "playground.heroEnvFirst",
-                              "Set the runtime env vars in the Env drawer on the right, then start chatting.",
-                            )
-                          : t(
-                              "playground.heroSubtitle",
-                              "Ask anything about {{name}}, or have it run with sample input.",
-                              { name: skillName },
-                            )}
-                      </p>
-                    </div>
-
-                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                      {starters.map((s) => (
-                        <button
-                          key={s.label}
-                          type="button"
-                          onClick={() => handleStarterClick(s.body)}
-                          disabled={envIncomplete}
-                          className="group flex flex-col items-start gap-1 rounded-xl border border-subtle bg-card/60 px-3.5 py-3 text-left transition-all hover:border-accent/60 hover:bg-card disabled:cursor-not-allowed disabled:opacity-40"
-                        >
-                          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-accent">
-                            {s.label}
-                          </span>
-                          <span className="line-clamp-2 font-text text-[13px] leading-snug text-body">
-                            {s.body}
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-
-                    <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta/70">
-                      {t(
-                        "playground.drawerHint",
-                        "Skill · Env · Package on the right edge",
-                      )}
-                    </p>
-                  </div>
-                </div>
+                <PlaygroundEmptyHero
+                  skillName={skillName}
+                  envIncomplete={envIncomplete}
+                  starters={starters}
+                  onStarterClick={handleStarterClick}
+                />
               ) : (
-                /* ─── Conversation ─── */
-                <div className="space-y-3 py-3">
-                  {messages.map((msg, idx) => {
-                    const isLastAssistant =
-                      msg.role === "assistant" &&
-                      idx === messages.length - 1 &&
-                      isStreaming;
-                    return (
-                      <ChatMessage
-                        key={msg.id}
-                        message={msg}
-                        toolCallStatuses={toolCallStatuses}
-                        isStreaming={isLastAssistant}
-                      />
-                    );
-                  })}
-
-                  {currentAssistantContent && (
-                    <ChatMessage
-                      message={{
-                        id: "streaming-buffer",
-                        role: "assistant",
-                        content: currentAssistantContent,
-                      }}
-                      toolCallStatuses={toolCallStatuses}
-                      isStreaming
-                    />
-                  )}
-
-                  {isStreaming && !currentAssistantContent && <ThinkingBubble />}
-
-                  {fileOutputs.map((file, idx) => (
-                    <div key={`file-${idx}`} className="flex justify-start">
-                      <div className="max-w-[88%] rounded-sm border border-subtle bg-card p-2.5">
-                        {file.mimeType.startsWith("image/") ? (
-                          <div>
-                            <img
-                              src={`data:${file.mimeType};base64,${file.content}`}
-                              alt={file.path}
-                              className="max-w-full rounded-sm"
-                            />
-                            <p className="mt-1.5 font-mono text-[10px] text-meta">{file.path} ({Math.round(file.size / 1024)}KB)</p>
-                          </div>
-                        ) : (
-                          <a
-                            href={`data:${file.mimeType};base64,${file.content}`}
-                            download={file.path.split("/").pop()}
-                            className="font-mono text-xs text-accent hover:underline"
-                          >
-                            {file.path} ({Math.round(file.size / 1024)}KB)
-                          </a>
-                        )}
-                      </div>
-                    </div>
-                  ))}
-
-                  {error && (
-                    <div className="rounded-sm border border-danger/30 bg-danger/5 px-3 py-2.5">
-                      <p className="font-text text-xs text-danger">{error}</p>
-                    </div>
-                  )}
-
-                  <div ref={messagesEndRef} />
-                </div>
+                <PlaygroundConversation
+                  ref={messagesEndRef}
+                  messages={messages}
+                  isStreaming={isStreaming}
+                  toolCallStatuses={toolCallStatuses}
+                  currentAssistantContent={currentAssistantContent}
+                  fileOutputs={fileOutputs}
+                  error={error}
+                />
               )}
             </div>
 
@@ -589,56 +414,14 @@ export function PlaygroundPage() {
 
         {/* ─── Right-edge rail (always visible — anchored to viewport
             so it stays put when the page scrolls) ─── */}
-        <div
-          className="fixed right-0 top-1/2 z-40 flex -translate-y-1/2 flex-col gap-1"
-          onMouseLeave={scheduleHoverClose}
-        >
-          {railTabs.map((tab) => {
-            const active = activeDrawer === tab.key;
-            const Icon = tab.Icon;
-            return (
-              <button
-                key={tab.key}
-                type="button"
-                onMouseEnter={() => openHover(tab.key)}
-                onClick={() => togglePin(tab.key)}
-                className={`group relative flex h-11 w-9 items-center justify-center rounded-l-sm border-y border-l transition-colors ${
-                  active
-                    ? "border-accent/60 bg-card text-accent"
-                    : "border-subtle bg-card/80 text-meta hover:border-accent/40 hover:text-strong"
-                }`}
-                aria-label={tab.ariaLabel}
-              >
-                <Icon className="h-4 w-4" />
-
-                {/* Horizontal tooltip — fades in on hover when the drawer
-                    for this tab is not already open. Matches the drawer
-                    header voice `[§ NAME]`. */}
-                {!active && (
-                  <span
-                    className="pointer-events-none absolute right-full top-1/2 mr-2 -translate-y-1/2 whitespace-nowrap rounded-sm border border-subtle bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-strong opacity-0 transition-opacity duration-150 group-hover:opacity-100"
-                    aria-hidden
-                  >
-                    [§&nbsp;{tab.tip}]
-                  </span>
-                )}
-
-                {tab.warn && (
-                  <span
-                    className="absolute -left-1 top-1.5 h-1.5 w-1.5 rounded-full bg-warning"
-                    aria-hidden
-                  />
-                )}
-                {pinnedDrawer === tab.key && (
-                  <span
-                    className="absolute -left-px inset-y-2 w-px bg-accent"
-                    aria-hidden
-                  />
-                )}
-              </button>
-            );
-          })}
-        </div>
+        <PlaygroundRail
+          tabs={railTabs}
+          activeDrawer={activeDrawer}
+          pinnedDrawer={pinnedDrawer}
+          onHoverOpen={openHover}
+          onHoverCloseScheduled={scheduleHoverClose}
+          onTogglePin={togglePin}
+        />
 
         {/* ─── Drawer overlay ─── */}
         <AnimatePresence>
@@ -707,100 +490,22 @@ export function PlaygroundPage() {
                 {/* Drawer body */}
                 <div className="flex min-h-0 flex-1 flex-col">
                   {activeDrawer === "env" && needsEnvVars && (
-                    <div className="flex min-h-0 flex-1 flex-col">
-                      {/* Header strip — same flat voice as the skill drawer. */}
-                      <div className="shrink-0 border-b border-subtle bg-elevated/30 px-5 py-4">
-                        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
-                          [§&nbsp;{t("playground.envVars")}]
-                        </div>
-                        <p className="mt-2 font-text text-sm leading-relaxed text-body">
-                          {t("playground.envVarsDesc")}
-                        </p>
-                      </div>
-
-                      {/* Form */}
-                      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-4">
-                        {envVarKeys.map((key) => {
-                          const filled = !!envVars[key]?.trim();
-                          return (
-                            <div key={key} className="space-y-1">
-                              <div className="flex items-center justify-between gap-2">
-                                <label
-                                  className="block min-w-0 flex-1 truncate font-mono text-[11px] text-strong"
-                                  title={key}
-                                >
-                                  {key}
-                                </label>
-                                <span
-                                  className={`shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] ${
-                                    filled ? "text-success" : "text-meta"
-                                  }`}
-                                >
-                                  {filled ? t("common.set") : t("common.required")}
-                                </span>
-                              </div>
-                              <input
-                                type="text"
-                                value={envVars[key] ?? ""}
-                                onChange={(e) => handleEnvVarChange(key, e.target.value)}
-                                placeholder={t("playground.enterValue")}
-                                className="w-full rounded-sm border border-subtle bg-page px-2.5 py-1.5 font-mono text-xs text-strong placeholder:text-meta/50 focus:border-accent/60 focus:outline-none"
-                              />
-                            </div>
-                          );
-                        })}
-                        {!allEnvVarsFilled && (
-                          <p className="pt-2 font-text text-[11px] leading-relaxed text-meta">
-                            {t(
-                              "playground.envVarsLockHint",
-                              "Chat is locked until every required env var has a value.",
-                            )}
-                          </p>
-                        )}
-                      </div>
-                    </div>
+                    <PlaygroundEnvDrawerBody
+                      envVarKeys={envVarKeys}
+                      envVars={envVars}
+                      allEnvVarsFilled={allEnvVarsFilled}
+                      onEnvVarChange={handleEnvVarChange}
+                    />
                   )}
 
                   {activeDrawer === "package" && (
-                    <div className="flex min-h-0 flex-1 flex-col">
-                      {/* Padded content area — must itself be a flex column
-                          so the preview's `flex-1 min-h-0` actually claims
-                          the remaining height and the file viewer scrolls
-                          internally instead of bleeding past the footer. */}
-                      <div className="flex min-h-0 flex-1 flex-col p-4">
-                        {packageLoading ? (
-                          <Skeleton lines={8} />
-                        ) : packageFiles.length > 0 ? (
-                          <SkillPackagePreview
-                            files={packageFiles}
-                            fileContents={packageContents}
-                            metadata={previewMetadata}
-                            editable={false}
-                            className="min-h-0 flex-1"
-                          />
-                        ) : (
-                          <div className="flex h-32 items-center justify-center">
-                            <p className="font-text text-xs text-meta">{t("playground.noPackage")}</p>
-                          </div>
-                        )}
-                      </div>
-
-                      {/* Footer — registry link pinned at the bottom,
-                          matching the Skill drawer's pattern. */}
-                      {skill && (
-                        <div className="flex shrink-0 items-center justify-between border-t border-subtle bg-elevated/30 px-5 py-3">
-                          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-meta">
-                            {skill.name}@v{skill.version}
-                          </span>
-                          <Link
-                            to={`/skills/${encodeURIComponent(skill.name)}`}
-                            className="font-mono text-[11px] text-accent hover:underline"
-                          >
-                            {t("playground.openInRegistry", "Open in registry →")}
-                          </Link>
-                        </div>
-                      )}
-                    </div>
+                    <PlaygroundPackageDrawerBody
+                      packageLoading={packageLoading}
+                      packageFiles={packageFiles}
+                      packageContents={packageContents}
+                      previewMetadata={previewMetadata}
+                      skill={skill}
+                    />
                   )}
                 </div>
               </motion.aside>


### PR DESCRIPTION
## Summary

\`pages/PlaygroundPage.tsx\`: **813 → 518 lines (−36%)**.

Six new components under \`components/playground/\`:

| File | Lines | Responsibility |
|---|---|---|
| \`PlaygroundHelpers.tsx\` | 101 | Pure helpers (\`extractEnvVarKeys\`, \`isRuntimeBased\`, \`defaultPromptStarters\`) + \`ThinkingBubble\` |
| \`PlaygroundEmptyHero.tsx\` | 86 | Centered welcome flag + 3 suggestion chips (env-aware lead sentence) |
| \`PlaygroundConversation.tsx\` | 109 | \`forwardRef\`: turns + streaming buffer + file outputs (image inline / link) + error + scroll anchor |
| \`PlaygroundRail.tsx\` | 101 | Fixed right-edge rail: hover-peek + click-to-pin + left tooltip + warning dot + active marker |
| \`PlaygroundEnvDrawerBody.tsx\` | 81 | Per-key input list + Set/Required pill + lock hint |
| \`PlaygroundPackageDrawerBody.tsx\` | 79 | \`SkillPackagePreview\` wrapper + registry-link footer |

## What's still inline in PlaygroundPage

State plumbing (queries for skill / package / chat / quota), refs (chat input handle, scroll anchor, scroll-stick tracker), the drawer outer container (\`motion.aside\` + backdrop), the composer (\`ChatInput\` + \`ModelPicker\` + \`QuotaInline\`), and the early-return states (no-skill / loading / 404 / over-limit).

The drawer-outer motion container is hard to bisect cleanly: it owns the close-timer, the AnimatePresence boundary, the pin/unpin button, and the \`[§ NAME]\` header — too many narrow props to pull out without making the contract uglier than the inline version.

## Behavior

Unchanged. The drawer still hover-peeks, click-pins, auto-pins-env-when-incomplete, closes on Esc, and persists the scroll-stick state across token flushes.

## Per the issue's "one PR per page" guidance

SkillDetailPage in #651, DocsPage in #659, this PR closes the **page-component portion** of #453.

Issue stays open for the **deferred \`usePlaygroundSession()\` hook extraction** (suggested in the issue body). That would pull queries / chat state / handlers out of the page entirely and likely bring it under 300L — but the data flow weaves through the JSX layout in ways that don't bisect into a small commit. Lifted as a follow-up rather than bundled here.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run test\` — 793 backend + 110 web + 17 sdk = 920 tests pass
- [ ] CI runs same suite
- [ ] Deploy ornn-web + smoke /playground for a runtime-based skill (env drawer auto-pins, lock hint shows) + a plain skill (env drawer hidden, hero starters enabled) + send a message (conversation renders + scroll-spy stays sticky)