### PR TITLE
chore(infra): direct ornn-api ingress for anonymous browse (#661)

### DIFF
--- a/.changeset/public-api-ingress-661.md
+++ b/.changeset/public-api-ingress-661.md
@@ -1,0 +1,12 @@
+---
+---
+
+Add direct ornn-api ingress that bypasses the NyxID proxy (#661).
+
+The web SPA today routes every backend call through `nyx-api.../api/v1/proxy/s/ornn-api/*`, and that proxy gates every request behind NyxID's auth — even routes that ornn-api itself codes as anonymous-friendly (announcements, skill-search, public skill reads). Net effect: a visitor landing on `ornn.chrono-ai.fun` without login sees the SPA shell but every API call 401s, so News / Registry / Docs pages stay empty (the #467 audit gap).
+
+This change adds `deployment/ornn-api/ingress.yaml` — a dedicated nginx Ingress that exposes ornn-api on its own host (`api.ornn-cluster.local` locally, `ornn-api.chrono-ai.fun` in prod once DNS + TLS land), so anonymous traffic can reach the public-read endpoints without the proxy gate. Authenticated routes (`/admin/*`, `/me/*`, all mutations) still enforce auth via ornn-api's per-route `nyxidAuthMiddleware` when reached this way, so private state isn't exposed by accident.
+
+Verified locally: anonymous `GET /livez`, `GET /api/v1/announcements/active`, and `GET /api/v1/skill-search?q=…` all return 200 through the new ingress.
+
+No package code changed; deployment-side fix only.

--- a/deployment/ornn-api/ingress.yaml
+++ b/deployment/ornn-api/ingress.yaml
@@ -1,0 +1,43 @@
+# Direct ornn-api ingress — bypasses NyxID proxy (#661).
+#
+# The web SPA today calls `nyx-api.chrono-ai.fun/api/v1/proxy/s/ornn-api/*`,
+# which gates every request behind NyxID's auth — even for endpoints that
+# ornn-api itself codes as anonymous-friendly (announcements, skill-search,
+# public skill reads). That's the gap audited in #467: a visitor landing
+# on ornn.chrono-ai.fun without login can see the SPA shell but every
+# API call 401s, so News / Registry / Docs pages stay empty.
+#
+# This ingress exposes ornn-api directly on its own host so anonymous
+# traffic on allowlisted paths can reach the public-read endpoints without
+# the NyxID auth gate. Authenticated routes (admin/*, /me/*, all mutations)
+# still go through NyxID — ornn-api's per-route nyxidAuthMiddleware enforces
+# them when reached this way too, so private state can't be exposed by
+# accident.
+#
+# Local: hits `api.ornn-cluster.local` (add to /etc/hosts).
+# Prod: needs DNS + TLS cert for `ornn-api.chrono-ai.fun` (or sibling host),
+#       handled out of repo by the cluster admin.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ornn-api-ingress
+  namespace: ${NAMESPACE}
+  annotations:
+    # Match ornn-web's body-size + timeout knobs so big skill ZIPs flow
+    # through this surface too when an authenticated client hits it.
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: api.ornn-cluster.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ornn-api
+                port:
+                  number: 3802


### PR DESCRIPTION
## Summary

Adds `deployment/ornn-api/ingress.yaml` — a dedicated nginx Ingress that exposes ornn-api on its own host (`api.ornn-cluster.local` locally; `ornn-api.chrono-ai.fun` in prod once DNS + TLS land), bypassing the NyxID proxy that today gates every backend call behind auth.

This is the deployment-side fix for the #467 audit gap: ornn-api already codes announcements, skill-search, and the public-read skill endpoints as anonymous-aware, but the proxy in front of it 401s before any of that code runs. Visitors landing on `ornn.chrono-ai.fun` without login see the SPA shell and nothing else.

The new ingress gives anonymous traffic a route that skips the proxy. Authenticated routes stay safe — ornn-api's per-route `nyxidAuthMiddleware` still enforces auth on `/admin/*`, `/me/*`, and every mutation when reached through this host.

## Test plan

- [x] `kubectl apply` succeeds against ornn-cluster ns
- [x] `GET https://api.ornn-cluster.local/livez` → 200
- [x] Anonymous `GET .../api/v1/announcements/active` → 200 with active record
- [x] Anonymous `GET .../api/v1/skill-search?q=test&limit=3` → 200 with public skills
- [ ] Prod: cluster admin lands DNS + TLS for `ornn-api.chrono-ai.fun` (or sibling host) — out-of-repo follow-up flagged in the YAML comments

Closes #661.