### PR TITLE
fix(web): TagInput duplicate handling — clear input + show error (#650 + #653)

### DIFF
--- a/.changeset/tag-input-dedup-650-653.md
+++ b/.changeset/tag-input-dedup-650-653.md
@@ -1,0 +1,20 @@
+---
+"ornn-web": patch
+---
+
+Fix Guided-create TagInput duplicate handling (#650 + #653).
+
+Two bugs against the same code path:
+
+- **#650** — typing a duplicate tag and pressing Enter left the rejected value in the input. The next typed character concatenated onto it, so `alpha` (rejected) + typing `beta` produced the tag `alphabeta`.
+- **#653** — the duplicate was rejected silently with no feedback, so the user couldn't tell whether the tag was added or eaten.
+
+Both fixed by:
+
+1. Clearing the input on duplicate (nothing to fix — the existing tag is valid), matching the success path.
+2. Surfacing `Already added` below the input on duplicate, mirroring `MultiValueInput`'s wording so the two multi-value components read the same.
+3. Clearing the transient error on the next keystroke so it never blocks editing.
+
+Pinned with a new `TagInput.test.tsx` (7 assertions covering the duplicate-clear-input contract, case/whitespace normalization, transient-error clearing, empty submissions, comma-commit, and Backspace removal).
+
+`MultiValueInput` (env vars, runtime deps) has the same `input stays after duplicate` pattern but rejects different cases (e.g. validation errors where keeping the typo visible helps the user fix it). Out of scope here; if surfaced by users will be a separate ticket.

--- a/ornn-web/src/components/form/TagInput.test.tsx
+++ b/ornn-web/src/components/form/TagInput.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * TagInput tests — pins the #650 / #653 duplicate-handling contract.
+ *
+ * What we lock in:
+ *   1. Adding a fresh tag commits and clears the input.
+ *   2. A duplicate is rejected, the input is cleared, AND an
+ *      `Already added` message renders (the bug was: silent reject
+ *      + stale input concatenating onto the next keystroke).
+ *   3. Typing after the duplicate clears the error so it never
+ *      blocks editing.
+ *   4. Empty / whitespace-only submissions are silently ignored.
+ *
+ * @module components/form/TagInput.test
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TagInput } from "./TagInput";
+
+function setup(initial: string[] = []) {
+  const onChange = vi.fn();
+  const utils = render(<TagInput tags={initial} onChange={onChange} />);
+  const input = utils.container.querySelector("input")!;
+  return { onChange, input, ...utils };
+}
+
+describe("TagInput", () => {
+  it("adds a new tag on Enter and clears the input", () => {
+    const { onChange, input } = setup([]);
+    fireEvent.change(input, { target: { value: "alpha" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith(["alpha"]);
+    expect(input.value).toBe("");
+  });
+
+  it("rejects a duplicate, clears the input, AND surfaces 'Already added'", () => {
+    // #650 — input must be cleared so the next keystroke doesn't
+    // concatenate onto the rejected value.
+    // #653 — the rejection must be visible to the user.
+    const { onChange, input } = setup(["alpha"]);
+    fireEvent.change(input, { target: { value: "alpha" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("");
+    expect(screen.getByText("Already added")).toBeInTheDocument();
+  });
+
+  it("normalizes case + whitespace before the duplicate check", () => {
+    const { onChange, input } = setup(["alpha"]);
+    fireEvent.change(input, { target: { value: "  ALPHA  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Already added")).toBeInTheDocument();
+  });
+
+  it("clears the transient error as soon as the user keeps typing", () => {
+    const { input } = setup(["alpha"]);
+    fireEvent.change(input, { target: { value: "alpha" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(screen.getByText("Already added")).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "b" } });
+    expect(screen.queryByText("Already added")).not.toBeInTheDocument();
+  });
+
+  it("silently ignores empty / whitespace-only Enter", () => {
+    const { onChange, input } = setup([]);
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("");
+    expect(screen.queryByText("Already added")).not.toBeInTheDocument();
+  });
+
+  it("commits on comma too (parity with Enter)", () => {
+    const { onChange, input } = setup([]);
+    fireEvent.change(input, { target: { value: "beta" } });
+    fireEvent.keyDown(input, { key: "," });
+    expect(onChange).toHaveBeenCalledWith(["beta"]);
+    expect(input.value).toBe("");
+  });
+
+  it("Backspace on empty input removes the last tag", () => {
+    const { onChange, input } = setup(["alpha", "beta"]);
+    fireEvent.keyDown(input, { key: "Backspace" });
+    expect(onChange).toHaveBeenCalledWith(["alpha"]);
+  });
+});

--- a/ornn-web/src/components/form/TagInput.tsx
+++ b/ornn-web/src/components/form/TagInput.tsx
@@ -1,3 +1,25 @@
+/**
+ * TagInput — multi-value tag input with a soft duplicate guard.
+ *
+ * Used by SkillForm + the Guided-create StepBasicInfo to collect
+ * `metadata.tag` entries. Tags are normalized to `trim().toLowerCase()`
+ * before insertion so casing + whitespace differences don't slip through
+ * the dup check.
+ *
+ * #650 / #653 — on Enter (or `,`) with a duplicate, the input was
+ * silently rejected: no error and the rejected text stayed in the
+ * field. Typing the next tag concatenated onto the stale value
+ * (`alpha` → `alpha` rejected → `beta` typed → result `alphabeta`).
+ * Fixed by:
+ *   1. Clearing the input on duplicate (nothing to fix — the existing
+ *      tag is already valid), matching the success path.
+ *   2. Surfacing a transient `Already added` error below the field,
+ *      mirroring `MultiValueInput`'s feedback wording so the two
+ *      multi-value inputs read the same.
+ * The error clears on the next keystroke so it never blocks typing.
+ *
+ * @module components/form/TagInput
+ */
 import { useState, useCallback } from "react";
 import { Badge, type BadgeProps } from "@/components/ui/Badge";
 import { MAX_TAGS } from "@/utils/constants";
@@ -21,20 +43,45 @@ export interface TagInputProps {
 
 export function TagInput({ tags, onChange, error, className = "" }: TagInputProps) {
   const [input, setInput] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
 
   const addTag = useCallback(
     (value: string) => {
       const trimmed = value.trim().toLowerCase();
-      if (!trimmed || tags.includes(trimmed) || tags.length >= MAX_TAGS) return;
+      // Empty after trim — silently swallow; nothing to flag, the user
+      // just pressed Enter on whitespace.
+      if (!trimmed) {
+        setInput("");
+        return;
+      }
+      // Max guard is also enforced by the disabled input below, but keep
+      // a defensive branch in case the prop is wired to bypass the UI
+      // (e.g. paste-then-Enter while at the cap).
+      if (tags.length >= MAX_TAGS) {
+        setInputError(`Maximum ${MAX_TAGS} tags`);
+        setInput("");
+        return;
+      }
+      if (tags.includes(trimmed)) {
+        // #650 + #653 — surface the rejection AND clear the input so
+        // the next keystroke doesn't concatenate onto the stale value.
+        setInputError("Already added");
+        setInput("");
+        return;
+      }
+      setInputError(null);
       onChange([...tags, trimmed]);
       setInput("");
     },
-    [tags, onChange]
+    [tags, onChange],
   );
 
   const removeTag = useCallback(
-    (tag: string) => onChange(tags.filter((t) => t !== tag)),
-    [tags, onChange]
+    (tag: string) => {
+      setInputError(null);
+      onChange(tags.filter((t) => t !== tag));
+    },
+    [tags, onChange],
   );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -46,6 +93,11 @@ export function TagInput({ tags, onChange, error, className = "" }: TagInputProp
       removeTag(tags[tags.length - 1]!);
     }
   };
+
+  // Prefer the live transient error (`inputError`) over the form-level
+  // `error` prop so the user sees feedback for the action they just
+  // took, not a stale parent-level message.
+  const displayError = inputError ?? error;
 
   return (
     <div className={`flex flex-col gap-1.5 ${className}`}>
@@ -68,14 +120,19 @@ export function TagInput({ tags, onChange, error, className = "" }: TagInputProp
         <input
           type="text"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={(e) => {
+            setInput(e.target.value);
+            // Any keystroke means the user is acting on the feedback;
+            // drop the transient error so it doesn't linger.
+            if (inputError) setInputError(null);
+          }}
           onKeyDown={handleKeyDown}
           placeholder={tags.length < MAX_TAGS ? "Type + Enter" : "Max tags reached"}
           disabled={tags.length >= MAX_TAGS}
           className="min-w-[100px] flex-1 border-none bg-transparent font-text text-sm text-strong outline-none placeholder:text-meta/50"
         />
       </div>
-      {error && <span className="text-xs text-danger">{error}</span>}
+      {displayError && <span className="text-xs text-danger">{displayError}</span>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two bugs against the same Guided-create tags input:

- **#650** — typing a duplicate tag and pressing Enter left the rejected value in the input. The next keystroke concatenated onto it, so `alpha` (rejected) + `beta` typed → `alphabeta`.
- **#653** — the duplicate rejection was silent, no feedback at all.

Both fixed in `TagInput.tsx`:
- On duplicate: clear the input + surface `Already added` below the field
- On keystroke: clear the transient error so it never blocks editing
- Empty/whitespace Enter stays silent
- Wording mirrors `MultiValueInput` (env vars, runtime deps) for consistency

## Test plan

- [x] New `TagInput.test.tsx` — 7 assertions covering dup-clears-input + error-visible + case/whitespace normalization + transient-error-clearing + empty silent + comma parity + Backspace removal
- [x] `bunx vitest run` — 117/117 ornn-web tests pass
- [x] `bunx tsc --noEmit` — clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: type duplicate tag, see `Already added` + clean input, type next tag — no concatenation

Closes #650.
Closes #653.