### PR TITLE
fix(api): admin user search matches display name + email (#587)

### DIFF
--- a/.changeset/admin-user-search-display-name-587.md
+++ b/.changeset/admin-user-search-display-name-587.md
@@ -1,0 +1,13 @@
+---
+"ornn-api": patch
+---
+
+Admin Users search now matches display name as well as email (#587).
+
+The search input's placeholder said "email or display name" but the Mongo filter only matched `email` with an anchored-prefix regex. Display names + display-name substrings were silently ignored, so admins typing `Haylee01` or `Proxy` got empty result lists even though those users existed.
+
+Fix is additive — the email behaviour is preserved (still an anchored, case-insensitive prefix match), and a case-insensitive **substring** match on `displayName` is OR'd in alongside it. Display names don't have a meaningful prefix (the issue's reproducer was `Proxy` matching `Ornn Local Proxy`), so substring is the right shape.
+
+Both the unbounded `findAllInRole` (the admin dashboard's paginated-in-memory path) and the paginated `listUsers` (the page-then-fetch path) use the same `buildUserSearchFilter` helper so they stay in sync.
+
+Regex metacharacters in the query are escaped, same as before — pinned with a new test so the escape stays in place.

--- a/ornn-api/src/domains/users/repository.test.ts
+++ b/ornn-api/src/domains/users/repository.test.ts
@@ -180,6 +180,71 @@ describe("listUsers", () => {
     expect(result.items.map((u) => u.userId)).toEqual(["n1"]);
   });
 
+  // #587 — placeholder said "email or display name" but only email
+  // matched. These pin the OR'd display-name path so a regression is
+  // caught loudly.
+  test("q= also matches display name (#587) — exact match", async () => {
+    const result = await repo.listUsers({
+      role: "normal",
+      page: 1,
+      pageSize: 10,
+      q: "Normal 1",
+    });
+    expect(result.items.map((u) => u.userId)).toEqual(["n1"]);
+  });
+
+  test("q= matches display-name substring, not just prefix (#587)", async () => {
+    // Reproducer from the issue: `Proxy` should match `Ornn Local Proxy`.
+    await repo.upsert({
+      userId: "p1",
+      email: "proxy@x.test",
+      displayName: "Ornn Local Proxy",
+      isAdmin: false,
+    });
+    const result = await repo.listUsers({
+      role: "normal",
+      page: 1,
+      pageSize: 10,
+      q: "Proxy",
+    });
+    expect(result.items.map((u) => u.userId)).toContain("p1");
+  });
+
+  test("q= display-name match is case-insensitive (#587)", async () => {
+    const result = await repo.listUsers({
+      role: "admin",
+      page: 1,
+      pageSize: 10,
+      q: "admin 1",
+    });
+    expect(result.items.map((u) => u.userId)).toEqual(["a1"]);
+  });
+
+  test("q= escapes regex metacharacters in display-name match (#587)", async () => {
+    // `.` is a regex metachar; if unescaped, "1.x" would match every
+    // display name. Pinning so the escape stays in place.
+    await repo.upsert({
+      userId: "z1",
+      email: "z1@x.test",
+      displayName: "Z (1.x)",
+      isAdmin: false,
+    });
+    const matches = await repo.listUsers({
+      role: "normal",
+      page: 1,
+      pageSize: 10,
+      q: "(1.x)",
+    });
+    expect(matches.items.map((u) => u.userId)).toEqual(["z1"]);
+    const nonMatches = await repo.listUsers({
+      role: "normal",
+      page: 1,
+      pageSize: 10,
+      q: "(1*x)",
+    });
+    expect(nonMatches.items.map((u) => u.userId)).not.toContain("z1");
+  });
+
   test("pagination respects pageSize + page", async () => {
     const first = await repo.listUsers({ role: "normal", page: 1, pageSize: 1 });
     const second = await repo.listUsers({ role: "normal", page: 2, pageSize: 1 });

--- a/ornn-api/src/domains/users/repository.ts
+++ b/ornn-api/src/domains/users/repository.ts
@@ -244,14 +244,8 @@ export class UserDirectoryRepository {
 
     const filter: Record<string, unknown> = {
       isAdmin: params.role === "admin",
+      ...buildUserSearchFilter(params.q),
     };
-    const q = params.q?.trim();
-    if (q) {
-      filter.email = {
-        $regex: `^${q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
-        $options: "i",
-      };
-    }
 
     const total = await this.collection.countDocuments(filter);
     const sortSpec: Record<string, 1 | -1> = {
@@ -288,14 +282,8 @@ export class UserDirectoryRepository {
   ): Promise<UserDirectoryDoc[]> {
     const filter: Record<string, unknown> = {
       isAdmin: role === "admin",
+      ...buildUserSearchFilter(q),
     };
-    const trimmed = q?.trim();
-    if (trimmed) {
-      filter.email = {
-        $regex: `^${trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
-        $options: "i",
-      };
-    }
     return this.collection.find(filter).limit(hardLimit).toArray();
   }
 
@@ -310,6 +298,38 @@ export class UserDirectoryRepository {
     ]);
     return { admin, normal: Math.max(0, total - admin), total };
   }
+}
+
+/**
+ * Build a Mongo filter fragment for the admin user-list search box.
+ *
+ * #587 — the box's placeholder says "email or display name" but the
+ * server only matched on email-prefix. Display names + substring
+ * keywords were silently ignored. Fix is additive:
+ *
+ *   - **Email** — keep the anchored prefix regex (it's the historical
+ *     behaviour, indexable, and matches the "type the local part" UX
+ *     admins already rely on).
+ *   - **DisplayName** — add a case-insensitive *substring* match.
+ *     Display names don't have a meaningful prefix (`Ornn Local Proxy`
+ *     should hit on `Proxy`, not just `Ornn`).
+ *
+ * `$or` lets either match. Empty / whitespace queries return an empty
+ * fragment so the role filter alone drives the query.
+ *
+ * Regex meta-chars are escaped so a literal `.` / `*` in a display name
+ * or local-part doesn't blow up the query (or DoS the matcher).
+ */
+function buildUserSearchFilter(q: string | undefined): Record<string, unknown> {
+  const trimmed = q?.trim();
+  if (!trimmed) return {};
+  const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return {
+    $or: [
+      { email: { $regex: `^${escaped}`, $options: "i" } },
+      { displayName: { $regex: escaped, $options: "i" } },
+    ],
+  };
 }
 
 function toEntry(doc: UserDirectoryDoc): UserDirectoryEntry {


### PR DESCRIPTION
## Summary

Admin Users search input's placeholder said "email or display name", but the Mongo filter only matched **email** with an anchored prefix regex. Display names + display-name substrings (`Haylee01`, `Proxy` for `Ornn Local Proxy`) were silently ignored on both the admin-user list and the normal-user list.

## Fix

Additive change in `domains/users/repository.ts`:

- **Email** keeps its anchored, case-insensitive prefix regex (preserved per the issue: "email prefixes match correctly").
- **DisplayName** gets a case-insensitive **substring** regex. Display names don't have a meaningful prefix — the issue's reproducer was `Proxy` → `Ornn Local Proxy`, which only works with substring.
- `$or` lets either match.
- Regex metacharacters escaped (preserved + pinned with a new test).

Extracted `buildUserSearchFilter()` so the unbounded path (`findAllInRole`, used by the admin dashboard service) and the paginated path (`listUsers`) share the filter shape and can't drift.

## Test plan

- [x] 4 new repository tests: exact display-name match, substring display-name match, case insensitivity, regex-meta escaping
- [x] `bun test src/domains/users/` — 21/21 pass
- [x] `bun test src/domains/admin-users/` — 8/8 unchanged
- [x] `bunx tsc --noEmit` — clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: search `Haylee01` and `Proxy` on `/admin/users` — both should match

Closes #587.