### PR TITLE
fix: chat composer length cap + visible counter (#654)

### DIFF
--- a/.changeset/chat-input-length-cap-654.md
+++ b/.changeset/chat-input-length-cap-654.md
@@ -1,0 +1,26 @@
+---
+"ornn-web": patch
+"ornn-api": patch
+---
+
+Chat composer length cap + counter (#654).
+
+The Playground + AI-generation chat composer accepted prompts of any length — the live reproducer was 24 000 chars typed, send button still enabled, no warning. Backend caps existed only for message *count* (100), never message *content*.
+
+Front-end (`ChatInput.tsx`):
+
+- `maxLength={32_000}` on the textarea — browser-side hard cap on typing / paste.
+- Live `<used> / <max>` counter appears once the input crosses 24 000 chars (75 %); stays hidden below that so the composer isn't chromed for normal use.
+- Counter flips danger-tone + send button disables when content is over the cap (defensive — `maxLength` should make this unreachable, but covers IME / non-browser-paste edge cases).
+- Imperative `setValue` (used by suggestion-prompt clicks) truncates past the cap so curated copy can't bypass the limit silently.
+
+Back-end:
+
+- `playgroundMessageSchema.content` adds `.max(MAX_CHAT_MESSAGE_CHARS)` — rejects with `400 content_too_long` (RFC 7807 envelope).
+- `skills/generation` JSON path validates prompt length AND each multi-turn message's content length symmetrically — rejects with `400 prompt_too_long` or `400 content_too_long`.
+
+The 32 000-char ceiling is `~8k tokens` at 4 chars/token. Generous for interactive prompts without enabling whole-novel pastes; the three constants are deliberately duplicated across `ChatInput.tsx`, `playground/routes.ts`, and `skills/generation/routes.ts` with cross-referencing comments so a change in one stays in step with the others.
+
+Pinned with `ChatInput.test.tsx` (7 assertions covering `maxLength` attribute, counter visibility, send-enable / disable, imperative truncate, empty disabled).
+
+Closes #654.

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -25,9 +25,23 @@ import { createLogger } from "../../shared/logger";
 const logger = createLogger("playgroundRoutes");
 
 // Zod schemas
+
+/**
+ * Per-message content cap (#654). Mirrors the frontend `MAX_INPUT_CHARS`
+ * in `ornn-web/src/components/playground/ChatInput.tsx`. ~8k tokens at
+ * 4 chars/token — generous for interactive prompts without enabling
+ * whole-novel pastes. The textarea hard-caps at this value via its
+ * `maxLength`, but the backend duplicates the check so a malicious /
+ * non-browser client can't slip past.
+ */
+const MAX_CHAT_MESSAGE_CHARS = 32_000;
+
 const playgroundMessageSchema = z.object({
   role: z.enum(["user", "assistant", "tool", "system"]),
-  content: z.string(),
+  content: z.string().max(
+    MAX_CHAT_MESSAGE_CHARS,
+    `Message content exceeds ${MAX_CHAT_MESSAGE_CHARS} character limit`,
+  ),
   toolCalls: z.array(z.object({
     id: z.string(),
     name: z.string(),

--- a/ornn-api/src/domains/skills/generation/routes.ts
+++ b/ornn-api/src/domains/skills/generation/routes.ts
@@ -30,6 +30,13 @@ import { z } from "zod";
 
 const logger = createLogger("skillGenerationRoutes");
 
+/**
+ * Per-message + per-prompt content cap (#654). Mirrors the playground
+ * chat schema's `MAX_CHAT_MESSAGE_CHARS` and the frontend
+ * `MAX_INPUT_CHARS` in `ChatInput.tsx`. Keep all three in sync.
+ */
+const MAX_GENERATION_CHARS = 32_000;
+
 export interface GenerationRoutesConfig {
   generationService: SkillGenerationService;
   /**
@@ -268,6 +275,21 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
 
         // Multi-turn format: messages array
         if (body.messages && Array.isArray(body.messages)) {
+          // #654 — per-message content cap. Mirrors the playground
+          // chat schema's `.max(MAX_CHAT_MESSAGE_CHARS)` so both
+          // surfaces enforce the same ceiling.
+          for (const m of body.messages) {
+            if (
+              m && typeof m === "object" && "content" in m &&
+              typeof (m as { content: unknown }).content === "string" &&
+              (m as { content: string }).content.length > MAX_GENERATION_CHARS
+            ) {
+              throw AppError.badRequest(
+                "content_too_long",
+                `Message content exceeds ${MAX_GENERATION_CHARS} character limit`,
+              );
+            }
+          }
           logger.info({ userId: authCtx.userId, messageCount: body.messages.length }, "Multi-turn generation request");
           const pf = await preflight(c, quotaService, llmProvidersService, requestedModelId);
           const keepAliveMs = await resolveKeepAliveMs(keepAliveIntervalMsResolver);
@@ -285,6 +307,13 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
 
         if (!body.prompt || typeof body.prompt !== "string") {
           throw AppError.badRequest("missing_prompt", "A 'prompt' field is required");
+        }
+        if (body.prompt.length > MAX_GENERATION_CHARS) {
+          // #654 — symmetric with the multi-turn branch above.
+          throw AppError.badRequest(
+            "prompt_too_long",
+            `Prompt exceeds ${MAX_GENERATION_CHARS} character limit`,
+          );
         }
         prompt = body.prompt;
       } else {

--- a/ornn-web/src/components/playground/ChatInput.test.tsx
+++ b/ornn-web/src/components/playground/ChatInput.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * ChatInput tests — pins the #654 length-cap contract.
+ *
+ * What we lock in:
+ *   1. `maxLength` is applied to the textarea (browser-side hard cap).
+ *   2. Counter is hidden during normal-length editing (no chrome).
+ *   3. Counter appears once the input crosses the warn threshold and
+ *      shows `<n> / <max>`.
+ *   4. Send button stays enabled within the limit.
+ *   5. Over-limit input flips the counter to the over-limit message
+ *      AND disables the send button.
+ *
+ * The over-limit case is forced by injecting `value` past `maxLength`
+ * via the imperative `setValue` handle (the textarea's `maxLength`
+ * would otherwise block direct typing past the cap — which is exactly
+ * the desired behaviour but inconvenient for this test).
+ *
+ * @module components/playground/ChatInput.test
+ */
+import { describe, it, expect, vi } from "vitest";
+import { createRef } from "react";
+import { act, render, fireEvent, screen } from "@testing-library/react";
+import { ChatInput, type ChatInputHandle } from "./ChatInput";
+
+// Minimal i18n stub — `useTranslation()` returns `t(key, opts)` that
+// echoes the key (with interpolated values for the count messages).
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (!opts) return key;
+      const c = opts.count !== undefined ? String(opts.count) : "";
+      const m = opts.max !== undefined ? String(opts.max) : "";
+      if (key === "chatInput.charCount") return `${c} / ${m}`;
+      if (key === "chatInput.overLimit") return `over (max ${m})`;
+      return key;
+    },
+  }),
+}));
+
+function setup(overrides: Partial<React.ComponentProps<typeof ChatInput>> = {}) {
+  const onSend = vi.fn();
+  const onAbort = vi.fn();
+  const ref = createRef<ChatInputHandle>();
+  const utils = render(
+    <ChatInput
+      ref={ref}
+      onSend={onSend}
+      onAbort={onAbort}
+      disabled={false}
+      isStreaming={false}
+      {...overrides}
+    />,
+  );
+  const textarea = utils.container.querySelector("textarea")!;
+  const sendBtn = utils.container.querySelector('button[aria-label="chatInput.sendMessage"]') as HTMLButtonElement | null;
+  return { onSend, onAbort, ref, textarea, sendBtn, ...utils };
+}
+
+describe("ChatInput length cap (#654)", () => {
+  it("applies maxLength to the textarea (browser-side hard cap)", () => {
+    const { textarea } = setup();
+    expect(textarea.maxLength).toBe(32000);
+  });
+
+  it("hides the counter for short inputs", () => {
+    const { textarea } = setup();
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    expect(screen.queryByText(/\d+ \/ 32000/)).not.toBeInTheDocument();
+  });
+
+  it("shows the counter past the warn threshold", () => {
+    const { textarea } = setup();
+    const long = "a".repeat(25_000);
+    fireEvent.change(textarea, { target: { value: long } });
+    expect(screen.getByText("25000 / 32000")).toBeInTheDocument();
+  });
+
+  it("send button stays enabled within the limit", () => {
+    const { textarea, sendBtn } = setup();
+    fireEvent.change(textarea, { target: { value: "a".repeat(25_000) } });
+    expect(sendBtn!.disabled).toBe(false);
+  });
+
+  it("flips the counter + disables send when over the limit", () => {
+    // Force value past the cap via the imperative handle (the textarea
+    // maxLength would otherwise block direct typing past 32k).
+    const { ref, sendBtn } = setup();
+    // setValue truncates by design; bypass it by writing the textarea
+    // through change with a value above the cap, mimicking a paste that
+    // the browser allows but the JS guard catches.
+    const { textarea } = setup();
+    const huge = "a".repeat(40_000);
+    // jsdom doesn't enforce maxLength on `value=` writes — perfect for
+    // simulating a non-browser client / IME composition past the cap.
+    fireEvent.change(textarea, { target: { value: huge } });
+    const sb = textarea.parentElement?.querySelector('button[aria-label="chatInput.sendMessage"]') as HTMLButtonElement;
+    expect(sb.disabled).toBe(true);
+    // The over-limit copy is the stubbed `over (max 32000)`.
+    expect(screen.getAllByText(/over \(max 32000\)/).length).toBeGreaterThan(0);
+    void ref; // ref kept in fixture for symmetry; not used here
+    void sendBtn;
+  });
+
+  it("imperative setValue truncates past the cap", () => {
+    const { ref, textarea } = setup();
+    act(() => {
+      ref.current!.setValue("a".repeat(50_000));
+    });
+    // After truncation the textarea value length must be ≤ MAX_INPUT_CHARS.
+    expect(textarea.value.length).toBe(32_000);
+  });
+
+  it("send button is disabled for empty input", () => {
+    const { sendBtn } = setup();
+    expect(sendBtn!.disabled).toBe(true);
+  });
+});

--- a/ornn-web/src/components/playground/ChatInput.tsx
+++ b/ornn-web/src/components/playground/ChatInput.tsx
@@ -3,6 +3,26 @@
  * Auto-resizing textarea with Enter=send, Shift+Enter=newline.
  * Shows stop button during streaming. Model selection lives in the
  * page-level ModelPicker (top-right surface header).
+ *
+ * #654 — adds a length cap + visible counter. Previously the textarea
+ * accepted unbounded content (24k chars was the live reproducer) and
+ * the send button stayed enabled regardless of length, so users could
+ * fire requests the backend would reject (or worse, accept + crash on
+ * downstream LLM token-limit). Now:
+ *
+ *   - `maxLength` on the textarea hard-caps at MAX_INPUT_CHARS — the
+ *     browser refuses typing/paste beyond that, no extra JS needed.
+ *   - A counter appears once the input crosses WARN_AT_CHARS so users
+ *     get warning room rather than a surprise wall.
+ *   - Counter goes danger-tone + send disables once the trimmed
+ *     content is over the limit (defensive — `maxLength` should make
+ *     this unreachable, but the explicit guard catches any IME / paste
+ *     edge case that slips past).
+ *
+ * The backend (`domains/playground/routes.ts` + `skills/generation/
+ * routes.ts`) caps content at the same 32 000-char ceiling — frontend
+ * is UX, backend is the hard line.
+ *
  * @module components/playground/ChatInput
  */
 
@@ -27,6 +47,17 @@ export interface ChatInputHandle {
 
 /** Maximum textarea height before scrolling. */
 const MAX_HEIGHT_PX = 200;
+
+/**
+ * Maximum input length. ~8k tokens at 4 chars/token — generous for
+ * interactive prompts without enabling whole-novel pastes. Mirrors the
+ * `.max()` cap on `playgroundMessageSchema.content` /
+ * `skills/generation` route bodies; if you change one, change both.
+ */
+const MAX_INPUT_CHARS = 32_000;
+
+/** Threshold above which the live counter becomes visible (~75%). */
+const WARN_AT_CHARS = 24_000;
 
 export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput({
   onSend,
@@ -55,7 +86,10 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     ref,
     () => ({
       setValue: (text: string) => {
-        setValue(text);
+        // Truncate suggestion-prompt clicks defensively — the suggestion
+        // catalogue is curated short copy today, but a future longer
+        // prompt shouldn't bypass the cap silently.
+        setValue(text.slice(0, MAX_INPUT_CHARS));
         // Defer focus so the new value's height calculation lands first.
         requestAnimationFrame(() => textareaRef.current?.focus());
       },
@@ -64,12 +98,16 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     [],
   );
 
+  const trimmedLength = value.trim().length;
+  const isOverLimit = trimmedLength > MAX_INPUT_CHARS;
+  const shouldShowCounter = value.length >= WARN_AT_CHARS;
+
   const handleSend = useCallback(() => {
     const trimmed = value.trim();
-    if (!trimmed || disabled) return;
+    if (!trimmed || disabled || trimmed.length > MAX_INPUT_CHARS) return;
     onSend(trimmed);
     setValue("");
-  }, [value, disabled, onSend]);
+  }, [value, disabled]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -81,7 +119,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     [handleSend],
   );
 
-  const canSend = value.trim().length > 0 && !disabled;
+  const canSend = trimmedLength > 0 && !disabled && !isOverLimit;
 
   return (
     <div className="px-1 pb-2 pt-2">
@@ -92,7 +130,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
         className={`relative flex items-end gap-2 rounded-2xl border bg-card px-3 py-2 transition-colors ${
           disabled
             ? "border-subtle/60"
-            : "border-subtle focus-within:border-accent/60 focus-within:ring-1 focus-within:ring-accent/30"
+            : isOverLimit
+              ? "border-danger/60 focus-within:border-danger/80 focus-within:ring-1 focus-within:ring-danger/30"
+              : "border-subtle focus-within:border-accent/60 focus-within:ring-1 focus-within:ring-accent/30"
         }`}
       >
         <textarea
@@ -101,6 +141,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
           disabled={disabled}
+          maxLength={MAX_INPUT_CHARS}
           placeholder={
             customPlaceholder
               ?? (disabled
@@ -140,6 +181,21 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
           </button>
         )}
       </div>
+      {/* Counter row — appears only past WARN_AT_CHARS so it doesn't
+          chrome the composer for normal use. Goes danger-tone past the
+          cap. */}
+      {shouldShowCounter && (
+        <p
+          className={`mt-1 text-right text-[11px] tabular-nums ${
+            isOverLimit ? "text-danger" : "text-meta/70"
+          }`}
+          aria-live="polite"
+        >
+          {isOverLimit
+            ? t("chatInput.overLimit", { max: MAX_INPUT_CHARS })
+            : t("chatInput.charCount", { count: value.length, max: MAX_INPUT_CHARS })}
+        </p>
+      )}
     </div>
   );
 });

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -621,7 +621,9 @@
     "awaitingTool": "Awaiting tool approval...",
     "placeholder": "Type a message... (Enter to send, Shift+Enter for newline)",
     "stopGeneration": "Stop generation",
-    "sendMessage": "Send message"
+    "sendMessage": "Send message",
+    "charCount": "{{count}} / {{max}}",
+    "overLimit": "Message too long. Maximum {{max}} characters."
   },
   "quota": {
     "surfacePlayground": "Playground",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -621,7 +621,9 @@
     "awaitingTool": "等待工具授权…",
     "placeholder": "输入消息…（Enter 发送，Shift+Enter 换行）",
     "stopGeneration": "停止生成",
-    "sendMessage": "发送消息"
+    "sendMessage": "发送消息",
+    "charCount": "{{count}} / {{max}}",
+    "overLimit": "消息过长。最多 {{max}} 个字符。"
   },
   "quota": {
     "surfacePlayground": "试验场",


### PR DESCRIPTION
## Summary

Playground + AI-generation chat composer accepted prompts of any length — live reproducer was 24 000 chars typed, send enabled, no warning. Backend caps existed only for message count (100), never message content.

**Frontend (`ChatInput.tsx`):**
- `maxLength={32_000}` on the textarea — browser hard cap
- Live counter (`<used> / <max>`) appears past 24 000 chars (75%); hidden below that
- Counter flips danger-tone + send disables when over cap (defensive — covers IME / non-browser paste)
- Imperative `setValue` truncates past the cap
- New i18n keys: `chatInput.charCount`, `chatInput.overLimit` (EN + ZH)

**Backend:**
- `playgroundMessageSchema.content.max(32_000)` → 400 `content_too_long` (RFC 7807)
- `skills/generation` JSON path validates prompt + each multi-turn message content → 400 `prompt_too_long` or `content_too_long`

The 32 000-char ceiling ≈ 8k tokens at 4 chars/token — generous for interactive prompts. Three constants deliberately duplicated with cross-referencing comments.

## Test plan

- [x] `ChatInput.test.tsx` — 7 new assertions (maxLength attribute, counter visibility, send-enable/disable, imperative truncate, empty disabled)
- [x] Full ornn-web suite: 124/124 pass; ornn-web typecheck clean
- [x] Full ornn-api suite: 797/797 pass; ornn-api typecheck clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: paste 30k chars → counter shows; paste 40k → counter danger + send disabled

Closes #654.