### PR TITLE
fix(web): validate guided supporting-file uploads (#655)

### DIFF
--- a/.changeset/folder-file-upload-validation-655.md
+++ b/.changeset/folder-file-upload-validation-655.md
@@ -1,0 +1,20 @@
+---
+"ornn-web": patch
+---
+
+Guided creation supporting-file upload now validates duplicate filenames + per-file size (#655).
+
+The Guided wizard's Step 3 file uploader accepted whatever the user dropped — including a second `run.js` into the same `scripts/` folder (silently stacked, would have produced two entries with the same path in the final ZIP) and a 55 MB blob (no warning, would have blown through the backend's 100 MB total cap on its own).
+
+Both guards now live inside `FolderFileUpload`'s `handleFileSelect`, so click + drop paths share them:
+
+1. **Duplicate filename inside the same target folder** → rejected with inline `<name> already exists in <folder>/. Remove it first to replace.` Auto-overwrite would silently drop content the user hadn't intentionally removed; making them hit Remove keeps the action explicit. Cross-folder duplicates stay allowed (different paths in the final ZIP).
+2. **Per-file size cap of 10 MiB** → rejected with `<name> is <size> — over the 10 MiB per-file limit.` Backend / ZIP pipeline still caps total uncompressed at ~100 MB (#443 / #633); 10 MiB per file keeps a single oversize artifact from eating the whole budget and surfaces the cap early.
+
+Both errors render under the drop zone with `aria-live="polite"`, auto-clear on the next successful upload or folder switch, and explicitly do NOT call `onUpload` — parent state stays untouched on rejection so there's nothing for the user to undo.
+
+A persistent `Per-file limit: 10 MiB` hint now sits above the file list so the cap is discoverable before the user picks a file.
+
+i18n: 3 new keys per locale (`guided.fileSizeHint`, `guided.fileTooLarge`, `guided.fileDuplicate`) in EN + ZH.
+
+Pinned with `FolderFileUpload.test.tsx` (6 assertions covering accept under cap, same-folder dup reject, cross-folder dup allowed, size-cap reject, error-clears-on-success, hint always visible).

--- a/ornn-web/src/components/form/FolderFileUpload.test.tsx
+++ b/ornn-web/src/components/form/FolderFileUpload.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * FolderFileUpload tests — pins the #655 upload-validation contract.
+ *
+ * What we lock in:
+ *   1. Duplicate filename inside the SAME target folder → rejected,
+ *      inline error visible, parent's `onUpload` never called.
+ *   2. Duplicate filename in a DIFFERENT folder is allowed (they end
+ *      up as different paths in the final ZIP).
+ *   3. File over 10 MiB → rejected with size-cap error, `onUpload`
+ *      not called.
+ *   4. Successful upload clears any prior error.
+ *
+ * @module components/form/FolderFileUpload.test
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { FolderFileUpload } from "./FolderFileUpload";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (!opts) return key;
+      // Echo back something searchable for the assertions.
+      const parts = Object.entries(opts).map(([k, v]) => `${k}=${v}`).join(" ");
+      return `${key} (${parts})`;
+    },
+  }),
+}));
+
+function makeFile(name: string, sizeBytes: number, type = "text/plain"): File {
+  // jsdom File supports a `size` property derived from the parts; pad
+  // with a zero-filled string of the requested length.
+  const blob = new Blob([new Uint8Array(sizeBytes)], { type });
+  return new File([blob], name, { type });
+}
+
+function setup(initial?: Map<string, File[]>) {
+  const onUpload = vi.fn();
+  const onRemove = vi.fn();
+  // The component expects `Map<UploadableFolder, File[]>`. Cast for
+  // test ergonomics — runtime shape is the same.
+  const files = (initial ?? new Map()) as unknown as Map<
+    "scripts" | "references" | "assets",
+    File[]
+  >;
+  const utils = render(
+    <FolderFileUpload
+      files={files as Map<"scripts" | "references" | "assets", File[]>}
+      onUpload={onUpload}
+      onRemove={onRemove}
+    />,
+  );
+  const hiddenInput = utils.container.querySelector('input[type="file"]') as HTMLInputElement;
+  return { onUpload, onRemove, hiddenInput, ...utils };
+}
+
+describe("FolderFileUpload (#655)", () => {
+  it("accepts a fresh file under the size cap", () => {
+    const { onUpload, hiddenInput } = setup();
+    const file = makeFile("run.js", 1024);
+    fireEvent.change(hiddenInput, { target: { files: [file] } });
+    expect(onUpload).toHaveBeenCalledTimes(1);
+    expect(onUpload).toHaveBeenCalledWith("scripts", file);
+  });
+
+  it("rejects a duplicate filename in the same folder", () => {
+    const existing = makeFile("run.js", 100);
+    const { onUpload, hiddenInput } = setup(
+      new Map([["scripts", [existing]]]) as never,
+    );
+    const dup = makeFile("run.js", 200);
+    fireEvent.change(hiddenInput, { target: { files: [dup] } });
+    expect(onUpload).not.toHaveBeenCalled();
+    expect(screen.getByText(/guided\.fileDuplicate/)).toBeInTheDocument();
+  });
+
+  it("allows the same filename in a DIFFERENT folder", () => {
+    // `README.md` in scripts/ is fine even if references/ has one too —
+    // they're separate paths in the final ZIP.
+    const existing = makeFile("README.md", 100);
+    const { onUpload, hiddenInput, container } = setup(
+      new Map([["references", [existing]]]) as never,
+    );
+    // Default selected folder is `scripts`, so this should pass.
+    const sameName = makeFile("README.md", 200);
+    fireEvent.change(hiddenInput, { target: { files: [sameName] } });
+    expect(onUpload).toHaveBeenCalledWith("scripts", sameName);
+    expect(container.textContent).not.toMatch(/guided\.fileDuplicate/);
+  });
+
+  it("rejects an over-cap file", () => {
+    const { onUpload, hiddenInput } = setup();
+    const huge = makeFile("blob.bin", 11 * 1024 * 1024);
+    fireEvent.change(hiddenInput, { target: { files: [huge] } });
+    expect(onUpload).not.toHaveBeenCalled();
+    expect(screen.getByText(/guided\.fileTooLarge/)).toBeInTheDocument();
+  });
+
+  it("clears the error on next successful upload", () => {
+    const { onUpload, hiddenInput } = setup();
+    // Trigger a size-cap rejection.
+    fireEvent.change(hiddenInput, {
+      target: { files: [makeFile("blob.bin", 11 * 1024 * 1024)] },
+    });
+    expect(screen.getByText(/guided\.fileTooLarge/)).toBeInTheDocument();
+    // Now a valid upload — error must clear.
+    fireEvent.change(hiddenInput, {
+      target: { files: [makeFile("ok.js", 100)] },
+    });
+    expect(onUpload).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/guided\.fileTooLarge/)).not.toBeInTheDocument();
+  });
+
+  it("always shows the size-limit hint so the cap is discoverable pre-upload", () => {
+    setup();
+    expect(screen.getByText(/guided\.fileSizeHint/)).toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/components/form/FolderFileUpload.tsx
+++ b/ornn-web/src/components/form/FolderFileUpload.tsx
@@ -2,6 +2,28 @@
  * Folder File Upload Component.
  * Upload files with target folder selection for skill packages.
  * Used in Guided Step 3 and Generative Mode review.
+ *
+ * #655 — the upload accepted any file regardless of name or size:
+ * duplicates in the same target folder stacked silently and a 55 MB
+ * file went through without a warning. Added two guards inside
+ * `handleFileSelect`, so both the click and drop paths are covered:
+ *
+ *   1. Duplicate filename inside the same target folder is rejected
+ *      with an inline `<name> already exists in <folder>/` error. The
+ *      user picks Remove on the existing chip if they really want to
+ *      replace it — auto-overwrite would silently drop unsaved
+ *      content.
+ *   2. Per-file size cap of 10 MiB. The backend / ZIP pipeline caps
+ *      total uncompressed at ~100 MB (#443 / #633); per-file 10 MiB
+ *      keeps a single oversize artifact from eating the whole budget
+ *      and signals the limit before the user assembles a doomed
+ *      package.
+ *
+ * Both errors render under the drop zone with `aria-live="polite"`,
+ * auto-clear on the next successful upload, and explicitly do NOT
+ * call `onUpload` — the parent state stays untouched on rejection so
+ * there's nothing for the user to undo.
+ *
  * @module components/form/FolderFileUpload
  */
 
@@ -27,6 +49,13 @@ const FOLDER_LABELS: Record<UploadableFolder, string> = {
   assets: "assets/",
 };
 
+/**
+ * Per-file size cap (#655). 10 MiB. Backend caps total uncompressed at
+ * ~100 MB; per-file 10 MiB keeps a single oversize artifact from
+ * eating the whole package budget and signals the limit early.
+ */
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
 export function FolderFileUpload({
   files,
   onUpload,
@@ -36,13 +65,41 @@ export function FolderFileUpload({
   const { t } = useTranslation();
   const [selectedFolder, setSelectedFolder] = useState<UploadableFolder>("scripts");
   const [isDragging, setIsDragging] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleFileSelect = useCallback(
     (file: File) => {
+      // #655 guard 1 — size cap. Reject before the parent ever sees
+      // the file, so its package-state stays clean.
+      if (file.size > MAX_FILE_SIZE_BYTES) {
+        setUploadError(
+          t("guided.fileTooLarge", {
+            name: file.name,
+            size: formatFileSize(file.size),
+            max: formatFileSize(MAX_FILE_SIZE_BYTES),
+          }),
+        );
+        return;
+      }
+      // #655 guard 2 — duplicate filename inside the SAME target
+      // folder. Cross-folder duplicates are fine (a `README.md` can
+      // live in references/ even if scripts/ has one too — they
+      // become different paths in the final ZIP).
+      const existing = files.get(selectedFolder) ?? [];
+      if (existing.some((f) => f.name === file.name)) {
+        setUploadError(
+          t("guided.fileDuplicate", {
+            name: file.name,
+            folder: FOLDER_LABELS[selectedFolder],
+          }),
+        );
+        return;
+      }
+      setUploadError(null);
       onUpload(selectedFolder, file);
     },
-    [selectedFolder, onUpload],
+    [selectedFolder, onUpload, files, t],
   );
 
   const handleDrop = useCallback(
@@ -74,7 +131,12 @@ export function FolderFileUpload({
             <button
               key={folder}
               type="button"
-              onClick={() => setSelectedFolder(folder)}
+              onClick={() => {
+                setSelectedFolder(folder);
+                // Folder switch is a fresh context — drop any stale
+                // error from a previous folder's reject.
+                setUploadError(null);
+              }}
               className={`
                 px-4 py-2 rounded font-mono text-sm transition-all cursor-pointer
                 ${
@@ -116,6 +178,25 @@ export function FolderFileUpload({
           className="hidden"
         />
       </div>
+
+      {/* Inline upload error — reserved for the live transient
+          reject. Cleared on the next successful upload or folder
+          switch. */}
+      {uploadError && (
+        <p
+          className="font-text text-xs text-danger"
+          aria-live="polite"
+          role="alert"
+        >
+          {uploadError}
+        </p>
+      )}
+
+      {/* Per-file size hint — always visible so users know the cap
+          before they pick the file. */}
+      <p className="font-text text-[11px] text-meta/60">
+        {t("guided.fileSizeHint", { max: formatFileSize(MAX_FILE_SIZE_BYTES) })}
+      </p>
 
       {/* File list grouped by folder */}
       <div className="space-y-4">

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -515,7 +515,10 @@
     "previewTitle": "Review & Create",
     "dropHint": "Drop file here or click to browse",
     "noFiles": "(no files)",
-    "remove": "Remove"
+    "remove": "Remove",
+    "fileSizeHint": "Per-file limit: {{max}}",
+    "fileTooLarge": "{{name}} is {{size}} — over the {{max}} per-file limit.",
+    "fileDuplicate": "{{name}} already exists in {{folder}}. Remove it first to replace."
   },
   "generative": {
     "backToModes": "Back to mode selection",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -515,7 +515,10 @@
     "previewTitle": "检查并创建",
     "dropHint": "拖拽文件到此处或点击选择",
     "noFiles": "（暂无文件）",
-    "remove": "移除"
+    "remove": "移除",
+    "fileSizeHint": "单文件上限：{{max}}",
+    "fileTooLarge": "{{name}} 大小为 {{size}}，超出单文件 {{max}} 上限。",
+    "fileDuplicate": "{{name}} 在 {{folder}} 中已存在。请先移除再替换。"
   },
   "generative": {
     "backToModes": "返回模式选择",


### PR DESCRIPTION
## Summary

Guided wizard's Step 3 file uploader accepted whatever the user dropped — duplicate filenames in the same target folder stacked silently, and a 55 MB blob went through without a warning.

Both guards now live inside `FolderFileUpload.handleFileSelect` (click + drop paths share them):

1. **Duplicate filename in same folder** → rejected with inline `<name> already exists in <folder>/. Remove it first to replace.` Cross-folder dups stay allowed.
2. **Per-file size cap of 10 MiB** → rejected with `<name> is <size> — over the 10 MiB per-file limit.`

Both errors `aria-live="polite"`, auto-clear on next success / folder switch. `onUpload` NOT called on reject so parent state stays clean. Persistent `Per-file limit: 10 MiB` hint above the file list.

i18n: 3 new keys in EN + ZH (`guided.fileSizeHint`, `fileTooLarge`, `fileDuplicate`).

## Test plan

- [x] `FolderFileUpload.test.tsx` — 6 assertions (accept under cap, same-folder dup reject, cross-folder dup allowed, size-cap reject, error-clears-on-success, hint visible)
- [x] Full ornn-web: 130/130 pass; typecheck clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: drop two `run.js` into `scripts/`, drop 11MB file

Closes #655.