### PR TITLE
fix(api): frontmatter validation errors are actionable (#649)

### DIFF
--- a/.changeset/frontmatter-actionable-errors-649.md
+++ b/.changeset/frontmatter-actionable-errors-649.md
@@ -1,0 +1,14 @@
+---
+"ornn-api": patch
+---
+
+Frontmatter validation errors now tell the user what to fix (#649).
+
+The Free / ZIP upload page already shows clear actionable messages for most validation failures (`version` semver rule, tag-regex rule, env-var UPPER_SNAKE_CASE rule), but the `tag`, `runtime`, `tool-list`, `runtime-env-var`, and `runtime-dependency` *item* schemas surfaced as bare `Invalid input: expected string, received null` when an author hit common YAML mistakes:
+
+- `tag: - ` (empty list-item dash) → YAML parses as `null`
+- `version: 0.1` (unquoted) → YAML parses as a number — already addressed in an earlier pass; pinned with a test here so it can't regress.
+
+Fix is additive: each item schema gains a Zod 4 `error` callback that handles `invalid_type` with a clear sentence including a concrete shape example (`tag: [my-tag]`, `runtime: [python]`, `runtime-env-var: [OPENAI_API_KEY]`, etc.). The existing `min`/`max`/`regex` messages still fire for non-null shape problems.
+
+Pinned with a new `skillFrontmatter.test.ts` — 8 assertions covering version-quoting, null-tag, uppercase-tag (regex preservation), null-env-var, null-runtime, null-tool, null-dependency, and a happy-path round trip.

--- a/ornn-api/src/shared/schemas/skillFrontmatter.test.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.test.ts
@@ -1,0 +1,125 @@
+/**
+ * SkillFrontmatter schema tests — pins the #649 actionable-error
+ * contract.
+ *
+ * These cases reproduce common user mistakes (unquoted YAML version,
+ * empty `- ` list items, bad regex shapes) and assert that the schema
+ * returns a message that tells the user *what to write instead*, not
+ * just "Invalid input".
+ *
+ * @module shared/schemas/skillFrontmatter.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { validateSkillFrontmatter } from "./skillFrontmatter";
+
+function base(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    name: "qa-sample",
+    description: "Sample description that is long enough",
+    version: "0.1",
+    metadata: { category: "plain", tag: ["qa"] },
+    ...overrides,
+  };
+}
+
+describe("validateSkillFrontmatter — actionable errors (#649)", () => {
+  test("unquoted numeric version → explains the YAML quoting trap", () => {
+    const r = validateSkillFrontmatter(base({ version: 0.1 }));
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "version")?.message ?? "";
+    expect(msg).toContain("quoted string");
+    expect(msg).toContain('version: "0.1"');
+  });
+
+  test("null tag (empty `- ` list item) → explains tag shape", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", tag: [null] } }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.tag.0")?.message ?? "";
+    expect(msg).toContain("non-empty lowercase strings");
+    expect(msg).toContain("`tag: [my-tag]`");
+    expect(msg).not.toMatch(/^Invalid input$/);
+  });
+
+  test("uppercase tag → existing regex message is preserved", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", tag: ["QA"] } }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.tag.0")?.message ?? "";
+    expect(msg).toContain("lowercase alphanumeric with hyphens");
+  });
+
+  test("null env var → explains UPPER_SNAKE_CASE shape", () => {
+    const r = validateSkillFrontmatter(
+      base({
+        metadata: {
+          category: "runtime-based",
+          "output-type": "text",
+          runtime: ["python"],
+          "runtime-env-var": [null],
+        },
+      }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.runtime-env-var.0")?.message ?? "";
+    expect(msg).toContain("UPPER_SNAKE_CASE");
+    expect(msg).toContain("OPENAI_API_KEY");
+  });
+
+  test("null runtime entry → actionable message", () => {
+    const r = validateSkillFrontmatter(
+      base({
+        metadata: {
+          category: "runtime-based",
+          "output-type": "text",
+          runtime: [null],
+        },
+      }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.runtime.0")?.message ?? "";
+    expect(msg).toContain("`runtime: [python]`");
+  });
+
+  test("null tool entry → actionable message", () => {
+    const r = validateSkillFrontmatter(
+      base({
+        metadata: { category: "tool-based", "tool-list": [null] },
+      }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.tool-list.0")?.message ?? "";
+    expect(msg).toContain("`tool-list: [Bash, Read]`");
+  });
+
+  test("null dependency entry → actionable message", () => {
+    const r = validateSkillFrontmatter(
+      base({
+        metadata: {
+          category: "runtime-based",
+          "output-type": "text",
+          runtime: ["python"],
+          "runtime-dependency": [null],
+        },
+      }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.runtime-dependency.0")?.message ?? "";
+    expect(msg).toContain("`runtime-dependency: [requests==2.31]`");
+  });
+
+  test("valid frontmatter still parses cleanly", () => {
+    const r = validateSkillFrontmatter(base());
+    expect(r.success).toBe(true);
+  });
+});

--- a/ornn-api/src/shared/schemas/skillFrontmatter.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.ts
@@ -14,11 +14,61 @@ export const OUTPUT_TYPES = ["text", "file"] as const;
 export type OutputType = (typeof OUTPUT_TYPES)[number];
 
 // Item-level schemas
-const tagItemSchema = z.string().min(1).max(30).regex(/^[a-z0-9-]+$/, "Tags must be lowercase alphanumeric with hyphens");
-const envVarItemSchema = z.string().min(1).max(100).regex(/^[A-Z_][A-Z0-9_]*$/, "Environment variable names must be UPPER_SNAKE_CASE");
-const toolItemSchema = z.string().min(1).max(100);
-const runtimeItemSchema = z.string().min(1).max(50);
-const dependencyItemSchema = z.string().min(1).max(200);
+//
+// #649 — YAML allows empty list items (`- ` on a line by itself parses
+// as `null`) and lets authors put non-string values where a string is
+// expected. Default Zod messages on those cases come back as bare
+// "Invalid input: expected string, received null" which doesn't tell
+// the author *what to write instead*. Each item schema below carries a
+// custom `error` callback for `invalid_type`; the existing
+// `min`/`max`/`regex` messages still fire for non-null shape problems.
+const tagItemSchema = z
+  .string({
+    error: (issue) =>
+      issue.code === "invalid_type"
+        ? 'tags must be non-empty lowercase strings with optional hyphens, e.g. `tag: [my-tag]` — an empty `- ` line in YAML parses as `null` and is not a valid tag.'
+        : undefined,
+  })
+  .min(1, "tags must not be empty")
+  .max(30, "tags must be at most 30 characters")
+  .regex(/^[a-z0-9-]+$/, "Tags must be lowercase alphanumeric with hyphens");
+const envVarItemSchema = z
+  .string({
+    error: (issue) =>
+      issue.code === "invalid_type"
+        ? 'runtime-env-var entries must be non-empty UPPER_SNAKE_CASE strings, e.g. `runtime-env-var: [OPENAI_API_KEY]` — an empty `- ` line in YAML parses as `null`.'
+        : undefined,
+  })
+  .min(1, "runtime-env-var entries must not be empty")
+  .max(100, "runtime-env-var entries must be at most 100 characters")
+  .regex(/^[A-Z_][A-Z0-9_]*$/, "Environment variable names must be UPPER_SNAKE_CASE");
+const toolItemSchema = z
+  .string({
+    error: (issue) =>
+      issue.code === "invalid_type"
+        ? 'tool-list entries must be non-empty strings, e.g. `tool-list: [Bash, Read]` — an empty `- ` line in YAML parses as `null`.'
+        : undefined,
+  })
+  .min(1, "tool-list entries must not be empty")
+  .max(100, "tool-list entries must be at most 100 characters");
+const runtimeItemSchema = z
+  .string({
+    error: (issue) =>
+      issue.code === "invalid_type"
+        ? 'runtime entries must be non-empty strings, e.g. `runtime: [python]` — an empty `- ` line in YAML parses as `null`.'
+        : undefined,
+  })
+  .min(1, "runtime entries must not be empty")
+  .max(50, "runtime entries must be at most 50 characters");
+const dependencyItemSchema = z
+  .string({
+    error: (issue) =>
+      issue.code === "invalid_type"
+        ? 'runtime-dependency entries must be non-empty strings, e.g. `runtime-dependency: [requests==2.31]` — an empty `- ` line in YAML parses as `null`.'
+        : undefined,
+  })
+  .min(1, "runtime-dependency entries must not be empty")
+  .max(200, "runtime-dependency entries must be at most 200 characters");
 
 // Metadata sub-schema (base, before refinement)
 export const metadataSchema = z.object({


### PR DESCRIPTION
## Summary

The Free / ZIP upload page already shows clear actionable messages for most validation failures (`version` semver, tag regex, env-var UPPER_SNAKE rule), but the `tag`, `runtime`, `tool-list`, `runtime-env-var`, and `runtime-dependency` *item* schemas surfaced as bare `Invalid input: expected string, received null` when an author hit common YAML traps:

- `tag: - ` (empty list-item dash) → YAML parses as `null`
- `version: 0.1` (unquoted) → YAML parses as a number (this one was already handled in an earlier pass; pinned with a test here so it can't regress)

## Fix

Each item schema gets a Zod 4 `error: (issue) => ...` callback that intercepts `invalid_type` with a sentence including a concrete shape example (`tag: [my-tag]`, `runtime: [python]`, `runtime-env-var: [OPENAI_API_KEY]`, etc.). Existing `min`/`max`/`regex` messages still fire for non-null shape failures.

## Test plan

- [x] New `skillFrontmatter.test.ts` — 8 assertions (version quoting, null tag, uppercase tag (regex preservation), null env-var, null runtime, null tool, null dep, happy-path)
- [x] `bun test` — 805/805 pass; typecheck clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: upload ZIP with `version: 0.1` and ZIP with `tag: [-]` — both now show actionable messages

Closes #649.