### PR TITLE
fix: install-card prompt pins to viewed skill version (#639)

### DIFF
--- a/.changeset/install-prompt-version-pin-639.md
+++ b/.changeset/install-prompt-version-pin-639.md
@@ -1,0 +1,28 @@
+---
+"ornn-api": minor
+"ornn-web": patch
+---
+
+Install-card prompt now pins to the viewed version (#639).
+
+When a user opened an older skill version (`?version=0.2`) the URL + file viewer correctly switched to that version, but the install card's prompt was still latest-shaped:
+
+- The pull commands (`nyxid proxy request …/json` + the `curl …/json` line) had no `?version=…`, so an agent following the prompt would silently install `latest` at install time instead of the version the user was actually looking at.
+- The prompt header didn't mention which version the user had viewed, so even careful agents couldn't tell.
+
+Fix is end-to-end:
+
+**Backend (`ornn-api`)**
+
+- `getSkillJson(idOrName, version?)` now accepts an optional `version` query — literal `<major>.<minor>` OR a dist-tag (#463). When set, the response uses that version's `storageKey` + `metadata`; otherwise the latest package is returned (unchanged behaviour for legacy callers).
+- Returns a new top-level `version` field so callers can confirm exactly which package they got.
+- `GET /api/v1/skills/:idOrName/json` reads `?version=` and threads it through. Bad version → `400 invalid_version`; missing version → `404 skill_version_not_found` (RFC 7807). Visibility check unchanged.
+- Bumped to **minor** because the response shape gains a new field.
+
+**Frontend (`ornn-web`)**
+
+- `buildTrySkillPrompt({…, version })` adds `?version=` to both pull URLs (curl + NyxID CLI via `--query version=…`), and to the footer `Ornn URL:`. Header line becomes `# Install Ornn skill: <name> @ <version>` and a "Pinned to version `<X>`" paragraph spells out why the URLs carry the query.
+- `SkillInstallCard` passes the currently-viewed `skill.version` straight through, so the prompt always matches the page.
+- No-version callers (theoretical "always pull latest" surfaces) are unaffected — the version is opt-in.
+
+Pinned with 3 new `buildTrySkillPrompt.test.ts` assertions (version-pinning surfaces, no-pin parity, dist-tag passes through unchanged) and the existing 9 cases re-verified.

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -547,6 +547,14 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
   /**
    * GET /skills/:idOrName/json — Return skill package as JSON with all file contents.
    * Requires: ornn:skill:read
+   *
+   * Query params:
+   *   - `version` (optional, #639) — literal `<major>.<minor>` or a
+   *     dist-tag (#463). When provided, the response carries that
+   *     version's package; otherwise latest is returned. Lets the
+   *     install-prompt `curl` / `nyxid proxy request` commands pin
+   *     to the version the user was viewing instead of silently
+   *     pulling whatever's `latest` at install time.
    */
   app.get(
     "/skills/:idOrName/json",
@@ -554,7 +562,8 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     requirePermission("ornn:skill:read"),
     async (c) => {
       const idOrName = c.req.param("idOrName");
-      logger.info({ idOrName }, "Skill jsonize request");
+      const version = c.req.query("version");
+      logger.info({ idOrName, version: version ?? null }, "Skill jsonize request");
 
       // Visibility check (#567) — the package contents endpoint must
       // not be more permissive than the metadata endpoint. Load the
@@ -578,7 +587,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         }
       }
 
-      const result = await skillService.getSkillJson(idOrName);
+      const result = await skillService.getSkillJson(idOrName, version);
       // Programmatic pull — closest signal to the north-star metric.
       // Fire-and-forget; the analytics service swallows its own errors.
       const authCtx = c.get("auth");

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -1116,11 +1116,26 @@ export class SkillService {
 
   /**
    * Return the full skill package as a JSON object with all file contents.
-   * Used by playground to inject skill context.
+   * Used by playground to inject skill context, and by the SkillInstallCard
+   * prompt's pull commands.
+   *
+   * #639 — accepts an optional `version` that may be a literal `<major>.
+   * <minor>` or a dist-tag (#463). When provided, the response uses that
+   * version's package (`storageKey` + `metadata` from `skill_versions`)
+   * instead of the skill doc's "latest" storage key. Identity fields
+   * (`name`) still come from the skill doc; `description` falls through
+   * to the skill doc too because version docs don't carry one.
+   *
+   * When `version` is omitted the response is the latest package — same
+   * as before.
    */
-  async getSkillJson(idOrName: string): Promise<{
+  async getSkillJson(
+    idOrName: string,
+    version?: string,
+  ): Promise<{
     name: string;
     description: string;
+    version: string;
     metadata: Record<string, unknown>;
     files: Record<string, string>;
   }> {
@@ -1133,8 +1148,39 @@ export class SkillService {
       throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
     }
 
+    // 1a. Resolve the requested version (literal or dist-tag, #463).
+    //     When unset OR empty-string, fall through to the skill doc's
+    //     latest storage. `resolveDistTag` returns `undefined` for
+    //     empty input, which we treat as "no pin requested".
+    let resolvedVersion = skill.latestVersion;
+    let storageKey = skill.storageKey;
+    let metadata: SkillMetadata = skill.metadata;
+    if (version !== undefined && version.length > 0) {
+      const literal = resolveDistTag(skill, version);
+      if (!literal) {
+        // Defensive — resolveDistTag's contract returns string for any
+        // non-empty input, but the type system widens to `| undefined`.
+        // Treat as malformed rather than crash.
+        throw AppError.badRequest(
+          "invalid_version",
+          `Could not resolve version '${version}'`,
+        );
+      }
+      parseVersion(literal); // 400 if malformed, before Mongo lookup
+      const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, literal);
+      if (!versionDoc) {
+        throw AppError.notFound(
+          "skill_version_not_found",
+          `Version '${literal}' not found for skill '${skill.name}'`,
+        );
+      }
+      resolvedVersion = versionDoc.version;
+      storageKey = versionDoc.storageKey;
+      metadata = versionDoc.metadata;
+    }
+
     // 2. Download ZIP from storage
-    const presigned = await this.storageClient.getPresignedUrl((await this.storageBucketResolver()), skill.storageKey);
+    const presigned = await this.storageClient.getPresignedUrl((await this.storageBucketResolver()), storageKey);
     const response = await fetch(presigned.presignedUrl);
     if (!response.ok) {
       throw AppError.internalError("package_download_failed", "Failed to download skill package from storage");
@@ -1177,12 +1223,16 @@ export class SkillService {
       }
     }
 
-    logger.info({ skillName: skill.name, fileCount: Object.keys(files).length }, "Skill jsonized");
+    logger.info(
+      { skillName: skill.name, version: resolvedVersion, fileCount: Object.keys(files).length },
+      "Skill jsonized",
+    );
 
     return {
       name: skill.name,
       description: skill.description,
-      metadata: skill.metadata as unknown as Record<string, unknown>,
+      version: resolvedVersion,
+      metadata: metadata as unknown as Record<string, unknown>,
       files,
     };
   }

--- a/ornn-web/src/components/skill/SkillInstallCard.tsx
+++ b/ornn-web/src/components/skill/SkillInstallCard.tsx
@@ -194,6 +194,11 @@ export function SkillInstallCard({ skill, className }: SkillInstallCardProps) {
 
   // The prompt is universally available — works for any skill the caller
   // can see. Memoised so flipping tabs doesn't re-stringify on every render.
+  //
+  // #639 — pass the version the user is currently viewing so the pull
+  // URLs include `?version=…`. Without this, copying the prompt from
+  // an older-version page would silently install whatever's `latest`
+  // at install time — the version dropdown on the page would lie.
   const prompt = useMemo(
     () =>
       buildTrySkillPrompt({
@@ -202,8 +207,9 @@ export function SkillInstallCard({ skill, className }: SkillInstallCardProps) {
         description: skill.description,
         metadata: skill.metadata ?? {},
         ornnOrigin: window.location.origin,
+        ...(skill.version ? { version: skill.version } : {}),
       }),
-    [skill.guid, skill.name, skill.description, skill.metadata],
+    [skill.guid, skill.name, skill.description, skill.metadata, skill.version],
   );
 
   // The npx path needs all three of: mirror feature on, skill public,

--- a/ornn-web/src/lib/buildTrySkillPrompt.test.ts
+++ b/ornn-web/src/lib/buildTrySkillPrompt.test.ts
@@ -157,4 +157,55 @@ describe("buildTrySkillPrompt", () => {
     expect(out).toContain(`Ornn URL: ${ORIGIN}/skills/${GUID}`);
     expect(out).not.toContain("https://ornn.chrono-ai.fun///");
   });
+
+  describe("version pinning (#639)", () => {
+    test("pins all three fetch surfaces to ?version=<v> when version is provided", () => {
+      const out = buildTrySkillPrompt({
+        guid: GUID,
+        name: "s",
+        description: "d",
+        metadata: {},
+        ornnOrigin: ORIGIN,
+        version: "0.2",
+      });
+      // Header acknowledges the pin so the user/agent sees it.
+      expect(out).toContain("# Install Ornn skill: s @ 0.2");
+      expect(out).toMatch(/Pinned to version `0.2`/);
+      // NyxID CLI option uses --query.
+      expect(out).toContain(
+        `nyxid proxy request ornn-api /api/v1/skills/${GUID}/json --query version=0.2`,
+      );
+      // Direct HTTPS curl URL pins via ?version=.
+      expect(out).toContain(`${ORIGIN}/api/v1/skills/${GUID}/json?version=0.2`);
+      // Ornn URL footer also points at the same version.
+      expect(out).toContain(`Ornn URL: ${ORIGIN}/skills/${GUID}?version=0.2`);
+    });
+
+    test("absent version → no pin header, no ?version=", () => {
+      const out = buildTrySkillPrompt({
+        guid: GUID,
+        name: "s",
+        description: "d",
+        metadata: {},
+        ornnOrigin: ORIGIN,
+      });
+      expect(out).not.toMatch(/Pinned to version/);
+      expect(out).not.toContain("?version=");
+      expect(out).not.toContain("--query version=");
+    });
+
+    test("URL-encodes the version (defensive — server only accepts <major>.<minor> but be safe)", () => {
+      const out = buildTrySkillPrompt({
+        guid: GUID,
+        name: "s",
+        description: "d",
+        metadata: {},
+        ornnOrigin: ORIGIN,
+        version: "stable",
+      });
+      // Plain dist-tag passes through unchanged.
+      expect(out).toContain("?version=stable");
+      expect(out).toContain("# Install Ornn skill: s @ stable");
+    });
+  });
 });

--- a/ornn-web/src/lib/buildTrySkillPrompt.ts
+++ b/ornn-web/src/lib/buildTrySkillPrompt.ts
@@ -47,6 +47,18 @@ export interface BuildTrySkillPromptInput {
   metadata: TrySkillPromptMetadata | Record<string, unknown>;
   /** e.g. `window.location.origin` passed in by the caller. */
   ornnOrigin: string;
+  /**
+   * Version the user was viewing when they hit Install (#639). When
+   * provided, the pull URLs pin to `?version=<X>` so the agent
+   * installs the exact version the user saw — not whatever's `latest`
+   * at install time. Also surfaces a "Installing version <X>" header
+   * line so the user/agent sees the pinning explicitly.
+   *
+   * Omit when the source is genuinely version-less (e.g. a hypothetical
+   * "always pull latest" CTA). For the install card on the skill
+   * detail page, always pass the viewed version.
+   */
+  version?: string;
 }
 
 const NONE = "none";
@@ -88,7 +100,7 @@ function renderToolList(tools: TrySkillPromptTool[]): string {
 }
 
 export function buildTrySkillPrompt(input: BuildTrySkillPromptInput): string {
-  const { guid, name, description, metadata, ornnOrigin } = input;
+  const { guid, name, description, metadata, ornnOrigin, version } = input;
   const category = asString((metadata as { category?: unknown }).category) ?? "plain";
   const runtimes = readRuntimes(metadata);
   const tools = readTools(metadata);
@@ -99,13 +111,27 @@ export function buildTrySkillPrompt(input: BuildTrySkillPromptInput): string {
   const toolLine = renderToolList(tools);
 
   const origin = ornnOrigin.replace(/\/+$/, "");
-  const skillUrl = `${origin}/skills/${guid}`;
-  const apiUrl = `${origin}/api/v1/skills/${guid}/json`;
+  // #639 — when the caller knows which version was being viewed, pin
+  // the URLs and the per-run NyxID command. Without this, the agent
+  // silently pulls `latest` at install time, which can be different
+  // from what the user saw on the page.
+  const versionQuery = version ? `?version=${encodeURIComponent(version)}` : "";
+  const versionParam = version ? ` --query version=${version}` : "";
+  const skillUrl = `${origin}/skills/${guid}${versionQuery}`;
+  const apiUrl = `${origin}/api/v1/skills/${guid}/json${versionQuery}`;
 
   return [
-    `# Install Ornn skill: ${name}`,
+    `# Install Ornn skill: ${name}${version ? ` @ ${version}` : ""}`,
     "",
     `> ${description}`,
+    ...(version
+      ? [
+          "",
+          `**Pinned to version \`${version}\`** — both fetch commands below carry`,
+          "`?version=…` so the agent installs the exact version that was open in",
+          "the browser, not whatever's currently `latest`.",
+        ]
+      : []),
     "",
     "You're being given an Ornn skill — a packaged AI capability",
     "(`SKILL.md` prompt + optional scripts + metadata). Follow the steps",
@@ -120,7 +146,7 @@ export function buildTrySkillPrompt(input: BuildTrySkillPromptInput): string {
     "",
     "**Option A — via NyxID CLI** (preferred if `nyxid` is installed and you've run `nyxid login`):",
     "```",
-    `nyxid proxy request ornn-api /api/v1/skills/${guid}/json --output json`,
+    `nyxid proxy request ornn-api /api/v1/skills/${guid}/json${versionParam} --output json`,
     "```",
     "",
     "**Option B — direct HTTPS** (if you already have a NyxID bearer token):",


### PR DESCRIPTION
## Summary

Opening an older skill version (`?version=0.2`) switched the URL + file viewer correctly, but the install card's prompt was still latest-shaped:

- Pull commands (`nyxid proxy request …/json`, `curl …/json`) had no `?version=…` → an agent following the prompt would silently install `latest` at install time.
- Header didn't mention the version → even careful agents couldn't tell.

## Fix end-to-end

**Backend (`ornn-api`)** — `getSkillJson(idOrName, version?)`:
- Optional `version` — literal `<major>.<minor>` OR a dist-tag (#463). When set, uses that version's `storageKey` + `metadata`; otherwise latest (unchanged for legacy callers).
- Returns new top-level `version` field so callers can confirm what they got.
- `GET /api/v1/skills/:idOrName/json?version=` wired through. Bad version → `400 invalid_version`; missing version → `404 skill_version_not_found` (RFC 7807).

**Frontend (`ornn-web`)**:
- `buildTrySkillPrompt({…, version})` adds `?version=` to both pull URLs (curl + `nyxid --query version=…`), and to the footer `Ornn URL:`. Header: `# Install Ornn skill: <name> @ <X>` + `Pinned to version <X>` paragraph.
- `SkillInstallCard` passes the viewed `skill.version` straight through. No-version callers unaffected — version is opt-in.

## Test plan

- [x] 3 new `buildTrySkillPrompt.test.ts` assertions: pin surfaces, no-pin parity, dist-tag passes through (12/12 in file)
- [x] ornn-web: 133/133 tests; typecheck clean
- [x] ornn-api: 805/805 tests; typecheck clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: open `?version=0.2`, copy install prompt → both URLs carry `?version=0.2`; header reads `@ 0.2`

Changeset is **minor** because `/json` response shape gains a new field.

Closes #639.