### PR TITLE
fix(web): Free/ZIP upload restores real pre-submit state on reject (#652)

### DIFF
--- a/.changeset/free-zip-upload-status-652.md
+++ b/.changeset/free-zip-upload-status-652.md
@@ -1,0 +1,9 @@
+---
+"ornn-web": patch
+---
+
+Free / ZIP upload no longer shows contradictory "structure is valid" on backend reject (#652).
+
+When the frontend validator flagged a ZIP as `invalid`, the user could flip `Skip validation` and submit anyway. The backend then rejected (e.g. `SKILL.md not found in package`), the rejection toast fired — but the page banner unconditionally fell back to `valid` and rendered "Skill package structure is valid." on top of the toast.
+
+`CreateSkillFreePage` now restores `pageState` to the original `validationResult.status` after a failed submit (`invalid` stays `invalid`, `warning` stays `warning`, `valid` stays `valid`). The success banner can never appear on a structure the frontend itself flagged as bad.

--- a/ornn-web/src/pages/skill/CreateSkillFreePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillFreePage.tsx
@@ -280,9 +280,14 @@ export function CreateSkillFreePage() {
     } catch (err) {
       const message = translateError(err, t("free.uploadFailed"));
       addToast({ type: "error", message });
-      setPageState(
-        validationResult?.status === "warning" ? "warning" : "valid",
-      );
+      // #652 — restore the page to whatever pre-submit state the
+      // frontend originally derived. The previous code unconditionally
+      // forced "valid" / "warning", which made the success banner
+      // ("Skill package structure is valid.") render on top of the
+      // backend's rejection toast — contradictory and confusing,
+      // especially when the user had skip-validation toggled past an
+      // "invalid" structure.
+      setPageState(validationResult?.status ?? "valid");
     }
   };
 


### PR DESCRIPTION
## Summary

When the frontend validator flagged a ZIP as `invalid`, the user could flip `Skip validation` and submit anyway. Backend rejected (e.g. `SKILL.md not found in package`), toast fired — but the page also rendered the success banner `Skill package structure is valid.` because the catch block unconditionally restored `pageState` to `valid` / `warning`.

Fix: restore to the original `validationResult.status` (`invalid` stays `invalid`). The success banner can never appear over a backend rejection.

## Test plan

- [x] 133/133 ornn-web tests; typecheck clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: upload bad ZIP → flip skip-validation → submit → see only the error toast, no green banner

Closes #652.