### PR TITLE
fix(web): three quota refresh races on Playground + Skill Gen (#629 + #630 + #624)

### DIFF
--- a/.changeset/quota-refresh-races-629-630-624.md
+++ b/.changeset/quota-refresh-races-629-630-624.md
@@ -1,0 +1,13 @@
+---
+"ornn-web": patch
+---
+
+Fix three Playground / Skill-Gen quota refresh races (#629 + #630 + #624).
+
+All three were the same family of "the chrome and the truth disagree":
+
+- **#629** — `QuotaInline` warning banner and `QuotaSummary` row both rendered `Math.round((used / ceiling) * 100)`. With `used=199, ceiling=200, remaining=1`, that's `99.5 → 100%` even though the chip next to it showed `1 Playground calls left`. New shared `displayUsagePercent(used, ceiling, remaining)` uses `Math.floor`, clamps to `[0, 99]` whenever `remaining > 0`, and only returns `100` when `remaining <= 0`. Pinned with 6 unit assertions.
+- **#630** — `usePlaygroundChat`'s `finish` / `error` handlers didn't invalidate `MY_QUOTA_KEY`. The page kept showing the pre-charge snapshot for up to 60 seconds (the next poll). Added `qc.invalidateQueries({ queryKey: MY_QUOTA_KEY })` on both terminal events so the chip / banner / over-limit gate reflect the actual remaining count immediately.
+- **#624** — `CreateSkillGenerativePage` (and `PlaygroundPage`) routed to `OverLimitPage` whenever `isOverLimit` flipped true, even if the user had a generated result / live conversation on screen. The post-charge quota poll arriving after the *final* allowed run would yank the result away. Now the over-limit redirect only fires on a *fresh* arrival (no preview / no messages); the Send button's existing `isOverLimit` disable still prevents new runs.
+
+Net effect: the user's last allowed run lands, the result stays visible, the chip flips to 0/N right away, and the banner copy stops contradicting the chip.

--- a/ornn-web/src/components/quota/QuotaInline.tsx
+++ b/ornn-web/src/components/quota/QuotaInline.tsx
@@ -18,6 +18,7 @@
 import { useTranslation } from "react-i18next";
 import type { Surface, SurfaceSnapshot } from "@/services/quotaApi";
 import { useMyQuota } from "@/hooks/useQuota";
+import { displayUsagePercent } from "./quotaDisplay";
 
 interface QuotaInlineProps {
   surface: Surface;
@@ -83,7 +84,9 @@ export function QuotaInline({ surface, className = "" }: QuotaInlineProps) {
   const warning = snap.warning && !exhausted;
 
   if (warning) {
-    const percent = cap > 0 ? Math.round((snap.used / cap) * 100) : 0;
+    // #629 — share the QuotaSummary helper so the inline banner can
+    // never claim "100% used this month" while a call still remains.
+    const percent = displayUsagePercent(snap.used, cap, remaining);
     const adminGrantSuffix =
       snap.adminGrant > 0
         ? t(

--- a/ornn-web/src/components/quota/QuotaSummary.tsx
+++ b/ornn-web/src/components/quota/QuotaSummary.tsx
@@ -14,6 +14,7 @@ import { createPortal } from "react-dom";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import type { QuotaSnapshot, SurfaceSnapshot } from "@/services/quotaApi";
+import { displayUsagePercent } from "./quotaDisplay";
 
 const SURFACE_LABEL: Record<"playground" | "skillGen", string> = {
   playground: "Playground",
@@ -39,9 +40,11 @@ function formatReset(iso: string): string {
   }
 }
 
-function pct(used: number, ceiling: number): number {
-  if (ceiling <= 0) return 0;
-  return Math.max(0, Math.min(100, Math.round((used / ceiling) * 100)));
+// `pct` now delegates to the shared `displayUsagePercent` so summary
+// + inline banner agree on the "never round up to 100% while a call
+// remains" contract from #629.
+function pct(used: number, ceiling: number, remaining: number): number {
+  return displayUsagePercent(used, ceiling, remaining);
 }
 
 interface SurfaceRowProps {
@@ -52,7 +55,7 @@ interface SurfaceRowProps {
 
 function SurfaceRow({ label, snapshot, resetAt }: SurfaceRowProps) {
   const ceiling = snapshot.defaultAllotment + snapshot.adminGrant;
-  const monthlyPct = pct(snapshot.used, ceiling);
+  const monthlyPct = pct(snapshot.used, ceiling, snapshot.remaining);
   const monthlyTone =
     snapshot.remaining <= 0
       ? "bg-danger"

--- a/ornn-web/src/components/quota/quotaDisplay.test.ts
+++ b/ornn-web/src/components/quota/quotaDisplay.test.ts
@@ -1,0 +1,39 @@
+/**
+ * displayUsagePercent tests — pins the #629 "never round up to 100%"
+ * contract.
+ *
+ * @module components/quota/quotaDisplay.test
+ */
+import { describe, it, expect } from "vitest";
+import { displayUsagePercent } from "./quotaDisplay";
+
+describe("displayUsagePercent", () => {
+  it("returns 0 when ceiling is 0", () => {
+    expect(displayUsagePercent(0, 0, 0)).toBe(0);
+  });
+
+  it("returns 100 when remaining is 0", () => {
+    expect(displayUsagePercent(100, 100, 0)).toBe(100);
+    expect(displayUsagePercent(50, 100, 0)).toBe(100);
+  });
+
+  it("clamps to 99 when 1 call remains and naive rounding would say 100", () => {
+    // #629 reproducer — used=199 ceiling=200 → 99.5% → naive round → 100.
+    // With remaining=1, must display 99%.
+    expect(displayUsagePercent(199, 200, 1)).toBe(99);
+  });
+
+  it("uses floor (not round) so 99.9% reads as 99%", () => {
+    expect(displayUsagePercent(999, 1000, 1)).toBe(99);
+  });
+
+  it("normal mid-range usage rounds down", () => {
+    expect(displayUsagePercent(50, 100, 50)).toBe(50);
+    expect(displayUsagePercent(49, 100, 51)).toBe(49);
+    expect(displayUsagePercent(1, 100, 99)).toBe(1);
+  });
+
+  it("clamps 0 from below (defensive against negative used)", () => {
+    expect(displayUsagePercent(-5, 100, 105)).toBe(0);
+  });
+});

--- a/ornn-web/src/components/quota/quotaDisplay.ts
+++ b/ornn-web/src/components/quota/quotaDisplay.ts
@@ -1,0 +1,35 @@
+/**
+ * Display-percentage helper shared by QuotaSummary + QuotaInline.
+ *
+ * #629 — the old `Math.round((used / ceiling) * 100)` could promote
+ * `99.5%` (e.g. `used=199, ceiling=200`) to `100%` even though
+ * `remaining=1`. The chip / "X remaining" copy next to it then
+ * contradicted the banner ("100% used this month" + "1 Playground
+ * calls left"). Pin the displayed percent so 100 never appears while
+ * any quota remains.
+ *
+ * @module components/quota/quotaDisplay
+ */
+
+/**
+ * Compute the integer percent to render in chrome ("100% used", the
+ * progress bar fill, etc.).
+ *
+ * Contract:
+ *   - 0 when ceiling is non-positive (nothing meaningful to show).
+ *   - `100` only when `remaining <= 0`. Below that, the result is
+ *     clamped to `[0, 99]` so the banner never claims "100% used"
+ *     while a call is still allowed.
+ *   - Always `Math.floor` so a usage of `99.5%` reads as `99%`, not
+ *     a misleading `100%`.
+ */
+export function displayUsagePercent(
+  used: number,
+  ceiling: number,
+  remaining: number,
+): number {
+  if (ceiling <= 0) return 0;
+  if (remaining <= 0) return 100;
+  const raw = (used / ceiling) * 100;
+  return Math.max(0, Math.min(99, Math.floor(raw)));
+}

--- a/ornn-web/src/hooks/usePlaygroundChat.ts
+++ b/ornn-web/src/hooks/usePlaygroundChat.ts
@@ -19,10 +19,12 @@
  */
 
 import { useCallback, useRef, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { usePlaygroundStore } from "@/stores/playgroundStore";
 import { streamChat, type StreamHandle } from "@/services/playgroundStreamApi";
 import type { PlaygroundChatEvent, FileOutput } from "@/types/playground";
 import { track } from "@/lib/analytics";
+import { MY_QUOTA_KEY } from "@/hooks/useQuota";
 
 /**
  * Pacer tick interval. 22 ms ≈ 45 chars/sec when the buffer is small,
@@ -64,6 +66,14 @@ function triggerFileDownload(file: FileOutput) {
 export function usePlaygroundChat() {
   const store = usePlaygroundStore();
   const streamRef = useRef<StreamHandle | null>(null);
+  // Backend charges quota inside the chat handler on `finish` /
+  // `error` — both are billable events. Without an explicit
+  // invalidate, the page renders the pre-charge `useMyQuota` snapshot
+  // until the 60-second poll lands. That's how #630 was happening:
+  // user consumed their last call, the UI still said "1 remaining"
+  // for up to a minute, and a hard refresh was the only way to see
+  // the over-limit state.
+  const qc = useQueryClient();
 
   // Pacer state — chars received from SSE that haven't been painted yet.
   const pendingTokensRef = useRef("");
@@ -142,6 +152,10 @@ export function usePlaygroundChat() {
           s.setError(event.message);
           s.setStreaming(false);
           track("playground.run.failed", { error: event.message });
+          // #630 — error paths can still bill (e.g. tool-call charged
+          // before the LLM blew up), so refresh the snapshot the same
+          // way as the success path.
+          qc.invalidateQueries({ queryKey: MY_QUOTA_KEY });
           break;
 
         case "finish":
@@ -151,10 +165,14 @@ export function usePlaygroundChat() {
           track("playground.run.completed", {
             finishReason: event.finishReason,
           });
+          // #630 — pull the post-charge snapshot so the chip / banner /
+          // OverLimitPage gate reflect the actual remaining count
+          // immediately instead of waiting for the 60s poll.
+          qc.invalidateQueries({ queryKey: MY_QUOTA_KEY });
           break;
       }
     },
-    [drainAll, ensurePacer],
+    [drainAll, ensurePacer, qc],
   );
 
   const sendMessage = useCallback(

--- a/ornn-web/src/pages/PlaygroundPage.tsx
+++ b/ornn-web/src/pages/PlaygroundPage.tsx
@@ -182,7 +182,13 @@ export function PlaygroundPage() {
     );
   }
 
-  if (isOverLimit && playgroundSnap && quotaSnapshot) {
+  // #624 (sibling) — only kick to OverLimitPage on a *fresh* arrival.
+  // Once the user has messages on screen, their conversation
+  // (including a just-completed final allowed run) must not be
+  // replaced by the quota gate when the post-charge quota poll
+  // arrives. The Send button is already disabled via `isOverLimit`
+  // inside the composer, so no new runs slip through.
+  if (isOverLimit && playgroundSnap && quotaSnapshot && !conversationActive) {
     return (
       <PageTransition>
         <OverLimitPage

--- a/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGenerativePage.tsx
@@ -257,7 +257,21 @@ export function CreateSkillGenerativePage() {
         "Describe the skill you want to create…",
       );
 
-  if (isOverLimit && skillGenSnap && quotaSnapshot) {
+  // #624 — only redirect to the over-limit page on a *fresh* arrival
+  // (no messages exchanged AND no generated preview). Once the user
+  // has produced a result this session, the quota poll dropping their
+  // remaining to 0 should NOT yank the result off-screen; the Send
+  // button is already disabled below via `isOverLimit`, which is the
+  // right gate (no new generations) without losing what's already on
+  // the page. Without this guard, the final allowed generation
+  // succeeds → quota refetch → page replaced → user can't save.
+  if (
+    isOverLimit &&
+    skillGenSnap &&
+    quotaSnapshot &&
+    !hasMessages &&
+    !hasPreview
+  ) {
     return (
       <PageTransition>
         <OverLimitPage


### PR DESCRIPTION
## Summary

All three are "the chrome and the truth disagree":

- **#629** — `Math.round((used/ceiling)*100)` promotes 99.5% to 100% even though `remaining=1`. Chip says "1 left", banner says "100% used". New shared `displayUsagePercent(used, ceiling, remaining)` uses `Math.floor` + clamps to `[0, 99]` whenever `remaining > 0`; returns 100 only when `remaining <= 0`. Used by `QuotaSummary` + `QuotaInline`.
- **#630** — `usePlaygroundChat`'s `finish`/`error` handlers didn't invalidate `MY_QUOTA_KEY`. Page kept the pre-charge snapshot for up to 60s. Added `qc.invalidateQueries` on both events.
- **#624** — `CreateSkillGenerativePage` (and sibling Playground gate) routed to `OverLimitPage` whenever `isOverLimit` flipped true, even with a generated result / live conversation on screen. Now the redirect only fires on a fresh arrival (no preview / no messages); the existing `isOverLimit` disable on the Send button still prevents new runs.

## Test plan

- [x] 6 new `quotaDisplay.test.ts` assertions (0-ceiling, exhausted=100, 199/200=99 reproducer, 999/1000=99 floor, mid-range, defensive)
- [x] 139/139 ornn-web tests; typecheck clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: get to last allowed call → run → result stays + chip flips to 0/N + no `100%` banner over `1 left`

Closes #629.
Closes #630.
Closes #624.