### PR TITLE
fix(web): drop dead X-User-* headers from createSkill + logActivity (#528)

### DIFF
--- a/.changeset/cors-cleanup-528.md
+++ b/.changeset/cors-cleanup-528.md
@@ -1,0 +1,13 @@
+---
+"ornn-web": patch
+---
+
+Remove dead `X-User-*` headers from skill-create + activity log (#528).
+
+`createSkill` (POST /api/v1/skills — used by Free / Guided / AI-generated save) and `logActivity` (POST /api/v1/activity/login|logout) still attached `X-User-Email` / `X-User-Display-Name` headers, leftover from a pre-NyxID-proxy auth model where the backend read identity off these headers. The backend hasn't read them in months (identity comes from the proxy-forwarded JWT), and the `apiClient.createHeaders` cleanup that struck the same code from the shared client missed these two raw-`fetch` callers.
+
+Sending them caused the browser's CORS preflight to ask permission for `X-User-Email` and `X-User-Display-Name`. The backend CORS allowlist is `["Content-Type", "Authorization"]` (`bootstrap.ts:744`), so the preflight response didn't include those headers — the browser then blocked the actual `POST` with a CORS error. End user sees: "Save Skill" never completes, DevTools shows preflight `204` then a `CORS error` on the real request.
+
+Net change: both callers now send only `Content-Type` + `Authorization` (matching the rest of the SDK), the preflight allow-headers list is fully satisfied, and the real request goes through.
+
+This is the definitive fix for the `POST /skills` case. The `PUT /skills/:id` case tracked in #565 doesn't send `X-User-*` itself, but the parallel login-time `logActivity` failure here was producing a CORS-error toast that could be misattributed to the in-flight PUT — worth re-verifying #565 after this lands.

--- a/ornn-web/src/services/activityApi.ts
+++ b/ornn-web/src/services/activityApi.ts
@@ -17,22 +17,23 @@ const logger = createLogger("activityApi");
  */
 export async function logActivity(action: "login" | "logout"): Promise<void> {
   try {
-    const { accessToken, user } = useAuthStore.getState();
+    const { accessToken } = useAuthStore.getState();
     if (!accessToken) {
       logger.warn("No access token, skipping activity log", { action });
       return;
     }
 
+    // #528 — `X-User-Email` / `X-User-Display-Name` used to ride along
+    // here. They were stripped by the NyxID proxy and never read by
+    // the backend (identity is sourced from the proxy-forwarded
+    // identity token), but the backend CORS allowlist doesn't include
+    // them — sending them tripped a preflight-blocked-by-CORS failure
+    // on every login. Same dead code as the `apiClient.createHeaders`
+    // cleanup; this caller was missed in the original sweep.
     const headers: HeadersInit = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
     };
-    if (user?.email) {
-      headers["X-User-Email"] = user.email;
-    }
-    if (user?.displayName) {
-      headers["X-User-Display-Name"] = user.displayName;
-    }
 
     const res = await fetch(`${API_BASE}/api/v1/activity/${action}`, {
       method: "POST",

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -86,20 +86,24 @@ export async function setSkillVersionDeprecation(
  * Create a new skill from a ZIP file. Sends the ZIP as a raw
  * application/zip body. New skills are always private — visibility is
  * managed afterward via the permissions panel on the skill detail page.
+ *
+ * #528 — `X-User-Email` / `X-User-Display-Name` headers used to ride
+ * along here. They were stripped by the NyxID proxy and never read by
+ * the backend (identity is sourced from the proxy-forwarded identity
+ * token), but the backend CORS allowlist is `["Content-Type",
+ * "Authorization"]`, so the preflight allowed-headers response didn't
+ * include them — the browser then blocked the actual POST with a
+ * CORS error. Same dead code as the `apiClient.createHeaders`
+ * cleanup; this was the last unmigrated caller of the ZIP-upload
+ * flow.
  */
 export async function createSkill(zipFile: File, skipValidation = false): Promise<SkillDetail> {
-  const { accessToken: token, user } = useAuthStore.getState();
+  const token = useAuthStore.getState().accessToken;
   const headers: HeadersInit = {
     "Content-Type": "application/zip",
   };
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
-  }
-  if (user?.email) {
-    headers["X-User-Email"] = user.email;
-  }
-  if (user?.displayName) {
-    headers["X-User-Display-Name"] = user.displayName;
   }
 
   const params = skipValidation ? "?skip_validation=true" : "";


### PR DESCRIPTION
## Summary

`createSkill` (POST /skills — Free / Guided / AI-gen save) and `logActivity` (POST /activity/login|logout) still sent `X-User-Email` / `X-User-Display-Name` headers, dead code from a pre-NyxID auth model. Backend reads identity off the proxy-forwarded JWT, not these headers. The shared `apiClient.createHeaders` cleanup missed these two raw-fetch callers.

The browser preflight asked permission for these headers, the backend CORS allowlist (`["Content-Type", "Authorization"]`) didn't list them, so the browser blocked the actual POST with CORS error. Symptom: preflight 204 → real request CORS error → save never completes.

Both callers now send only `Content-Type` + `Authorization`. Preflight allow-headers list is fully satisfied; real request goes through.

## #565 note

The PUT `/skills/:id` path doesn't send `X-User-*` itself — root cause differs. But login-time `logActivity` failure here likely produced a parallel CORS toast that could be misattributed to the in-flight PUT. Worth re-verifying #565 after this deploys.

## Test plan

- [x] 133/133 ornn-web tests; typecheck clean
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: Free upload + Guided save + AI-gen save all complete

Closes #528.