### PR TITLE
fix(web): Guided env-var input enforces 30-item cap inline (#683)

### DIFF
--- a/.changeset/env-var-30-item-cap-683.md
+++ b/.changeset/env-var-30-item-cap-683.md
@@ -1,0 +1,9 @@
+---
+"ornn-web": patch
+---
+
+Guided-create env-var input now enforces the 30-item cap inline (#683).
+
+`runtime-env-var` is capped at 30 in both the frontend frontmatter schema (`shared/schemas/skillFrontmatter.ts`) and the backend Zod schema. The Guided wizard's env-var input was a `MultiValueInput` with no `max` prop, so it defaulted to 50 — the page happily accepted chip 31. Submit-time Zod validation then blocked navigation, but the NEXT button stayed enabled with no inline feedback; users saw "click NEXT, nothing happens".
+
+Passing `max={30}` to the env-var `MultiValueInput` surfaces the cap in the field header (`N/30`), disables the input at the cap, and rejects pasted-past-cap input inline with the existing "Maximum 30 values" copy. Runtime dependencies (capped at 50 in both schemas) stay at the default, matching their real limit.

--- a/ornn-web/src/components/skill/guided/StepBasicInfo.tsx
+++ b/ornn-web/src/components/skill/guided/StepBasicInfo.tsx
@@ -214,6 +214,16 @@ export function StepBasicInfo({
                 placeholder={t("guided.envVarsPlaceholder")}
                 helperText={t("guided.envVarsHelper")}
                 badgeColor="yellow"
+                // #683 — frontend + backend frontmatter schemas both
+                // cap `runtime-env-var` at 30. Without `max={30}` the
+                // component defaulted to 50, so the input happily
+                // accepted up to 50 chips and only the Zod submit-time
+                // validator caught the overage — NEXT just appeared to
+                // not work. Passing the explicit cap surfaces the
+                // limit in the field header (`N/30`), disables the
+                // input at the cap, and rejects pasted-past-cap input
+                // inline with "Maximum 30 values".
+                max={30}
                 validate={(v) =>
                   /^[A-Z_][A-Z0-9_]*$/.test(v)
                     ? null


### PR DESCRIPTION
## Summary

`runtime-env-var` is capped at 30 in both the frontend + backend Zod schemas. Guided's env-var `MultiValueInput` had no `max` prop, defaulting to 50. Submit-time validation blocked NEXT but with no inline feedback → "nothing happens" UX.

Passing `max={30}` surfaces the cap in the header (`N/30`), disables input at cap, rejects past-cap input inline with existing "Maximum 30 values" copy. Runtime deps (capped at 50) stay at default.

## Test plan

- [x] 133/133 ornn-web tests; typecheck clean
- [ ] CI green
- [ ] Reproduce on local cluster: add 31 env vars in Guided → input disabled at 30 with `30/30` header

Closes #683.