### PR TITLE
fix(web): Registry page localises end-to-end in ZH mode (#682)

### DIFF
--- a/.changeset/registry-i18n-sweep-682.md
+++ b/.changeset/registry-i18n-sweep-682.md
@@ -1,0 +1,15 @@
+---
+"ornn-web": patch
+---
+
+Registry page now respects Chinese locale across every tab (#682).
+
+Two classes of bug, both mass-bleeding English copy into the Chinese UI:
+
+**Class 1 — keys called from source never existed in either locale file.** `ExplorePage.tsx` reads `t("explore.filterTags", "Tag")`, `t("explore.noServices", "No system services yet.")`, `t("explore.systemSkillsHint", "…")`, etc. through 14 distinct keys that were never added to `en.json` or `zh.json`. Without a matching key in either locale, i18n falls back to the second arg (the English literal) regardless of language. ZH users saw English literals everywhere. Added the missing keys to BOTH locale files. Also renamed the source's two intro paragraphs (`systemSkillsHint` → `systemSkillsIntro`, `sharedHint` → `sharedWithMeIntro`) to match the new canonical key names so future readers don't trip on the legacy fallback-only labels.
+
+**Class 2 — literal strings never wired through i18n.** `SearchBar.tsx` had 5 hardcoded English strings (`Keyword`, `Semantic`, the two placeholders, the two `title=` tooltips). `SkillCard.tsx` had `Public`, `Private`, `Via organization`, `Shared by {name}` baked in. `Pagination.tsx` had `Prev` / `Next` baked in (used on every paginated list — Registry, admin tables, lifetime drawer). All converted to `t("…")` calls; new keys added to both locale files; `Public` / `Private` / `Prev` / `Next` reuse the existing `common.*` keys (already translated in ZH).
+
+Net result: Registry page reads end-to-end Chinese in ZH mode — search bar, all four tabs' filter headings + empty states, skill-card badges, and pagination. Product names (`NyxID`) stay untranslated per the issue's guidance. Date formatting is not addressed here — Intl `toLocaleString` already respects the system locale on the browser side; the calling pages set their own `locale` param if they want to force `zh-CN`.
+
+139 / 0 fail ornn-web tests; typecheck clean.

--- a/ornn-web/src/components/search/SearchBar.tsx
+++ b/ornn-web/src/components/search/SearchBar.tsx
@@ -1,12 +1,14 @@
 import { useSearchStore } from "@/stores/searchStore";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 export interface SearchBarProps {
   className?: string;
 }
 
 export function SearchBar({ className = "" }: SearchBarProps) {
+  const { t } = useTranslation();
   const setQuery = useSearchStore((s) => s.setQuery);
   const storeQuery = useSearchStore((s) => s.query);
   const mode = useSearchStore((s) => s.mode);
@@ -43,8 +45,8 @@ export function SearchBar({ className = "" }: SearchBarProps) {
           onChange={(e) => setLocalValue(e.target.value)}
           placeholder={
             isSemanticMode
-              ? "Describe what you're looking for..."
-              : "Search skills by name, description, or tags..."
+              ? t("search.placeholderSemantic", "Describe what you're looking for...")
+              : t("search.placeholderKeyword", "Search skills by name, description, or tags...")
           }
           className="neon-input w-full rounded py-3 pr-4 pl-12 font-text text-strong placeholder:text-meta/50"
         />
@@ -54,7 +56,11 @@ export function SearchBar({ className = "" }: SearchBarProps) {
       <button
         type="button"
         onClick={() => setMode(isSemanticMode ? "keyword" : "semantic")}
-        title={isSemanticMode ? "Switch to keyword search" : "Switch to semantic search"}
+        title={
+          isSemanticMode
+            ? t("search.toggleToKeyword", "Switch to keyword search")
+            : t("search.toggleToSemantic", "Switch to semantic search")
+        }
         className={`
           flex items-center gap-2 shrink-0 rounded border px-4 py-3 font-text text-sm transition-all
           ${isSemanticMode
@@ -76,7 +82,9 @@ export function SearchBar({ className = "" }: SearchBarProps) {
             />
           </svg>
         )}
-        {isSemanticMode ? "Semantic" : "Keyword"}
+        {isSemanticMode
+          ? t("search.modeSemantic", "Semantic")
+          : t("search.modeKeyword", "Keyword")}
       </button>
     </div>
   );

--- a/ornn-web/src/components/skill/SkillCard.tsx
+++ b/ornn-web/src/components/skill/SkillCard.tsx
@@ -50,8 +50,11 @@ export interface SkillCardProps {
  * `permissionSummary` which the backend computes per-request.
  */
 function PermissionBadges({ skill }: { skill: SkillSearchResult }) {
+  // Reach `t` via the parent's hook context — the badge labels are
+  // short visible UI strings (#682) and must localize.
+  const { t } = useTranslation();
   if (!skill.isPrivate) {
-    return <Badge color="green">🌐 Public</Badge>;
+    return <Badge color="green">🌐 {t("common.public")}</Badge>;
   }
   const ps = skill.permissionSummary;
   const userCount = ps?.sharedUserCount ?? 0;
@@ -59,7 +62,7 @@ function PermissionBadges({ skill }: { skill: SkillSearchResult }) {
   const hasGrants = userCount > 0 || orgCount > 0;
   return (
     <>
-      {!hasGrants && <Badge color="cyan">🔒 Private</Badge>}
+      {!hasGrants && <Badge color="cyan">🔒 {t("common.private")}</Badge>}
       {userCount > 0 && <Badge color="magenta">👥 {userCount}</Badge>}
       {orgCount > 0 && <Badge color="cyan">🏢 {orgCount}</Badge>}
     </>
@@ -135,12 +138,12 @@ export function SkillCard({
           `myAccessReason` with a grant-based value. */}
       {skill.myAccessReason === "shared-via-org" && (
         <p className="mb-2 font-text text-[11px] uppercase tracking-wider text-meta">
-          Via organization
+          {t("skillComponents.card.viaOrganization", "Via organization")}
         </p>
       )}
       {skill.myAccessReason === "shared-direct" && (
         <p className="mb-2 font-text text-[11px] uppercase tracking-wider text-meta">
-          Shared by {displayName}
+          {t("skillComponents.card.sharedBy", "Shared by {{name}}", { name: displayName })}
         </p>
       )}
 

--- a/ornn-web/src/components/ui/Pagination.tsx
+++ b/ornn-web/src/components/ui/Pagination.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Button } from "./Button";
 
 export interface PaginationProps {
@@ -8,6 +9,12 @@ export interface PaginationProps {
 }
 
 export function Pagination({ page, totalPages, onPageChange, className = "" }: PaginationProps) {
+  // #682 — `Prev` / `Next` labels are visible UI strings on every
+  // paginated list (Registry, admin tables, lifetime drawer). They
+  // were hardcoded, so ZH mode kept showing the English words. Pull
+  // from `common.prev` / `common.next` which already exist in both
+  // locale files.
+  const { t } = useTranslation();
   if (totalPages <= 1) return null;
 
   const pages = buildPageNumbers(page, totalPages);
@@ -20,7 +27,7 @@ export function Pagination({ page, totalPages, onPageChange, className = "" }: P
         disabled={page <= 1}
         onClick={() => onPageChange(page - 1)}
       >
-        Prev
+        {t("common.prev")}
       </Button>
 
       {pages.map((p, i) =>
@@ -46,7 +53,7 @@ export function Pagination({ page, totalPages, onPageChange, className = "" }: P
         disabled={page >= totalPages}
         onClick={() => onPageChange(page + 1)}
       >
-        Next
+        {t("common.next")}
       </Button>
     </nav>
   );

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -75,14 +75,31 @@
     "systemSkills": "System Skills",
     "publicSkills": "Public Skills",
     "mySkills": "My Skills",
-    "sharedWithMe": "Shared With Me",
-    "noSkillsFound": "No skills found",
-    "noSharedSkills": "No one has shared a skill with you yet.",
-    "tryAdjusting": "Try adjusting your search, or upload the first skill.",
-    "noSkillsYet": "No skills yet",
-    "createFirst": "Create your first skill to get started",
+    "sharedWithMe": "Shared with me",
+    "noSkillsFound": "No public skills match",
+    "noSharedSkills": "Nothing has been shared with you yet",
+    "tryAdjusting": "Try adjusting your search or filters.",
+    "noSkillsYet": "You haven't created any skills yet",
+    "noSystemSkills": "No system skills yet",
+    "createFirst": "Create your first skill to get started.",
     "uploadSkill": "Upload Skill",
-    "createSkill": "Create Skill"
+    "createSkill": "Create Skill",
+    "filterService": "NyxID service",
+    "filterTags": "Tag",
+    "filterAuthors": "Author",
+    "filterSharedWithUsers": "Shared with users",
+    "filterSharedWithOrgs": "Shared with orgs",
+    "filterSharedByUsers": "Shared by users",
+    "filterSharedByOrgs": "Shared via orgs",
+    "noServices": "No system services yet.",
+    "noTags": "No tags yet.",
+    "noAuthors": "No authors yet.",
+    "notSharedWithUsers": "You haven't shared any skills with specific users.",
+    "notSharedWithOrgs": "You haven't shared any skills with orgs.",
+    "notSharedByUsers": "Nobody has shared with you directly.",
+    "notSharedByOrgs": "No orgs have shared anything with you.",
+    "systemSkillsIntro": "System skills are skills tied to a NyxID admin service. Platform admins tie any skill to any admin service to publish it as a system skill.",
+    "sharedWithMeIntro": "When someone grants you access to a private skill — either directly or via an org — it shows up here."
   },
   "mySkills": {
     "searchPlaceholder": "Search your skills...",
@@ -970,6 +987,14 @@
     "adminUnlimitedUsageTitle": "Admin · Unlimited usage",
     "quotaUsageDetails": "Quota usage details"
   },
+  "search": {
+    "placeholderKeyword": "Search skills by name, description, or tags...",
+    "placeholderSemantic": "Describe what you're looking for...",
+    "toggleToKeyword": "Switch to keyword search",
+    "toggleToSemantic": "Switch to semantic search",
+    "modeKeyword": "Keyword",
+    "modeSemantic": "Semantic"
+  },
   "skillComponents": {
     "generateModal": {
       "title": "Generate Skill",
@@ -977,7 +1002,9 @@
       "add": "Add"
     },
     "card": {
-      "linkedToGithub": "Linked to GitHub"
+      "linkedToGithub": "Linked to GitHub",
+      "viaOrganization": "Via organization",
+      "sharedBy": "Shared by {{name}}"
     },
     "grid": {
       "emptyTitle": "No skills found",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -76,13 +76,30 @@
     "publicSkills": "公共技能",
     "mySkills": "我的技能",
     "sharedWithMe": "分享给我的",
-    "noSkillsFound": "未找到技能",
+    "noSkillsFound": "没有匹配的公共技能。",
     "noSharedSkills": "还没有人把技能分享给你。",
-    "tryAdjusting": "尝试调整搜索条件，或上传第一个技能。",
-    "noSkillsYet": "暂无技能",
-    "createFirst": "创建你的第一个技能开始吧",
+    "tryAdjusting": "尝试调整搜索条件或筛选项。",
+    "noSkillsYet": "你还没有创建任何技能。",
+    "noSystemSkills": "暂无系统技能。",
+    "createFirst": "创建你的第一个技能开始吧。",
     "uploadSkill": "上传技能",
-    "createSkill": "创建技能"
+    "createSkill": "创建技能",
+    "filterService": "NyxID 服务",
+    "filterTags": "标签",
+    "filterAuthors": "作者",
+    "filterSharedWithUsers": "分享给的用户",
+    "filterSharedWithOrgs": "分享给的组织",
+    "filterSharedByUsers": "用户分享给我",
+    "filterSharedByOrgs": "通过组织分享",
+    "noServices": "暂无系统服务。",
+    "noTags": "暂无标签。",
+    "noAuthors": "暂无作者。",
+    "notSharedWithUsers": "你还没有把任何技能分享给特定用户。",
+    "notSharedWithOrgs": "你还没有把任何技能分享给组织。",
+    "notSharedByUsers": "暂时没有人直接分享技能给你。",
+    "notSharedByOrgs": "暂时没有组织分享技能给你。",
+    "systemSkillsIntro": "系统技能是绑定到 NyxID 管理员服务的技能。平台管理员可以将任意技能绑定到管理员服务，将其发布为系统技能。",
+    "sharedWithMeIntro": "当其他人或组织向你授予某个私有技能的访问权限时，它会出现在这里。"
   },
   "mySkills": {
     "searchPlaceholder": "搜索你的技能…",
@@ -970,6 +987,14 @@
     "adminUnlimitedUsageTitle": "管理员 · 无限用量",
     "quotaUsageDetails": "配额使用详情"
   },
+  "search": {
+    "placeholderKeyword": "按名称、描述或标签搜索技能…",
+    "placeholderSemantic": "描述你想找什么…",
+    "toggleToKeyword": "切换到关键词搜索",
+    "toggleToSemantic": "切换到语义搜索",
+    "modeKeyword": "关键词",
+    "modeSemantic": "语义"
+  },
   "skillComponents": {
     "generateModal": {
       "title": "生成技能",
@@ -977,7 +1002,9 @@
       "add": "添加"
     },
     "card": {
-      "linkedToGithub": "已关联到 GitHub"
+      "linkedToGithub": "已关联到 GitHub",
+      "viaOrganization": "通过组织共享",
+      "sharedBy": "由 {{name}} 共享"
     },
     "grid": {
       "emptyTitle": "未找到技能",

--- a/ornn-web/src/pages/ExplorePage.tsx
+++ b/ornn-web/src/pages/ExplorePage.tsx
@@ -712,15 +712,20 @@ function emptyTitle(tab: ExploreTab, t: (key: string, fallback?: string) => stri
 }
 
 function emptyDescription(tab: ExploreTab, t: (key: string, fallback?: string) => string): string {
+  // #682 — point at the canonical i18n keys (`systemSkillsIntro` /
+  // `sharedWithMeIntro`) so both EN + ZH locales pick up the right
+  // copy. The old `systemSkillsHint` / `sharedHint` keys never
+  // existed in either locale file, so i18n was always falling back
+  // to the English literal for both languages.
   if (tab === "system")
     return t(
-      "explore.systemSkillsHint",
+      "explore.systemSkillsIntro",
       "System skills are skills tied to a NyxID admin service. Platform admins tie any skill to any admin service to publish it as a system skill.",
     );
   if (tab === "public") return t("explore.tryAdjusting", "Try adjusting your search or filters.");
   if (tab === "my-skills") return t("explore.createFirst", "Create your first skill to get started.");
   return t(
-    "explore.sharedHint",
+    "explore.sharedWithMeIntro",
     "When someone grants you access to a private skill — either directly or via an org — it shows up here.",
   );
 }


### PR DESCRIPTION
## Summary

Two classes of i18n bug, both bleeding English into ZH:

- **Class 1** — `ExplorePage.tsx` called 14 keys (`explore.filterTags`, `explore.noServices`, `explore.systemSkillsHint`, etc.) that were never added to either locale file. i18n falls back to the English literal in BOTH modes. Added the missing keys to en.json + zh.json. Renamed two intro paragraphs (`systemSkillsHint` → `systemSkillsIntro`, `sharedHint` → `sharedWithMeIntro`) so the source matches the canonical key names.
- **Class 2** — literals in `SearchBar.tsx` (5 strings: Keyword, Semantic, placeholders, tooltips), `SkillCard.tsx` (Public, Private, Via organization, Shared by {name}), `Pagination.tsx` (Prev, Next — visible on every paginated list across the app). All converted to `t()`. Public/Private/Prev/Next reuse existing `common.*` keys.

Product names (`NyxID`) stay untranslated per issue guidance. Date formatting is `Intl.toLocaleString`-driven on the browser side; not addressed here.

## Test plan

- [x] 139/139 ornn-web tests; typecheck clean
- [x] en.json + zh.json parse cleanly
- [ ] CI green
- [ ] Reproduce on local cluster after deploy: switch to ZH, walk all 4 Registry tabs + search bar + pagination — every visible string in Chinese

Closes #682.