### PR TITLE
docs(readme): trim badge row to CI + release + license (#688)

### DIFF
--- a/.changeset/readme-badge-trim-688.md
+++ b/.changeset/readme-badge-trim-688.md
@@ -1,0 +1,4 @@
+---
+---
+
+Trim the `README.md` badge row to CI / release / license, and drop the status / model-agnostic / HTTP·MCP pills below the hero (#688). Removes the broken `codecov unknown`, the noisy `last commit` and `discussions` badges, the vanity `stars` badge, and three positioning pills that are already shown inside the hero SVG. Surveyed 20 popular SDK / API repos; the trimmed set matches the dominant `version + license + CI` pattern. Docs-only, no code or schema change.

--- a/README.md
+++ b/README.md
@@ -7,22 +7,12 @@
 
 <p align="center">
   <a href="https://github.com/ChronoAIProject/Ornn/actions/workflows/ci.yml"><img src="https://github.com/ChronoAIProject/Ornn/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://codecov.io/gh/ChronoAIProject/Ornn"><img src="https://codecov.io/gh/ChronoAIProject/Ornn/branch/develop/graph/badge.svg" alt="Coverage" /></a>
   <a href="https://github.com/ChronoAIProject/Ornn/releases"><img src="https://img.shields.io/github/v/release/ChronoAIProject/Ornn" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/ChronoAIProject/Ornn" alt="License" /></a>
-  <a href="https://github.com/ChronoAIProject/Ornn/commits/develop"><img src="https://img.shields.io/github/last-commit/ChronoAIProject/Ornn/develop" alt="Last commit" /></a>
-  <a href="https://github.com/ChronoAIProject/Ornn/discussions"><img src="https://img.shields.io/github/discussions/ChronoAIProject/Ornn" alt="Discussions" /></a>
-  <a href="https://github.com/ChronoAIProject/Ornn/stargazers"><img src="https://img.shields.io/github/stars/ChronoAIProject/Ornn?style=flat" alt="Stars" /></a>
 </p>
 
 <p align="center">
   <img src="ornn-web/public/hero-brand.svg" alt="Ornn — agent-facing skill-lifecycle API" width="100%" />
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/status-alpha-orange" alt="Project status: alpha" />
-  <img src="https://img.shields.io/badge/model-agnostic-blue" alt="Model-agnostic" />
-  <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20MCP-blueviolet" alt="HTTP and MCP" />
 </p>
 
 <p align="center"><strong>The agent-facing skill-lifecycle API for AI agents.</strong></p>


### PR DESCRIPTION
## Summary

Trim the README header to just the three load-bearing trust signals and remove duplicate / vanity / broken badges.

- **Badge row** — drop `codecov` (broken, "unknown"), `last commit`, `discussions`, `stars`. Keep `CI`, `release`, `license`.
- **Status pills** — drop the entire `status: alpha / model-agnostic / HTTP·MCP` row beneath the hero (the latter two are already inside the hero SVG; status pills are virtually unused across popular OSS).
- Net diff: 4 insertions, 10 deletions.

## Why

Surveyed 20 popular dev-tool / SDK / API repos (Prisma, Vite, Bun, Next.js, Anthropic SDK, MCP SDK, Hono, Astro, Nuxt, Resend, shadcn/ui, TanStack Query, tRPC, LangChain, Biome, Turborepo, NestJS, pnpm, SWR, Supabase). Frequency:

| Badge | Adoption |
|---|---|
| version (npm/pypi) | 15/20 |
| license | 12/20 |
| discord/community | 9/20 |
| downloads | 6/20 |
| CI | 4/20 |
| **stars** | **2/20** |

Stars badges are explicitly **not standard** in this category — none of the SDK/API client projects use them. Status pills are non-existent in the sample. The trimmed set matches the dominant `version + license + CI` pattern; `release` stands in for the version badge until the SDKs are published to npm / PyPI (will switch to `@chronoai/ornn-sdk` npm + `ornn-sdk` PyPI version badges then).

## Test plan

- [x] `README.md` renders correctly via local markdown preview.
- [x] `.changeset/readme-badge-trim-688.md` empty changeset present.
- [ ] GitHub README view shows the trimmed 3-badge row + hero + tagline + nav.

Closes #688