### PR TITLE
docs(readme): swap hero to <picture> with dark variant (#692)

### DIFF
--- a/.changeset/readme-hero-dark-swap-692.md
+++ b/.changeset/readme-hero-dark-swap-692.md
@@ -1,0 +1,4 @@
+---
+---
+
+Wire the README hero to swap between `hero-brand.svg` (light) and `hero-brand-dark.svg` (dark) via a `<picture>` + `prefers-color-scheme` block (#692), matching the light/dark swap the wordmark logo at the top of the README already uses. Pure markup change — the dark asset was already stored under `ornn-web/public/` (#690). Docs-only, no code or schema delta.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@
 </p>
 
 <p align="center">
-  <img src="ornn-web/public/hero-brand.svg" alt="Ornn — agent-facing skill-lifecycle API" width="100%" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="ornn-web/public/hero-brand-dark.svg">
+    <img src="ornn-web/public/hero-brand.svg" alt="Ornn — agent-facing skill-lifecycle API" width="100%" />
+  </picture>
 </p>
 
 <p align="center"><strong>The agent-facing skill-lifecycle API for AI agents.</strong></p>


### PR DESCRIPTION
## Summary

Wrap the README hero in a `<picture>` block so GitHub viewers in **dark mode** get `hero-brand-dark.svg` while **light-mode** viewers keep `hero-brand.svg`. Mirrors the existing light/dark swap that the wordmark logo at the top of the README already uses, so the header is internally consistent.

## Diff (1-line wiring)

\`\`\`diff
 <p align="center">
-  <img src="ornn-web/public/hero-brand.svg" alt="Ornn — agent-facing skill-lifecycle API" width="100%" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="ornn-web/public/hero-brand-dark.svg">
+    <img src="ornn-web/public/hero-brand.svg" alt="Ornn — agent-facing skill-lifecycle API" width="100%" />
+  </picture>
 </p>
\`\`\`

## Why

Dark-mode readers were getting a light hero (white background, light parchment palette) against a dark GitHub page below a properly themed wordmark — header wasn't internally consistent. With the swap, both halves of the header (wordmark + hero) follow the viewer's GitHub theme.

The dark asset was already checked in via #690, so this PR is pure markup wiring.

## Test plan

- [x] `README.md` renders correctly via local markdown preview (light source resolves; dark source path verified to exist on disk).
- [x] Empty changeset present so `check-changeset.yml` passes.
- [ ] Visit GitHub README in dark theme and confirm `hero-brand-dark.svg` is the one rendered.
- [ ] Visit GitHub README in light theme and confirm `hero-brand.svg` still renders.

Closes #692