### PR TITLE
docs(readme): rework header + remove premature SDK section (#701)

### DIFF
--- a/.changeset/readme-header-rework-701.md
+++ b/.changeset/readme-header-rework-701.md
@@ -1,0 +1,4 @@
+---
+---
+
+README polish for #701 — drop the small `<picture>` logo at the top, lock the hero to `hero-brand-dark.svg` (no theme swap) and wrap it in a link to ornn.chrono-ai.fun, collapse the badges + tagline onto a single left-aligned line ("The skill lifecycle API for AI agents, not another marketplace."), left-align the nav, and remove the premature `## SDK quickstart` section + its nav entry since `@chronoai/ornn-sdk` and `ornn-sdk` are not yet published. Docs-only; no package code touched.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 <p>
   <a href="#what-is-ornn">What is Ornn</a> ·
   <a href="#how-it-works">How it works</a> ·
-  <a href="#sdk-quickstart">SDK quickstart</a> ·
   <a href="#quickstart">Quickstart</a> ·
   <a href="#how-ornn-compares">How Ornn compares</a> ·
   <a href="#examples">Examples</a> ·
@@ -61,49 +60,6 @@ Closest analog: **npm registry + npm CLI fused, model-agnostic** — works for C
 The agent talks to `ornn-api` through `nyxid`, which brokers authentication and authorization on the agent's behalf. Skills are versioned artifacts that the agent pulls, runs in a sandbox, and (optionally) publishes back.
 
 For a deeper view, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
-
-## SDK quickstart
-
-Call Ornn directly from code. The SDKs wrap `/api/v1/*` and handle auth header injection, response-envelope unwrapping, and structured errors.
-
-**TypeScript** ([`sdk/typescript`](sdk/typescript))
-
-```bash
-# Pre-publish — install from this monorepo via `bun link` or
-# git-subdirectory pinning. See docs/SDK_PUBLISHING.md.
-bun add @chronoai/ornn-sdk
-```
-
-```ts
-import { OrnnClient } from "@chronoai/ornn-sdk";
-
-const ornn = new OrnnClient({
-  baseUrl: "https://ornn.chrono-ai.fun",
-  token: process.env.ORNN_TOKEN,
-});
-const result = await ornn.search({ q: "pdf parsing" });
-console.log(result.items[0]);
-```
-
-**Python** ([`sdk/python`](sdk/python))
-
-```bash
-pip install ornn-sdk
-```
-
-```python
-import os
-from ornn_sdk import OrnnClient
-
-ornn = OrnnClient(
-    base_url="https://ornn.chrono-ai.fun",
-    token=os.environ["ORNN_TOKEN"],
-)
-result = ornn.search(q="pdf parsing")
-print(result.items[0])
-```
-
-Token sources are pluggable — for dynamic refresh flows, pass `getToken` (TS) / `token_resolver` (Python) instead of a static `token`. See [`sdk/typescript/README.md`](sdk/typescript/README.md) and [`sdk/python/README.md`](sdk/python/README.md) for the full reference.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,17 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="ornn-web/public/logo-dark.svg">
-    <img src="ornn-web/public/logo-light.svg" width="200" alt="Ornn" />
-  </picture>
+  <a href="https://ornn.chrono-ai.fun">
+    <img src="ornn-web/public/hero-brand-dark.svg" alt="Ornn — agent-facing skill-lifecycle API" width="100%" />
+  </a>
 </p>
 
-<p align="center">
+<p>
   <a href="https://github.com/ChronoAIProject/Ornn/actions/workflows/ci.yml"><img src="https://github.com/ChronoAIProject/Ornn/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://github.com/ChronoAIProject/Ornn/releases"><img src="https://img.shields.io/github/v/release/ChronoAIProject/Ornn" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/ChronoAIProject/Ornn" alt="License" /></a>
+  &nbsp;<strong>The skill lifecycle API for AI agents, not another marketplace.</strong>
 </p>
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="ornn-web/public/hero-brand-dark.svg">
-    <img src="ornn-web/public/hero-brand.svg" alt="Ornn — agent-facing skill-lifecycle API" width="100%" />
-  </picture>
-</p>
-
-<p align="center"><strong>The agent-facing skill-lifecycle API for AI agents.</strong></p>
-
-<p align="center">
-  Ornn official website — <a href="https://ornn.chrono-ai.fun">ornn.chrono-ai.fun</a>
-</p>
-
-<p align="center">
+<p>
   <a href="#what-is-ornn">What is Ornn</a> ·
   <a href="#how-it-works">How it works</a> ·
   <a href="#sdk-quickstart">SDK quickstart</a> ·


### PR DESCRIPTION
Closes #701.

## Summary

README header was visually generic + triple-centered, and the `## SDK quickstart` section was advertising packages that aren't published yet. This PR tightens the top of the README and removes the premature SDK pitch.

- **Drop the small `<picture>` logo** at the very top — redundant with the hero brand image directly below.
- **Lock the hero to `hero-brand-dark.svg`** regardless of GitHub theme (the dark variant is the canonical brand visual) and wrap it in `<a href="https://ornn.chrono-ai.fun">` so a click on the hero jumps to the official site.
- **Stop centering everything** — badges + tagline render on a single left-aligned line; nav links also left-aligned. The hero stays centered (full-width image).
- **Inline tagline next to the badges**: *"The skill lifecycle API for AI agents, not another marketplace."* — sharper positioning, matches the CLAUDE.md agent-API framing. Drops the redundant standalone "Ornn official website — …" line (the hero image is now the official-site link).
- **Remove `## SDK quickstart` + the matching nav entry**. `@chronoai/ornn-sdk` (TS) and `ornn-sdk` (Python) are not yet published; pointing readers at `bun add` / `pip install` commands that won't resolve is worse than silence. This section will come back in a focused follow-up once the SDKs ship.

## Commit decomposition

Three commits, in dependency order — each one stands on its own:

1. `docs(readme): rework header — drop logo, dark-only clickable hero, badges + tagline inline (#701)` — header/layout changes only; SDK section + nav entry left in place so the intermediate tree stays consistent.
2. `docs(readme): remove premature SDK quickstart section (#701)` — drops the H2 and the nav entry together.
3. `docs: changeset for #701` — empty (docs-only) changeset to satisfy `check-changeset.yml`.

## Test plan

- [ ] Open the README on GitHub in **dark theme** — hero renders as the dark-brand SVG; clicking it navigates to https://ornn.chrono-ai.fun.
- [ ] Open the README on GitHub in **light theme** — hero is still the dark-brand SVG (no theme swap); clicking it still navigates to https://ornn.chrono-ai.fun.
- [ ] Badges (CI / release / license) render on a single left-aligned line followed inline by **"The skill lifecycle API for AI agents, not another marketplace."**.
- [ ] Nav links left-aligned; no `SDK quickstart` entry.
- [ ] Page no longer contains a `## SDK quickstart` section; in-page TOC matches the remaining nav entries.
- [ ] CI green (lint, typecheck, docker-build, check-changeset).