### PR TITLE
docs(readme): restyle How-it-works mermaid with Editorial Forge palette (#705)

### DIFF
--- a/.changeset/readme-mermaid-restyle-705.md
+++ b/.changeset/readme-mermaid-restyle-705.md
@@ -1,0 +1,4 @@
+---
+---
+
+Restyle the README `## How it works` Mermaid diagram with the Editorial Forge palette for #705. Uses Mermaid's `init` directive + per-node `classDef` to map directly onto DESIGN.md tokens: obsidian + graphite subgraph fills, forged-metal (`#1A1610` / `#221E16`) node fills with steel borders and parchment text, ember (`#FF7322`) anchored on `ornn-api` as the brand-voice protagonist, arc-blue (`#5BC8E8`) on `NyxID` as the restricted secondary diagrammatic accent (auth / identity = "cool side of the forge"). Subgraph titles render UPPERCASE. Locked to dark in both GitHub themes — per DESIGN.md's carve-out for operational / code-chrome surfaces, consistent with the dark-only hero. Docs-only; no package code touched.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,29 @@ Ornn closes the gaps. One model-agnostic registry, one API surface, and a CLI (`
 ## How it works
 
 ```mermaid
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "background": "#0B0907",
+    "primaryColor": "#1A1610",
+    "primaryTextColor": "#F1ECDE",
+    "primaryBorderColor": "#3A3328",
+    "lineColor": "#C9BFAD",
+    "secondaryColor": "#221E16",
+    "tertiaryColor": "#14110B",
+    "fontFamily": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace",
+    "fontSize": "14px"
+  }
+}}%%
 flowchart LR
-    subgraph local["Your machine"]
+    subgraph local["YOUR MACHINE"]
+        direction TB
         Agent["AI agent<br/>(any model)"]
         CLI["nyxid CLI"]
         Skill["Pulled skills<br/>(local runtime)"]
     end
-    subgraph cloud["Ornn cloud (ornn.chrono-ai.fun)"]
+    subgraph cloud["ORNN CLOUD · ornn.chrono-ai.fun"]
+        direction TB
         API["ornn-api"]
         Auth["NyxID<br/>(auth + identity)"]
         Store[("Skill registry<br/>+ versioned artifacts")]
@@ -56,6 +72,22 @@ flowchart LR
     API -->|exec| Sandbox
     API -.->|skill artifact| Agent
     Agent -->|runs| Skill
+
+    classDef ember fill:#FF7322,stroke:#C9460D,color:#14130E,stroke-width:1.5px,font-weight:bold
+    classDef arc fill:#5BC8E8,stroke:#3A8FB8,color:#14130E,stroke-width:1.5px,font-weight:bold
+    classDef forged fill:#1A1610,stroke:#3A3328,color:#F1ECDE,stroke-width:1px
+    classDef storage fill:#221E16,stroke:#3A3328,color:#C9BFAD,stroke-width:1px
+
+    class Agent forged
+    class CLI forged
+    class Skill forged
+    class Sandbox forged
+    class API ember
+    class Auth arc
+    class Store storage
+
+    style local fill:#14110B,stroke:#3A3328,color:#C9BFAD,stroke-width:1px
+    style cloud fill:#08070A,stroke:#3A3328,color:#C9BFAD,stroke-width:1.5px
 ```
 
 Every API call is mediated by [`nyxid`](https://github.com/ChronoAIProject/NyxID) — the shared identity + brokering layer ChronoAI uses across products. The agent never holds a long-lived token: `nyxid` refreshes credentials transparently and brokers per-service access for each request.


### PR DESCRIPTION
Closes #705.

## Summary

The Mermaid diagram from #703 currently renders with Mermaid's default lavender + light-yellow subgraph styling — exactly the generic SaaS-template visual neighborhood DESIGN.md's Differentiation Guardrails tell us to avoid. This PR restyles it to the dark **Editorial Forge** palette so the diagram matches the dark-only hero (#702) and speaks the same brand language as the website.

### Why dark in both GitHub themes

Mermaid renders a single static palette regardless of GitHub theme. DESIGN.md explicitly carves out this case:

> *"Some surfaces may remain dark in both themes when the metaphor requires operational contrast: terminal and code-chrome surfaces, install or command surfaces, selective contrast islands where high signal-to-noise matters."*

A system architecture diagram is exactly that kind of operational surface. Locking it to dark also means the README's header gestalt (dark hero → dark diagram) reads consistently regardless of which GitHub theme the visitor uses.

### Token map

Mermaid \`%%{init: themeVariables}%%\` + per-node \`classDef\` mapped directly onto DESIGN.md primitive + semantic tokens:

| Element | DESIGN.md token | Hex |
|---|---|---|
| Canvas / \"ORNN CLOUD\" subgraph | \`obsidian\` (dark) | \`#0B0907\` / \`#08070A\` |
| \"YOUR MACHINE\" subgraph | \`graphite\` | \`#14110B\` |
| Forged-metal node fill | \`color-surface-card\` (dark) | \`#1A1610\` |
| Storage node (cylinder) | \`iron\` | \`#221E16\` |
| Borders | \`steel\` | \`#3A3328\` |
| Strong text on dark nodes | \`parchment\` | \`#F1ECDE\` |
| Edges + body text | \`bone\` | \`#C9BFAD\` |
| **Ember anchor on \`ornn-api\`** | \`color-accent-primary\` (dark) | \`#FF7322\` |
| Ember border | \`ember-dim\` | \`#C9460D\` |
| **Arc-blue on \`NyxID\`** | \`color-accent-secondary\` (dark) | \`#5BC8E8\` |
| Arc border | \`arc-dim\` | \`#3A8FB8\` |

### Brand voice assignments

- **\`ornn-api\` carries the ember** — the brand action voice, single anchor per DESIGN.md's "restrained heat" principle. It's the protagonist of the diagram, so it gets the heat.
- **\`NyxID\` carries the arc-blue** — DESIGN.md's restricted secondary diagrammatic role (auth / identity = "cool side of the forge"). This is the canonical use case the arc-blue role was added for.
- Every other node stays in forged-metal (card fill + steel border + parchment text).
- The two subgraphs use slightly different fills (\`graphite\` vs \`obsidian\`) so they read as different materials without breaking the single-ember rule.
- Subgraph titles render UPPERCASE per DESIGN.md display direction (\`Space Grotesk Bold UPPERCASE\` aesthetic — GitHub Mermaid's font sandbox prevents loading the actual face, but the casing carries the voice).

### Out of scope

- Diagram structure, nodes, and edges are unchanged from #703 — purely a styling pass.
- Header (#702), README content (#703) — untouched.
- No package or product code. Docs-only.

## Commit decomposition

1. \`docs(readme): restyle How-it-works mermaid with Editorial Forge palette (#705)\` — the styling change in one focused commit.
2. \`docs: changeset for #705\` — empty (docs-only) changeset to satisfy \`check-changeset.yml\`.

## Test plan

- [ ] Open the README on GitHub in **dark theme** — diagram renders dark, ornn-api is ember-orange, NyxID is arc-blue, every other node is forged-metal dark with parchment text, subgraph titles are UPPERCASE.
- [ ] Open the README on GitHub in **light theme** — same dark diagram (the operational-surface carve-out is the explicit design intent). Verify the dark island reads cleanly against the light README body without optical jarring.
- [ ] Diagram structure / edges / labels are unchanged vs the previous render — only the colors + node fills + subgraph backgrounds changed.
- [ ] CI green (lint, typecheck, docker-build, check-changeset).