### PR TITLE
docs(readme): polish How-it-works mermaid — bracketed titles, edge-label bg, material contrast (#707)

### DIFF
--- a/.changeset/readme-mermaid-polish-707.md
+++ b/.changeset/readme-mermaid-polish-707.md
@@ -1,0 +1,9 @@
+---
+---
+
+Polish the README `## How it works` Mermaid diagram for #707 — fixes from the #705 forge-palette render:
+1. Subgraph titles use the DESIGN.md bracketed mono pattern (`[ § YOUR MACHINE ]` / `[ § ORNN CLOUD ]`) and drop the `ornn.chrono-ai.fun` suffix so they stop being clipped.
+2. `edgeLabelBackground` set to canvas (`#0B0907`) so edge labels float on the dark background instead of rendering as dark-on-dark rectangles.
+3. `clusterBkg` / `clusterBorder` set as defaults; `[ § YOUR MACHINE ]` lifted to `iron` (`#221E16`) while `[ § ORNN CLOUD ]` stays at `graphite` (`#14110B`) for a gentle material contrast.
+4. Node and edge labels trimmed to one line (no more parenthetical subtitles) so the diagram fits the GitHub viewport without overflow.
+5. Bonus: `CLI ==>|HTTPS| API` is thick + ember-tinted via `linkStyle 1` (the load-bearing action edge — single localized accent per DESIGN.md's allowance for wire / pulse effects), node strokes bumped to 1.5–2px for the "forged metal" feel, default `lineColor` dropped to `ash` so the ember edge wins the visual weight contest. Docs-only; no package code touched.

--- a/README.md
+++ b/README.md
@@ -43,40 +43,43 @@ Ornn closes the gaps. One model-agnostic registry, one API surface, and a CLI (`
     "primaryColor": "#1A1610",
     "primaryTextColor": "#F1ECDE",
     "primaryBorderColor": "#3A3328",
-    "lineColor": "#C9BFAD",
+    "lineColor": "#7E776B",
     "secondaryColor": "#221E16",
     "tertiaryColor": "#14110B",
+    "edgeLabelBackground": "#0B0907",
+    "clusterBkg": "#14110B",
+    "clusterBorder": "#3A3328",
     "fontFamily": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace",
-    "fontSize": "14px"
+    "fontSize": "13px"
   }
 }}%%
 flowchart LR
-    subgraph local["YOUR MACHINE"]
+    subgraph local["[ § YOUR MACHINE ]"]
         direction TB
-        Agent["AI agent<br/>(any model)"]
+        Agent["AI agent"]
         CLI["nyxid CLI"]
-        Skill["Pulled skills<br/>(local runtime)"]
+        Skill["Pulled skills"]
     end
-    subgraph cloud["ORNN CLOUD · ornn.chrono-ai.fun"]
+    subgraph cloud["[ § ORNN CLOUD ]"]
         direction TB
         API["ornn-api"]
-        Auth["NyxID<br/>(auth + identity)"]
-        Store[("Skill registry<br/>+ versioned artifacts")]
-        Sandbox["Sandbox<br/>(remote execution)"]
+        Auth["NyxID"]
+        Store[("Skill registry")]
+        Sandbox["Sandbox"]
     end
 
-    Agent -->|invokes| CLI
-    CLI -->|HTTPS| API
-    API -->|verify token| Auth
-    API -->|read / write| Store
+    Agent -->|invoke| CLI
+    CLI ==>|HTTPS| API
+    API -->|verify| Auth
+    API -->|r/w| Store
     API -->|exec| Sandbox
-    API -.->|skill artifact| Agent
-    Agent -->|runs| Skill
+    API -.->|artifact| Agent
+    Agent -->|run| Skill
 
-    classDef ember fill:#FF7322,stroke:#C9460D,color:#14130E,stroke-width:1.5px,font-weight:bold
-    classDef arc fill:#5BC8E8,stroke:#3A8FB8,color:#14130E,stroke-width:1.5px,font-weight:bold
-    classDef forged fill:#1A1610,stroke:#3A3328,color:#F1ECDE,stroke-width:1px
-    classDef storage fill:#221E16,stroke:#3A3328,color:#C9BFAD,stroke-width:1px
+    classDef ember fill:#FF7322,stroke:#C9460D,color:#14130E,stroke-width:2px,font-weight:bold
+    classDef arc fill:#5BC8E8,stroke:#3A8FB8,color:#14130E,stroke-width:2px,font-weight:bold
+    classDef forged fill:#1A1610,stroke:#3A3328,color:#F1ECDE,stroke-width:1.5px
+    classDef storage fill:#221E16,stroke:#3A3328,color:#C9BFAD,stroke-width:1.5px
 
     class Agent forged
     class CLI forged
@@ -86,8 +89,10 @@ flowchart LR
     class Auth arc
     class Store storage
 
-    style local fill:#14110B,stroke:#3A3328,color:#C9BFAD,stroke-width:1px
-    style cloud fill:#08070A,stroke:#3A3328,color:#C9BFAD,stroke-width:1.5px
+    style local fill:#221E16,stroke:#3A3328,color:#F1ECDE,stroke-width:1.5px
+    style cloud fill:#14110B,stroke:#3A3328,color:#F1ECDE,stroke-width:1.5px
+
+    linkStyle 1 stroke:#FF7322,stroke-width:2.5px
 ```
 
 Every API call is mediated by [`nyxid`](https://github.com/ChronoAIProject/NyxID) — the shared identity + brokering layer ChronoAI uses across products. The agent never holds a long-lived token: `nyxid` refreshes credentials transparently and brokers per-service access for each request.


### PR DESCRIPTION
Closes #707.

## Summary

The #705 forge-palette restyle nailed the colors but the rendered diagram still had four polish issues. Fixed in one focused pass.

### Before → After

| # | Issue | Fix |
|---|---|---|
| 1 | Subgraph titles \`"Your machine"\` and \`"Ornn cloud (ornn.chrono-ai.fun)"\` clipped to \`YOUR MACHIN\` / \`ORNN CLOUD · ornn.chrono-ai.fu\` because the computed subgraph width was narrower than the title text | Drop the URL suffix; switch to the DESIGN.md bracketed mono pattern: \`[ § YOUR MACHINE ]\` / \`[ § ORNN CLOUD ]\` |
| 2 | Edge labels rendered as dark-on-dark rectangles (Mermaid defaults \`edgeLabelBackground\` to white, paints visible blocks on dark canvas) | Set \`edgeLabelBackground: "#0B0907"\` so labels float on the obsidian canvas with no backdrop |
| 3 | Both subgraph fills near-black → no material contrast between local and cloud | Lift \`[ § YOUR MACHINE ]\` to \`iron\` (\`#221E16\`), keep \`[ § ORNN CLOUD ]\` at \`graphite\` (\`#14110B\`). Gentle distinction, single-ember rule intact |
| 4 | Every node carried a parenthetical subtitle, widening the diagram past the GitHub viewport — \`Sandbox\` partially behind the pan-zoom UI | Trim node labels to one line; tighten edge labels (\`read / write\` → \`r/w\`, \`skill artifact\` → \`artifact\`, etc.) |

### Bonus refinements

- **\`CLI ==>|HTTPS| API\` is now thick + ember-tinted** via \`linkStyle 1\`. The load-bearing action edge gets a single localized accent — DESIGN.md explicitly allows "localized glow / wire / pulse effects as accents rather than baseline decoration".
- Node strokes bumped to **1.5–2px** for the forged-metal feel.
- Subgraph title text switches from \`bone\` (body) to **\`parchment\`** (strong) — they're headings.
- Default \`lineColor\` drops from \`bone\` to **\`ash\`** so the ember edge + node accents win the visual weight contest.

### What's unchanged

- Diagram graph (nodes, edges, directions, layout) — same as #705. Purely a styling + labelling polish.
- Token vocabulary stays the same (DESIGN.md primitive + semantic).
- Header (#702), README structure (#703), palette decision (#705).
- No package or product code. Docs-only.

## Commit decomposition

1. \`docs(readme): polish How-it-works mermaid — bracketed titles, edge-label bg, material contrast (#707)\` — the polish pass.
2. \`docs: changeset for #707\` — empty (docs-only) changeset.

## Test plan

- [ ] Open the README on GitHub in **dark** theme — subgraph titles render in full as \`[ § YOUR MACHINE ]\` / \`[ § ORNN CLOUD ]\` (no clipping); edge labels float on the canvas without dark rectangles; the two subgraphs read as different materials; \`Sandbox\` fully visible; HTTPS edge is the ember-tinted thick arrow.
- [ ] Same in **light** theme — diagram stays dark (per #705 design intent) and reads cleanly against the light README body.
- [ ] Diagram nodes + edges + directions identical to the previous render; only typography, labels, and surface colors changed.
- [ ] CI green (lint, typecheck, docker-build, check-changeset).