### PR TITLE
fix(api): route LLM requests on provider apiFormat (#574)

### DIFF
--- a/.changeset/llm-apiformat-routing-574.md
+++ b/.changeset/llm-apiformat-routing-574.md
@@ -1,0 +1,18 @@
+---
+"ornn-api": patch
+---
+
+NyxLlmClient now routes outbound LLM calls on the resolved provider's `apiFormat` (#574).
+
+Background: the admin LLM Provider form exposes `apiFormat: chat-completion | responses`, but the runtime client hard-coded `{gatewayUrl}/responses` for both `stream()` and `complete()` and ignored the setting. Providers behind the Chat Completions API — DeepSeek and any OpenAI-compatible gateway without `/responses` — returned 404 on every skill generation request, surfacing in the UI as a misleading "LLM Gateway error (404)" even though the model/key/gateway were all configured correctly.
+
+Fix: thread `apiFormat` through `resolveLlmProviderForSurface` (`bootstrap.ts`) into the new `LlmProviderResolution.apiFormat` field, and dispatch inside `NyxLlmClient`:
+
+- `responses` → `POST {gatewayUrl}/responses` with the native Responses-API body (unchanged behavior).
+- `chat-completion` → `POST {gatewayUrl}/chat/completions` with a translated body (`input` → `messages`, `developer` role → `system`, `max_output_tokens` → `max_tokens`, `instructions` prepended as a `system` message, tools projected into OpenAI function-tool shape). The Chat Completions SSE stream is normalized so each `choices[].delta.content` chunk is yielded as a Responses-API `response.output_text.delta` event — consumers (skill generation + playground) stay format-agnostic.
+
+Tool-call delta normalization for the chat-completion path is intentionally out of scope here; it is tracked in #608 (playground runtime/mixed skills not triggering `execute_in_sandbox` under chat-completion providers).
+
+Trailing slashes on `gatewayUrl` are still trimmed before path concatenation, and the empty-`gatewayUrl` `LLM_PROVIDER_NOT_CONFIGURED` fail-closed branch is preserved.
+
+Coverage: new `src/clients/nyxid/llm.test.ts` covers both formats — endpoint dispatch, body translation (role/field/tool mapping), text-delta normalization, content-part flattening, SA-token fallback, trailing-slash trim, fail-closed, and non-2xx surfacing. 11 tests, all green.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -120,6 +120,7 @@ import { migrateLegacyMirrorIntoSettings } from "./domains/settings/sections/mir
 import { LlmProvidersRepository } from "./domains/settings/llmProviders/repository";
 import { LlmProvidersService } from "./domains/settings/llmProviders/service";
 import { createLlmProvidersRoutes } from "./domains/settings/llmProviders/routes";
+import type { ApiFormat } from "./domains/settings/llmProviders/types";
 import { SettingsExporter } from "./domains/settings/exportImport/exporter";
 import { SettingsImporter } from "./domains/settings/exportImport/importer";
 import { createSettingsExportImportRoutes } from "./domains/settings/exportImport/routes";
@@ -312,20 +313,30 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
 
   // Convenience: resolve the LLM provider for a given surface in a
   // single Promise, projecting whichever auth shape the provider uses
-  // into the simpler `{ gatewayUrl, apiKey }` contract `NyxLlmClient`
-  // speaks. `apiKey` empty means "use SA token-exchange flow".
+  // into the simpler `{ gatewayUrl, apiKey, apiFormat }` contract
+  // `NyxLlmClient` speaks. `apiKey` empty means "use SA token-exchange
+  // flow". `apiFormat` selects the upstream endpoint shape (#574); when
+  // no provider is configured we still return a default so the type
+  // shape stays narrow — the empty `gatewayUrl` is what triggers the
+  // fail-closed branch downstream.
   const resolveLlmProviderForSurface = async (
     surface: "playground" | "skillGen",
-  ): Promise<{ gatewayUrl: string; apiKey: string }> => {
+  ): Promise<{ gatewayUrl: string; apiKey: string; apiFormat: ApiFormat }> => {
     const sec =
       surface === "playground"
         ? await settingsService.getPlayground()
         : await settingsService.getSkillGen();
-    if (!sec.defaultProviderId) return { gatewayUrl: "", apiKey: "" };
+    if (!sec.defaultProviderId) {
+      return { gatewayUrl: "", apiKey: "", apiFormat: "responses" };
+    }
     const provider = await llmProvidersService.get(sec.defaultProviderId);
-    if (!provider) return { gatewayUrl: "", apiKey: "" };
+    if (!provider) return { gatewayUrl: "", apiKey: "", apiFormat: "responses" };
     const apiKey = provider.auth.kind === "apiKey" ? provider.auth.apiKey : "";
-    return { gatewayUrl: provider.gatewayUrl, apiKey };
+    return {
+      gatewayUrl: provider.gatewayUrl,
+      apiKey,
+      apiFormat: provider.apiFormat,
+    };
   };
 
   // Same pattern, returning the per-surface model + token cap +

--- a/ornn-api/src/clients/nyxid/llm.test.ts
+++ b/ornn-api/src/clients/nyxid/llm.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Tests for #574: NyxLlmClient must dispatch on the resolved
+ * provider's `apiFormat` — `responses` hits `/responses` with native
+ * body, `chat-completion` hits `/chat/completions` with translated
+ * body and normalizes text deltas back into Responses-API event shape.
+ *
+ * Tool-call delta normalization for chat-completion is out of scope here
+ * (tracked in #608).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  NyxLlmClient,
+  type LlmProviderResolution,
+  type ResponsesApiStreamEvent,
+} from "./llm";
+import type { NyxidSaTokenProvider } from "./base";
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+const STUB_SA_TOKEN: NyxidSaTokenProvider = {
+  getAccessToken: async () => "sa-token-xyz",
+} as unknown as NyxidSaTokenProvider;
+
+function makeResolver(resolution: LlmProviderResolution) {
+  return async () => resolution;
+}
+
+/** Build an SSE Response body from a sequence of `data:` payloads. */
+function sseResponse(events: string[]): Response {
+  const body = events.map((e) => `data: ${e}\n\n`).join("") + "data: [DONE]\n\n";
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+const originalFetch = globalThis.fetch;
+let capturedRequests: CapturedRequest[];
+let fetchHandler: (req: Request) => Promise<Response> | Response;
+
+beforeEach(() => {
+  capturedRequests = [];
+  fetchHandler = () => new Response("no handler set", { status: 500 });
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const rawBody = init?.body;
+    let parsedBody: unknown = rawBody;
+    if (typeof rawBody === "string") {
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        /* leave as string */
+      }
+    }
+    const headers: Record<string, string> = {};
+    const initHeaders = init?.headers;
+    if (initHeaders instanceof Headers) {
+      initHeaders.forEach((v, k) => { headers[k] = v; });
+    } else if (Array.isArray(initHeaders)) {
+      for (const [k, v] of initHeaders) headers[k] = v;
+    } else if (initHeaders && typeof initHeaders === "object") {
+      Object.assign(headers, initHeaders);
+    }
+    capturedRequests.push({ url, method, body: parsedBody, headers });
+    const req = new Request(url, init);
+    return fetchHandler(req);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// stream() — endpoint + body dispatch
+// ---------------------------------------------------------------------------
+
+describe("NyxLlmClient.stream() routing on apiFormat", () => {
+  it("apiFormat=responses → POST /responses with native body", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({ type: "response.output_text.delta", delta: "hello" }),
+      ]);
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://gateway.example.com",
+        apiKey: "sk-direct",
+        apiFormat: "responses",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "gpt-test",
+      input: [{ role: "user", content: "hi" }],
+      instructions: "be brief",
+    })) events.push(e);
+
+    expect(capturedRequests).toHaveLength(1);
+    expect(capturedRequests[0]!.url).toBe("https://gateway.example.com/responses");
+    expect(capturedRequests[0]!.method).toBe("POST");
+    expect(capturedRequests[0]!.headers["Authorization"]).toBe("Bearer sk-direct");
+    expect(capturedRequests[0]!.body).toMatchObject({
+      model: "gpt-test",
+      input: [{ role: "user", content: "hi" }],
+      instructions: "be brief",
+      stream: true,
+      store: false,
+    });
+    expect(events).toEqual([
+      { type: "response.output_text.delta", delta: "hello" },
+    ]);
+  });
+
+  it("apiFormat=chat-completion → POST /chat/completions with translated body", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({ choices: [{ delta: { content: "Hel" } }] }),
+        JSON.stringify({ choices: [{ delta: { content: "lo" } }] }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] }),
+      ]);
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.deepseek.com/",
+        apiKey: "sk-deepseek",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "deepseek-v4-flash",
+      input: [
+        { role: "developer", content: "you are helpful" },
+        { role: "user", content: "summarize" },
+      ],
+      instructions: "respond in english",
+      max_output_tokens: 256,
+      temperature: 0.3,
+    })) events.push(e);
+
+    expect(capturedRequests).toHaveLength(1);
+    expect(capturedRequests[0]!.url).toBe("https://api.deepseek.com/chat/completions");
+    expect(capturedRequests[0]!.body).toMatchObject({
+      model: "deepseek-v4-flash",
+      messages: [
+        { role: "system", content: "respond in english" },
+        { role: "system", content: "you are helpful" },
+        { role: "user", content: "summarize" },
+      ],
+      max_tokens: 256,
+      temperature: 0.3,
+      stream: true,
+    });
+    // No `input` / `max_output_tokens` should leak into chat-completion body.
+    expect((capturedRequests[0]!.body as Record<string, unknown>).input).toBeUndefined();
+    expect((capturedRequests[0]!.body as Record<string, unknown>).max_output_tokens).toBeUndefined();
+
+    // Text deltas normalized into Responses-API shape.
+    expect(events).toEqual([
+      { type: "response.output_text.delta", delta: "Hel" },
+      { type: "response.output_text.delta", delta: "lo" },
+    ]);
+  });
+
+  it("chat-completion translates tools array into OpenAI function-tool shape", async () => {
+    fetchHandler = () => sseResponse([]);
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+      tools: [
+        {
+          type: "function",
+          name: "do_thing",
+          description: "does the thing",
+          parameters: { type: "object", properties: { x: { type: "string" } } },
+        },
+      ],
+    })) events.push(e);
+
+    expect((capturedRequests[0]!.body as Record<string, unknown>).tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "do_thing",
+          description: "does the thing",
+          parameters: { type: "object", properties: { x: { type: "string" } } },
+        },
+      },
+    ]);
+  });
+
+  it("flattens Responses-API content parts into a string for chat-completion", async () => {
+    fetchHandler = () => sseResponse([]);
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: "part 1 " },
+            { type: "input_text", text: "part 2" },
+          ],
+        },
+      ],
+    })) events.push(e);
+
+    const body = capturedRequests[0]!.body as { messages: Array<{ role: string; content: string }> };
+    expect(body.messages).toEqual([{ role: "user", content: "part 1 part 2" }]);
+  });
+
+  it("trims trailing slash from gatewayUrl for both formats", async () => {
+    fetchHandler = () => sseResponse([]);
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com///",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "x" }],
+    })) events.push(e);
+    expect(capturedRequests[0]!.url).toBe("https://api.example.com/chat/completions");
+  });
+
+  it("falls back to SA token when resolved apiKey is empty", async () => {
+    fetchHandler = () => sseResponse([]);
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "x" }],
+    })) events.push(e);
+    expect(capturedRequests[0]!.headers["Authorization"]).toBe("Bearer sa-token-xyz");
+  });
+
+  it("fails closed when gatewayUrl is empty (no provider configured)", async () => {
+    const client = new NyxLlmClient({
+      resolver: makeResolver({ gatewayUrl: "", apiKey: "", apiFormat: "responses" }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+    await expect(async () => {
+      for await (const _e of client.stream({
+        model: "m",
+        input: [{ role: "user", content: "x" }],
+      })) {
+        /* drain */
+      }
+    }).toThrow(/LLM_PROVIDER_NOT_CONFIGURED/);
+    expect(capturedRequests).toHaveLength(0);
+  });
+
+  it("surfaces upstream non-2xx as sanitized error", async () => {
+    fetchHandler = () =>
+      new Response("Not Found: /responses", { status: 404 });
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "responses",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+    await expect(async () => {
+      for await (const _e of client.stream({
+        model: "m",
+        input: [{ role: "user", content: "x" }],
+      })) {
+        /* drain */
+      }
+    }).toThrow(/LLM Gateway error \(404\)/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// complete() — endpoint + body dispatch
+// ---------------------------------------------------------------------------
+
+describe("NyxLlmClient.complete() routing on apiFormat", () => {
+  it("apiFormat=responses → POST /responses, returns output[]", async () => {
+    fetchHandler = () =>
+      jsonResponse({
+        output: [{ type: "message", content: [{ type: "output_text", text: "hi" }] }],
+      });
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "responses",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const out = await client.complete({
+      model: "m",
+      input: [{ role: "user", content: "ping" }],
+    });
+    expect(capturedRequests[0]!.url).toBe("https://api.example.com/responses");
+    expect((capturedRequests[0]!.body as Record<string, unknown>).stream).toBe(false);
+    expect(out).toEqual([
+      { type: "message", content: [{ type: "output_text", text: "hi" }] },
+    ]);
+  });
+
+  it("apiFormat=chat-completion → POST /chat/completions, normalizes to ResponsesApiOutput[]", async () => {
+    fetchHandler = () =>
+      jsonResponse({
+        choices: [{ message: { role: "assistant", content: "hello world" } }],
+      });
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const out = await client.complete({
+      model: "m",
+      input: [{ role: "user", content: "say hi" }],
+    });
+    expect(capturedRequests[0]!.url).toBe("https://api.example.com/chat/completions");
+    expect((capturedRequests[0]!.body as Record<string, unknown>).stream).toBe(false);
+    expect(out).toEqual([
+      { type: "message", content: [{ type: "output_text", text: "hello world" }] },
+    ]);
+  });
+
+  it("returns [] when chat-completion response has empty content", async () => {
+    fetchHandler = () =>
+      jsonResponse({ choices: [{ message: { role: "assistant", content: "" } }] });
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+    const out = await client.complete({
+      model: "m",
+      input: [{ role: "user", content: "say nothing" }],
+    });
+    expect(out).toEqual([]);
+  });
+});

--- a/ornn-api/src/clients/nyxid/llm.ts
+++ b/ornn-api/src/clients/nyxid/llm.ts
@@ -1,17 +1,37 @@
 /**
- * HTTP client for Nyx Provider LLM Gateway (Responses API format).
- * All LLM calls (skill generation + playground chat) go through this client.
- * Authenticates using a Service Account (SA) token obtained via client_credentials grant.
+ * HTTP client for the Nyx Provider LLM Gateway.
+ *
+ * Dispatches to one of two upstream API formats per call based on the
+ * resolved provider's `apiFormat`:
+ *
+ * - `responses`        → `{gatewayUrl}/responses`        (native shape)
+ * - `chat-completion`  → `{gatewayUrl}/chat/completions` (OpenAI-style)
+ *
+ * Callers always speak Responses-API shapes (input messages, tools,
+ * `ResponsesApiStreamEvent`). For chat-completion providers the client
+ * translates the request body on the way out and normalizes the SSE
+ * stream / completion payload back into Responses-API event shape on
+ * the way in, so consumers (skill generation + playground) do not need
+ * to branch on apiFormat (#574).
+ *
+ * Tool-call delta normalization for chat-completion is intentionally
+ * out of scope here — tracked in #608.
+ *
+ * Authenticates using a Service Account (SA) token obtained via
+ * client_credentials grant when the resolved provider has no direct
+ * apiKey.
+ *
  * @module clients/nyxid/llm
  */
 
 import { createLogger } from "../../shared/logger";
+import type { ApiFormat } from "../../domains/settings/llmProviders/types";
 import type { NyxidSaTokenProvider } from "./base";
 
 const logger = createLogger("nyxLlmClient");
 
 // ---------------------------------------------------------------------------
-// Types
+// Types — caller-facing (Responses-API shape, format-agnostic)
 // ---------------------------------------------------------------------------
 
 export interface ResponsesApiInputMessage {
@@ -91,13 +111,35 @@ function sanitizeErrorResponse(status: number, rawText: string): string {
   return `LLM Gateway error (${status}): ${truncated}`;
 }
 
+/**
+ * Flatten a Responses-API content union into a single string for
+ * Chat Completions, which accepts string content for most roles.
+ * Preserves text order; non-text parts are dropped (no Responses-API
+ * non-text parts are produced by callers today).
+ */
+function flattenContentToString(
+  content: string | ResponsesApiContentPart[],
+): string {
+  if (typeof content === "string") return content;
+  return content.map((p) => p.text).join("");
+}
+
+/** Responses-API `developer` role maps to Chat Completions `system`. */
+function mapRoleToChatCompletion(
+  role: ResponsesApiInputMessage["role"],
+): "user" | "assistant" | "system" {
+  return role === "developer" ? "system" : role;
+}
+
 // ---------------------------------------------------------------------------
-// SSE Parser
+// SSE Parser (shared across both formats)
 // ---------------------------------------------------------------------------
 
-async function* parseSSEStream(
-  response: Response,
-): AsyncIterable<ResponsesApiStreamEvent> {
+interface RawSseEvent {
+  data: string;
+}
+
+async function* parseSSELines(response: Response): AsyncIterable<RawSseEvent> {
   const reader = response.body?.getReader();
   if (!reader) {
     throw new Error("Response body is not readable");
@@ -118,21 +160,115 @@ async function* parseSSEStream(
       for (const line of lines) {
         if (line.startsWith("data: ")) {
           const data = line.slice(6).trim();
-          if (data === "[DONE]") return;
           if (!data) continue;
-
-          try {
-            const event = JSON.parse(data) as ResponsesApiStreamEvent;
-            yield event;
-          } catch {
-            logger.debug({ data: data.slice(0, 100) }, "Failed to parse SSE event");
-          }
+          yield { data };
         }
       }
     }
   } finally {
     reader.releaseLock();
   }
+}
+
+/** Parse Responses-API SSE: each `data:` is a JSON event object. */
+async function* parseResponsesStream(
+  response: Response,
+): AsyncIterable<ResponsesApiStreamEvent> {
+  for await (const { data } of parseSSELines(response)) {
+    if (data === "[DONE]") return;
+    try {
+      yield JSON.parse(data) as ResponsesApiStreamEvent;
+    } catch {
+      logger.debug({ data: data.slice(0, 100) }, "Failed to parse SSE event");
+    }
+  }
+}
+
+/**
+ * Parse Chat Completions SSE and translate text deltas into
+ * Responses-API event shape so consumers stay format-agnostic.
+ *
+ * For #574, only text deltas (`choices[].delta.content`) are
+ * translated — emitted as `response.output_text.delta`. Tool-call
+ * delta normalization is tracked in #608.
+ */
+async function* parseChatCompletionStream(
+  response: Response,
+): AsyncIterable<ResponsesApiStreamEvent> {
+  for await (const { data } of parseSSELines(response)) {
+    if (data === "[DONE]") return;
+    let chunk: {
+      choices?: Array<{
+        delta?: { content?: string | null };
+      }>;
+    };
+    try {
+      chunk = JSON.parse(data);
+    } catch {
+      logger.debug({ data: data.slice(0, 100) }, "Failed to parse chat-completion chunk");
+      continue;
+    }
+    const delta = chunk.choices?.[0]?.delta?.content;
+    if (typeof delta === "string" && delta.length > 0) {
+      yield { type: "response.output_text.delta", delta };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request body builders
+// ---------------------------------------------------------------------------
+
+function buildResponsesBody(
+  params: NyxLlmStreamParams | NyxLlmCompleteParams,
+  stream: boolean,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: params.model,
+    input: params.input,
+    max_output_tokens: params.max_output_tokens ?? 8192,
+    temperature: params.temperature ?? 0.7,
+    stream,
+    store: false,
+  };
+  if (params.instructions) body.instructions = params.instructions;
+  if (params.tools && params.tools.length > 0) body.tools = params.tools;
+  return body;
+}
+
+function buildChatCompletionBody(
+  params: NyxLlmStreamParams | NyxLlmCompleteParams,
+  stream: boolean,
+): Record<string, unknown> {
+  const messages: Array<{ role: "user" | "assistant" | "system"; content: string }> = [];
+  if (params.instructions) {
+    messages.push({ role: "system", content: params.instructions });
+  }
+  for (const m of params.input) {
+    messages.push({
+      role: mapRoleToChatCompletion(m.role),
+      content: flattenContentToString(m.content),
+    });
+  }
+
+  const body: Record<string, unknown> = {
+    model: params.model,
+    messages,
+    max_tokens: params.max_output_tokens ?? 8192,
+    temperature: params.temperature ?? 0.7,
+    stream,
+  };
+  if (params.tools && params.tools.length > 0) {
+    body.tools = params.tools.map((t) => ({
+      type: "function" as const,
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+      },
+    }));
+  }
+  return body;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,8 +281,8 @@ async function* parseSSEStream(
  * collection) so an admin's edit lands on the next call without a pod
  * restart. The resolver chooses the right provider for the surface
  * (playground vs skill-gen) and projects its `auth` discriminated
- * union into the simpler {gatewayUrl, apiKey?} shape this client
- * speaks.
+ * union into the simpler {gatewayUrl, apiKey?, apiFormat} shape this
+ * client speaks.
  *
  * - `gatewayUrl` is required (validated upstream when the admin saves
  *   the provider) — empty string means "no provider configured" and
@@ -155,19 +291,24 @@ async function* parseSSEStream(
  * - `apiKey` empty triggers the SA token-exchange path
  *   (`NyxidSaTokenProvider`). Most providers behind the NyxID proxy
  *   use SA flow; direct-key providers (third-party gateways) bypass it.
+ * - `apiFormat` selects the upstream endpoint + body shape (#574). Empty
+ *   gateway short-circuits before this matters; otherwise defaults to
+ *   `responses` for backward compatibility if the resolver omits it.
  */
 export interface LlmProviderResolution {
   gatewayUrl: string;
   apiKey: string;
+  apiFormat: ApiFormat;
 }
 
 export type LlmProviderResolver = () => Promise<LlmProviderResolution>;
 
 export interface NyxLlmClientConfig {
   /**
-   * Resolves the effective gateway URL + apiKey for every LLM call from
-   * admin settings. NO env fallback: if the resolver returns an empty
-   * `gatewayUrl`, the call fails-closed with `LLM_PROVIDER_NOT_CONFIGURED`.
+   * Resolves the effective gateway URL + apiKey + apiFormat for every
+   * LLM call from admin settings. NO env fallback: if the resolver
+   * returns an empty `gatewayUrl`, the call fails-closed with
+   * `LLM_PROVIDER_NOT_CONFIGURED`.
    */
   resolver: LlmProviderResolver;
   /**
@@ -190,9 +331,9 @@ export class NyxLlmClient {
   }
 
   /**
-   * Resolve the effective gateway URL + auth header for the current
-   * call. Pulls the provider config from settings; SA token is fetched
-   * on demand when the provider has no direct apiKey.
+   * Resolve the effective gateway URL + auth header + apiFormat for the
+   * current call. Pulls the provider config from settings; SA token is
+   * fetched on demand when the provider has no direct apiKey.
    *
    * Fails-closed when no provider is configured — callers see a
    * structured error rather than a stale env URL.
@@ -200,46 +341,41 @@ export class NyxLlmClient {
   private async resolveCallTarget(): Promise<{
     gatewayUrl: string;
     authHeader: string;
+    apiFormat: ApiFormat;
   }> {
     const provider = await this.resolver();
     const gatewayUrl = provider.gatewayUrl?.trim().replace(/\/+$/, "");
     if (!gatewayUrl) {
       throw new Error("LLM_PROVIDER_NOT_CONFIGURED: no gatewayUrl in settings");
     }
+    const apiFormat: ApiFormat = provider.apiFormat ?? "responses";
 
     if (provider.apiKey && provider.apiKey.trim().length > 0) {
-      return { gatewayUrl, authHeader: `Bearer ${provider.apiKey.trim()}` };
+      return { gatewayUrl, authHeader: `Bearer ${provider.apiKey.trim()}`, apiFormat };
     }
 
     const token = await this.saTokenProvider.getAccessToken();
-    return { gatewayUrl, authHeader: `Bearer ${token}` };
+    return { gatewayUrl, authHeader: `Bearer ${token}`, apiFormat };
   }
 
   /**
-   * Streaming LLM call using Responses API format.
-   * Returns an AsyncIterable of SSE events.
+   * Streaming LLM call. Returns an AsyncIterable of Responses-API
+   * shaped SSE events regardless of upstream format.
    */
   async *stream(params: NyxLlmStreamParams): AsyncIterable<ResponsesApiStreamEvent> {
-    const { gatewayUrl, authHeader } = await this.resolveCallTarget();
-    logger.info({ model: params.model, gatewayUrl }, "Starting LLM stream request");
+    const { gatewayUrl, authHeader, apiFormat } = await this.resolveCallTarget();
+    logger.info(
+      { model: params.model, gatewayUrl, apiFormat },
+      "Starting LLM stream request",
+    );
 
-    const body: Record<string, unknown> = {
-      model: params.model,
-      input: params.input,
-      max_output_tokens: params.max_output_tokens ?? 8192,
-      temperature: params.temperature ?? 0.7,
-      stream: true,
-      store: false,
-    };
+    const path = apiFormat === "chat-completion" ? "/chat/completions" : "/responses";
+    const body =
+      apiFormat === "chat-completion"
+        ? buildChatCompletionBody(params, true)
+        : buildResponsesBody(params, true);
 
-    if (params.instructions) {
-      body.instructions = params.instructions;
-    }
-    if (params.tools && params.tools.length > 0) {
-      body.tools = params.tools;
-    }
-
-    const response = await fetch(`${gatewayUrl}/responses`, {
+    const response = await fetch(`${gatewayUrl}${path}`, {
       method: "POST",
       headers: {
         "Authorization": authHeader,
@@ -251,43 +387,44 @@ export class NyxLlmClient {
     if (!response.ok) {
       const rawText = await response.text().catch(() => "");
       const message = sanitizeErrorResponse(response.status, rawText);
-      logger.error({ status: response.status, model: params.model }, message);
+      logger.error({ status: response.status, model: params.model, apiFormat }, message);
       throw new Error(message);
     }
 
+    const parser =
+      apiFormat === "chat-completion"
+        ? parseChatCompletionStream(response)
+        : parseResponsesStream(response);
+
     let eventCount = 0;
-    for await (const event of parseSSEStream(response)) {
+    for await (const event of parser) {
       eventCount++;
       yield event;
     }
-    logger.info({ totalEvents: eventCount, model: params.model }, "LLM stream completed");
+    logger.info(
+      { totalEvents: eventCount, model: params.model, apiFormat },
+      "LLM stream completed",
+    );
   }
 
   /**
-   * Non-streaming LLM call using Responses API format.
-   * Returns the output array from the response.
+   * Non-streaming LLM call. Returns Responses-API `ResponsesApiOutput[]`
+   * regardless of upstream format.
    */
   async complete(params: NyxLlmCompleteParams): Promise<ResponsesApiOutput[]> {
-    const { gatewayUrl, authHeader } = await this.resolveCallTarget();
-    logger.info({ model: params.model, gatewayUrl }, "Starting LLM complete request");
+    const { gatewayUrl, authHeader, apiFormat } = await this.resolveCallTarget();
+    logger.info(
+      { model: params.model, gatewayUrl, apiFormat },
+      "Starting LLM complete request",
+    );
 
-    const body: Record<string, unknown> = {
-      model: params.model,
-      input: params.input,
-      max_output_tokens: params.max_output_tokens ?? 8192,
-      temperature: params.temperature ?? 0.7,
-      stream: false,
-      store: false,
-    };
+    const path = apiFormat === "chat-completion" ? "/chat/completions" : "/responses";
+    const body =
+      apiFormat === "chat-completion"
+        ? buildChatCompletionBody(params, false)
+        : buildResponsesBody(params, false);
 
-    if (params.instructions) {
-      body.instructions = params.instructions;
-    }
-    if (params.tools && params.tools.length > 0) {
-      body.tools = params.tools;
-    }
-
-    const response = await fetch(`${gatewayUrl}/responses`, {
+    const response = await fetch(`${gatewayUrl}${path}`, {
       method: "POST",
       headers: {
         "Authorization": authHeader,
@@ -299,8 +436,18 @@ export class NyxLlmClient {
     if (!response.ok) {
       const rawText = await response.text().catch(() => "");
       const message = sanitizeErrorResponse(response.status, rawText);
-      logger.error({ status: response.status, model: params.model }, message);
+      logger.error({ status: response.status, model: params.model, apiFormat }, message);
       throw new Error(message);
+    }
+
+    if (apiFormat === "chat-completion") {
+      const result = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string | null } }>;
+      };
+      const text = result.choices?.[0]?.message?.content ?? "";
+      return text
+        ? [{ type: "message", content: [{ type: "output_text", text }] }]
+        : [];
     }
 
     const result = (await response.json()) as { output: ResponsesApiOutput[] };


### PR DESCRIPTION
## Summary

- `NyxLlmClient` now dispatches on the resolved provider's `apiFormat` — `responses` keeps hitting `/responses`, `chat-completion` routes to `/chat/completions` with a translated body and SSE stream normalized back into Responses-API event shape.
- `bootstrap.ts:resolveLlmProviderForSurface` threads `provider.apiFormat` through `LlmProviderResolution` (new field).
- 11 new colocated tests (`ornn-api/src/clients/nyxid/llm.test.ts`) cover endpoint dispatch, body translation, text-delta normalization, content-part flattening, SA token fallback, trailing-slash trim, fail-closed, and non-2xx surfacing.

Tool-call delta normalization for chat-completion is intentionally out of scope here — that is #608.

## Test plan

- [x] `bun test src/clients/nyxid/llm.test.ts` — 11/11 green
- [x] `bun run typecheck:api` — zero new errors in changed files (`llm.ts`, `bootstrap.ts`)
- [x] Full `ornn-api` suite — no new regressions (18 pre-existing failures on `develop` all in `validateSkillFrontmatter #649`, unrelated)
- [ ] Local manual: configure DeepSeek provider with `apiFormat: chat-completion`, run AI skill generation — should now succeed instead of returning 404
- [ ] Local manual: existing `apiFormat: responses` providers continue to work unchanged

Fixes #574