### PR TITLE
fix(api): reuse chrono-sandbox session across tool rounds (#531)

### DIFF
--- a/.changeset/sandbox-session-persistence-531.md
+++ b/.changeset/sandbox-session-persistence-531.md
@@ -1,0 +1,20 @@
+---
+"ornn-api": patch
+---
+
+PlaygroundChatService now reuses a per-language chrono-sandbox session across tool-use rounds within one chat (#531).
+
+Background: every `execute_in_sandbox` tool call went to chrono-sandbox's one-shot `/execute` endpoint, which provisions a fresh kernel each invocation. As a result, anything a previous round installed (CLIs like `nyxid`, npm packages, generated files, env writes) was lost the next round. The LLM would `nyxid login`, then the next call would see no login. Users assumed the flow was working because each individual call succeeded — but the chat-level state never accumulated.
+
+Fix: in `chat()`, declare a per-stream `Map<language, sessionId>` plus a `createdSessionIds` list. The first `execute_in_sandbox` call for a given language lazily calls `sandboxClient.createSession({ language, dependencies, env, inputFiles, ttlSecs: 600, networkEnabled: true })` and records the session id; subsequent same-language calls hit `sessionExecute(sessionId, ...)` against the persistent kernel. A different language inside the same chat (e.g. javascript then python) lazily creates a second session.
+
+The whole tool loop is wrapped in `try / finally`; on exit (normal, error, abort) we best-effort `deleteSession` every session we created. chrono-sandbox also expires via `ttlSecs`, so a delete failure logs at `warn` and otherwise falls through — leftover sessions TTL out.
+
+Fail-open fallbacks preserve pre-fix behaviour if the session layer is unavailable:
+
+- `createSession` throws → log warn, fall back to one-shot `execute()` for that round; no session recorded.
+- `sessionExecute` throws → log warn, drop the stale session id from the map (next same-language call will recreate), fall back to one-shot `execute()` for that round.
+
+Plain (non-sandbox) chats touch nothing — no createSession, no deleteSession, zero overhead.
+
+Coverage: new colocated `src/domains/playground/chatService.test.ts` exercises the path with a stub `NyxLlmClient` (queued per-round event sequences) and a recording sandbox stub — asserts session creation count, sessionExecute reuse, multi-language isolation, finally-cleanup, both fail-open branches, plain-chat no-op, and delete-failure suppression. 8 tests, all green.

--- a/ornn-api/src/domains/playground/chatService.test.ts
+++ b/ornn-api/src/domains/playground/chatService.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for #531: PlaygroundChatService must reuse a per-language
+ * chrono-sandbox session across tool-use rounds in one chat so
+ * installed CLIs, env writes, and filesystem state survive between
+ * successive `execute_in_sandbox` tool calls.
+ *
+ * Scope:
+ * - First execute_in_sandbox call creates one session and uses
+ *   sessionExecute (NOT the one-shot /execute endpoint).
+ * - Same-language follow-up calls hit sessionExecute with the same
+ *   session id — no second createSession.
+ * - Different-language call creates a second session.
+ * - Sessions are cleaned up in the finally block.
+ * - createSession failure transparently falls back to one-shot execute
+ *   so the playground stays usable even if the session layer is down.
+ * - sessionExecute failure drops the stale session and falls back to
+ *   one-shot execute for that round.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { PlaygroundChatService } from "./chatService";
+import type {
+  CreateSessionParams,
+  SandboxExecuteParams,
+  SandboxExecuteResult,
+  SessionExecuteParams,
+  SessionResponse,
+} from "../../clients/sandboxClient";
+import type {
+  NyxLlmClient,
+  NyxLlmStreamParams,
+  ResponsesApiStreamEvent,
+} from "../../clients/nyxid/llm";
+import type { SkillService } from "../skills/crud/service";
+import type { PlaygroundChatEvent } from "../../shared/types/index";
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+interface ToolCallSpec {
+  name: string;
+  args: Record<string, unknown>;
+  id?: string;
+}
+
+function makeToolCallEvents(spec: ToolCallSpec): ResponsesApiStreamEvent[] {
+  return [
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: spec.id ?? `call-${spec.name}-${Math.random().toString(36).slice(2, 8)}`,
+        call_id: spec.id ?? `call-${spec.name}-${Math.random().toString(36).slice(2, 8)}`,
+        name: spec.name,
+        arguments: JSON.stringify(spec.args),
+      },
+    },
+  ];
+}
+
+const STOP_EVENTS: ResponsesApiStreamEvent[] = [
+  { type: "response.output_text.delta", delta: "done" },
+];
+
+/** Per-round event sequence — pops on each `.stream()` invocation. */
+function makeLlmClient(rounds: ResponsesApiStreamEvent[][]): NyxLlmClient {
+  const queue = [...rounds];
+  return {
+    async *stream(_params: NyxLlmStreamParams): AsyncIterable<ResponsesApiStreamEvent> {
+      const events = queue.shift() ?? STOP_EVENTS;
+      for (const e of events) yield e;
+    },
+    complete: (async () => []) as NyxLlmClient["complete"],
+  } as unknown as NyxLlmClient;
+}
+
+const SKILL_SERVICE_STUB: SkillService = {
+  getSkillJson: async () => ({ name: "stub", description: "", metadata: {}, files: {} }),
+} as unknown as SkillService;
+
+const DEFAULTS_RESOLVER = async () => ({
+  model: "test-model",
+  maxOutputTokens: 256,
+  temperature: 0.5,
+});
+
+interface SandboxCalls {
+  createSession: Array<{ params: CreateSessionParams }>;
+  sessionExecute: Array<{ sessionId: string; params: SessionExecuteParams }>;
+  execute: Array<{ params: SandboxExecuteParams }>;
+  deleteSession: string[];
+}
+
+function makeSandboxClient(opts: {
+  failCreate?: boolean;
+  failSessionExecute?: boolean;
+}): { client: NonNullable<unknown>; calls: SandboxCalls } {
+  const calls: SandboxCalls = {
+    createSession: [],
+    sessionExecute: [],
+    execute: [],
+    deleteSession: [],
+  };
+  let nextSessionId = 0;
+  const okResult: SandboxExecuteResult = {
+    success: true,
+    output: { stdout: "", stderr: "", exit_code: 0, display_data: [], execution_time_ms: 1 },
+  };
+
+  const client = {
+    async createSession(params: CreateSessionParams): Promise<SessionResponse> {
+      calls.createSession.push({ params });
+      if (opts.failCreate) throw new Error("simulated createSession failure");
+      const session_id = `sess-${++nextSessionId}`;
+      return { session_id, status: "ready", expires_at: Date.now() + 600_000 };
+    },
+    async sessionExecute(
+      sessionId: string,
+      params: SessionExecuteParams,
+    ): Promise<SandboxExecuteResult> {
+      calls.sessionExecute.push({ sessionId, params });
+      if (opts.failSessionExecute) throw new Error("simulated sessionExecute failure");
+      return okResult;
+    },
+    async execute(params: SandboxExecuteParams): Promise<SandboxExecuteResult> {
+      calls.execute.push({ params });
+      return okResult;
+    },
+    async deleteSession(sessionId: string): Promise<void> {
+      calls.deleteSession.push(sessionId);
+    },
+    async *executeStream() { /* unused */ },
+    async *sessionExecuteStream() { /* unused */ },
+    async listSessions() { return { sessions: [] }; },
+  };
+
+  return { client, calls };
+}
+
+async function drain(stream: AsyncIterable<PlaygroundChatEvent>): Promise<PlaygroundChatEvent[]> {
+  const events: PlaygroundChatEvent[] = [];
+  for await (const e of stream) events.push(e);
+  return events;
+}
+
+function makeService(
+  llmRounds: ResponsesApiStreamEvent[][],
+  sandbox: ReturnType<typeof makeSandboxClient>,
+): PlaygroundChatService {
+  return new PlaygroundChatService({
+    llmClient: makeLlmClient(llmRounds),
+    sandboxClient: sandbox.client as never,
+    skillService: SKILL_SERVICE_STUB,
+    defaultsResolver: DEFAULTS_RESOLVER,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// #531 — session reuse across same-language sandbox calls
+// ---------------------------------------------------------------------------
+
+describe("PlaygroundChatService — sandbox session persistence (#531)", () => {
+  it("first execute_in_sandbox call creates one session and uses sessionExecute (not one-shot)", async () => {
+    const sandbox = makeSandboxClient({});
+    const service = makeService(
+      [
+        makeToolCallEvents({
+          name: "execute_in_sandbox",
+          args: { script: "console.log('hi')", language: "javascript", dependencies: ["axios"] },
+        }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+
+    expect(sandbox.calls.createSession).toHaveLength(1);
+    expect(sandbox.calls.createSession[0]!.params).toMatchObject({
+      language: "javascript",
+      dependencies: ["axios"],
+    });
+    expect(sandbox.calls.sessionExecute).toHaveLength(1);
+    expect(sandbox.calls.sessionExecute[0]!.sessionId).toBe("sess-1");
+    expect(sandbox.calls.execute).toHaveLength(0);
+  });
+
+  it("two same-language calls reuse one session — only one createSession", async () => {
+    const sandbox = makeSandboxClient({});
+    const service = makeService(
+      [
+        makeToolCallEvents({ name: "execute_in_sandbox", args: { script: "step 1", language: "python" } }),
+        makeToolCallEvents({ name: "execute_in_sandbox", args: { script: "step 2", language: "python" } }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+
+    expect(sandbox.calls.createSession).toHaveLength(1);
+    expect(sandbox.calls.sessionExecute).toHaveLength(2);
+    expect(sandbox.calls.sessionExecute.every((c) => c.sessionId === "sess-1")).toBe(true);
+    expect(sandbox.calls.sessionExecute.map((c) => c.params.script)).toEqual(["step 1", "step 2"]);
+    expect(sandbox.calls.execute).toHaveLength(0);
+  });
+
+  it("different languages get separate sessions", async () => {
+    const sandbox = makeSandboxClient({});
+    const service = makeService(
+      [
+        makeToolCallEvents({ name: "execute_in_sandbox", args: { script: "js", language: "javascript" } }),
+        makeToolCallEvents({ name: "execute_in_sandbox", args: { script: "py", language: "python" } }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+
+    expect(sandbox.calls.createSession).toHaveLength(2);
+    expect(sandbox.calls.createSession.map((c) => c.params.language)).toEqual(["javascript", "python"]);
+    expect(sandbox.calls.sessionExecute).toHaveLength(2);
+    expect(sandbox.calls.sessionExecute.map((c) => c.sessionId)).toEqual(["sess-1", "sess-2"]);
+  });
+
+  it("sessions are deleted in the finally block at end of chat", async () => {
+    const sandbox = makeSandboxClient({});
+    const service = makeService(
+      [
+        makeToolCallEvents({ name: "execute_in_sandbox", args: { script: "x", language: "python" } }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+
+    expect(sandbox.calls.deleteSession).toEqual(["sess-1"]);
+  });
+
+  it("createSession failure falls back to one-shot /execute — no crash", async () => {
+    const sandbox = makeSandboxClient({ failCreate: true });
+    const service = makeService(
+      [
+        makeToolCallEvents({
+          name: "execute_in_sandbox",
+          args: { script: "x", language: "javascript", dependencies: ["lodash"] },
+        }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    const events = await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+
+    expect(sandbox.calls.createSession).toHaveLength(1);
+    expect(sandbox.calls.sessionExecute).toHaveLength(0);
+    expect(sandbox.calls.execute).toHaveLength(1);
+    expect(sandbox.calls.execute[0]!.params).toMatchObject({
+      language: "javascript",
+      dependencies: ["lodash"],
+      script: "x",
+    });
+    expect(sandbox.calls.deleteSession).toEqual([]);
+    expect(events.some((e) => e.type === "tool-result")).toBe(true);
+  });
+
+  it("sessionExecute failure drops the stale session and falls back to one-shot", async () => {
+    const sandbox = makeSandboxClient({ failSessionExecute: true });
+    const service = makeService(
+      [
+        makeToolCallEvents({ name: "execute_in_sandbox", args: { script: "x", language: "python" } }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+
+    expect(sandbox.calls.createSession).toHaveLength(1);
+    expect(sandbox.calls.sessionExecute).toHaveLength(1);
+    expect(sandbox.calls.execute).toHaveLength(1);
+  });
+
+  it("plain (non-sandbox) chats create no sessions", async () => {
+    const sandbox = makeSandboxClient({});
+    const service = makeService([STOP_EVENTS], sandbox);
+
+    await drain(service.chat("u1", { messages: [{ role: "user", content: "hi" }] }));
+
+    expect(sandbox.calls.createSession).toHaveLength(0);
+    expect(sandbox.calls.sessionExecute).toHaveLength(0);
+    expect(sandbox.calls.execute).toHaveLength(0);
+    expect(sandbox.calls.deleteSession).toHaveLength(0);
+  });
+
+  it("deleteSession failure does not surface to the caller", async () => {
+    const sandbox = makeSandboxClient({});
+    // Force deleteSession to throw on the one created session.
+    const originalDelete = (sandbox.client as { deleteSession: (id: string) => Promise<void> }).deleteSession;
+    (sandbox.client as { deleteSession: (id: string) => Promise<void> }).deleteSession = async (id) => {
+      sandbox.calls.deleteSession.push(id);
+      throw new Error("simulated delete failure");
+    };
+
+    const service = makeService(
+      [
+        makeToolCallEvents({ name: "execute_in_sandbox", args: { script: "x", language: "python" } }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    // Should complete without throwing despite the delete failure.
+    const events = await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+    expect(events.some((e) => e.type === "finish")).toBe(true);
+    expect(sandbox.calls.deleteSession).toEqual(["sess-1"]);
+    // Restore in case the test runner shares state.
+    (sandbox.client as { deleteSession: (id: string) => Promise<void> }).deleteSession = originalDelete;
+  });
+});

--- a/ornn-api/src/domains/playground/chatService.ts
+++ b/ornn-api/src/domains/playground/chatService.ts
@@ -11,7 +11,10 @@ import type {
   ResponsesApiInputMessage,
   ResponsesApiTool,
 } from "../../clients/nyxid/llm";
-import type { SandboxClient } from "../../clients/sandboxClient";
+import type {
+  SandboxClient,
+  SandboxExecuteResult,
+} from "../../clients/sandboxClient";
 import type { SkillService } from "../skills/crud/service";
 import type { PlaygroundChatEvent } from "../../shared/types/index";
 import { createLogger } from "../../shared/logger";
@@ -59,6 +62,39 @@ const anyKnownEventSchema = z.union([
   contentPartDeltaEventSchema,
   outputItemDoneEventSchema,
 ]);
+
+/** Server-side tool-call return shape consumed by the playground stream. */
+interface ToolCallResult {
+  text: string;
+  files: Array<{ path: string; content: string; size: number; mimeType: string }>;
+}
+
+/**
+ * Translate a chrono-sandbox `SandboxExecuteResult` (both /execute and
+ * /sessions/{id}/execute return this shape) into the {text, files}
+ * envelope the playground stream feeds back to the LLM and emits as
+ * `file-output` events to the client.
+ */
+function formatSandboxResult(result: SandboxExecuteResult): ToolCallResult {
+  const files = (result.output?.files ?? [])
+    .filter((f): f is typeof f & { content: string } => !!f.content && !f.error)
+    .map((f) => ({
+      path: f.path,
+      content: f.content,
+      size: f.size ?? 0,
+      mimeType: guessMimeType(f.path),
+    }));
+
+  const filesSummary = files.length > 0
+    ? `\nFiles retrieved: ${files.map((f) => `${f.path} (${f.size} bytes)`).join(", ")}`
+    : "";
+
+  const text = result.success
+    ? `Execution succeeded (exit code ${result.output?.exit_code}).\nstdout:\n${result.output?.stdout ?? ""}\nstderr:\n${result.output?.stderr ?? ""}${filesSummary}`
+    : `Execution failed: ${result.error?.message ?? "unknown error"}\nstdout:\n${result.output?.stdout ?? ""}\nstderr:\n${result.output?.stderr ?? ""}`;
+
+  return { text, files };
+}
 
 /** Guess MIME type from file extension. */
 function guessMimeType(path: string): string {
@@ -286,169 +322,289 @@ export class PlaygroundChatService {
       }
     }
 
-    // Tool-use loop: stream LLM → if tool call → execute → feed result → stream again
-    const MAX_TOOL_ROUNDS = 5;
-    for (let round = 0; round <= MAX_TOOL_ROUNDS; round++) {
-      try {
-        const streamEvents = this.llmClient.stream({
-          model,
-          input,
-          max_output_tokens: defaults.maxOutputTokens,
-          temperature: defaults.temperature,
-          tools: PLAYGROUND_TOOLS,
-        });
+    // Per-chat sandbox session reuse (#531). Same-language tool calls
+    // within one chat share a persistent kernel — installed CLIs,
+    // filesystem state, and env survive across rounds. Sessions are
+    // created lazily on first execute_in_sandbox call and torn down
+    // best-effort in `finally`. Keyed by language because chrono-sandbox
+    // kernels are per-language; a TS skill and a Python skill in the
+    // same chat each get their own session.
+    const sandboxSessions = new Map<string, string>();
+    const createdSessionIds: string[] = [];
 
-        let pendingToolCall: { id: string; name: string; args: Record<string, unknown> } | null = null;
+    try {
+      // Tool-use loop: stream LLM → if tool call → execute → feed result → stream again
+      const MAX_TOOL_ROUNDS = 5;
+      for (let round = 0; round <= MAX_TOOL_ROUNDS; round++) {
+        try {
+          const streamEvents = this.llmClient.stream({
+            model,
+            input,
+            max_output_tokens: defaults.maxOutputTokens,
+            temperature: defaults.temperature,
+            tools: PLAYGROUND_TOOLS,
+          });
 
-        for await (const event of streamEvents) {
-          if (abortSignal?.aborted) {
-            yield { type: "error", message: "Request aborted" };
-            yield { type: "finish", finishReason: "abort" };
+          let pendingToolCall: { id: string; name: string; args: Record<string, unknown> } | null = null;
+
+          for await (const event of streamEvents) {
+            if (abortSignal?.aborted) {
+              yield { type: "error", message: "Request aborted" };
+              yield { type: "finish", finishReason: "abort" };
+              return;
+            }
+
+            // #449 — parse with a discriminated Zod union instead of
+            // `as any`. Unknown event types are ignored (forward-compat
+            // with new upstream events); shape-mismatch on a known event
+            // logs at debug and is dropped.
+            const parsed = anyKnownEventSchema.safeParse(event);
+            if (!parsed.success) {
+              logger.debug(
+                { issues: parsed.error.issues.slice(0, 2) },
+                "Unrecognized LLM event shape — dropping",
+              );
+              continue;
+            }
+            const parsedEvent = parsed.data;
+
+            // Stream text deltas to client
+            if (parsedEvent.type === "response.output_text.delta") {
+              yield { type: "text-delta", delta: parsedEvent.delta };
+              continue;
+            }
+            if (parsedEvent.type === "response.content_part.delta") {
+              const delta = parsedEvent.delta;
+              if (delta?.type === "output_text" && typeof delta.text === "string") {
+                yield { type: "text-delta", delta: delta.text };
+              }
+              continue;
+            }
+
+            // Capture complete function call from output_item.done
+            // This event contains everything: item.id, item.name, item.arguments
+            if (parsedEvent.type === "response.output_item.done") {
+              const item = parsedEvent.item;
+              if (item?.type === "function_call") {
+                const toolName = item.name ?? "";
+                const toolCallId = item.call_id ?? item.id ?? "";
+                let args: Record<string, unknown> = {};
+                try {
+                  args = JSON.parse(item.arguments ?? "{}");
+                } catch {
+                  logger.error({ rawArgs: String(item.arguments).slice(0, 200) }, "Failed to parse function call arguments");
+                }
+                pendingToolCall = { id: toolCallId, name: toolName, args };
+                logger.info({ toolName, toolCallId }, "Tool call received from LLM");
+              }
+              continue;
+            }
+          }
+
+          // If no tool call, we're done
+          if (!pendingToolCall) {
+            yield { type: "finish", finishReason: "stop" };
             return;
           }
 
-          // #449 — parse with a discriminated Zod union instead of
-          // `as any`. Unknown event types are ignored (forward-compat
-          // with new upstream events); shape-mismatch on a known event
-          // logs at debug and is dropped.
-          const parsed = anyKnownEventSchema.safeParse(event);
-          if (!parsed.success) {
-            logger.debug(
-              { issues: parsed.error.issues.slice(0, 2) },
-              "Unrecognized LLM event shape — dropping",
-            );
-            continue;
-          }
-          const parsedEvent = parsed.data;
+          // Auto-execute the tool call server-side
+          logger.info({ toolName: pendingToolCall.name, round }, "Auto-executing tool call");
+          yield { type: "tool-call", toolCall: pendingToolCall };
 
-          // Stream text deltas to client
-          if (parsedEvent.type === "response.output_text.delta") {
-            yield { type: "text-delta", delta: parsedEvent.delta };
-            continue;
-          }
-          if (parsedEvent.type === "response.content_part.delta") {
-            const delta = parsedEvent.delta;
-            if (delta?.type === "output_text" && typeof delta.text === "string") {
-              yield { type: "text-delta", delta: delta.text };
-            }
-            continue;
+          const toolResult = await this.executeToolCall(
+            pendingToolCall,
+            sandboxSessions,
+            createdSessionIds,
+          );
+          yield { type: "tool-result", toolCallId: pendingToolCall.id, result: toolResult.text };
+
+          // Emit file outputs if any
+          for (const file of toolResult.files) {
+            yield { type: "file-output", file };
           }
 
-          // Capture complete function call from output_item.done
-          // This event contains everything: item.id, item.name, item.arguments
-          if (parsedEvent.type === "response.output_item.done") {
-            const item = parsedEvent.item;
-            if (item?.type === "function_call") {
-              const toolName = item.name ?? "";
-              const toolCallId = item.call_id ?? item.id ?? "";
-              let args: Record<string, unknown> = {};
-              try {
-                args = JSON.parse(item.arguments ?? "{}");
-              } catch {
-                logger.error({ rawArgs: String(item.arguments).slice(0, 200) }, "Failed to parse function call arguments");
-              }
-              pendingToolCall = { id: toolCallId, name: toolName, args };
-              logger.info({ toolName, toolCallId }, "Tool call received from LLM");
-            }
-            continue;
-          }
-        }
+          // Feed tool result back to LLM for next round
+          input.push({
+            role: "assistant" as const,
+            content: `[Tool call: ${pendingToolCall.name}(${JSON.stringify(pendingToolCall.args)})]`,
+          });
+          input.push({
+            role: "user" as const,
+            content: `Tool result for ${pendingToolCall.name}: ${toolResult.text}`,
+          });
 
-        // If no tool call, we're done
-        if (!pendingToolCall) {
-          yield { type: "finish", finishReason: "stop" };
+        } catch (err) {
+          logger.error({ userId, err, round }, "Chat stream error");
+          yield { type: "error", message: err instanceof Error ? err.message : "Stream failed" };
+          yield { type: "finish", finishReason: "error" };
           return;
         }
+      }
 
-        // Auto-execute the tool call server-side
-        logger.info({ toolName: pendingToolCall.name, round }, "Auto-executing tool call");
-        yield { type: "tool-call", toolCall: pendingToolCall };
-
-        const toolResult = await this.executeToolCall(pendingToolCall);
-        yield { type: "tool-result", toolCallId: pendingToolCall.id, result: toolResult.text };
-
-        // Emit file outputs if any
-        for (const file of toolResult.files) {
-          yield { type: "file-output", file };
-        }
-
-        // Feed tool result back to LLM for next round
-        input.push({
-          role: "assistant" as const,
-          content: `[Tool call: ${pendingToolCall.name}(${JSON.stringify(pendingToolCall.args)})]`,
-        });
-        input.push({
-          role: "user" as const,
-          content: `Tool result for ${pendingToolCall.name}: ${toolResult.text}`,
-        });
-
-      } catch (err) {
-        logger.error({ userId, err, round }, "Chat stream error");
-        yield { type: "error", message: err instanceof Error ? err.message : "Stream failed" };
-        yield { type: "finish", finishReason: "error" };
-        return;
+      yield { type: "finish", finishReason: "stop" };
+    } finally {
+      // Best-effort session cleanup. chrono-sandbox sessions also
+      // expire via ttlSecs, but explicit teardown frees the container
+      // immediately. Swallow errors — a leftover session will TTL out.
+      if (createdSessionIds.length > 0) {
+        await Promise.allSettled(
+          createdSessionIds.map(async (sessionId) => {
+            try {
+              await this.sandboxClient.deleteSession(sessionId);
+            } catch (err) {
+              logger.warn(
+                { sessionId, err: (err as Error).message },
+                "Sandbox session delete failed — relying on TTL",
+              );
+            }
+          }),
+        );
       }
     }
-
-    yield { type: "finish", finishReason: "stop" };
   }
 
   /**
-   * Execute a tool call server-side. Returns text result and any output files.
+   * Execute a tool call server-side. Returns text result and any
+   * output files. `sandboxSessions` and `createdSessionIds` are
+   * owned by the caller (`chat()`) — per-chat state that lets
+   * `execute_in_sandbox` reuse the same chrono-sandbox kernel across
+   * tool-use rounds so installed CLIs, env, and filesystem persist
+   * (#531).
    */
   private async executeToolCall(
     toolCall: { id: string; name: string; args: Record<string, unknown> },
-  ): Promise<{ text: string; files: Array<{ path: string; content: string; size: number; mimeType: string }> }> {
+    sandboxSessions: Map<string, string>,
+    createdSessionIds: string[],
+  ): Promise<ToolCallResult> {
     const { name, args } = toolCall;
-    const noFiles: Array<{ path: string; content: string; size: number; mimeType: string }> = [];
 
     if (name === "execute_in_sandbox") {
-      try {
-        const result = await this.sandboxClient.execute({
-          script: (args.script as string) ?? "",
-          language: (args.language as string) ?? "python",
-          outputType: (args.output_type as "text" | "file") ?? "text",
-          env: (args.env as Record<string, string>) ?? {},
-          dependencies: (args.dependencies as string[]) ?? [],
-          retrieveFiles: (args.retrieve_files as string[]) ?? [],
-          inputFiles: (args.input_files as Array<{ path: string; content: string }>) ?? [],
-          timeoutSecs: (args.timeout_secs as number) ?? 120,
-        });
-
-        // Extract retrieved files
-        const files = (result.output?.files ?? [])
-          .filter((f): f is typeof f & { content: string } => !!f.content && !f.error)
-          .map((f) => ({
-            path: f.path,
-            content: f.content,
-            size: f.size ?? 0,
-            mimeType: guessMimeType(f.path),
-          }));
-
-        const filesSummary = files.length > 0
-          ? `\nFiles retrieved: ${files.map((f) => `${f.path} (${f.size} bytes)`).join(", ")}`
-          : "";
-
-        const text = result.success
-          ? `Execution succeeded (exit code ${result.output?.exit_code}).\nstdout:\n${result.output?.stdout ?? ""}\nstderr:\n${result.output?.stderr ?? ""}${filesSummary}`
-          : `Execution failed: ${result.error?.message ?? "unknown error"}\nstdout:\n${result.output?.stdout ?? ""}\nstderr:\n${result.output?.stderr ?? ""}`;
-
-        return { text, files };
-      } catch (err) {
-        return { text: `Sandbox execution failed: ${err instanceof Error ? err.message : String(err)}`, files: noFiles };
-      }
+      return await this.runSandboxToolCall(args, sandboxSessions, createdSessionIds);
     }
 
     if (name === "load_skill") {
       try {
         const skillJson = await this.skillService.getSkillJson((args.skill_id as string) ?? "");
-        return { text: JSON.stringify(skillJson, null, 2), files: noFiles };
+        return { text: JSON.stringify(skillJson, null, 2), files: [] };
       } catch (err) {
-        return { text: `Failed to load skill: ${err instanceof Error ? err.message : String(err)}`, files: noFiles };
+        return { text: `Failed to load skill: ${err instanceof Error ? err.message : String(err)}`, files: [] };
       }
     }
 
-    return { text: `Unknown tool: ${name}`, files: noFiles };
+    return { text: `Unknown tool: ${name}`, files: [] };
+  }
+
+  /**
+   * Dispatch a single `execute_in_sandbox` tool call.
+   *
+   * Lazily reuses a per-language chrono-sandbox session for the chat —
+   * the first call for a language pays the createSession cost (with
+   * the LLM-supplied dependency list installed once); subsequent
+   * same-language calls hit the persistent kernel and see prior CLI
+   * installs, env writes, and filesystem state (#531).
+   *
+   * Fail-open fallbacks keep one-call behaviour identical to
+   * pre-session if session APIs error: createSession failure or
+   * sessionExecute failure both retry via the one-shot `/execute`
+   * endpoint, log a warning, and (for sessionExecute) drop the stale
+   * session id so the next call can recreate.
+   */
+  private async runSandboxToolCall(
+    args: Record<string, unknown>,
+    sandboxSessions: Map<string, string>,
+    createdSessionIds: string[],
+  ): Promise<ToolCallResult> {
+    const script = (args.script as string) ?? "";
+    const language = (args.language as string) ?? "python";
+    const outputType = (args.output_type as "text" | "file") ?? "text";
+    const env = (args.env as Record<string, string>) ?? {};
+    const dependencies = (args.dependencies as string[]) ?? [];
+    const retrieveFiles = (args.retrieve_files as string[]) ?? [];
+    const inputFiles = (args.input_files as Array<{ path: string; content: string }>) ?? [];
+    const timeoutSecs = (args.timeout_secs as number) ?? 120;
+
+    let sessionId = sandboxSessions.get(language);
+
+    if (!sessionId) {
+      try {
+        const session = await this.sandboxClient.createSession({
+          language,
+          dependencies,
+          env,
+          inputFiles,
+          // 10 min covers a typical multi-round playground session; the
+          // server also bumps last_used_at on each execute, so an
+          // active chat won't expire mid-conversation.
+          ttlSecs: 600,
+          networkEnabled: true,
+        });
+        sessionId = session.session_id;
+        sandboxSessions.set(language, sessionId);
+        createdSessionIds.push(sessionId);
+        logger.info(
+          { language, sessionId, deps: dependencies.length },
+          "Sandbox session created for chat",
+        );
+      } catch (err) {
+        logger.warn(
+          { language, err: (err as Error).message },
+          "createSession failed — falling back to one-shot execute",
+        );
+        return await this.runSandboxOneShot({
+          script, language, outputType, env, dependencies,
+          retrieveFiles, inputFiles, timeoutSecs,
+        });
+      }
+    }
+
+    try {
+      const result = await this.sandboxClient.sessionExecute(sessionId, {
+        script,
+        language,
+        outputType,
+        env,
+        inputFiles,
+        retrieveFiles,
+        timeoutSecs,
+      });
+      return formatSandboxResult(result);
+    } catch (err) {
+      logger.warn(
+        { sessionId, language, err: (err as Error).message },
+        "sessionExecute failed — dropping session and falling back to one-shot",
+      );
+      sandboxSessions.delete(language);
+      return await this.runSandboxOneShot({
+        script, language, outputType, env, dependencies,
+        retrieveFiles, inputFiles, timeoutSecs,
+      });
+    }
+  }
+
+  /**
+   * One-shot fallback path used when session APIs are unavailable.
+   * Matches the legacy pre-#531 behaviour exactly so a broken sandbox
+   * session layer never makes the playground worse than it was.
+   */
+  private async runSandboxOneShot(params: {
+    script: string;
+    language: string;
+    outputType: "text" | "file";
+    env: Record<string, string>;
+    dependencies: string[];
+    retrieveFiles: string[];
+    inputFiles: Array<{ path: string; content: string }>;
+    timeoutSecs: number;
+  }): Promise<ToolCallResult> {
+    try {
+      const result = await this.sandboxClient.execute(params);
+      return formatSandboxResult(result);
+    } catch (err) {
+      return {
+        text: `Sandbox execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        files: [],
+      };
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- Playground tool-use loop now lazily creates a per-language chrono-sandbox session and reuses it for every same-language `execute_in_sandbox` call within one chat — installed CLIs (`nyxid`, npm packages), env writes, and filesystem state survive across rounds.
- Sessions are cleaned up in a `finally` block; chrono-sandbox `ttlSecs` is a backstop.
- Fail-open: if `createSession` or `sessionExecute` errors, the round falls back to one-shot `/execute` (legacy behaviour). Plain non-sandbox chats touch nothing.
- 8 new colocated tests in `chatService.test.ts`, all green.

## Test plan

- [x] `bun test src/domains/playground/chatService.test.ts` — 8/8 green
- [x] `bun run typecheck:api` — no new errors in `chatService.ts`
- [x] Full `ornn-api` suite — 722 pass / 18 unrelated pre-existing failures (`validateSkillFrontmatter #649`)
- [ ] Local manual: in playground, run a skill that does `nyxid login` in round 1, then `nyxid proxy …` in round 2 — second call should see the auth from the first
- [ ] Local manual: confirm plain (non-sandbox) chat still works and creates no sessions

Fixes #531