### PR TITLE
fix(api): normalize chat-completion tool calls into Responses events (#608)

### DIFF
--- a/.changeset/chat-completion-tool-calls-608.md
+++ b/.changeset/chat-completion-tool-calls-608.md
@@ -1,0 +1,27 @@
+---
+"ornn-api": patch
+---
+
+NyxLlmClient now normalizes Chat Completions tool-call deltas into the same Responses-API `response.output_item.done` / `function_call` events the playground tool loop already consumes (#608).
+
+Background: #574 routed chat-completion providers to `/chat/completions` and translated text deltas, but the stream parser ignored `choices[].delta.tool_calls`. The playground tool-use loop in `chatService.ts` only matches on Responses-API `response.output_item.done` with `item.type === "function_call"`, so when a chat-completion provider (DeepSeek, Together, any OpenAI-compat gateway) responded with a tool call, no `function_call` event ever reached the loop. The model's `execute_in_sandbox(...)` invocation arrived as plain assistant text and got rendered as JSON in the chat instead of being executed — runtime-based and mixed skills appeared to "respond" without ever running the sandbox.
+
+Fix: `parseChatCompletionStream` keeps a per-index `Map<number, ToolCallAccumulator>` carrying `{id, name, arguments}`. Each `choices[].delta.tool_calls[]` chunk merges into its index buffer (id + name arrive on the first chunk for that call; the `arguments` JSON string accumulates across many chunks). A turn flushes when any of: explicit `finish_reason` (`tool_calls`, `stop`, anything non-null), upstream `[DONE]` sentinel, or stream EOF — whichever fires first. A `flushed` guard makes flush idempotent so we never double-emit if multiple end signals fire.
+
+The synthesized event matches the Responses-API shape `chatService.ts` already validates with Zod (`outputItemDoneEventSchema`):
+
+```js
+{
+  type: "response.output_item.done",
+  item: {
+    type: "function_call",
+    id, call_id, name, arguments,  // arguments is the accumulated JSON string
+  },
+}
+```
+
+This way zero changes are needed in `chatService.ts` — its existing `pendingToolCall` capture + `executeToolCall` dispatch path works for both upstream formats now.
+
+Parallel tool calls within one assistant turn are supported (one done event per index, emitted in index order). Missing `index` falls back to 0 (treated as a single tool call). Streams that close without `[DONE]` or `finish_reason` still flush at EOF so a buffered call is never lost.
+
+Coverage: 6 new tests appended to `src/clients/nyxid/llm.test.ts` — chunked accumulation + finish_reason flush, EOF flush without [DONE], parallel tool calls, idempotent flush across finish_reason+[DONE], intermixed text+tool deltas (correct event order), missing `index` fallback. All 17 tests in the file green; full ornn-api suite has no new regressions.

--- a/ornn-api/src/clients/nyxid/llm.test.ts
+++ b/ornn-api/src/clients/nyxid/llm.test.ts
@@ -644,3 +644,211 @@ describe("NyxLlmClient.complete() routing on apiFormat", () => {
     ]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #608 — chat-completion tool-call delta normalization
+// ---------------------------------------------------------------------------
+
+describe("chat-completion stream tool-call normalization (#608)", () => {
+  function makeClient(): NyxLlmClient {
+    return new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+  }
+
+  it("accumulates tool_calls across chunks and emits one output_item.done on finish_reason=tool_calls", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({
+          choices: [{
+            delta: {
+              tool_calls: [{
+                index: 0,
+                id: "call_abc",
+                type: "function",
+                function: { name: "execute_in_sandbox", arguments: "" },
+              }],
+            },
+          }],
+        }),
+        JSON.stringify({
+          choices: [{
+            delta: { tool_calls: [{ index: 0, function: { arguments: "{\"scr" } }] },
+          }],
+        }),
+        JSON.stringify({
+          choices: [{
+            delta: { tool_calls: [{ index: 0, function: { arguments: "ipt\":\"x\"}" } }] },
+          }],
+        }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      ]);
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of makeClient().stream({
+      model: "deepseek-v4",
+      input: [{ role: "user", content: "run x" }],
+      tools: [{
+        type: "function",
+        name: "execute_in_sandbox",
+        description: "run",
+        parameters: { type: "object" },
+      }],
+    })) events.push(e);
+
+    const done = events.filter((e) => e.type === "response.output_item.done");
+    expect(done).toHaveLength(1);
+    expect(done[0]).toEqual({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "call_abc",
+        call_id: "call_abc",
+        name: "execute_in_sandbox",
+        arguments: "{\"script\":\"x\"}",
+      },
+    });
+  });
+
+  it("flushes a buffered tool call when stream ends without [DONE] or finish_reason", async () => {
+    // Body has no [DONE] sentinel and no finish_reason — just an EOF.
+    fetchHandler = () =>
+      new Response(
+        `data: ${JSON.stringify({
+          choices: [{
+            delta: {
+              tool_calls: [{
+                index: 0,
+                id: "call_z",
+                function: { name: "t", arguments: "{\"a\":1}" },
+              }],
+            },
+          }],
+        })}\n\n`,
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of makeClient().stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+    })) events.push(e);
+
+    const done = events.find((e) => e.type === "response.output_item.done");
+    expect(done).toEqual({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "call_z",
+        call_id: "call_z",
+        name: "t",
+        arguments: "{\"a\":1}",
+      },
+    });
+  });
+
+  it("supports parallel tool calls — one done event per index", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({
+          choices: [{
+            delta: {
+              tool_calls: [
+                { index: 0, id: "call_a", function: { name: "fn_a", arguments: "{}" } },
+                { index: 1, id: "call_b", function: { name: "fn_b", arguments: "{}" } },
+              ],
+            },
+          }],
+        }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      ]);
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of makeClient().stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+    })) events.push(e);
+
+    const done = events.filter((e) => e.type === "response.output_item.done");
+    expect(done).toHaveLength(2);
+    expect((done[0]!.item as { id: string }).id).toBe("call_a");
+    expect((done[1]!.item as { id: string }).id).toBe("call_b");
+  });
+
+  it("only flushes once when finish_reason and [DONE] both arrive", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({
+          choices: [{
+            delta: {
+              tool_calls: [{ index: 0, id: "call_x", function: { name: "fn", arguments: "{}" } }],
+            },
+            finish_reason: "tool_calls",
+          }],
+        }),
+      ]);
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of makeClient().stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+    })) events.push(e);
+
+    const done = events.filter((e) => e.type === "response.output_item.done");
+    expect(done).toHaveLength(1);
+  });
+
+  it("intermixed text + tool_call deltas produce text-delta then done event in order", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({ choices: [{ delta: { content: "thinking…" } }] }),
+        JSON.stringify({
+          choices: [{
+            delta: {
+              tool_calls: [{ index: 0, id: "call_q", function: { name: "fn", arguments: "{}" } }],
+            },
+          }],
+        }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      ]);
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of makeClient().stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+    })) events.push(e);
+
+    expect(events.map((e) => e.type)).toEqual([
+      "response.output_text.delta",
+      "response.output_item.done",
+    ]);
+  });
+
+  it("tool_calls.index missing → falls back to index 0", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({
+          choices: [{
+            delta: {
+              tool_calls: [{ id: "call_noix", function: { name: "fn", arguments: "{}" } }],
+            },
+            finish_reason: "tool_calls",
+          }],
+        }),
+      ]);
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of makeClient().stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+    })) events.push(e);
+
+    const done = events.find((e) => e.type === "response.output_item.done");
+    expect((done?.item as { id: string }).id).toBe("call_noix");
+  });
+});

--- a/ornn-api/src/clients/nyxid/llm.ts
+++ b/ornn-api/src/clients/nyxid/llm.ts
@@ -11,13 +11,10 @@
  * `ResponsesApiStreamEvent`). For chat-completion providers the client
  * translates the request body on the way out and normalizes the SSE
  * stream / completion payload back into Responses-API event shape on
- * the way in, so consumers (skill generation + playground) do not need
- * to branch on apiFormat (#574).
- *
- * Chat-completion tool-call normalization is implemented: streamed
- * `choices[].delta.tool_calls[]` fragments are accumulated and flushed
- * as `response.output_item.done` function_call events, and non-streamed
- * `choices[].message.tool_calls[]` map to `function_call` outputs (#608).
+ * the way in — both text deltas (#574) and accumulated tool-call
+ * deltas synthesized into `response.output_item.done` /
+ * `function_call` events (#608) — so consumers (skill generation +
+ * playground tool loop) never branch on apiFormat.
  *
  * Authenticates using a Service Account (SA) token obtained via
  * client_credentials grant when the resolved provider has no direct
@@ -188,56 +185,76 @@ async function* parseResponsesStream(
 }
 
 /**
- * Parse Chat Completions SSE and translate both text deltas and
- * tool-call deltas into Responses-API event shape so consumers stay
- * format-agnostic.
+ * Internal accumulator for a single OpenAI Chat Completions tool call
+ * as it streams in. `id` + `name` arrive on the first delta for that
+ * tool-call index; `arguments` is a JSON string that accumulates
+ * across many chunks before the model finishes emitting it.
+ */
+interface ToolCallAccumulator {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+/**
+ * Parse Chat Completions SSE and translate it into Responses-API
+ * event shape so downstream consumers (skill generation, playground
+ * tool-use loop) stay format-agnostic.
  *
- * Text deltas (`choices[].delta.content`) pass through as
- * `response.output_text.delta`. Tool-call fragments
- * (`choices[].delta.tool_calls[]`) arrive incrementally — `id`/`name`
- * land on the first fragment, `function.arguments` streams across many
- * — so we accumulate per `index` and flush each completed call as a
- * single `response.output_item.done` function_call event (matching the
- * Responses-API shape the playground consumer reads). We never parse the
- * arguments mid-stream; the consumer parses the assembled JSON (#608).
+ * - `choices[].delta.content` chunks → `response.output_text.delta`
+ *   events (#574).
+ * - `choices[].delta.tool_calls` chunks are buffered per tool-call
+ *   index (id + name + accumulated JSON arguments). When the turn
+ *   completes (explicit `finish_reason` of `"tool_calls"` /
+ *   `"stop"`, upstream `[DONE]`, or EOF), each buffered tool call is
+ *   emitted as a synthesized `response.output_item.done` event with
+ *   `item.type === "function_call"` — the exact shape the playground
+ *   loop already consumes (#608). Without this the playground never
+ *   sees a tool call from chat-completion providers and renders
+ *   `execute_in_sandbox(...)` as plain text instead of running it.
  */
 async function* parseChatCompletionStream(
   response: Response,
 ): AsyncIterable<ResponsesApiStreamEvent> {
-  const toolCalls = new Map<number, { id: string; name: string; argsBuffer: string }>();
+  const toolCalls = new Map<number, ToolCallAccumulator>();
   let flushed = false;
 
-  function* flush(): Generator<ResponsesApiStreamEvent> {
+  function* flushToolCalls(): Generator<ResponsesApiStreamEvent> {
     if (flushed) return;
     flushed = true;
-    for (const index of [...toolCalls.keys()].sort((a, b) => a - b)) {
-      const call = toolCalls.get(index)!;
+    const indices = [...toolCalls.keys()].sort((a, b) => a - b);
+    for (const idx of indices) {
+      const tc = toolCalls.get(idx)!;
       yield {
         type: "response.output_item.done",
         item: {
           type: "function_call",
-          id: call.id,
-          call_id: call.id,
-          name: call.name,
-          arguments: call.argsBuffer,
+          id: tc.id,
+          call_id: tc.id,
+          name: tc.name,
+          arguments: tc.arguments,
         },
       };
     }
   }
 
   for await (const { data } of parseSSELines(response)) {
-    if (data === "[DONE]") break;
+    if (data === "[DONE]") {
+      yield* flushToolCalls();
+      return;
+    }
     let chunk: {
       choices?: Array<{
         delta?: {
           content?: string | null;
           tool_calls?: Array<{
-            index: number;
+            index?: number;
             id?: string;
+            type?: string;
             function?: { name?: string; arguments?: string };
           }>;
         };
-        finish_reason?: string;
+        finish_reason?: string | null;
       }>;
     };
     try {
@@ -248,34 +265,45 @@ async function* parseChatCompletionStream(
     }
 
     const choice = chunk.choices?.[0];
-    const textDelta = choice?.delta?.content;
-    if (typeof textDelta === "string" && textDelta.length > 0) {
-      yield { type: "response.output_text.delta", delta: textDelta };
+    if (!choice) continue;
+
+    const text = choice.delta?.content;
+    if (typeof text === "string" && text.length > 0) {
+      yield { type: "response.output_text.delta", delta: text };
     }
 
-    const fragments = choice?.delta?.tool_calls;
-    if (fragments) {
-      for (const frag of fragments) {
-        const existing = toolCalls.get(frag.index) ?? { id: "", name: "", argsBuffer: "" };
-        if (frag.id) existing.id = frag.id;
-        if (frag.function?.name) existing.name = frag.function.name;
-        if (typeof frag.function?.arguments === "string") {
-          existing.argsBuffer += frag.function.arguments;
+    const deltaToolCalls = choice.delta?.tool_calls;
+    if (Array.isArray(deltaToolCalls)) {
+      for (const piece of deltaToolCalls) {
+        // OpenAI uses `index` to disambiguate parallel tool calls
+        // within one assistant turn. Missing index → assume a single
+        // tool call at index 0.
+        const idx = typeof piece.index === "number" ? piece.index : 0;
+        const acc = toolCalls.get(idx) ?? { id: "", name: "", arguments: "" };
+        if (piece.id) acc.id = piece.id;
+        if (piece.function?.name) acc.name = piece.function.name;
+        if (typeof piece.function?.arguments === "string") {
+          acc.arguments += piece.function.arguments;
         }
-        toolCalls.set(frag.index, existing);
+        toolCalls.set(idx, acc);
       }
     }
 
-    if (choice?.finish_reason === "tool_calls") {
-      yield* flush();
+    // Some providers (DeepSeek, Together, …) terminate a tool-call
+    // turn with finish_reason=tool_calls; others emit
+    // finish_reason=stop alongside the final tool-call delta. Treat
+    // any non-null finish_reason as "no more deltas this turn" and
+    // flush so the playground loop sees the tool call before
+    // [DONE] / EOF.
+    if (choice.finish_reason && toolCalls.size > 0) {
+      yield* flushToolCalls();
     }
   }
 
-  // Flush on stream end / [DONE] in case the upstream omitted the
-  // `finish_reason: "tool_calls"` chunk but still streamed tool calls.
-  if (toolCalls.size > 0) {
-    yield* flush();
-  }
+  // Stream ended without a [DONE] sentinel (some upstreams just
+  // close the body). Flush any pending tool calls so we don't drop
+  // them on the floor.
+  yield* flushToolCalls();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `parseChatCompletionStream` now accumulates `delta.tool_calls` chunks per index and emits synthesized `response.output_item.done` / `function_call` events on flush. The playground tool-use loop already matches on that shape, so zero changes were needed in `chatService.ts`.
- Flushes on any of: explicit `finish_reason` (`tool_calls` / `stop` / non-null), upstream `[DONE]`, or stream EOF. Flush is idempotent via a `flushed` guard.
- Parallel tool calls supported (one done event per index, emitted in index order). Missing `index` falls back to 0.
- 6 new tests appended to `llm.test.ts`, 17/17 in file green.

## Test plan

- [x] `bun test src/clients/nyxid/llm.test.ts` — 17/17 green
- [x] `bun run typecheck:api` — no new errors in `llm.ts`
- [x] Full `ornn-api` suite — no new regressions
- [ ] Local manual: configure a DeepSeek (chat-completion) provider for playground; run a runtime-based skill — `execute_in_sandbox` should be called by the loop, not rendered as text. Combined with the session reuse from #531, multi-round runtime skills should now work end-to-end on chat-completion providers.

Fixes #608