### PR TITLE
fix(api): drop deactivated NyxID services from system-services facet (#715)

### DIFF
--- a/.changeset/filter-deactivated-nyxid-services-715.md
+++ b/.changeset/filter-deactivated-nyxid-services-715.md
@@ -1,0 +1,18 @@
+---
+"ornn-api": patch
+---
+
+`/skill-facets/system-services` now drops services NyxID has deactivated, and the NyxID catalog cache TTL drops from 60s → 10s (#715).
+
+Background: when NyxID deactivates a service (`DELETE /api/v1/services/:id` is a soft delete that flips `is_active: false`), Ornn kept exposing it. The DB aggregation behind `/skill-facets/system-services` reads `nyxidServiceId/slug/label` straight off skill documents, so any skill ever bound to that service still surfaced the service as a usable filter chip. Per-caller paths (`/me/nyxid-services`, `/nyxid-services/:serviceId/skills`) already filtered `is_active=false` inside `NyxidServiceClient.listServicesForCaller`, but the 60-second cache widened the visibility lag after deactivation.
+
+Fix:
+
+- `NyxidServiceClient.listActiveServiceIdsAsPlatform(saToken)` (new): SA-token fetch of NyxID's `/services`, projected to a `Set<string>` of active service ids. Separate from the per-caller cache (one slot — SA view is uniform). Fail-soft: returns `null` on non-2xx or thrown fetch so callers preserve current behaviour when NyxID is unreachable. Same 10s TTL as the per-caller cache.
+- `cacheTtlMs` lowered from `60_000` to `10_000`. After a NyxID deactivation, every Ornn surface that goes through `findVisibleToCaller` (`/me/nyxid-services`, reverse lookup) drops the service within at most 10s instead of 60s.
+- `invalidateCache()` also clears the platform cache so admin-side hooks can force a refresh.
+- `/skill-facets/system-services` (search/routes) now intersects the DB aggregation with the platform active set when `nyxidServiceClient` + `getSaAccessToken` are wired in; falls through to the pre-#715 raw aggregation if either is missing or the SA fetch fails. Bootstrap wires both.
+
+Out of scope: skill detail still shows the historical `nyxidServiceId/slug/label` even when the service is deactivated. The QA report lists this as one of several acceptable mitigations; the simplest "stop misrepresenting the service as usable" path is to ensure the facet (the discovery surface) doesn't advertise it. A follow-up can mark the detail panel as "service unavailable" if we want a louder signal.
+
+Coverage: colocated `clients/nyxid/service.test.ts` exercises the per-caller `is_active=false` drop (pre-existing defence-in-depth), missing-`is_active` default-to-active, the new platform method (SA token + URL, caching, fail-soft on 5xx and network throw, empty SA short-circuit, `invalidateCache` re-fetch). 8 tests, all green.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -712,6 +712,8 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
     llmClient: nyxLlmClient,
     defaultModelResolver: async () =>
       (await resolveSurfaceDefaults("playground")).model,
+    nyxidServiceClient,
+    getSaAccessToken,
   });
 
   // ---- Domain: Skill Generation ----

--- a/ornn-api/src/clients/nyxid/service.test.ts
+++ b/ornn-api/src/clients/nyxid/service.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for #715: deactivated NyxID services must not be exposed as
+ * usable system services. `NyxidServiceClient.listServicesForCaller`
+ * already drops `is_active: false` rows on a per-caller view; the new
+ * `listActiveServiceIdsAsPlatform` adds the platform-wide active set
+ * that anonymous-friendly aggregators (skill-facets/system-services)
+ * cross-check against.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { NyxidServiceClient } from "./service";
+
+interface CapturedRequest {
+  url: string;
+  authorization: string;
+}
+
+const originalFetch = globalThis.fetch;
+let captured: CapturedRequest[];
+let fetchHandler: () => Promise<Response> | Response;
+
+beforeEach(() => {
+  captured = [];
+  fetchHandler = () => new Response("no handler", { status: 500 });
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const headers = init?.headers as Record<string, string> | undefined;
+    captured.push({ url, authorization: headers?.Authorization ?? "" });
+    return fetchHandler();
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makeClient(): NyxidServiceClient {
+  return new NyxidServiceClient({
+    resolver: async () => ({
+      baseApiUrl: "https://nyxid.example.com",
+      tokenBaseUrl: "https://nyxid.example.com",
+      audience: "test",
+      clientId: "c",
+      clientSecret: "s",
+    } as never),
+  });
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("NyxidServiceClient.listServicesForCaller — already drops is_active=false", () => {
+  it("filters inactive services from the per-caller projection (#715 defence-in-depth)", async () => {
+    fetchHandler = () =>
+      jsonResponse({
+        services: [
+          { id: "svc-active", slug: "active", name: "Active", visibility: "public", is_active: true, created_by: "u" },
+          { id: "svc-dead", slug: "dead", name: "Dead", visibility: "public", is_active: false, created_by: "u" },
+        ],
+      });
+
+    const out = await makeClient().listServicesForCaller("user-token");
+    expect(out.map((s) => s.id)).toEqual(["svc-active"]);
+  });
+
+  it("defaults missing is_active to active (preserves legacy NyxID responses)", async () => {
+    fetchHandler = () =>
+      jsonResponse({
+        services: [{ id: "svc-x", slug: "x", visibility: "public", created_by: "u" }],
+      });
+    const out = await makeClient().listServicesForCaller("user-token");
+    expect(out).toHaveLength(1);
+    expect(out[0]!.isActive).toBe(true);
+  });
+});
+
+describe("NyxidServiceClient.listActiveServiceIdsAsPlatform (#715)", () => {
+  it("returns a Set of active service ids using the SA token", async () => {
+    fetchHandler = () =>
+      jsonResponse({
+        services: [
+          { id: "svc-1", slug: "a", visibility: "public", is_active: true, created_by: "u" },
+          { id: "svc-2", slug: "b", visibility: "public", is_active: false, created_by: "u" },
+          { id: "svc-3", slug: "c", visibility: "private", is_active: true, created_by: "u" },
+        ],
+      });
+
+    const ids = await makeClient().listActiveServiceIdsAsPlatform("sa-token-xyz");
+    expect(ids).toBeInstanceOf(Set);
+    expect([...(ids ?? [])].sort()).toEqual(["svc-1", "svc-3"]);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.url).toBe("https://nyxid.example.com/api/v1/services");
+    expect(captured[0]!.authorization).toBe("Bearer sa-token-xyz");
+  });
+
+  it("caches across calls — single upstream fetch within TTL", async () => {
+    fetchHandler = () => jsonResponse({ services: [{ id: "svc-1", slug: "a", is_active: true }] });
+    const client = makeClient();
+    await client.listActiveServiceIdsAsPlatform("sa-token");
+    await client.listActiveServiceIdsAsPlatform("sa-token");
+    expect(captured).toHaveLength(1);
+  });
+
+  it("fail-soft → returns null on non-2xx (caller skips filtering)", async () => {
+    fetchHandler = () => new Response("upstream is down", { status: 503 });
+    const ids = await makeClient().listActiveServiceIdsAsPlatform("sa-token");
+    expect(ids).toBeNull();
+  });
+
+  it("fail-soft → returns null on network throw", async () => {
+    fetchHandler = () => Promise.reject(new Error("ECONNRESET"));
+    const ids = await makeClient().listActiveServiceIdsAsPlatform("sa-token");
+    expect(ids).toBeNull();
+  });
+
+  it("returns null when SA token is empty (won't make an unauth call)", async () => {
+    const client = makeClient();
+    const ids = await client.listActiveServiceIdsAsPlatform("");
+    expect(ids).toBeNull();
+    expect(captured).toHaveLength(0);
+  });
+
+  it("invalidateCache() drops the platform cache so the next call re-fetches", async () => {
+    fetchHandler = () => jsonResponse({ services: [{ id: "svc-1", slug: "a", is_active: true }] });
+    const client = makeClient();
+    await client.listActiveServiceIdsAsPlatform("sa-token");
+    expect(captured).toHaveLength(1);
+    client.invalidateCache();
+    await client.listActiveServiceIdsAsPlatform("sa-token");
+    expect(captured).toHaveLength(2);
+  });
+});

--- a/ornn-api/src/clients/nyxid/service.ts
+++ b/ornn-api/src/clients/nyxid/service.ts
@@ -55,15 +55,25 @@ export class NyxidServiceClient {
   private readonly resolver: NyxidConfigResolver;
   /**
    * Per-user-token cache. Keyed by the bearer token so two callers don't
-   * leak each other's view. 60-second TTL — services don't change often,
-   * but we don't want to hold an admin's view stale for 5 minutes when
-   * they just toggled visibility.
+   * leak each other's view. Short TTL: when an admin deactivates a
+   * service in NyxID we want Ornn surfaces to drop it promptly (#715).
+   * Pre-#715 this was 60s, which left a window where Ornn still
+   * advertised a service NyxID had deactivated; 10s is the new ceiling.
    */
   private readonly cache = new Map<
     string,
     { services: NyxidCatalogService[]; expiresAt: number }
   >();
-  private readonly cacheTtlMs = 60 * 1000;
+  private readonly cacheTtlMs = 10 * 1000;
+
+  /**
+   * Dedicated cache for the platform-wide active-service id set
+   * resolved via the SA token (`listActiveServiceIdsAsPlatform`). The
+   * SA view is identical for every caller, so one cache slot is
+   * enough — separate from the per-caller `cache` above to avoid
+   * cross-contaminating visibility scopes.
+   */
+  private platformActiveCache: { ids: Set<string>; expiresAt: number } | null = null;
 
   constructor(opts: { resolver: NyxidConfigResolver }) {
     this.resolver = opts.resolver;
@@ -152,5 +162,60 @@ export class NyxidServiceClient {
   invalidateCache(userAccessToken?: string): void {
     if (userAccessToken) this.cache.delete(userAccessToken);
     else this.cache.clear();
+    this.platformActiveCache = null;
+  }
+
+  /**
+   * Resolve the platform-wide set of *active* NyxID service ids using
+   * an SA token (NyxID admin view → every service, before filtering).
+   * Used by Ornn surfaces that need to know "is this service still
+   * usable" independent of the calling user — most importantly the
+   * anonymous-friendly `/skill-facets/system-services` aggregator,
+   * which would otherwise advertise services NyxID has deactivated
+   * (#715).
+   *
+   * Errors fail-soft: when NyxID is unreachable we return `null` so
+   * callers can decide whether to skip the filter (preserve current
+   * behaviour) or fail-closed. Cached for 10s to keep the hot path
+   * cheap without prolonging the visibility lag after a deactivation.
+   */
+  async listActiveServiceIdsAsPlatform(saToken: string): Promise<Set<string> | null> {
+    if (!saToken) return null;
+    const now = Date.now();
+    if (this.platformActiveCache && this.platformActiveCache.expiresAt > now) {
+      return this.platformActiveCache.ids;
+    }
+    try {
+      const baseUrl = await this.resolveBaseUrl();
+      const resp = await fetch(`${baseUrl}/api/v1/services`, {
+        headers: { Authorization: `Bearer ${saToken}` },
+      });
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => "");
+        logger.warn(
+          { status: resp.status, body: body.slice(0, 200) },
+          "NyxID /services SA fetch failed; returning null (no filter)",
+        );
+        return null;
+      }
+      const json = (await resp.json()) as RawListResponse | RawCatalogService[];
+      const raw: RawCatalogService[] = Array.isArray(json)
+        ? json
+        : json.services ?? json.items ?? [];
+      const ids = new Set<string>();
+      for (const r of raw) {
+        if (!r.id) continue;
+        if (r.is_active === false) continue;
+        ids.add(r.id);
+      }
+      this.platformActiveCache = { ids, expiresAt: now + this.cacheTtlMs };
+      return ids;
+    } catch (err) {
+      logger.warn(
+        { err: (err as Error).message },
+        "NyxID /services SA fetch threw; returning null (no filter)",
+      );
+      return null;
+    }
   }
 }

--- a/ornn-api/src/domains/skills/search/bootstrap.ts
+++ b/ornn-api/src/domains/skills/search/bootstrap.ts
@@ -16,6 +16,7 @@ import { SearchService } from "./service";
 import { createSearchRoutes } from "./routes";
 import type { SkillRepository } from "../crud/repository";
 import type { NyxLlmClient } from "../../../clients/nyxid/llm";
+import type { NyxidServiceClient } from "../../../clients/nyxid/service";
 
 export interface SkillSearchWiring {
   readonly service: SearchService;
@@ -32,6 +33,12 @@ export function wireSkillSearch(deps: {
    * route through the new section in the caller.
    */
   defaultModelResolver: () => Promise<string>;
+  /**
+   * NyxID catalog client + SA token accessor. Powers the live
+   * deactivation filter for `/skill-facets/system-services` (#715).
+   */
+  nyxidServiceClient: NyxidServiceClient;
+  getSaAccessToken: () => Promise<string>;
 }): SkillSearchWiring {
   const service = new SearchService({
     skillRepo: deps.skillRepo,
@@ -41,6 +48,8 @@ export function wireSkillSearch(deps: {
   const routes = createSearchRoutes({
     searchService: service,
     skillRepo: deps.skillRepo,
+    nyxidServiceClient: deps.nyxidServiceClient,
+    getSaAccessToken: deps.getSaAccessToken,
   });
   return { service, routes };
 }

--- a/ornn-api/src/domains/skills/search/routes.ts
+++ b/ornn-api/src/domains/skills/search/routes.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { SearchService } from "./service";
 import type { SkillRepository } from "../crud/repository";
+import type { NyxidServiceClient } from "../../../clients/nyxid/service";
 import {
   type AuthVariables,
   nyxidAuthMiddleware,
@@ -69,10 +70,19 @@ function parseCsv(raw: string | undefined): string[] | undefined {
 export interface SearchRoutesConfig {
   searchService: SearchService;
   skillRepo: SkillRepository;
+  /**
+   * NyxID catalog client + SA-token accessor. Used by
+   * `/skill-facets/system-services` to drop services NyxID has
+   * deactivated since the skill's `nyxidServiceId` was cached (#715).
+   * Optional so test wiring can omit the live filter; when omitted
+   * the facet returns the raw DB aggregation (pre-#715 behaviour).
+   */
+  nyxidServiceClient?: NyxidServiceClient;
+  getSaAccessToken?: () => Promise<string>;
 }
 
 export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables: AuthVariables }> {
-  const { searchService, skillRepo } = config;
+  const { searchService, skillRepo, nyxidServiceClient, getSaAccessToken } = config;
   const app = new Hono<{ Variables: AuthVariables }>();
 
   const optionalAuth = optionalAuthMiddleware();
@@ -261,6 +271,28 @@ export function createSearchRoutes(config: SearchRoutesConfig): Hono<{ Variables
    */
   app.get("/skill-facets/system-services", optionalAuth, async (c) => {
     const items = await skillRepo.aggregateSystemServices();
+
+    // Cross-check against NyxID's live active set (#715). The DB
+    // aggregation snapshots the service id/slug/label that was current
+    // when each skill was last bound, so a service NyxID has since
+    // deactivated still shows up here even though it's no longer
+    // bindable or usable. Drop those.
+    if (nyxidServiceClient && getSaAccessToken) {
+      try {
+        const saToken = await getSaAccessToken();
+        const activeIds = await nyxidServiceClient.listActiveServiceIdsAsPlatform(saToken);
+        if (activeIds) {
+          const filtered = items.filter((it) => activeIds.has(it.id));
+          return c.json({ data: { items: filtered }, error: null });
+        }
+      } catch (err) {
+        logger.warn(
+          { err: (err as Error).message },
+          "Failed to resolve active NyxID services; returning unfiltered facet",
+        );
+      }
+    }
+
     return c.json({ data: { items }, error: null });
   });
 


### PR DESCRIPTION
## Summary

- `/skill-facets/system-services` now intersects the DB aggregation with NyxID's live active set (via a new `NyxidServiceClient.listActiveServiceIdsAsPlatform(saToken)`), so services NyxID has deactivated stop appearing as filter chips.
- NyxID catalog cache TTL drops 60s → 10s — `/me/nyxid-services` and `/nyxid-services/:serviceId/skills` (which already filter `is_active=false`) now reflect deactivations within 10s instead of 60s.
- Both code paths fail-soft: if NyxID is unreachable, the facet falls back to the legacy raw aggregation rather than emptying the response.
- 8 new colocated tests in `service.test.ts`.

## Test plan

- [x] `bun test src/clients/nyxid/service.test.ts` — 8/8 green
- [x] `bun run typecheck:api` — no new errors
- [x] Full `ornn-api` suite — 730 pass / 18 unrelated pre-existing failures (validateSkillFrontmatter #649)
- [ ] Local manual: per the QA repro — create a NyxID public service, bind a skill, deactivate the service, wait ≥10s, hit `/skill-facets/system-services` and confirm the service no longer appears.

Out of scope: skill-detail still shows the historical `nyxidServiceId/slug/label` even when the service is deactivated. The issue lists multiple acceptable mitigations; closing the discovery surface is the highest-leverage one. Follow-up can mark detail as 'service unavailable' if we want a louder signal.

Fixes #715