### PR TITLE
fix(web): P1 i18n cluster (#695 #696 #697 #719 #722 #731)

### DIFF
--- a/.changeset/i18n-batch-695-696-697-719-722-731.md
+++ b/.changeset/i18n-batch-695-696-697-719-722-731.md
@@ -1,0 +1,25 @@
+---
+"ornn-web": patch
+---
+
+P1 i18n cluster: 6 admin/creation surfaces now follow the active UI language (#695, #696, #697, #719, #722, #731).
+
+Background: the global language switch translated the outer chrome but several surfaces leaked English (or in #731's case, Chinese) literals through `placeholder=`, `aria-label=`, hardcoded JSX text, and Zod inline messages. None of these are user-authored copy; they're application chrome.
+
+Fixes:
+
+- **#731 Broadcasts list dates**: `BroadcastsPage` rendered `createdAt`/`updatedAt` with `toLocaleString(undefined, ROW_DATE_FMT)`, so `Intl` fell back to the browser locale. Switched the first arg to `i18n.language` (already in scope as `lang`) so the date format follows the Ornn UI language.
+
+- **#695 Guided Create validation errors**: `skillCreateSchemas` had hardcoded English Zod messages (`"Name must be at least 2 characters"`, etc.). Introduced `makeBasicInfoSchema(t)` / `makeContentSchema(t)` factories; messages route through `guided.validation.*` keys. The static `basicInfoSchema` / `contentSchema` exports stay for type derivation and tests. `CreateSkillGuidedPage` memoizes a per-`t` localized schema and passes it to `useForm` so a language switch rebuilds the resolver.
+
+- **#696 Markdown editor (used by Broadcast drawer)**: three hardcoded strings in `MarkdownEditor.tsx` — `"Preview"`, `"Nothing to preview yet..."`, and the Markdown help-text — now route through `markdownEditor.*`. `BroadcastEditDrawer` itself was already fully `t()`-ified.
+
+- **#697 Admin Users table**: column header labels (`Username`, `Email`, `Skills`, `Last active`, `Activities`, `First joined`), the filter placeholder, the empty-state copy (`No users found.`), the row action label (`Grant quota`), the formatted-date null fallback (`Never`), and the sort `aria-label` (`Sort by ${col.label}`) all route through `adminUsersTable.*`. `COLUMNS` moved inside the component as a `useMemo` keyed on `t`.
+
+- **#719 NyxID service binding panel**: `AdvancedOptionsModal` already used `t()` with English string fallbacks for the binding intro, unbound option, unbound description, admin/personal tier labels, empty-state, and force-public warning — but the `nyxidService.*` keys were never added to either JSON. Added the full Chinese set (and codified the English fallback as the official `en.json` entry) so the translations actually resolve at runtime.
+
+- **#722 Admin shell**: `Sidebar` mobile header (`"Navigation"`) and `SettingsNav`'s 9 hardcoded entries (`"LLM Providers"`, `"Playground"`, `"Skill Generation"`, `"GitHub Mirror"`, `"NyxID Integration"`, `"Skill Auditing"`, `"PostHog"`, `"Service Binding List"`, `"Export / Import"`) now route through `sidebar.navigation` / `adminSettingsNav.*`.
+
+JSON additions: 5 new top-level namespaces in both `en.json` and `zh.json` — `nyxidService`, `markdownEditor`, `adminUsersTable`, `sidebar`, `adminSettingsNav` — plus a `guided.validation` block. No deletions or renames in existing keys.
+
+Out of scope: `AnnouncementsPage` shares the same `ROW_DATE_FMT, undefined)` pattern as the Broadcasts page; can ride a follow-up since #731 only names Broadcasts. Pre-existing `validateSkillFrontmatter #649` test failures (6) are unrelated.

--- a/ornn-web/src/components/admin/AdminUsersTable.tsx
+++ b/ornn-web/src/components/admin/AdminUsersTable.tsx
@@ -9,7 +9,8 @@
  * @module components/admin/AdminUsersTable
  */
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Card";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -34,21 +35,13 @@ interface AdminUsersTableProps {
   description?: string;
 }
 
-const COLUMNS: Array<{
+type ColumnDef = {
   id: keyof AdminUserRow | "actions";
   label: string;
   sortAsc?: AdminUsersSort;
   sortDesc?: AdminUsersSort;
   align?: "left" | "right";
-}> = [
-  { id: "displayName", label: "Username", sortAsc: "displayName:asc", sortDesc: "displayName:desc" },
-  { id: "email", label: "Email", sortAsc: "email:asc", sortDesc: "email:desc" },
-  { id: "skillCount", label: "Skills", sortAsc: "skillCount:asc", sortDesc: "skillCount:desc", align: "right" },
-  { id: "lastActiveAt", label: "Last active", sortAsc: "lastActiveAt:asc", sortDesc: "lastActiveAt:desc", align: "right" },
-  { id: "activityCount", label: "Activities", sortAsc: "activityCount:asc", sortDesc: "activityCount:desc", align: "right" },
-  { id: "firstJoinedAt", label: "First joined", sortAsc: "firstJoinedAt:asc", sortDesc: "firstJoinedAt:desc", align: "right" },
-  { id: "actions", label: "", align: "right" },
-];
+};
 
 function formatDateUTC(iso: string | null, nullLabel: string): string {
   if (!iso) return nullLabel;
@@ -65,10 +58,23 @@ function formatDateUTC(iso: string | null, nullLabel: string): string {
 }
 
 export function AdminUsersTable({ role, title, description }: AdminUsersTableProps) {
+  const { t } = useTranslation();
   const [page, setPage] = useState(1);
   const [query, setQuery] = useState("");
   const debounced = useDebounce(query, 300);
   const [sort, setSort] = useState<AdminUsersSort>("lastActiveAt:desc");
+
+  // COLUMNS rebuild per-`t` so column headers + sort aria labels
+  // follow the active UI language (#697).
+  const COLUMNS = useMemo<ColumnDef[]>(() => [
+    { id: "displayName", label: t("adminUsersTable.columnUsername"), sortAsc: "displayName:asc", sortDesc: "displayName:desc" },
+    { id: "email", label: t("adminUsersTable.columnEmail"), sortAsc: "email:asc", sortDesc: "email:desc" },
+    { id: "skillCount", label: t("adminUsersTable.columnSkills"), sortAsc: "skillCount:asc", sortDesc: "skillCount:desc", align: "right" },
+    { id: "lastActiveAt", label: t("adminUsersTable.columnLastActive"), sortAsc: "lastActiveAt:asc", sortDesc: "lastActiveAt:desc", align: "right" },
+    { id: "activityCount", label: t("adminUsersTable.columnActivities"), sortAsc: "activityCount:asc", sortDesc: "activityCount:desc", align: "right" },
+    { id: "firstJoinedAt", label: t("adminUsersTable.columnFirstJoined"), sortAsc: "firstJoinedAt:asc", sortDesc: "firstJoinedAt:desc", align: "right" },
+    { id: "actions", label: "", align: "right" },
+  ], [t]);
 
   const usersQuery = useQuery({
     queryKey: ["admin", "users", role, debounced, page, sort] as const,
@@ -86,7 +92,7 @@ export function AdminUsersTable({ role, title, description }: AdminUsersTablePro
   const items = usersQuery.data?.items ?? [];
   const totalPages = usersQuery.data?.totalPages ?? 1;
 
-  const toggleSort = (col: typeof COLUMNS[number]) => {
+  const toggleSort = (col: ColumnDef) => {
     if (!col.sortAsc || !col.sortDesc) return;
     if (sort === col.sortDesc) setSort(col.sortAsc);
     else setSort(col.sortDesc);
@@ -111,7 +117,7 @@ export function AdminUsersTable({ role, title, description }: AdminUsersTablePro
             setQuery(e.target.value);
             setPage(1);
           }}
-          placeholder="Filter by email or display name…"
+          placeholder={t("adminUsersTable.filterPlaceholder")}
           aria-label={`Filter ${title}`}
           className="w-full max-w-xs rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-mono text-xs text-strong placeholder:text-meta/70 focus:border-accent focus:bg-card focus:outline-none"
         />
@@ -125,7 +131,7 @@ export function AdminUsersTable({ role, title, description }: AdminUsersTablePro
             {translateError(usersQuery.error, "Failed to load users")}
           </p>
         ) : items.length === 0 ? (
-          <p className="py-8 text-center font-text text-meta">No users found.</p>
+          <p className="py-8 text-center font-text text-meta">{t("adminUsersTable.empty")}</p>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
@@ -145,7 +151,7 @@ export function AdminUsersTable({ role, title, description }: AdminUsersTablePro
                           <button
                             type="button"
                             onClick={() => toggleSort(col)}
-                            aria-label={`Sort by ${col.label}`}
+                            aria-label={t("adminUsersTable.sortByPrefix", { label: col.label })}
                             className={`inline-flex items-center gap-1 hover:text-accent ${
                               isAsc || isDesc ? "text-strong" : ""
                             }`}
@@ -178,7 +184,7 @@ export function AdminUsersTable({ role, title, description }: AdminUsersTablePro
                       {u.skillCount.toLocaleString()}
                     </td>
                     <td className="px-4 py-3 text-right font-mono text-[11px] text-meta">
-                      {formatDateUTC(u.lastActiveAt, "Never")}
+                      {formatDateUTC(u.lastActiveAt, t("adminUsersTable.never"))}
                     </td>
                     <td className="px-4 py-3 text-right font-mono text-[12px] text-body">
                       {u.activityCount.toLocaleString()}
@@ -191,7 +197,7 @@ export function AdminUsersTable({ role, title, description }: AdminUsersTablePro
                         to={`/admin/quota?userId=${encodeURIComponent(u.userId)}&surface=playground`}
                         className="font-mono text-[11px] uppercase tracking-[0.14em] text-accent hover:text-accent-muted"
                       >
-                        Grant quota
+                        {t("adminUsersTable.grantQuota")}
                       </Link>
                     </td>
                   </tr>

--- a/ornn-web/src/components/admin/settings/SettingsNav.tsx
+++ b/ornn-web/src/components/admin/settings/SettingsNav.tsx
@@ -12,21 +12,21 @@
 import { NavLink } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
-interface NavEntry {
+interface NavEntrySource {
   to: string;
-  label: string;
+  i18nKey: string;
 }
 
-const SECTIONS: NavEntry[] = [
-  { to: "/admin/settings/llm-providers", label: "LLM Providers" },
-  { to: "/admin/settings/playground", label: "Playground" },
-  { to: "/admin/settings/skill-generation", label: "Skill Generation" },
-  { to: "/admin/settings/mirror", label: "GitHub Mirror" },
-  { to: "/admin/settings/integrations/nyxid", label: "NyxID Integration" },
-  { to: "/admin/settings/skill-audit", label: "Skill Auditing" },
-  { to: "/admin/settings/posthog", label: "PostHog" },
-  { to: "/admin/settings/extras", label: "Service Binding List" },
-  { to: "/admin/settings/export-import", label: "Export / Import" },
+const SECTIONS: NavEntrySource[] = [
+  { to: "/admin/settings/llm-providers", i18nKey: "llmProviders" },
+  { to: "/admin/settings/playground", i18nKey: "playground" },
+  { to: "/admin/settings/skill-generation", i18nKey: "skillGeneration" },
+  { to: "/admin/settings/mirror", i18nKey: "githubMirror" },
+  { to: "/admin/settings/integrations/nyxid", i18nKey: "nyxidIntegration" },
+  { to: "/admin/settings/skill-audit", i18nKey: "skillAuditing" },
+  { to: "/admin/settings/posthog", i18nKey: "postHog" },
+  { to: "/admin/settings/extras", i18nKey: "serviceBinding" },
+  { to: "/admin/settings/export-import", i18nKey: "exportImport" },
 ];
 
 interface SettingsNavProps {
@@ -52,7 +52,7 @@ export function SettingsNav({ className = "" }: SettingsNavProps) {
             }`
           }
         >
-          {s.label}
+          {t(`adminSettingsNav.${s.i18nKey}`)}
         </NavLink>
       ))}
     </nav>

--- a/ornn-web/src/components/form/MarkdownEditor.tsx
+++ b/ornn-web/src/components/form/MarkdownEditor.tsx
@@ -269,7 +269,7 @@ export function MarkdownEditor({
               ) : (
                 <>
                   <PreviewIcon className="h-4 w-4" />
-                  <span className="hidden sm:inline">Preview</span>
+                  <span className="hidden sm:inline">{t("markdownEditor.preview")}</span>
                 </>
               )}
             </button>
@@ -298,7 +298,7 @@ export function MarkdownEditor({
                 </div>
               ) : (
                 <p className="text-meta font-text text-sm italic">
-                  Nothing to preview yet...
+                  {t("markdownEditor.emptyPreview")}
                 </p>
               )}
             </motion.div>
@@ -334,7 +334,7 @@ export function MarkdownEditor({
 
       {/* Help text */}
       <p className="text-xs text-meta font-text">
-        Supports Markdown formatting. Use **bold**, _italic_, `code`, and more.
+        {t("markdownEditor.helpText")}
       </p>
     </div>
   );

--- a/ornn-web/src/components/layout/Sidebar.tsx
+++ b/ornn-web/src/components/layout/Sidebar.tsx
@@ -128,7 +128,7 @@ export function Sidebar({
       {isMobile && (
         <div className="flex h-14 items-center justify-between border-b border-subtle px-4">
           <span className="font-display text-sm uppercase tracking-wider text-accent">
-            Navigation
+            {t("sidebar.navigation")}
           </span>
           <button
             type="button"

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -1,4 +1,47 @@
 {
+  "nyxidService": {
+    "intro": "Binding a skill to a NyxID admin service marks it as a system skill (forced public). Binding to one of your personal services leaves the privacy alone.",
+    "untied": "No binding (unbound)",
+    "untiedDesc": "This skill is not bound to any NyxID service. Privacy and sharing remain manually controlled.",
+    "adminTier": "Admin services (system)",
+    "personalTier": "Personal services",
+    "noServices": "No NyxID services available. Ask a platform admin or register one in NyxID.",
+    "willForcePublic": "Binding to an admin service will force this skill to be public. Other share settings (users / orgs) are kept but ignored while the skill is public.",
+    "tieSuccess": "Service bound",
+    "untieSuccess": "Service unbound"
+  },
+  "markdownEditor": {
+    "preview": "Preview",
+    "emptyPreview": "Nothing to preview yet...",
+    "helpText": "Supports Markdown formatting. Use **bold**, _italic_, `code`, and more."
+  },
+  "adminUsersTable": {
+    "filterPlaceholder": "Filter by email or display name…",
+    "empty": "No users found.",
+    "never": "Never",
+    "grantQuota": "Grant quota",
+    "columnUsername": "Username",
+    "columnEmail": "Email",
+    "columnSkills": "Skills",
+    "columnLastActive": "Last active",
+    "columnActivities": "Activities",
+    "columnFirstJoined": "First joined",
+    "sortByPrefix": "Sort by {{label}}"
+  },
+  "sidebar": {
+    "navigation": "Navigation"
+  },
+  "adminSettingsNav": {
+    "llmProviders": "LLM Providers",
+    "playground": "Playground",
+    "skillGeneration": "Skill Generation",
+    "githubMirror": "GitHub Mirror",
+    "nyxidIntegration": "NyxID Integration",
+    "skillAuditing": "Skill Auditing",
+    "postHog": "PostHog",
+    "serviceBinding": "Service Binding List",
+    "exportImport": "Export / Import"
+  },
   "common": {
     "save": "Save",
     "cancel": "Cancel",
@@ -470,6 +513,13 @@
     "startGithub": "Import"
   },
   "guided": {
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "nameMax": "Name must be at most 64 characters",
+      "nameShape": "Must start with a letter or number, only lowercase, numbers, and hyphens",
+      "descMin": "Description must be at least 10 characters",
+      "contentMin": "Content must be at least 50 characters"
+    },
     "backToModes": "Back to mode selection",
     "header": "CREATE SKILL",
     "headerDesc": "Follow the steps below to create a new skill",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -1,4 +1,47 @@
 {
+  "nyxidService": {
+    "intro": "将技能绑定到 NyxID 管理员服务会将其标记为系统技能（强制公开）。绑定到个人服务则不会改变隐私设置。",
+    "untied": "未绑定",
+    "untiedDesc": "该技能未绑定任何 NyxID 服务。隐私和共享设置仍由你手动控制。",
+    "adminTier": "管理员服务（系统）",
+    "personalTier": "个人服务",
+    "noServices": "没有可用的 NyxID 服务。请联系平台管理员或在 NyxID 中注册一个。",
+    "willForcePublic": "绑定到管理员服务将强制把该技能设为公开。其他共享设置（用户 / 组织）会被保留，但在技能公开期间不生效。",
+    "tieSuccess": "服务已绑定",
+    "untieSuccess": "服务已解绑"
+  },
+  "markdownEditor": {
+    "preview": "预览",
+    "emptyPreview": "暂无可预览内容…",
+    "helpText": "支持 Markdown 格式。可使用 **粗体**、_斜体_、`代码` 等。"
+  },
+  "adminUsersTable": {
+    "filterPlaceholder": "按邮箱或显示名称筛选…",
+    "empty": "未找到用户。",
+    "never": "从未",
+    "grantQuota": "授予配额",
+    "columnUsername": "用户名",
+    "columnEmail": "邮箱",
+    "columnSkills": "技能数",
+    "columnLastActive": "最近活跃",
+    "columnActivities": "活动数",
+    "columnFirstJoined": "首次加入",
+    "sortByPrefix": "按 {{label}} 排序"
+  },
+  "sidebar": {
+    "navigation": "导航"
+  },
+  "adminSettingsNav": {
+    "llmProviders": "LLM 提供方",
+    "playground": "Playground",
+    "skillGeneration": "技能生成",
+    "githubMirror": "GitHub 镜像",
+    "nyxidIntegration": "NyxID 集成",
+    "skillAuditing": "技能审计",
+    "postHog": "PostHog",
+    "serviceBinding": "服务绑定列表",
+    "exportImport": "导出 / 导入"
+  },
   "common": {
     "save": "保存",
     "cancel": "取消",
@@ -470,6 +513,13 @@
     "startGithub": "导入"
   },
   "guided": {
+    "validation": {
+      "nameMin": "技能名称至少需要 2 个字符",
+      "nameMax": "技能名称最多 64 个字符",
+      "nameShape": "必须以字母或数字开头，仅允许小写字母、数字和短横线",
+      "descMin": "描述至少需要 10 个字符",
+      "contentMin": "正文内容至少需要 50 个字符"
+    },
     "backToModes": "返回模式选择",
     "header": "创建技能",
     "headerDesc": "按下方步骤创建新技能",

--- a/ornn-web/src/pages/admin/BroadcastsPage.tsx
+++ b/ornn-web/src/pages/admin/BroadcastsPage.tsx
@@ -281,13 +281,13 @@ export function BroadcastsPage() {
                       </td>
                       <td className="px-4 py-3 align-top font-mono text-[11px] text-meta">
                         {new Date(b.createdAt).toLocaleString(
-                          undefined,
+                          lang,
                           ROW_DATE_FMT,
                         )}
                       </td>
                       <td className="px-4 py-3 align-top font-mono text-[11px] text-meta">
                         {new Date(b.updatedAt).toLocaleString(
-                          undefined,
+                          lang,
                           ROW_DATE_FMT,
                         )}
                       </td>

--- a/ornn-web/src/pages/skill/CreateSkillGuidedPage.tsx
+++ b/ornn-web/src/pages/skill/CreateSkillGuidedPage.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import { useForm } from "react-hook-form";
+import { useForm, type Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AnimatePresence } from "framer-motion";
 import { PageTransition } from "@/components/layout/PageTransition";
@@ -26,7 +26,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { track } from "@/lib/analytics";
 import { buildSkillMd } from "@/utils/frontmatterBuilder";
 import { buildFileTreeFromFolders, readUploadedFileContents } from "@/utils/fileTreeBuilder";
-import { basicInfoSchema, contentSchema, type BasicInfoData, type BasicInfoInput, type ContentData, type ContentInput } from "@/utils/skillCreateSchemas";
+import { basicInfoSchema, contentSchema, makeBasicInfoSchema, makeContentSchema, type BasicInfoData, type BasicInfoInput, type ContentData, type ContentInput } from "@/utils/skillCreateSchemas";
 import type { FileNode } from "@/components/editor/FileTree";
 import type { SkillMetadata, SkillMetadataBlock, UploadableFolder } from "@/types/skillPackage";
 import { createDefaultSkillMetadata } from "@/types/skillPackage";
@@ -120,9 +120,30 @@ export function CreateSkillGuidedPage() {
     new Map(),
   );
 
-  // Basic info form (nested metadata)
+  // Schemas are rebuilt per-`t` so a language switch refreshes the
+  // validation messages (#695). `t` is cast because react-i18next's
+  // overloaded TFunction doesn't structurally match the simple
+  // signature `makeXSchema` accepts. The resulting schema is cast to
+  // the static schema type so `zodResolver`'s precise typing on the
+  // existing `basicInfoSchema` / `contentSchema` exports keeps working
+  // — at runtime the localized factory is what produces error
+  // messages.
+  const tx = t as unknown as (key: string) => string;
+  const basicInfoSchemaLocalized = useMemo(
+    () => makeBasicInfoSchema(tx) as typeof basicInfoSchema,
+    [tx],
+  );
+  const contentSchemaLocalized = useMemo(
+    () => makeContentSchema(tx) as typeof contentSchema,
+    [tx],
+  );
+
   const basicInfoForm = useForm<BasicInfoInput, unknown, BasicInfoData>({
-    resolver: zodResolver(basicInfoSchema),
+    // Cast: zodResolver infers a slightly different Resolver shape
+    // from the factory's return type; structurally identical to the
+    // one inferred from the static `basicInfoSchema`, which the
+    // pre-#695 code used here directly.
+    resolver: zodResolver(basicInfoSchemaLocalized) as Resolver<BasicInfoInput, unknown, BasicInfoData>,
     defaultValues: {
       name: formData.name,
       description: formData.description,
@@ -141,7 +162,7 @@ export function CreateSkillGuidedPage() {
 
   // Content form
   const contentForm = useForm<ContentInput, unknown, ContentData>({
-    resolver: zodResolver(contentSchema),
+    resolver: zodResolver(contentSchemaLocalized) as Resolver<ContentInput, unknown, ContentData>,
     defaultValues: {
       readmeMd: formData.readmeMd,
     },

--- a/ornn-web/src/utils/skillCreateSchemas.ts
+++ b/ornn-web/src/utils/skillCreateSchemas.ts
@@ -3,57 +3,89 @@
  * Zod schemas and derived types for the guided skill creation wizard.
  * Uses the canonical frontmatter schema's refined metadata sub-schema
  * for consistent conditional validation.
+ *
+ * Validation messages render through `t()` so they follow the active
+ * UI language (#695). Each consumer passes a translator into the
+ * `make…Schema(t)` factory and memoizes the resulting schema against
+ * the current `t` reference so a language switch rebuilds the form
+ * resolver without rerendering everything.
+ *
+ * Static schemas (`basicInfoSchema`, `contentSchema`) remain exported
+ * with literal English fallbacks for type-derivation and any non-UI
+ * caller (tests, server-side reuse). The factories are the canonical
+ * UI entrypoint.
+ *
  * @module utils/skillCreateSchemas
  */
 
 import { z } from "zod";
 import { refinedMetadataSchema } from "./skillFrontmatterSchema";
 
-/**
- * Step 1 schema: basic metadata with nested metadata, optional Claude fields,
- * and conditional tool/runtime requirements enforced by refinedMetadataSchema.
- */
-export const basicInfoSchema = z.object({
-  name: z
-    .string()
-    .min(2, "Name must be at least 2 characters")
-    .max(64, "Name must be at most 64 characters")
-    .regex(
-      /^[a-z0-9][a-z0-9-]*$/,
-      "Must start with a letter or number, only lowercase, numbers, and hyphens",
-    ),
-  description: z
-    .string()
-    .min(10, "Description must be at least 10 characters")
-    .max(500),
+/** i18next-shaped translator. Loose signature so the real
+ *  `TFunction` from react-i18next (variadic options, overloaded
+ *  return types) assigns cleanly without a hard runtime dependency. */
+type Translator = (key: string, ...rest: unknown[]) => string;
 
-  /** Nested metadata with conditional validation */
-  metadata: refinedMetadataSchema,
+const EN_MESSAGES = {
+  nameMin: "Name must be at least 2 characters",
+  nameMax: "Name must be at most 64 characters",
+  nameShape: "Must start with a letter or number, only lowercase, numbers, and hyphens",
+  descMin: "Description must be at least 10 characters",
+  contentMin: "Content must be at least 50 characters",
+} as const;
 
-  /** SPDX license identifier */
-  license: z.string().max(50).optional(),
-
-  /** Compatibility information */
-  compatibility: z.string().max(200).optional(),
-
-  // --- Advanced Claude fields (collapsed by default) ---
-
-  disableModelInvocation: z.boolean().default(false),
-  userInvocable: z.boolean().default(true),
-  allowedTools: z.array(z.string()).default([]),
-  model: z.string().max(100).optional(),
-  context: z.array(z.string()).default([]),
-  agent: z.string().max(100).optional(),
-  argumentHint: z.string().max(500).optional(),
-  hooks: z.record(z.string(), z.unknown()).optional(),
-});
+function msg(t: Translator | undefined, key: keyof typeof EN_MESSAGES): string {
+  const en = EN_MESSAGES[key];
+  return t ? t(`guided.validation.${key}`, en) : en;
+}
 
 /**
- * Step 2 schema: markdown body content for SKILL.md.
+ * Step 1 schema factory: basic metadata with nested metadata, optional
+ * Claude fields, and conditional tool/runtime requirements enforced by
+ * refinedMetadataSchema. Pass `t` from `useTranslation()`; omit for
+ * the English-fallback static shape.
  */
-export const contentSchema = z.object({
-  readmeMd: z.string().min(50, "Content must be at least 50 characters"),
-});
+export function makeBasicInfoSchema(t?: Translator) {
+  return z.object({
+    name: z
+      .string()
+      .min(2, msg(t, "nameMin"))
+      .max(64, msg(t, "nameMax"))
+      .regex(/^[a-z0-9][a-z0-9-]*$/, msg(t, "nameShape")),
+    description: z
+      .string()
+      .min(10, msg(t, "descMin"))
+      .max(500),
+
+    metadata: refinedMetadataSchema,
+    license: z.string().max(50).optional(),
+    compatibility: z.string().max(200).optional(),
+
+    disableModelInvocation: z.boolean().default(false),
+    userInvocable: z.boolean().default(true),
+    allowedTools: z.array(z.string()).default([]),
+    model: z.string().max(100).optional(),
+    context: z.array(z.string()).default([]),
+    agent: z.string().max(100).optional(),
+    argumentHint: z.string().max(500).optional(),
+    hooks: z.record(z.string(), z.unknown()).optional(),
+  });
+}
+
+/**
+ * Step 2 schema factory: markdown body content for SKILL.md.
+ */
+export function makeContentSchema(t?: Translator) {
+  return z.object({
+    readmeMd: z.string().min(50, msg(t, "contentMin")),
+  });
+}
+
+/** Static English-fallback schemas — preserve the original export
+ *  surface for callers that don't have a `t` in scope (tests, type
+ *  derivation, server-side reuse). */
+export const basicInfoSchema = makeBasicInfoSchema();
+export const contentSchema = makeContentSchema();
 
 // `Input` is the pre-validation shape (fields with `.default(...)` are
 // optional); `Data` is the post-validation shape (defaults applied, so


### PR DESCRIPTION
## Summary

Single PR closing six P1 i18n bugs that left literal English (and one Chinese-format date) leaking through after the global language switch:

- **#731** BroadcastsPage row dates: `toLocaleString(undefined, …)` → `toLocaleString(i18n.language, …)`
- **#695** Guided Create validation: `skillCreateSchemas` Zod messages move into `make…Schema(t)` factories routed through `guided.validation.*`; `CreateSkillGuidedPage` memoizes per-`t`.
- **#696** MarkdownEditor: \"Preview\", \"Nothing to preview yet…\", and help-text route through `markdownEditor.*`.
- **#697** AdminUsersTable: column headers + filter placeholder + empty state + Grant-quota action + \"Never\" + sort aria-label route through `adminUsersTable.*`. `COLUMNS` moved inside, memoized on `t`.
- **#719** AdvancedOptionsModal NyxID binding panel already called `t()` with English fallbacks — the `nyxidService.*` keys were missing from both JSONs. Added.
- **#722** Sidebar mobile header + SettingsNav 9 entries route through `sidebar.navigation` / `adminSettingsNav.*`.

5 new top-level namespaces in en.json + zh.json. No key renames or deletions.

## Test plan

- [x] `bun run typecheck:web` — no new errors in changed files
- [x] `bun run test:web` — 144 pass / 6 pre-existing `validateSkillFrontmatter #649` failures, no new regressions
- [ ] Local manual: switch UI to Chinese, walk through each surface listed above and confirm copy is fully Chinese; switch to English and confirm the reverse (especially #731 date format).

Out of scope: AnnouncementsPage has the same `toLocaleString(undefined)` pattern — follow-up.

Fixes #695, Fixes #696, Fixes #697, Fixes #719, Fixes #722, Fixes #731