### PR TITLE
fix(web): drop credentials:'include' from login activity POST (#709)

### DIFF
--- a/.changeset/login-telemetry-cors-709.md
+++ b/.changeset/login-telemetry-cors-709.md
@@ -1,0 +1,9 @@
+---
+"ornn-web": patch
+---
+
+`logActivity` no longer sets `credentials: "include"`, unblocking the post-OAuth `POST /api/v1/activity/login` call on the hosted environment (#709).
+
+The endpoint is Bearer-token-authenticated; it never read cookies. The lone `credentials: "include"` set in `activityApi.ts` (the rest of the SPA's `apiClient` calls never set it) forced the browser to demand `Access-Control-Allow-Credentials: true` plus a specific (non-`*`) `Access-Control-Allow-Origin` on the preflight response. The NyxID proxy doesn't emit those for this endpoint, so the preflight failed and every login on `ornn.chrono-ai.fun` ate a `TypeError: Failed to fetch`. Authenticated GETs through the same proxy keep working because they're simple requests (no preflight) and the rest of the POST endpoints don't set `credentials`.
+
+Dropping the flag brings this call into line with every other authenticated POST in the SPA and the preflight succeeds.

--- a/ornn-web/src/services/activityApi.ts
+++ b/ornn-web/src/services/activityApi.ts
@@ -30,6 +30,16 @@ export async function logActivity(action: "login" | "logout"): Promise<void> {
     // them — sending them tripped a preflight-blocked-by-CORS failure
     // on every login. Same dead code as the `apiClient.createHeaders`
     // cleanup; this caller was missed in the original sweep.
+    //
+    // #709 — `credentials: "include"` was a second preflight trap.
+    // The Bearer token already authenticates the request; no cookies
+    // ride this endpoint and the rest of the SPA's `apiClient` calls
+    // never set `credentials`. With `include`, the browser demanded
+    // `Access-Control-Allow-Credentials: true` + a specific (non-*)
+    // `Access-Control-Allow-Origin` on the preflight response — which
+    // the NyxID proxy doesn't return for this endpoint — and blocked
+    // the POST. Dropping it brings this call in line with the rest of
+    // the SPA and the preflight succeeds.
     const headers: HeadersInit = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
@@ -38,7 +48,6 @@ export async function logActivity(action: "login" | "logout"): Promise<void> {
     const res = await fetch(`${API_BASE}/api/v1/activity/${action}`, {
       method: "POST",
       headers,
-      credentials: "include",
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary

`activityApi.logActivity` was the only call in the SPA setting `credentials: "include"`. The endpoint is Bearer-authenticated; no cookies ride it. With `include` set, the browser demanded `Access-Control-Allow-Credentials: true` + a specific (non-`*`) `Access-Control-Allow-Origin` on the preflight, which the NyxID proxy doesn't emit for this endpoint. So every post-OAuth login on `ornn.chrono-ai.fun` ate a `TypeError: Failed to fetch`. Authenticated GETs through the same proxy keep working (simple requests, no preflight).

## Test plan

- [x] `bun run typecheck:web` — clean
- [ ] Local manual: log in on prod, confirm `POST /api/v1/activity/login` returns 200 instead of being CORS-blocked.

Fixes #709