### PR TITLE
fix(web): preserve backend error.message envelope on non-2xx (#694)

### DIFF
--- a/.changeset/error-envelope-extraction-694.md
+++ b/.changeset/error-envelope-extraction-694.md
@@ -1,0 +1,11 @@
+---
+"ornn-web": patch
+---
+
+`apiClient.handleResponse` now extracts the actionable `error.message` from the legacy `{ data: null, error: { code, message } }` envelope on non-2xx responses, in addition to the RFC 7807 `application/problem+json` shape it already handled (#694).
+
+Pre-#694, `handleResponse` parsed only `body.code / body.detail / body.title` on non-2xx. Several backend domains (LLM provider model sync, settings validation under #456, anything still funnelling through `AppError → buildErrorEnvelope`) keep emitting the legacy envelope, so their structured `error.message` was discarded and the frontend surfaced only the generic literal "An unexpected error occurred" — losing actionable detail like `"MODEL_LIST_UNREACHABLE: Provider model-list endpoint failed: …"` or `"INVALID_SETTING: postHogHost: URL host is private/loopback/link-local; set ORNN_URL_ALLOWLIST_CIDR to allow"`.
+
+Fix: in the non-2xx branch, try `body.error.{code,message}` first (the more actionable shape when present), then fall back to RFC 7807's `body.{code,detail,title}`, then to the generic literal. `ApiClientError.code` and `.message` now carry whichever was richer.
+
+Out of scope: no new unit test added because the existing module-init chain (`apiClient → authStore → …`) fails to load cleanly in vitest's headless environment without additional setup; the per-domain `onError` callsites already exercise `translateError(err, fallback)` against real `ApiClientError` instances in `pages/admin/settings/*` and `components/skill/*` flows. Manual repro per the issue body (LLM provider sync against an invalid model-list URL; saving PostHog config with a loopback host) is the gate.

--- a/ornn-web/src/services/apiClient.ts
+++ b/ornn-web/src/services/apiClient.ts
@@ -119,19 +119,35 @@ async function handleResponse<T>(response: Response): Promise<ApiResponse<T>> {
   const json = (await response.json()) as unknown;
 
   if (!response.ok) {
-    // Error responses are RFC 7807 `application/problem+json` (#456)
-    // — fields at the body root. The pre-#456 `{ data, error: {…} }`
-    // envelope is no longer emitted.
-    const problem = (json ?? {}) as {
+    // Two error body shapes are observed on non-2xx responses:
+    //
+    //   1. RFC 7807 `application/problem+json` (#456) — `{ code, detail,
+    //      title, status }` at the body root. Newer endpoints emit this.
+    //   2. Legacy `{ data: null, error: { code, message } }` envelope.
+    //      Several domain routes (LLM provider sync, settings validation)
+    //      still throw via `AppError → buildErrorEnvelope` which keeps
+    //      this shape with a non-2xx status, and #694 surfaced that the
+    //      frontend was discarding their actionable `error.message`.
+    //
+    // Try the envelope first because `error.message` is the most
+    // actionable when present; fall back to RFC 7807 fields; final
+    // fallback is the generic literal.
+    const body = (json ?? {}) as {
       code?: string;
       detail?: string;
       title?: string;
       status?: number;
+      error?: { code?: string; message?: string };
     };
+    const envelopeCode = body.error?.code;
+    const envelopeMessage = body.error?.message;
     throw new ApiClientError(
-      problem.code ?? "unknown_error",
-      problem.detail ?? problem.title ?? "An unexpected error occurred",
-      problem.status ?? response.status,
+      envelopeCode ?? body.code ?? "unknown_error",
+      envelopeMessage ??
+        body.detail ??
+        body.title ??
+        "An unexpected error occurred",
+      body.status ?? response.status,
     );
   }
 


### PR DESCRIPTION
## Summary

`apiClient.handleResponse` was only parsing RFC 7807 \`problem+json\` fields (\`body.code\` / \`.detail\` / \`.title\`) on non-2xx, so legacy \`{ data: null, error: { code, message } }\` envelopes (LLM provider sync, settings validation, anything via \`AppError → buildErrorEnvelope\`) fell through to the generic \"An unexpected error occurred\" literal.

Fix: try \`body.error.{code,message}\` first (more actionable when present), then RFC 7807, then generic.

## Test plan

- [x] \`bun run typecheck:web\` — clean
- [ ] Local manual: LLM provider sync against an invalid model-list URL — toast shows the backend's \`MODEL_LIST_UNREACHABLE: …\` instead of the generic literal.
- [ ] Local manual: PostHog config with a loopback host — toast shows the backend's \`INVALID_SETTING: postHogHost: …\` instead of the generic literal.

No new unit test: \`apiClient → authStore → …\` module-init fails under vitest without extra setup; per-domain \`onError → translateError\` callsites already exercise the path with real \`ApiClientError\` instances.

Fixes #694