### PR TITLE
fix(web): refresh all-versions list + z-bump toast above modals (#699)

### DIFF
--- a/.changeset/versions-modal-stale-699.md
+++ b/.changeset/versions-modal-stale-699.md
@@ -1,0 +1,11 @@
+---
+"ornn-web": patch
+---
+
+The All-versions modal now drops a deleted version row immediately, and the result toast renders above any open modal (#699).
+
+Two distinct issues piled up after a version delete:
+
+1. **Stale list**: `useDeleteSkillVersion` invalidated `[SKILLS_KEY, idOrName]`, `[SKILLS_KEY]`, `[MY_SKILLS_KEY]`, and per-version audit caches, but not `[SKILL_VERSIONS_KEY, idOrName]` — the very query the All-versions modal subscribes to. So the deleted row stayed visible, and a second click on its delete button hit the backend with `SKILL_VERSION_NOT_FOUND`. Added the missing invalidation.
+
+2. **Obscured toast**: `ToastContainer` portal and the `Modal` portal both sit at `z-50`, so when both are mounted the toast is rendered behind the modal overlay and the success/error feedback for an in-modal action (delete or deprecate from the All-versions modal) becomes dim and unreadable. Bumped `ToastContainer` to `z-[60]` so toasts always sit above modals — single source of truth, no per-call escape hatches needed.

--- a/ornn-web/src/components/ui/Toast.tsx
+++ b/ornn-web/src/components/ui/Toast.tsx
@@ -166,7 +166,11 @@ export function ToastContainer({
 
   return (
     <div
-      className={`pointer-events-none fixed z-50 flex flex-col gap-3 ${POSITION_STYLES[position]} ${className}`}
+      // z-[60] (#699) — modals sit at z-50; without this bump the
+      // toast portal renders behind any open modal overlay and the
+      // operation result for an in-modal action (e.g. delete inside
+      // the all-versions modal) becomes dim and unreadable.
+      className={`pointer-events-none fixed z-[60] flex flex-col gap-3 ${POSITION_STYLES[position]} ${className}`}
       role="region"
       aria-label={t("common.aria.notifications")}
     >

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -383,6 +383,11 @@ export function useDeleteSkillVersion(idOrName: string) {
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY, idOrName] });
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
+      // #699 — the All-versions modal subscribes to
+      // [SKILL_VERSIONS_KEY, idOrName]; without this invalidation
+      // the deleted row stays visible and a second delete click
+      // hits the backend with the now-missing version.
+      queryClient.invalidateQueries({ queryKey: [SKILL_VERSIONS_KEY, idOrName] });
       queryClient.invalidateQueries({
         predicate: (q) =>
           Array.isArray(q.queryKey) &&


### PR DESCRIPTION
## Summary

Two issues after a version delete inside the All-versions modal:

1. \`useDeleteSkillVersion\` missed invalidating \`[SKILL_VERSIONS_KEY, idOrName]\`; modal kept the deleted row and a second click 404'd. Added.
2. \`ToastContainer\` and \`Modal\` both at \`z-50\`; toast rendered behind modal overlay. Bumped Toast to \`z-[60]\`.

## Test plan

- [x] \`bun run typecheck:web\` clean
- [ ] Local manual: open All-versions modal, delete a non-latest version, confirm row disappears immediately and the toast renders above the modal.

Fixes #699