### PR TITLE
fix(web): poll bell notifications list on same 30s as count (#728)

### DIFF
--- a/.changeset/notification-dropdown-stale-728.md
+++ b/.changeset/notification-dropdown-stale-728.md
@@ -1,0 +1,9 @@
+---
+"ornn-web": patch
+---
+
+`useNotifications` now polls on the same 30s interval as the unread-count query, so the bell dropdown stays in sync with the badge (#728).
+
+Background: the bell badge subscribes to `useUnreadNotificationCount` (polled every `UNREAD_POLL_MS` = 30s) and the dropdown list to `useNotifications` (no `refetchInterval`, only `staleTime: 10_000`). When a new targeted broadcast lands, the count poll ticks to `1` and the badge updates — but `useNotifications` only re-fetches on remount/invalidation, so an open (or just-mounted-but-still-fresh) dropdown showed the pre-broadcast list. Users saw "1 unread" + a list that didn't contain it.
+
+Fix: add `refetchInterval: UNREAD_POLL_MS` to `useNotifications` so the two queries tick together. `refetchIntervalInBackground: false` mirrors the count query — no traffic when the tab is hidden. `staleTime` stays at 10s so quick remounts (e.g. dropdown toggle) still serve cached data without an extra round-trip.

--- a/ornn-web/src/hooks/useNotifications.ts
+++ b/ornn-web/src/hooks/useNotifications.ts
@@ -31,6 +31,14 @@ export function useNotifications(opts: ListNotificationsOptions = {}) {
     queryFn: () => fetchNotifications(opts),
     enabled: isAuthed,
     staleTime: 10_000,
+    // #728 — bell dropdown subscribes to this query. Without a
+    // refetch interval, the badge (from useUnreadNotificationCount,
+    // polled every 30s) would tick to a new count while the list
+    // stayed frozen — user sees "1 unread" with a dropdown that
+    // doesn't actually show the new item. Mirror the count's poll
+    // so the two stay in sync.
+    refetchInterval: isAuthed ? UNREAD_POLL_MS : false,
+    refetchIntervalInBackground: false,
   });
 }
 


### PR DESCRIPTION
## Summary

Bell badge ticked to 1 from useUnreadNotificationCount (30s poll), but the dropdown list (useNotifications) had no refetchInterval. The dropdown stayed frozen on the pre-broadcast list while the badge said unread.

Fix: mirror UNREAD_POLL_MS on useNotifications. Both queries tick together.

## Test plan

- [x] \`bun run typecheck:web\` clean
- [ ] Local manual: keep bell visible, admin pushes a targeted broadcast, badge ticks within 30s, dropdown opens and contains the new item.

Fixes #728