### PR TITLE
fix(web): include path + rephrase required-gates in section form errors (#698)

### DIFF
--- a/.changeset/admin-settings-zod-actionable-698.md
+++ b/.changeset/admin-settings-zod-actionable-698.md
@@ -1,0 +1,19 @@
+---
+"ornn-web": patch
+---
+
+`useSectionForm` validation errors now include the offending field path and rephrase length-1 string failures as "is required" instead of the raw `Too small: expected string to have >=1 characters` (#698).
+
+The shared admin-settings form hook joined `i.message` only when surfacing Zod validation issues. The Mirror section (and every other section that uses `.min(1)` as a required-field gate) ended up emitting a single SectionShell alert that read like:
+
+> Too small: expected string to have >=1 characters; Too small: expected string to have >=1 characters; Too small: expected string to have >=1 characters; ...
+
+— with no indication of which fields needed filling.
+
+Fix: prefix each issue with `path.join(".")`, and for the specific `code: "too_small"` + `type: "string"` + `minimum: 1` triple swap the message to `is required`. Renders as:
+
+> owner: is required; repo: is required; branch: is required; appId: is required; installationId: is required; appPrivateKey: is required
+
+— actionable from the alert alone, no schema-by-schema rewrite needed.
+
+Per-section schemas can still ship their own friendlier messages (`.min(1, "Owner is required")`) — those flow through `i.message` unchanged.

--- a/ornn-web/src/components/admin/settings/useSectionForm.ts
+++ b/ornn-web/src/components/admin/settings/useSectionForm.ts
@@ -84,7 +84,26 @@ export function useSectionForm<T>({
     if (schema) {
       const parsed = schema.safeParse(draft);
       if (!parsed.success) {
-        setError(parsed.error.issues.map((i) => i.message).join("; "));
+        // #698 — prefix each issue with its path so admins can see
+        // which field failed instead of staring at a wall of repeated
+        // "Too small: expected string to have >=1 characters" entries.
+        // Length-1 string issues also rephrase as "is required" since
+        // that's what the form actually means for the affected sections
+        // (Mirror, NyxID Integration, etc. all use .min(1) as a
+        // required-field gate).
+        setError(
+          parsed.error.issues
+            .map((i) => {
+              const path = i.path.length > 0 ? i.path.join(".") : "";
+              const isRequiredGate =
+                i.code === "too_small" &&
+                (i as { type?: string }).type === "string" &&
+                (i as { minimum?: number }).minimum === 1;
+              const message = isRequiredGate ? "is required" : i.message;
+              return path ? `${path}: ${message}` : message;
+            })
+            .join("; "),
+        );
         return;
       }
     }


### PR DESCRIPTION
## Summary

\`useSectionForm\` joined \`i.message\` only — Mirror, NyxID Integration, etc. all use \`.min(1)\` as a required gate, so the alert collapsed to a wall of identical \`Too small: expected string to have >=1 characters\` with no field hint.

Fix: prefix each issue with \`path.join(".")\` and rephrase the too_small/string/min=1 triple as \`is required\`. Per-section custom \`.min(1, "Owner is required")\` messages still flow through unchanged.

## Test plan

- [x] \`bun run typecheck:web\` clean
- [ ] Local manual: \`/admin/settings/mirror\` → enable mirror with empty fields → Save → alert lists \`owner: is required; repo: is required; ...\` instead of \`Too small: ...\` repeated.

Fixes #698