### PR TITLE
fix(web): surface failed audit rerun on Skill Detail (#718)

### DIFF
--- a/.changeset/audit-rerun-silent-fail-718.md
+++ b/.changeset/audit-rerun-silent-fail-718.md
@@ -1,0 +1,11 @@
+---
+"ornn-web": patch
+---
+
+Skill Detail now surfaces a "latest rerun failed" indicator next to the score so a failed audit rerun is no longer invisible (#718).
+
+Background: `auditSummaryByVersion` returns the latest *completed* audit per version. When a rerun ends in `failed`, the summary still points at the previous successful record, and Skill Detail renders that stale score — visually identical to "current passing audit". Admins only discovered the failure by opening Audit History.
+
+Fix: `useSkillDetail` already loads `versionAuditHistory` (newest-first across all statuses) to compute `versionAuditRunning`. Compute one more derived flag from it — `versionAuditLatestFailed = history[0].status === "failed" && newer than the displayed completed audit` — and thread it through to `AuditVerdictPill` as the new `latestRerunFailed` prop. The pill keeps the old completed score (so admins can still see the last-good number) and renders a danger-toned banner directly below: "Latest rerun failed — score above is from the prior audit. Check audit history for details." (`skillDetail.auditLatestFailed`).
+
+No backend change. The shape `getAudit` returns is unchanged — the gap was that the *latest-of-any-status* signal was already in hand and just wasn't propagated.

--- a/ornn-web/src/components/skill/AuditVerdictPill.tsx
+++ b/ornn-web/src/components/skill/AuditVerdictPill.tsx
@@ -21,9 +21,22 @@ export interface AuditVerdictPillProps {
   // exactOptionalPropertyTypes (#657)
   audit?: AuditRecord | undefined;
   running?: boolean | undefined;
+  /**
+   * True when the most recent audit attempt for the current version
+   * ended in `failed` and is newer than the displayed completed
+   * `audit`. Causes the pill to render the failure state alongside
+   * (not in place of) any prior completed verdict, so admins see
+   * the rerun failed instead of staring at the now-stale score
+   * (#718).
+   */
+  latestRerunFailed?: boolean | undefined;
 }
 
-export function AuditVerdictPill({ audit, running }: AuditVerdictPillProps) {
+export function AuditVerdictPill({
+  audit,
+  running,
+  latestRerunFailed,
+}: AuditVerdictPillProps) {
   const { t } = useTranslation();
 
   // In-flight audit takes precedence over the cached completed result —
@@ -73,24 +86,52 @@ export function AuditVerdictPill({ audit, running }: AuditVerdictPillProps) {
         : t("skillDetail.auditFailLabel", "Risk");
 
   return (
-    <div className={`mb-3.5 flex items-center gap-3 rounded-sm border p-3 ${tone}`}>
-      <div
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-current text-page"
-        aria-hidden
-      >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
-      </div>
-      <div className="flex flex-col gap-0.5">
-        <div>
-          <span className="font-display text-2xl font-semibold leading-none">
-            {audit.overallScore.toFixed(1)}
-          </span>
-          <span className="ml-1 font-mono text-[11px] tracking-wide text-meta">/ 10</span>
+    <>
+      <div className={`mb-3.5 flex items-center gap-3 rounded-sm border p-3 ${tone}`}>
+        <div
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-current text-page"
+          aria-hidden
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
         </div>
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em]">{label}</span>
+        <div className="flex flex-col gap-0.5">
+          <div>
+            <span className="font-display text-2xl font-semibold leading-none">
+              {audit.overallScore.toFixed(1)}
+            </span>
+            <span className="ml-1 font-mono text-[11px] tracking-wide text-meta">/ 10</span>
+          </div>
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em]">{label}</span>
+        </div>
       </div>
-    </div>
+      {latestRerunFailed && (
+        <div
+          className="-mt-2.5 mb-3.5 flex items-start gap-2 rounded-sm border border-danger/30 bg-danger-soft p-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-danger"
+          role="status"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="mt-0.5 shrink-0"
+            aria-hidden
+          >
+            <path d="M12 9v2m0 4h.01" />
+            <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+          </svg>
+          <span>
+            {t(
+              "skillDetail.auditLatestFailed",
+              "Latest rerun failed — score above is from the prior audit. Check audit history for details.",
+            )}
+          </span>
+        </div>
+      )}
+    </>
   );
 }

--- a/ornn-web/src/hooks/useSkillDetail.ts
+++ b/ornn-web/src/hooks/useSkillDetail.ts
@@ -355,6 +355,21 @@ export function useSkillDetail(idOrName: string | undefined) {
   const versionAudit = skill ? auditSummaryByVersion?.[skill.version] : undefined;
   const versionAuditRunning =
     versionAuditHistory?.some((r) => r.status === "running") ?? false;
+  // #718 — `auditSummaryByVersion` returns the latest *completed*
+  // record per version, so a newer failed rerun was invisible on
+  // Skill Detail and admins kept seeing the stale prior score as
+  // though it were current. `versionAuditHistory` lists every
+  // record newest-first; if the most recent entry is `failed`
+  // (and newer than the displayed completed audit, when one
+  // exists) we surface that explicitly through `AuditVerdictPill`.
+  const latestVersionAudit = versionAuditHistory?.[0];
+  const versionAuditLatestFailed = Boolean(
+    latestVersionAudit &&
+    latestVersionAudit.status === "failed" &&
+    (!versionAudit ||
+      new Date(latestVersionAudit.createdAt).getTime() >
+        new Date(versionAudit.completedAt ?? versionAudit.createdAt).getTime()),
+  );
   const ownerDisplayName =
     isOwner && user?.displayName
       ? user.displayName
@@ -387,6 +402,7 @@ export function useSkillDetail(idOrName: string | undefined) {
     auditSummaryByVersion,
     versionAudit,
     versionAuditRunning,
+    versionAuditLatestFailed,
     ownerDisplayName,
     ownerAvatarUrl,
     // ── mutations exposed for the modals' loading states ──

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -91,6 +91,7 @@ export function SkillDetailPage() {
     auditSummaryByVersion,
     versionAudit,
     versionAuditRunning,
+    versionAuditLatestFailed,
     ownerDisplayName,
     ownerAvatarUrl,
     deleteMutation,
@@ -310,7 +311,11 @@ export function SkillDetailPage() {
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
                 {t("skillDetail.cardAudit", "Audit")}
               </h3>
-              <AuditVerdictPill audit={versionAudit} running={versionAuditRunning} />
+              <AuditVerdictPill
+                audit={versionAudit}
+                running={versionAuditRunning}
+                latestRerunFailed={versionAuditLatestFailed}
+              />
               <p className="font-mono text-[11px] leading-relaxed tracking-wide text-meta">
                 {versionAuditRunning
                   ? t("skillDetail.auditRunningHint", "Scoring against the audit engine — this usually takes 30–60 seconds.")


### PR DESCRIPTION
## Summary

\`auditSummaryByVersion\` returns the latest *completed* audit per version, so a failed rerun was invisible on Skill Detail — admins only saw the stale prior score. Compute \`versionAuditLatestFailed\` from \`versionAuditHistory\` (already loaded for the running-poll) and render a danger-toned banner below the score: 'Latest rerun failed — score above is from the prior audit.'

No backend change.

## Test plan

- [x] \`bun run typecheck:web\` clean
- [ ] Per the QA repro: trigger one passing audit, swap the audit default model to an invalid id, trigger a rerun, restore the model, reload Skill Detail — the prior score still renders, with a danger banner below saying the rerun failed.

Fixes #718