### PR TITLE
fix(api): keep user env values out of LLM prompt + override at sandbox-time (#721)

### DIFF
--- a/.changeset/playground-env-isolation-721.md
+++ b/.changeset/playground-env-isolation-721.md
@@ -1,0 +1,16 @@
+---
+"ornn-api": patch
+---
+
+Playground no longer puts user-supplied env *values* into the LLM prompt and server-side overrides any value the model emits at `execute_in_sandbox` time (#721).
+
+Before this change, `buildSkillContext` injected `KEY=value` pairs into the developer message so the model could pass them through to `execute_in_sandbox`. When a chat-completion provider returned the tool call as plain assistant text instead of a structured tool-call frame (the failure mode #608 fixed for compliant providers — but a non-compliant model can still emit raw JSON in `text-delta`), the env values appeared verbatim in the user-visible transcript. Even with the secret value redacted on the wire, the bug surface was that the secret had ever passed through the LLM at all.
+
+Fix has two layers:
+
+- **Developer message**: list only the env-var *names* the user provided, with a placeholder shape `KEY=<provided-server-side>` and a brief instruction telling the model to reference each by name. The model never has the literal value, so it can't echo it.
+- **Tool dispatch**: `runSandboxToolCall` merges `request.envVars` (the real values, supplied by the UI / API caller) *on top of* `args.env` (whatever the model produced). User-supplied keys always win at execution time. Keys the model legitimately invents (sentinel markers, etc.) ride through unchanged.
+
+Net effect: even if a future regression lets the model serialize a tool call as text again, the transcript carries `KEY=<provided-server-side>` instead of the secret, and the sandbox still runs with the real value because the merge happens on the server before `sessionExecute`.
+
+Coverage: 2 new tests in `chatService.test.ts` cover the user-override-wins case (real value replaces model's guessed value, untouched keys ride through) and the no-envVars passthrough case (model-only env reaches sandbox unchanged). All 10 tests in the file green.

--- a/ornn-api/src/domains/playground/chatService.test.ts
+++ b/ornn-api/src/domains/playground/chatService.test.ts
@@ -321,3 +321,64 @@ describe("PlaygroundChatService — sandbox session persistence (#531)", () => {
     (sandbox.client as { deleteSession: (id: string) => Promise<void> }).deleteSession = originalDelete;
   });
 });
+
+// ---------------------------------------------------------------------------
+// #721 — user-supplied env values must not flow through the LLM
+// ---------------------------------------------------------------------------
+
+describe("PlaygroundChatService — env value isolation (#721)", () => {
+  it("user-provided envVars override the model's args.env at sandbox-execute time", async () => {
+    const sandbox = makeSandboxClient({});
+    const service = makeService(
+      [
+        makeToolCallEvents({
+          name: "execute_in_sandbox",
+          args: {
+            script: "print(env)",
+            language: "python",
+            // Simulate a model that emitted a guessed/leaky value.
+            env: { SECRET_TOKEN: "model-guessed-value", PUBLIC_FLAG: "model-set" },
+          },
+        }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    await drain(
+      service.chat(
+        "u1",
+        {
+          messages: [{ role: "user", content: "go" }],
+          envVars: { SECRET_TOKEN: "REAL_SECRET_FROM_UI" },
+        },
+      ),
+    );
+
+    expect(sandbox.calls.sessionExecute).toHaveLength(1);
+    const envSeen = sandbox.calls.sessionExecute[0]!.params.env as Record<string, string>;
+    // Real value wins over model-supplied placeholder.
+    expect(envSeen.SECRET_TOKEN).toBe("REAL_SECRET_FROM_UI");
+    // Keys the user didn't override ride through.
+    expect(envSeen.PUBLIC_FLAG).toBe("model-set");
+  });
+
+  it("no envVars passed → sandbox env is exactly what the model produced", async () => {
+    const sandbox = makeSandboxClient({});
+    const service = makeService(
+      [
+        makeToolCallEvents({
+          name: "execute_in_sandbox",
+          args: { script: "x", language: "python", env: { MARKER: "test123" } },
+        }),
+        STOP_EVENTS,
+      ],
+      sandbox,
+    );
+
+    await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+
+    const envSeen = sandbox.calls.sessionExecute[0]!.params.env as Record<string, string>;
+    expect(envSeen).toEqual({ MARKER: "test123" });
+  });
+});

--- a/ornn-api/src/domains/playground/chatService.ts
+++ b/ornn-api/src/domains/playground/chatService.ts
@@ -415,6 +415,7 @@ export class PlaygroundChatService {
             pendingToolCall,
             sandboxSessions,
             createdSessionIds,
+            request.envVars,
           );
           yield { type: "tool-result", toolCallId: pendingToolCall.id, result: toolResult.text };
 
@@ -475,11 +476,17 @@ export class PlaygroundChatService {
     toolCall: { id: string; name: string; args: Record<string, unknown> },
     sandboxSessions: Map<string, string>,
     createdSessionIds: string[],
+    userEnvVars: Record<string, string> | undefined,
   ): Promise<ToolCallResult> {
     const { name, args } = toolCall;
 
     if (name === "execute_in_sandbox") {
-      return await this.runSandboxToolCall(args, sandboxSessions, createdSessionIds);
+      return await this.runSandboxToolCall(
+        args,
+        sandboxSessions,
+        createdSessionIds,
+        userEnvVars,
+      );
     }
 
     if (name === "load_skill") {
@@ -513,11 +520,26 @@ export class PlaygroundChatService {
     args: Record<string, unknown>,
     sandboxSessions: Map<string, string>,
     createdSessionIds: string[],
+    userEnvVars: Record<string, string> | undefined,
   ): Promise<ToolCallResult> {
     const script = (args.script as string) ?? "";
     const language = (args.language as string) ?? "python";
     const outputType = (args.output_type as "text" | "file") ?? "text";
-    const env = (args.env as Record<string, string>) ?? {};
+    // #721 — user-provided env values always win over what the model
+    // supplied in `args.env`. Since #721 we no longer feed the actual
+    // env *values* into the developer message; the model only sees
+    // placeholder shapes (`KEY=<provided-server-side>`) and is told
+    // to reference them by name. Here we replace whatever the model
+    // emitted with the real values for any key the user supplied,
+    // closing the leak path where a chat-completion provider could
+    // serialize the tool call as assistant text and echo the env
+    // back to the user. Keys the model added that aren't in
+    // `userEnvVars` ride through unchanged (the model legitimately
+    // sets ad-hoc env like sentinel markers).
+    const env: Record<string, string> = {
+      ...((args.env as Record<string, string>) ?? {}),
+      ...(userEnvVars ?? {}),
+    };
     const dependencies = (args.dependencies as string[]) ?? [];
     const retrieveFiles = (args.retrieve_files as string[]) ?? [];
     const inputFiles = (args.input_files as Array<{ path: string; content: string }>) ?? [];
@@ -630,11 +652,25 @@ export class PlaygroundChatService {
       lines.push("");
     }
 
-    // Add user-provided env vars
+    // #721 — list ONLY the env var NAMES the user provided values for,
+    // never the values themselves. If the model ever echoes the
+    // developer message back (as it can do when chat-completion
+    // providers serialize `execute_in_sandbox` to assistant text
+    // instead of a structured tool call), the transcript would leak
+    // the user's secret. The server-side path (`runSandboxToolCall`)
+    // injects the real values into the sandbox env at execution
+    // time — the LLM never needs the literal value to issue the
+    // tool call.
     if (envVars && Object.keys(envVars).length > 0) {
       lines.push("### User-provided Environment Variables");
-      for (const [key, value] of Object.entries(envVars)) {
-        lines.push(`- ${key}=${value}`);
+      lines.push(
+        "The user has supplied values for the variables below. Reference each",
+        "by name when constructing `execute_in_sandbox`'s `env` argument —",
+        "the runtime will inject the real values server-side. DO NOT attempt to",
+        "guess, repeat, or echo the values; you do not have them.",
+      );
+      for (const key of Object.keys(envVars)) {
+        lines.push(`- ${key}=<provided-server-side>`);
       }
       lines.push("");
     }


### PR DESCRIPTION
Two-layer fix. (1) `buildSkillContext` lists only env-var names + placeholder `KEY=<provided-server-side>`. (2) `runSandboxToolCall` merges `request.envVars` on top of `args.env`. 10 tests in chatService.test.ts green. Fixes #721