### PR TITLE
fix(web): P2 cluster — mirror route, card alignment, search placeholder, org name (#716 #725 #727 #729)

### DIFF
--- a/.changeset/p2-batch-716-725-727-729.md
+++ b/.changeset/p2-batch-716-725-727-729.md
@@ -1,0 +1,18 @@
+---
+"ornn-web": patch
+---
+
+P2 UX cluster: four small admin/registry papercuts (#716, #725, #727, #729).
+
+- **#716 Admin Mirror dashboard route**: `/admin/mirror` used to redirect to `/admin/settings/mirror`, and the section's "Open mirror dashboard" link pointed at `/admin/skills`. Net effect: no reachable UI for manual reconcile / status counts. `MirrorPage` (full operations console — counts grid, reconcile button, status header) is now lazy-mounted at `/admin/mirror` again, and the section link points there instead of Admin Skills.
+
+- **#725 Mode-selection cards alignment**: the four mode cards on `/skills/new` share a layout but the description paragraph had no min-height, so a shorter copy (Free Mode) shifted the bullet list up versus its neighbours. Added `min-h-[3rem] sm:min-h-[3.5rem]` to the description `<p>` so all four bullet lists start on the same baseline.
+
+- **#727 Keyword search placeholder lied about tags**: the placeholder advertised "name, description, or tags" but the backend keyword search doesn't match tags (the tag chip facet is the supported path). Updated `search.placeholderKeyword` in both en and zh to drop "or tags" — and the in-component fallback string to match.
+
+- **#729 Shared With Me cards now show the org name**: the access-reason sub-line on `SkillCard` rendered a generic "Via organization" even though `skill.sharedViaOrgId` was already populated. Look it up against `useMyOrgs()`'s membership list and render the new `viaOrganizationNamed` key (`Via {{org}}` / `通过 {{org}} 共享`). Falls back to the old generic copy when the org isn't in the caller's memberships (rare — server only sets `sharedViaOrgId` to an org the caller belongs to, but defence-in-depth).
+
+Out of scope:
+
+- **#723** (Notifications page can't scroll past viewport) — needs investigation of `RootLayout`'s `overflow-hidden` policy and any layout regressions adjacent pages might depend on.
+- **#726** (Registry semantic search with empty query renders the no-skills empty state instead of "enter a description") — needs a small UX state in the search component to distinguish "validation gate hit" from "no matches". Both will follow up.

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -157,6 +157,9 @@ const AdminAnnouncementsPage = lazy(() =>
 const AdminBroadcastsPage = lazy(() =>
   import("@/pages/admin").then((m) => ({ default: m.BroadcastsPage })),
 );
+const MirrorPage = lazy(() =>
+  import("@/pages/admin/MirrorPage").then((m) => ({ default: m.MirrorPage })),
+);
 
 // Settings layout + section components live under pages/admin/settings.
 const SettingsLayout = lazy(() =>
@@ -293,13 +296,13 @@ const router = createBrowserRouter(
               <Route path="/admin/announcements" element={<AdminAnnouncementsPage />} />
               <Route path="/admin/broadcasts" element={<AdminBroadcastsPage />} />
 
-              {/* /admin/mirror keeps working but redirects to the new
-                  settings/mirror section so existing deep-links + bookmarks
-                  continue to land on the right surface. */}
-              <Route
-                path="/admin/mirror"
-                element={<Navigate to="/admin/settings/mirror" replace />}
-              />
+              {/* /admin/mirror is the deep mirror operations console
+                  (counts, manual reconcile, status). It used to redirect
+                  to /admin/settings/mirror, but that left admins with no
+                  reachable "Manual reconcile" / "Reconcile now" control
+                  (#716). The settings section now links here for the
+                  full operations view. */}
+              <Route path="/admin/mirror" element={<MirrorPage />} />
 
               <Route path="/admin/settings" element={<SettingsLayout />}>
                 <Route

--- a/ornn-web/src/components/search/SearchBar.tsx
+++ b/ornn-web/src/components/search/SearchBar.tsx
@@ -46,7 +46,7 @@ export function SearchBar({ className = "" }: SearchBarProps) {
           placeholder={
             isSemanticMode
               ? t("search.placeholderSemantic", "Describe what you're looking for...")
-              : t("search.placeholderKeyword", "Search skills by name, description, or tags...")
+              : t("search.placeholderKeyword", "Search skills by name or description...")
           }
           className="neon-input w-full rounded py-3 pr-4 pl-12 font-text text-strong placeholder:text-meta/50"
         />

--- a/ornn-web/src/components/skill/SkillCard.tsx
+++ b/ornn-web/src/components/skill/SkillCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/Badge";
 import type { BadgeProps } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import type { SkillSearchResult } from "@/types/search";
+import { useMyOrgs } from "@/hooks/useMe";
 
 const TAG_COLORS: NonNullable<BadgeProps["color"]>[] = ["cyan", "magenta", "yellow", "green"];
 
@@ -101,6 +102,18 @@ export function SkillCard({
   const displayName = ownerDisplayName || skill.createdByDisplayName || skill.createdByEmail || skill.createdBy;
   const timestamp = skill.updatedOn || skill.createdOn;
 
+  // #729 — resolve the specific org that granted access for
+  // `shared-via-org` cards. The skill carries `sharedViaOrgId`; the
+  // current user's NyxID memberships carry display names. Match on
+  // `userId` (NyxID org ids are NyxID user ids). Falls back to the
+  // generic "Via organization" label when the lookup misses (org is
+  // not in the caller's memberships, or the orgs query is loading).
+  const { data: myOrgs } = useMyOrgs();
+  const viaOrgName =
+    skill.myAccessReason === "shared-via-org" && skill.sharedViaOrgId
+      ? myOrgs?.find((o) => o.userId === skill.sharedViaOrgId)?.displayName
+      : undefined;
+
   return (
     <Card
       hoverable
@@ -138,7 +151,11 @@ export function SkillCard({
           `myAccessReason` with a grant-based value. */}
       {skill.myAccessReason === "shared-via-org" && (
         <p className="mb-2 font-text text-[11px] uppercase tracking-wider text-meta">
-          {t("skillComponents.card.viaOrganization", "Via organization")}
+          {viaOrgName
+            ? t("skillComponents.card.viaOrganizationNamed", "Via {{org}}", {
+                org: viaOrgName,
+              })
+            : t("skillComponents.card.viaOrganization", "Via organization")}
         </p>
       )}
       {skill.myAccessReason === "shared-direct" && (

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -1038,7 +1038,7 @@
     "quotaUsageDetails": "Quota usage details"
   },
   "search": {
-    "placeholderKeyword": "Search skills by name, description, or tags...",
+    "placeholderKeyword": "Search skills by name or description...",
     "placeholderSemantic": "Describe what you're looking for...",
     "toggleToKeyword": "Switch to keyword search",
     "toggleToSemantic": "Switch to semantic search",
@@ -1054,6 +1054,7 @@
     "card": {
       "linkedToGithub": "Linked to GitHub",
       "viaOrganization": "Via organization",
+        "viaOrganizationNamed": "Via {{org}}",
       "sharedBy": "Shared by {{name}}"
     },
     "grid": {

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -1038,7 +1038,7 @@
     "quotaUsageDetails": "配额使用详情"
   },
   "search": {
-    "placeholderKeyword": "按名称、描述或标签搜索技能…",
+    "placeholderKeyword": "按名称或描述搜索技能…",
     "placeholderSemantic": "描述你想找什么…",
     "toggleToKeyword": "切换到关键词搜索",
     "toggleToSemantic": "切换到语义搜索",
@@ -1054,6 +1054,7 @@
     "card": {
       "linkedToGithub": "已关联到 GitHub",
       "viaOrganization": "通过组织共享",
+      "viaOrganizationNamed": "通过 {{org}} 共享",
       "sharedBy": "由 {{name}} 共享"
     },
     "grid": {

--- a/ornn-web/src/pages/admin/settings/sections/MirrorSection.tsx
+++ b/ornn-web/src/pages/admin/settings/sections/MirrorSection.tsx
@@ -178,7 +178,7 @@ export function MirrorSection() {
             />
 
             <Link
-              to="/admin/skills"
+              to="/admin/mirror"
               className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.14em] text-accent hover:text-accent-muted"
             >
               {t("adminSettings.sections.mirror.openDashboard")}

--- a/ornn-web/src/pages/skill/UploadSkillPage.tsx
+++ b/ornn-web/src/pages/skill/UploadSkillPage.tsx
@@ -204,7 +204,14 @@ export function UploadSkillPage() {
                         {t(card.titleKey)}
                       </h2>
 
-                      <p className="font-text text-sm sm:text-base text-meta mb-4 sm:mb-6">
+                      {/*
+                        Fixed min-height so the bullet list below starts
+                        on the same vertical baseline across all four
+                        cards regardless of description length (#725).
+                        The Free Mode description is ~1 line; Generative
+                        and GitHub spill to ~2 lines on common viewports.
+                      */}
+                      <p className="font-text text-sm sm:text-base text-meta mb-4 sm:mb-6 min-h-[3rem] sm:min-h-[3.5rem]">
                         {t(card.descKey)}
                       </p>
 


### PR DESCRIPTION
## Summary

Four small papercuts in one PR:

- **#716** `/admin/mirror` lazy-mounts `MirrorPage` again (counts + manual reconcile + status header). MirrorSection link → `/admin/mirror` (was `/admin/skills`).
- **#725** Mode-selection cards: description gets min-h so the four bullet lists share a baseline.
- **#727** Keyword search placeholder drops 'or tags' (en + zh + component fallback) since the backend doesn't actually search tags.
- **#729** Shared With Me `SkillCard` resolves the org name from `useMyOrgs` and renders `viaOrganizationNamed` (`Via {{org}}` / `通过 {{org}} 共享`); falls back to the generic copy when the lookup misses.

Out of scope follow-ups: #723 (notifications scroll), #726 (semantic empty-query UX).

## Test plan

- [x] `bun run typecheck:web` — no new errors in touched files (pre-existing cron-parser failure on develop is unrelated)
- [ ] Local manual per QA repros for each of the four issues.

Fixes #716, Fixes #725, Fixes #727, Fixes #729