### PR TITLE
fix(api): friendly sandbox error in playground transcript (#530)

### DIFF
--- a/.changeset/friendly-sandbox-errors-530.md
+++ b/.changeset/friendly-sandbox-errors-530.md
@@ -1,0 +1,13 @@
+---
+"ornn-api": patch
+---
+
+`runSandboxOneShot` now translates chrono-sandbox HTTP errors into a one-line user-facing message and logs structured diagnostics, so the playground transcript stops surfacing raw JSON like `Sandbox service error (500): {"error":"internal_error","error_code":1006,"message":"An internal error occurred"}` (#530).
+
+Background: `SandboxClient.post` throws an `Error` whose message is `"Sandbox service error (<status>): <raw body>"`. The playground catch handler spat that string straight into the chat. The QA's repro on the `nyxid` skill (`https://ornn.chrono-ai.fun/playground?skill=nyxid` → `LIST CAPABILITIES`) hit a chrono-sandbox internal 500 with `error_code: 1006` and the transcript showed the raw JSON envelope verbatim — useless to the user, and presented as if the failure were the user's fault.
+
+Fix: new `formatSandboxError` helper parses the `"Sandbox service error (<status>): <body>"` shape. If the body is the structured `{ error, error_code, message }` envelope, it returns a friendly sentence keyed off `status` (500 / 1006 → transient sandbox-server hint, 503/504 → timeout hint, anything else → `HTTP <status> [code N]: <message>`). When the body isn't JSON or the regex doesn't match, it falls back to the raw message so any new upstream shape still reaches the operator. Pino `error` log carries `language`, `scriptLen`, and the raw error message so admins can grep production for 1006-class failures without scrolling chat transcripts.
+
+The underlying chrono-sandbox 500s themselves are out of scope — those originate inside the sandbox runtime, not Ornn. This change is about UX of the failure surface.
+
+`runSandboxToolCall`'s `sessionExecute` catch path stays as-is (it already falls back to the one-shot path, which now formats the error before returning).

--- a/ornn-api/src/domains/playground/chatService.ts
+++ b/ornn-api/src/domains/playground/chatService.ts
@@ -70,6 +70,46 @@ interface ToolCallResult {
 }
 
 /**
+ * Translate a thrown error from `sandboxClient.{execute,sessionExecute}`
+ * into a user-facing one-liner for the playground transcript (#530).
+ *
+ * `SandboxClient.post` throws an `Error` whose message is
+ * `"Sandbox service error (<status>): <raw body text>"`. The raw body
+ * is often an `{ error, error_code, message }` JSON envelope from
+ * chrono-sandbox; the legacy formatter spat that JSON straight into
+ * the chat. Try to parse the body — if it's the structured envelope
+ * we surface a friendly sentence plus an internal-code hint admins
+ * can grep on. Otherwise fall back to the raw message so any new
+ * upstream shape still makes it to the operator.
+ */
+function formatSandboxError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const match = raw.match(/^Sandbox service error \((\d+)\): (.*)$/s);
+  if (!match) return `Sandbox execution failed: ${raw}`;
+  const status = match[1]!;
+  const body = match[2]!;
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: string;
+      error_code?: number;
+      message?: string;
+    };
+    const codeHint =
+      typeof parsed.error_code === "number" ? ` [code ${parsed.error_code}]` : "";
+    const summary = parsed.message ?? parsed.error ?? `HTTP ${status}`;
+    if (status === "500" || (parsed.error_code === 1006)) {
+      return `Sandbox is having trouble running this script${codeHint}. This is usually a transient sandbox-server issue — try again, or simplify the script if it keeps failing.`;
+    }
+    if (status === "504" || status === "503") {
+      return `Sandbox timed out / temporarily unavailable${codeHint}. Try again in a few seconds.`;
+    }
+    return `Sandbox execution failed (HTTP ${status})${codeHint}: ${summary}`;
+  } catch {
+    return `Sandbox execution failed (HTTP ${status}): ${body.slice(0, 200)}`;
+  }
+}
+
+/**
  * Translate a chrono-sandbox `SandboxExecuteResult` (both /execute and
  * /sessions/{id}/execute return this shape) into the {text, files}
  * envelope the playground stream feeds back to the LLM and emits as
@@ -622,10 +662,15 @@ export class PlaygroundChatService {
       const result = await this.sandboxClient.execute(params);
       return formatSandboxResult(result);
     } catch (err) {
-      return {
-        text: `Sandbox execution failed: ${err instanceof Error ? err.message : String(err)}`,
-        files: [],
-      };
+      logger.error(
+        {
+          language: params.language,
+          scriptLen: params.script.length,
+          err: (err as Error).message,
+        },
+        "Sandbox one-shot execute failed",
+      );
+      return { text: formatSandboxError(err), files: [] };
     }
   }
 


### PR DESCRIPTION
## Summary

`SandboxClient.post` throws raw `Sandbox service error (500): {…JSON…}` and the playground transcript echoed the JSON verbatim. New `formatSandboxError` parses the envelope and surfaces a one-liner (transient-hint for 500/1006, timeout-hint for 503/504, generic shape for others). Structured Pino log for ops grep.

The chrono-sandbox 500 itself (the nyxid CLI hitting internal_error / 1006) is **out of scope** — fix the surface, not the root cause, which lives in the sandbox runtime.

## Test plan

- [x] `bun run typecheck:api` clean
- [ ] Per-QA repro: hosted nyxid playground → `LIST CAPABILITIES` → confirm transcript shows the friendly hint instead of `{\"error\":\"internal_error\",...}`.

Fixes #530
EOF
)