### PR TITLE
fix(web): notifications scroll + semantic-empty validation (#723 #726)

### DIFF
--- a/.changeset/p2-followup-723-726.md
+++ b/.changeset/p2-followup-723-726.md
@@ -1,0 +1,9 @@
+---
+"ornn-web": patch
+---
+
+P2 follow-up: notifications page can scroll past the viewport and Registry semantic search with an empty query shows an actionable validation message instead of the generic empty state (#723, #726).
+
+- **#723** — `RootLayout`'s `<main>` is `overflow-hidden`; `NotificationsPage` had no own scroll container, so once the list exceeded the viewport, older notifications were clipped and unreachable via wheel/touch scroll. Wrapped the page body in an `h-full overflow-y-auto` shell — same pattern `UploadSkillPage` uses for the same root-layout constraint.
+
+- **#726** — Registry's semantic-search button could flip on while the input was empty; the backend correctly returned `400 QUERY_REQUIRED` but `ExplorePage` rendered the regular "No public skills match" empty state, indistinguishable from a legitimate zero-result search. Added a `semanticGateUnmet = mode === "semantic" && !query.trim()` check that swaps the empty state for an `EmptyState` with explicit copy: `Enter a search description / Semantic search needs a description of what you're looking for. Type a phrase in the search box above, or switch back to Keyword mode.` (+ Chinese translation). The backend queries keep firing (cheap, cached) but the user sees a clear validation hint instead of a misleading null result.

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -115,6 +115,8 @@
     "auditHistory": "Audit history"
   },
   "explore": {
+    "semanticQueryRequiredTitle": "Enter a search description",
+    "semanticQueryRequiredDesc": "Semantic search needs a description of what you're looking for. Type a phrase in the search box above, or switch back to Keyword mode.",
     "systemSkills": "System Skills",
     "publicSkills": "Public Skills",
     "mySkills": "My Skills",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -115,6 +115,8 @@
     "auditHistory": "审计历史"
   },
   "explore": {
+    "semanticQueryRequiredTitle": "请输入搜索描述",
+    "semanticQueryRequiredDesc": "语义搜索需要描述你要找的内容。请在上方搜索框中输入一段描述，或切换回关键字模式。",
     "systemSkills": "系统技能",
     "publicSkills": "公共技能",
     "mySkills": "我的技能",

--- a/ornn-web/src/pages/ExplorePage.tsx
+++ b/ornn-web/src/pages/ExplorePage.tsx
@@ -111,6 +111,12 @@ export function ExplorePage() {
   const selectedSourceUsers = parseCsvParam(searchParams.get("srcUsers"));
 
   const { query, mode } = useSearchStore();
+  // #726 — semantic search requires a query; the backend rejects an
+  // empty `q` with 400 QUERY_REQUIRED and the regular empty state
+  // ("No skills match") looks indistinguishable from a legitimate
+  // zero-result search. When the gate isn't met, render a clear
+  // validation EmptyState instead of the generic "no skills" copy.
+  const semanticGateUnmet = mode === "semantic" && !query.trim();
 
   const { data: systemData, isLoading: systemLoading } = useSystemSkills({
     query: query || undefined,
@@ -286,17 +292,30 @@ export function ExplorePage() {
                 ))}
               </div>
             ) : items.length === 0 ? (
-              <EmptyState
-                title={emptyTitle(activeTab, t as (k: string, f?: string) => string)}
-                description={emptyDescription(activeTab, t as (k: string, f?: string) => string)}
-                action={
-                  activeTab === "my-skills" && isAuthenticated ? (
-                    <Button onClick={() => navigate("/skills/new")}>
-                      {t("explore.createSkill", "Create a skill")}
-                    </Button>
-                  ) : undefined
-                }
-              />
+              semanticGateUnmet ? (
+                <EmptyState
+                  title={t(
+                    "explore.semanticQueryRequiredTitle",
+                    "Enter a search description",
+                  )}
+                  description={t(
+                    "explore.semanticQueryRequiredDesc",
+                    "Semantic search needs a description of what you're looking for. Type a phrase in the search box above, or switch back to Keyword mode.",
+                  )}
+                />
+              ) : (
+                <EmptyState
+                  title={emptyTitle(activeTab, t as (k: string, f?: string) => string)}
+                  description={emptyDescription(activeTab, t as (k: string, f?: string) => string)}
+                  action={
+                    activeTab === "my-skills" && isAuthenticated ? (
+                      <Button onClick={() => navigate("/skills/new")}>
+                        {t("explore.createSkill", "Create a skill")}
+                      </Button>
+                    ) : undefined
+                  }
+                />
+              )
             ) : (
               <motion.div
                 variants={containerVariants}

--- a/ornn-web/src/pages/NotificationsPage.tsx
+++ b/ornn-web/src/pages/NotificationsPage.tsx
@@ -91,6 +91,14 @@ export function NotificationsPage() {
 
   return (
     <PageTransition>
+      {/*
+        Outer wrapper provides the vertical scroll surface (#723).
+        `RootLayout`'s `<main>` is `overflow-hidden`, so without this
+        the notification list is clipped once it exceeds the viewport
+        and older entries can never be reached by wheel/touch scroll.
+        Same pattern as `UploadSkillPage`.
+      */}
+      <div className="h-full overflow-y-auto">
       <div className="mx-auto w-full max-w-4xl px-6 py-10">
         <header className="mb-6 flex flex-wrap items-center justify-between gap-4">
           <div>
@@ -210,6 +218,7 @@ export function NotificationsPage() {
             ))}
           </ul>
         )}
+      </div>
       </div>
 
       <NotificationDetailModal


### PR DESCRIPTION
## Summary

- **#723** `NotificationsPage` body wrapped in `h-full overflow-y-auto` so the list can scroll past viewport height (was clipped by RootLayout's `overflow-hidden`).
- **#726** `ExplorePage` swaps the generic "No skills match" empty state for an explicit "Enter a search description" EmptyState when semantic mode is active with an empty query. Backend 400s become invisible chatter; user sees a validation hint.

## Test plan

- [x] `bun run typecheck:web` clean
- [ ] Local: `/notifications` with > viewport-height of entries → can scroll to oldest row.
- [ ] Local: `/registry` → switch to Semantic with empty input → see 'Enter a search description' instead of 'No public skills match'.

Fixes #723, Fixes #726