### PR TITLE
fix: stale share-target metadata — search filter + flagged chips (#720)

### DIFF
--- a/.changeset/stale-share-target-720.md
+++ b/.changeset/stale-share-target-720.md
@@ -1,0 +1,15 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+Stale share-target grants are now visible-but-flagged in the Permissions modal, and `skill-search?scope=shared-with-me` defensively drops results pointing at orgs the caller is no longer in (#720).
+
+**Backend (`SearchService.search`):** after `enrichItem` builds the items, when `scope === "shared-with-me"` a zero-trust pass drops any item whose `myAccessReason === "shared-via-org"` but whose `sharedViaOrgId` isn't in the caller's current `userOrgIds`. `applyScope` already gates this at the DB layer, so this is defence-in-depth against cache lag / partially-replicated writes / future query regressions — and a `warn`-level Pino entry tags any drop so data drift is visible.
+
+**Frontend (`PermissionsModal`):**
+
+- Orgs: `fetchOrgSummary` previously back-filled a `null` lookup with the raw org id as the display name, silently hiding the staleness. Now each entry carries `isUnresolved: boolean` (true when NyxID can't resolve the id). Unresolved rows render with a warning-toned row background, an "unresolved" badge with a triangle icon, and a tooltip pointing the owner at the uncheck box to revoke. Click-to-revoke flows through the existing `toggleOrg` path.
+- Users: when `resolveUsers` doesn't return a row for an id, the placeholder `{ userId, email: "", displayName: userId }` survives — that signal now drives a danger-toned chip + triangle icon + tooltip explaining the user is gone, with the existing `×` button revoking.
+
+Net effect: owners see exactly what they've granted, see which grants point at entities that no longer resolve, and can clean them up in two clicks. The `skill-search` zero-trust filter ensures the calling user never sees a shared-with-me skill they can't actually open even if the underlying DB / cache disagrees with effective org membership.

--- a/ornn-api/src/domains/skills/search/service.ts
+++ b/ornn-api/src/domains/skills/search/service.ts
@@ -136,9 +136,39 @@ export class SearchService {
     const queryTimeMs = Date.now() - startTime;
     logger.info({ mode, scope, query: query.slice(0, 50), total, queryTimeMs }, "Search completed");
 
-    const items = skills.map((s) =>
+    const rawItems = skills.map((s) =>
       enrichItem(s, { callerUserId: currentUserId, callerOrgIds: userOrgIds }),
     );
+
+    // #720 — zero-trust filter for shared-with-me. applyScope at the
+    // DB layer already gates on the caller's effective orgs, but a
+    // stale cache, a partially-replicated write, or a future query
+    // regression could let a skill leak through that points at an
+    // org the caller is no longer in. Drop such items unconditionally
+    // — the user can't actually open them (skill detail correctly
+    // 404s, that's verified) so surfacing them in search results is
+    // pure misinformation. We log when this trips so cache/data drift
+    // is visible.
+    let items = rawItems;
+    if (scope === "shared-with-me") {
+      const orgSet = new Set(userOrgIds);
+      const filtered = rawItems.filter((item) => {
+        if (item.myAccessReason !== "shared-via-org") return true;
+        if (!item.sharedViaOrgId) return false;
+        return orgSet.has(item.sharedViaOrgId);
+      });
+      if (filtered.length !== rawItems.length) {
+        logger.warn(
+          {
+            userId: currentUserId,
+            droppedCount: rawItems.length - filtered.length,
+            orgsConsidered: userOrgIds.length,
+          },
+          "shared-with-me defensive filter dropped result(s) — applyScope and effective orgs disagree",
+        );
+      }
+      items = filtered;
+    }
     const totalPages = Math.ceil(total / pageSize);
 
     return {

--- a/ornn-web/src/components/skill/PermissionsModal.tsx
+++ b/ornn-web/src/components/skill/PermissionsModal.tsx
@@ -111,28 +111,36 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
     queryKey: ["orgs-backfill", unknownOrgIds.sort().join(",")],
     queryFn: async () => {
       const resolved = await Promise.all(unknownOrgIds.map((id) => fetchOrgSummary(id)));
-      return resolved
-        .map(
-          (entry, i) =>
-            // `i` is bounded by `unknownOrgIds.length` (Promise.all
-            // preserves indexing). `!` is safe under
-            // noUncheckedIndexedAccess (#450).
-            entry ?? { userId: unknownOrgIds[i]!, displayName: unknownOrgIds[i]!, avatarUrl: null },
-        )
-        .filter((e) => !!e);
+      return resolved.map((entry, i) => {
+        // `i` is bounded by `unknownOrgIds.length` (Promise.all preserves
+        // indexing). `!` is safe under noUncheckedIndexedAccess (#450).
+        const orgId = unknownOrgIds[i]!;
+        // #720 — entry is null when NyxID couldn't resolve the id (org
+        // deleted, or caller can't see it). Keep the row visible so
+        // the owner can revoke, but flag `isUnresolved` so the chip
+        // gets the warning treatment.
+        return entry
+          ? { ...entry, isUnresolved: false }
+          : { userId: orgId, displayName: orgId, avatarUrl: null, isUnresolved: true };
+      });
     },
     enabled: isOpen && unknownOrgIds.length > 0,
     staleTime: 5 * 60_000,
   });
 
   const allOrgOptions = useMemo(() => {
-    const map = new Map<string, { userId: string; displayName: string; isMember: boolean }>();
+    const map = new Map<string, { userId: string; displayName: string; isMember: boolean; isUnresolved: boolean }>();
     for (const o of myOrgs) {
-      map.set(o.userId, { userId: o.userId, displayName: o.displayName, isMember: true });
+      map.set(o.userId, { userId: o.userId, displayName: o.displayName, isMember: true, isUnresolved: false });
     }
     for (const o of fetchedUnknownOrgs) {
       if (!map.has(o.userId)) {
-        map.set(o.userId, { userId: o.userId, displayName: o.displayName, isMember: false });
+        map.set(o.userId, {
+          userId: o.userId,
+          displayName: o.displayName,
+          isMember: false,
+          isUnresolved: o.isUnresolved,
+        });
       }
     }
     return Array.from(map.values());
@@ -286,7 +294,17 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
                   return (
                     <label
                       key={org.userId}
-                      className="flex items-center gap-2 cursor-pointer py-1 px-2 rounded hover:bg-accent/5"
+                      className={`flex items-center gap-2 cursor-pointer py-1 px-2 rounded hover:bg-accent/5 ${
+                        org.isUnresolved ? "bg-warning-soft/40" : ""
+                      }`}
+                      title={
+                        org.isUnresolved
+                          ? (t(
+                              "permissions.orgUnresolvedTip",
+                              "This organization is no longer reachable in NyxID. Uncheck to revoke the stale grant.",
+                            ) as string)
+                          : undefined
+                      }
                     >
                       <input
                         type="checkbox"
@@ -297,11 +315,19 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
                       <span className="font-text text-sm text-strong truncate">
                         {org.displayName}
                       </span>
-                      {!org.isMember && (
+                      {org.isUnresolved ? (
+                        <span className="ml-auto inline-flex items-center gap-1 rounded-sm border border-warning/40 px-1.5 py-[1px] font-mono text-[10px] uppercase tracking-wider text-warning">
+                          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                            <path d="M12 9v2m0 4h.01" />
+                            <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                          </svg>
+                          {t("permissions.orgUnresolved", "unresolved")}
+                        </span>
+                      ) : !org.isMember ? (
                         <span className="font-mono text-[10px] text-meta ml-auto">
                           {t("permissions.notMember", "not member")}
                         </span>
-                      )}
+                      ) : null}
                     </label>
                   );
                 })}
@@ -328,22 +354,49 @@ export function PermissionsModal({ isOpen, onClose, skill }: PermissionsModalPro
                   isPublic ? "opacity-60 pointer-events-none" : ""
                 }`}
               >
-                {sharedUsers.map((u) => (
-                  <span
-                    key={u.userId}
-                    className="inline-flex items-center gap-2 px-2 py-1 rounded-full border border-accent/30 bg-accent/5 font-mono text-xs text-strong h-fit"
-                  >
-                    <span>{u.email || u.displayName || u.userId}</span>
-                    <button
-                      type="button"
-                      onClick={() => removeUser(u.userId)}
-                      className="text-danger hover:text-danger/80 cursor-pointer"
-                      aria-label={t("permissions.removeUser", "Remove") as string}
+                {sharedUsers.map((u) => {
+                  // #720 — user couldn't be resolved via the directory.
+                  // `resolveUsers` leaves the placeholder
+                  // `{ userId, email: "", displayName: userId }` in place
+                  // when a lookup misses, so `!u.email && u.displayName === u.userId`
+                  // is the signal that the grant points at a user who no
+                  // longer exists (or who the caller can't see).
+                  const isUnresolved = !u.email && u.displayName === u.userId;
+                  return (
+                    <span
+                      key={u.userId}
+                      className={`inline-flex items-center gap-2 px-2 py-1 rounded-full border font-mono text-xs h-fit ${
+                        isUnresolved
+                          ? "border-warning/40 bg-warning-soft/40 text-warning"
+                          : "border-accent/30 bg-accent/5 text-strong"
+                      }`}
+                      title={
+                        isUnresolved
+                          ? (t(
+                              "permissions.userUnresolvedTip",
+                              "This user could not be resolved. They may have left or been removed; click × to revoke the stale grant.",
+                            ) as string)
+                          : undefined
+                      }
                     >
-                      ×
-                    </button>
-                  </span>
-                ))}
+                      {isUnresolved && (
+                        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                          <path d="M12 9v2m0 4h.01" />
+                          <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                        </svg>
+                      )}
+                      <span>{u.email || u.displayName || u.userId}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeUser(u.userId)}
+                        className="text-danger hover:text-danger/80 cursor-pointer"
+                        aria-label={t("permissions.removeUser", "Remove") as string}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
                 {sharedUsers.length === 0 && (
                   <p className="font-text text-xs text-meta italic w-full">
                     {t("permissions.noUsersYet", "No users added yet.")}


### PR DESCRIPTION
Backend zero-trust filter on shared-with-me search + PermissionsModal stale-chip UI. Per user's design call: keep chips, add 'unresolved' warning + tooltip + click-to-revoke. Fixes #720