### PR TITLE
docs: prep release v0.9.0

### DIFF
--- a/.changeset/release-notes-v0.9.0.md
+++ b/.changeset/release-notes-v0.9.0.md
@@ -1,0 +1,4 @@
+---
+---
+
+Release prep for v0.9.0 — adds the dated `.github/release-notes-20260529.md` used as the GitHub Release body. Docs/CI-only; no package version impact beyond the feature changesets already on develop (#753).

--- a/.github/release-notes-20260529.md
+++ b/.github/release-notes-20260529.md
@@ -1,0 +1,47 @@
+## Fixed
+
+- Returning to a tab no longer triggers an unexpected logout.
+- Saving a skill and logging in no longer fail with CORS errors.
+- Editing a skill's package no longer returns a 404.
+- Chat-completion LLM providers (e.g. DeepSeek) now work for generation.
+- Saving an LLM provider keeps its model list and default.
+- Playground keeps sandbox state — logins, installs — across tool calls.
+- Playground shows friendly errors and a proper not-found state.
+- Quota chip and banners now match the real remaining count.
+- Guided/Free create shows validation errors inline and respects backend rejects.
+- Frontmatter and settings errors now explain how to fix them.
+- Notifications sync, scroll fully, and toasts surface above modals.
+- Deactivated NyxID services no longer appear as filters.
+- Permissions modal flags shares pointing at removed users or orgs.
+- Skill Detail flags when the latest audit rerun failed.
+- Admin papercuts — display-name search, Mirror dashboard, recipients popover.
+- Private skill contents no longer leak through the JSON endpoint.
+- Playground no longer routes secret env values through the LLM.
+- Registry, admin tables, and creation flows now fully localize to Chinese.
+- Few technical bugs fixed.
+
+## New Feature
+
+- Cursor pagination on skill search, with an SDK auto-pagination iterator.
+- Dist-tags pin skill versions to named channels like latest and stable.
+- Idempotency-Key header makes state-changing requests retry-safe.
+- Sliding-window rate limiting with standard rate-limit headers.
+- Published JSON Schema for SKILL.md frontmatter, for editor autocomplete.
+- Subresource-Integrity hashes on version manifests for verified installs.
+- Install prompt now pins pull commands to the version you're viewing.
+- One-command local dev with docker-compose, plus starter example skills.
+- Technical enhancement.
+
+## Changed
+
+- Breaking: errors now use RFC 7807 problem+json with lowercase_snake_case codes.
+- Breaking: version writes require the skill GUID, not its name.
+- Breaking: deprecation is now signaled via standard RFC 8594 headers.
+- Breaking: removed the legacy `ownerId` field from skill responses.
+- Canonical `?q=` search param; the legacy `?query=` still works.
+- Resource-creating POSTs return 201 with a Location header.
+- "Skip validation" on import now also bypasses frontmatter checks.
+- Chat composer caps prompt length with a live counter.
+- Upload size and zip-bomb limits now enforced on the backend too.
+- Production builds no longer log auth or analytics to the browser console.
+- Technical enhancement.


### PR DESCRIPTION
Closes #753.

Adds the dated release-notes file (`.github/release-notes-20260529.md`) so the upcoming `develop → main` cut produces a tagged **v0.9.0** Release with curated user-facing notes.

~97 changesets have accumulated on develop since v0.8.0. Highest fixed-pair bump is **minor**, so both packages go `0.8.0 → 0.9.0` in fixed mode. The release is API-contract heavy — **5 breaking changes** to `/api/v1/*` (RFC 7807 envelope, `lowercase_snake_case` codes, GUID-only version writes, RFC 8594 deprecation headers, `ownerId` removal), all pre-1.0 minor bumps per convention.

## Test plan

- [x] `release-notes-20260529.md` is lexically greater than the prior latest (`20260516.md`), so the release workflow picks this file.
- [x] All three sections (`## Fixed` / `## New Feature` / `## Changed`) present; no `(write here)` placeholders — `check-release-notes.yml` will pass.
- [x] No leading HTML comment block (template comment not copied in); bullets follow template style (6–12 words, plain prose, no PR refs, technical items collapsed into the trailing bullet per section).
- [x] Adversarially verified against all 97 changesets — every user-facing change represented or correctly clustered; 5 breaking changes flagged.