### PR TITLE
fix(web): drop credentials:include from skill create/update/deprecate (#732)

### DIFF
--- a/.changeset/skill-cors-credentials-732.md
+++ b/.changeset/skill-cors-credentials-732.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Fix hosted CORS failure blocking skill save / update / version-deprecation (#732). `skillApi.ts` set `credentials: "include"` on three raw-fetch calls (`createSkill`, `updateSkillPackage`, `setSkillVersionDeprecation`). These authenticate with the `Authorization: Bearer` header, never cookies, so the flag was unnecessary — and fatal: a credentialed request forbids a wildcard `Access-Control-Allow-Origin: *`, which the NyxID proxy returns, so the browser blocked every request at the CORS layer with "Failed to fetch". #528 only removed the dead `X-User-*` headers and #709 cleared the same trap in `activityApi.ts`; the `skillApi.ts` siblings were missed. Dropping `credentials: "include"` restores hosted skill creation, package update, and version deprecation.

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -67,7 +67,6 @@ export async function setSkillVersionDeprecation(
     {
       method: "PATCH",
       headers,
-      credentials: "include",
       body: JSON.stringify(body),
     },
   );
@@ -96,6 +95,15 @@ export async function setSkillVersionDeprecation(
  * CORS error. Same dead code as the `apiClient.createHeaders`
  * cleanup; this was the last unmigrated caller of the ZIP-upload
  * flow.
+ *
+ * #732 / #709 — also drop `credentials: "include"` here (and on the
+ * PUT/PATCH siblings below). These calls authenticate with the
+ * `Authorization: Bearer` header, never cookies. With
+ * `credentials: "include"` the browser rejects the NyxID proxy's
+ * wildcard `Access-Control-Allow-Origin: *` (a credentialed request
+ * forbids wildcard ACAO), blocking the request at the CORS layer
+ * before it leaves the browser — the exact "Failed to fetch" symptom
+ * in #732. Same trap #709 already cleared in activityApi.ts.
  */
 export async function createSkill(zipFile: File, skipValidation = false): Promise<SkillDetail> {
   const token = useAuthStore.getState().accessToken;
@@ -111,7 +119,6 @@ export async function createSkill(zipFile: File, skipValidation = false): Promis
     method: "POST",
     headers,
     body: zipFile,
-    credentials: "include",
   });
 
   if (!response.ok) {
@@ -151,7 +158,6 @@ export async function updateSkillPackage(id: string, zipFile: File, skipValidati
     method: "PUT",
     headers,
     body: zipFile,
-    credentials: "include",
   });
 
   if (!response.ok) {


### PR DESCRIPTION
Closes #732.

## Problem

Hosted skill **save / package-update / version-deprecate** are blocked at the browser CORS layer (`Failed to fetch`). Confirmed live on the deployed v0.9.0 (`0.9.0+t1780045110763`):

```
$ curl -i -X OPTIONS 'https://nyx-api.chrono-ai.fun/api/v1/proxy/s/ornn-api/api/v1/skills' \
    -H 'Origin: https://ornn.chrono-ai.fun' -H 'Access-Control-Request-Method: POST'
HTTP/2 204
access-control-allow-origin: *
access-control-allow-credentials: true
```

## Root cause

`ornn-web/src/services/skillApi.ts` set `credentials: "include"` on three raw-fetch calls — `createSkill` (POST /skills), `updateSkillPackage` (PUT /skills/:id, #565), `setSkillVersionDeprecation` (PATCH …/versions/:version). They authenticate via the `Authorization: Bearer` header, never cookies, so the flag is unnecessary — and fatal: a credentialed request forbids a wildcard `Access-Control-Allow-Origin: *`, so the browser blocks the preflight.

`#528` only stripped the dead `X-User-*` headers from these callers; `#709` cleared the same `credentials` trap in `activityApi.ts` but the `skillApi.ts` siblings were missed. This applies the identical one-line removal to all three — the last credentialed raw-fetch callers in the SPA.

## Fix

Remove `credentials: "include"` from the three calls. Auth header unchanged; request becomes non-credentialed so the proxy's wildcard ACAO is accepted.

## Test plan

- [x] `bun run typecheck` — clean (all 3 projects).
- [x] `bun run lint` — 0 errors.
- [x] No test asserted the old `credentials` value.
- [ ] After deploy: hosted Build → generate → **save** succeeds; package update + version-deprecate succeed; no CORS error in console.

## Follow-up (out of scope, NyxID-side)

The proxy returns `Access-Control-Allow-Origin: *` **and** `Access-Control-Allow-Credentials: true` — an invalid CORS combination. Worth fixing on the proxy so future credentialed flows aren't trapped.