### PR TITLE
docs: prep release v0.9.1

### DIFF
--- a/.changeset/release-notes-v0.9.1.md
+++ b/.changeset/release-notes-v0.9.1.md
@@ -1,0 +1,4 @@
+---
+---
+
+Release prep for v0.9.1 — adds the dated `.github/release-notes-20260530.md` used as the GitHub Release body. Docs/CI-only; no package version impact beyond the CORS hotfix changeset already on develop (#761).

--- a/.github/release-notes-20260530.md
+++ b/.github/release-notes-20260530.md
@@ -1,0 +1,11 @@
+## Fixed
+
+- Saving, updating, or deprecating a skill no longer fails with a CORS error.
+
+## New Feature
+
+- Technical enhancement.
+
+## Changed
+
+- Technical enhancement.


### PR DESCRIPTION
Closes #761.

Adds `.github/release-notes-20260530.md` for the **v0.9.1** patch cut. Single hotfix on develop since v0.9.0: **#732** (drop `credentials:"include"` from skill create/update/deprecate — restores hosted skill saving through the NyxID proxy), merged via #760. Both packages go `0.9.0 → 0.9.1` in fixed mode.

## Test plan

- [x] Dated `20260530` so it sorts after v0.9.0's same-UTC-day `20260529` file (workflow picks the lexically-greatest 8-digit dated file).
- [x] All three sections present; thin New Feature / Changed carry the trailing bucket bullet per the gate; no `(write here)` — `check-release-notes.yml` passes.
- [x] Empty changeset included for `check-changeset` (docs/CI-only), same as v0.9.0 prep.