### PR TITLE
[Bug] Enforce private-skill visibility on playground skill-load (BOLA)

### DIFF
--- a/.changeset/auto-806-playground-skill-bola.md
+++ b/.changeset/auto-806-playground-skill-bola.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Fix an authorization gap where the playground could load a private skill's full contents without checking the caller's read access. `getSkillJson` now requires a caller actor and enforces `canReadSkill` for both the `skillId` and `load_skill` paths, so a private skill is only readable by its owner, users/orgs it is shared with, or a platform admin.

--- a/ornn-api/src/domains/playground/chatService.test.ts
+++ b/ornn-api/src/domains/playground/chatService.test.ts
@@ -33,6 +33,8 @@ import type {
 } from "../../clients/nyxid/llm";
 import type { SkillService } from "../skills/crud/service";
 import type { PlaygroundChatEvent } from "../../shared/types/index";
+import { AppError } from "../../shared/types/index";
+import { canReadSkill, type ActorContext, type SkillOwnership } from "../skills/crud/authorize";
 
 // ---------------------------------------------------------------------------
 // Stubs
@@ -75,8 +77,37 @@ function makeLlmClient(rounds: ResponsesApiStreamEvent[][]): NyxLlmClient {
   } as unknown as NyxLlmClient;
 }
 
+// #806 — a private skill fixture used to exercise object-level
+// authorization on both skill-load paths. The marker string below must
+// appear in the package contents and ONLY in the package contents, so a
+// "contents leaked?" assertion can grep the transcript for it.
+const SECRET_MARKER = "SUPER_SECRET_SKILL_BODY_4f2a";
+const PRIVATE_SKILL_FIXTURE: SkillOwnership = {
+  createdBy: "owner-1",
+  isPrivate: true,
+  sharedWithUsers: ["shared-1"],
+  sharedWithOrgs: ["org-9"],
+};
+
+/**
+ * Authz-aware stub: runs the REAL `canReadSkill` against the private
+ * fixture and the actor it was handed. Denied → throws the same
+ * `skill_not_found` AppError the production service throws; allowed →
+ * returns a package whose files embed `SECRET_MARKER`.
+ */
 const SKILL_SERVICE_STUB: SkillService = {
-  getSkillJson: async () => ({ name: "stub", description: "", metadata: {}, files: {} }),
+  getSkillJson: async (_idOrName: string, actor: ActorContext) => {
+    if (!canReadSkill(PRIVATE_SKILL_FIXTURE, actor)) {
+      throw AppError.notFound("skill_not_found", `Skill '${_idOrName}' not found`);
+    }
+    return {
+      name: "demo-skill",
+      description: "",
+      version: "1.0",
+      metadata: {},
+      files: { "SKILL.md": `# demo\n${SECRET_MARKER}` },
+    };
+  },
 } as unknown as SkillService;
 
 const DEFAULTS_RESOLVER = async () => ({
@@ -380,5 +411,112 @@ describe("PlaygroundChatService — env value isolation (#721)", () => {
 
     const envSeen = sandbox.calls.sessionExecute[0]!.params.env as Record<string, string>;
     expect(envSeen).toEqual({ MARKER: "test123" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #806 — object-level authorization (BOLA / OWASP API1) on skill loads.
+//
+// Two bypass paths must both be gated by the caller's actor:
+//   (a) the `request.skillId` developer-message injection
+//   (b) the `load_skill` tool call
+//
+// The stub runs the REAL `canReadSkill` against PRIVATE_SKILL_FIXTURE, so
+// these tests exercise the production policy end-to-end through chat().
+// ---------------------------------------------------------------------------
+
+const STRANGER: ActorContext = { userId: "stranger", memberships: [], isPlatformAdmin: false };
+const OWNER: ActorContext = { userId: "owner-1", memberships: [], isPlatformAdmin: false };
+const SHARED_USER: ActorContext = { userId: "shared-1", memberships: [], isPlatformAdmin: false };
+const ORG_MEMBER: ActorContext = {
+  userId: "someone-else",
+  memberships: [{ userId: "org-9", role: "member", displayName: "Org Nine" }],
+  isPlatformAdmin: false,
+};
+const ADMIN: ActorContext = { userId: "admin-1", memberships: [], isPlatformAdmin: true };
+
+/** True if any emitted event's serialized form contains the secret marker. */
+function leaksMarker(events: PlaygroundChatEvent[]): boolean {
+  return events.some((e) => JSON.stringify(e).includes(SECRET_MARKER));
+}
+
+/** Drive a chat over the `request.skillId` injection path for `actor`. */
+async function runSkillIdPath(actor: ActorContext): Promise<PlaygroundChatEvent[]> {
+  const sandbox = makeSandboxClient({});
+  const service = makeService([STOP_EVENTS], sandbox);
+  return drain(
+    service.chat(
+      "u1",
+      { messages: [{ role: "user", content: "go" }], skillId: "demo-skill" },
+      undefined,
+      { actor },
+    ),
+  );
+}
+
+/** Drive a chat that issues a single `load_skill` tool call for `actor`. */
+async function runLoadSkillPath(actor: ActorContext): Promise<PlaygroundChatEvent[]> {
+  const sandbox = makeSandboxClient({});
+  const service = makeService(
+    [makeToolCallEvents({ name: "load_skill", args: { skill_id: "demo-skill" } }), STOP_EVENTS],
+    sandbox,
+  );
+  return drain(
+    service.chat("u1", { messages: [{ role: "user", content: "load it" }] }, undefined, { actor }),
+  );
+}
+
+describe("PlaygroundChatService — skill-load authorization (#806)", () => {
+  it("(1) stranger via skillId path → error event, NO skill contents injected", async () => {
+    const events = await runSkillIdPath(STRANGER);
+    const err = events.find((e) => e.type === "error");
+    expect(err).toBeDefined();
+    expect((err as { message: string }).message).toContain("Failed to load skill");
+    expect(events.some((e) => e.type === "finish" && (e as { finishReason?: string }).finishReason === "error")).toBe(true);
+    expect(leaksMarker(events)).toBe(false);
+  });
+
+  it("(2) stranger via load_skill tool → access-denied tool result, NO contents", async () => {
+    const events = await runLoadSkillPath(STRANGER);
+    const toolResult = events.find((e) => e.type === "tool-result") as { result: string } | undefined;
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.result).toContain("Failed to load skill");
+    expect(toolResult!.result).not.toContain(SECRET_MARKER);
+    expect(leaksMarker(events)).toBe(false);
+  });
+
+  it("(3) owner-1 succeeds on both paths", async () => {
+    // skillId path: no error event, finishes normally.
+    const skillIdEvents = await runSkillIdPath(OWNER);
+    expect(skillIdEvents.some((e) => e.type === "error")).toBe(false);
+    expect(skillIdEvents.some((e) => e.type === "finish")).toBe(true);
+    // load_skill path: tool result carries the package contents.
+    const loadEvents = await runLoadSkillPath(OWNER);
+    const toolResult = loadEvents.find((e) => e.type === "tool-result") as { result: string } | undefined;
+    expect(toolResult!.result).toContain(SECRET_MARKER);
+  });
+
+  it("(4) shared-1 (per-user grant) succeeds on both paths", async () => {
+    const skillIdEvents = await runSkillIdPath(SHARED_USER);
+    expect(skillIdEvents.some((e) => e.type === "error")).toBe(false);
+    const loadEvents = await runLoadSkillPath(SHARED_USER);
+    const toolResult = loadEvents.find((e) => e.type === "tool-result") as { result: string } | undefined;
+    expect(toolResult!.result).toContain(SECRET_MARKER);
+  });
+
+  it("(5) org-9 member (per-org grant) succeeds on both paths", async () => {
+    const skillIdEvents = await runSkillIdPath(ORG_MEMBER);
+    expect(skillIdEvents.some((e) => e.type === "error")).toBe(false);
+    const loadEvents = await runLoadSkillPath(ORG_MEMBER);
+    const toolResult = loadEvents.find((e) => e.type === "tool-result") as { result: string } | undefined;
+    expect(toolResult!.result).toContain(SECRET_MARKER);
+  });
+
+  it("(6) platform admin succeeds on both paths", async () => {
+    const skillIdEvents = await runSkillIdPath(ADMIN);
+    expect(skillIdEvents.some((e) => e.type === "error")).toBe(false);
+    const loadEvents = await runLoadSkillPath(ADMIN);
+    const toolResult = loadEvents.find((e) => e.type === "tool-result") as { result: string } | undefined;
+    expect(toolResult!.result).toContain(SECRET_MARKER);
   });
 });

--- a/ornn-api/src/domains/playground/chatService.ts
+++ b/ornn-api/src/domains/playground/chatService.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../clients/sandboxClient";
 import type { SkillService } from "../skills/crud/service";
 import type { PlaygroundChatEvent } from "../../shared/types/index";
+import { type ActorContext, SYSTEM_ACTOR } from "../skills/crud/authorize";
 import { createLogger } from "../../shared/logger";
 import { z } from "zod";
 
@@ -310,8 +311,13 @@ export class PlaygroundChatService {
     userId: string,
     request: PlaygroundChatRequest,
     abortSignal?: AbortSignal,
-    options?: { modelId?: string },
+    options?: { modelId?: string; actor?: ActorContext },
   ): AsyncGenerator<PlaygroundChatEvent> {
+    // #806 — object-level authorization for skill loads. The route
+    // builds the caller's real actor; internal/test callers that omit
+    // it fall back to SYSTEM_ACTOR. This single actor gates BOTH skill
+    // bypass paths below (skillId injection + the load_skill tool).
+    const actor = options?.actor ?? SYSTEM_ACTOR;
     // Resolve LLM defaults from admin settings on every call so
     // operator updates land without a pod restart.
     let defaults: PlaygroundLlmDefaults;
@@ -347,7 +353,7 @@ export class PlaygroundChatService {
     // Auto-inject skill context if skillId is provided
     if (request.skillId) {
       try {
-        const skillJson = await this.skillService.getSkillJson(request.skillId);
+        const skillJson = await this.skillService.getSkillJson(request.skillId, actor);
         const skillContext = this.buildSkillContext(skillJson, request.envVars);
         input.unshift({
           role: "developer" as const,
@@ -456,6 +462,7 @@ export class PlaygroundChatService {
             sandboxSessions,
             createdSessionIds,
             request.envVars,
+            actor,
           );
           yield { type: "tool-result", toolCallId: pendingToolCall.id, result: toolResult.text };
 
@@ -517,6 +524,7 @@ export class PlaygroundChatService {
     sandboxSessions: Map<string, string>,
     createdSessionIds: string[],
     userEnvVars: Record<string, string> | undefined,
+    actor: ActorContext,
   ): Promise<ToolCallResult> {
     const { name, args } = toolCall;
 
@@ -531,7 +539,10 @@ export class PlaygroundChatService {
 
     if (name === "load_skill") {
       try {
-        const skillJson = await this.skillService.getSkillJson((args.skill_id as string) ?? "");
+        // #806 — gate the load through the caller's actor. A skill the
+        // caller can't read throws skill_not_found here, so the tool
+        // result below carries the denial string, never the contents.
+        const skillJson = await this.skillService.getSkillJson((args.skill_id as string) ?? "", actor);
         return { text: JSON.stringify(skillJson, null, 2), files: [] };
       } catch (err) {
         return { text: `Failed to load skill: ${err instanceof Error ? err.message : String(err)}`, files: [] };

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -19,6 +19,7 @@ import {
   nyxidAuthMiddleware,
   requirePermission,
   getAuth,
+  readUserOrgMemberships,
 } from "../../middleware/nyxidAuth";
 import { validateBody, getValidatedBody } from "../../middleware/validate";
 import { createLogger } from "../../shared/logger";
@@ -124,6 +125,20 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
       if (resolution.kind !== "ok") throwModelResolutionError(resolution);
       const resolvedModelId = resolution.modelId;
 
+      // #806 — build the caller's object-level authorization actor and
+      // thread it into the chat service. This mirrors the actor build in
+      // GET /skills/:idOrName/json and depends on nyxidOrgLookupMiddleware
+      // being mounted in bootstrap.ts ahead of the playground routes so
+      // `readUserOrgMemberships` resolves the caller's org memberships.
+      // The chat service uses this single actor to gate BOTH skill bypass
+      // paths (the `skillId` injection and the `load_skill` tool).
+      const memberships = await readUserOrgMemberships(c);
+      const actor = {
+        userId: authCtx.userId,
+        memberships,
+        isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
+      };
+
       // Record a `playground` pull if the chat is bound to a skill. The
       // chat service loads the skill internally; we duplicate the lookup
       // here so analytics doesn't change the chat-service contract. Cost
@@ -227,6 +242,7 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
         try {
           for await (const event of chatService.chat(authCtx.userId, chatRequest, signal, {
             modelId: resolvedModelId,
+            actor,
           })) {
             await writeEvent(event);
             if (event.type === "tool-result") outcome = "skill_error";

--- a/ornn-api/src/domains/skills/crud/authorize.ts
+++ b/ornn-api/src/domains/skills/crud/authorize.ts
@@ -44,6 +44,9 @@ export interface ActorContext {
   isPlatformAdmin: boolean;
 }
 
+/** Internal/system caller — bypasses visibility (mirror, server-side jobs). */
+export const SYSTEM_ACTOR: ActorContext = { userId: "__system__", memberships: [], isPlatformAdmin: true };
+
 /** Returns true when `actor` is allowed to read the skill. */
 export function canReadSkill(skill: SkillOwnership, actor: ActorContext): boolean {
   if (!skill.isPrivate) return true;

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -565,29 +565,31 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       const version = c.req.query("version");
       logger.info({ idOrName, version: version ?? null }, "Skill jsonize request");
 
+      // Build the caller's actor once — `requirePermission` above
+      // guarantees authCtx is set. Used both for the defense-in-depth
+      // pre-check below and threaded into the service call (#806).
+      const authCtxForVisibility = c.get("auth");
+      if (!authCtxForVisibility) {
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+      }
+      const memberships = await readUserOrgMemberships(c);
+      const actor = {
+        userId: authCtxForVisibility.userId,
+        memberships,
+        isPlatformAdmin: authCtxForVisibility.permissions.includes("ornn:admin:skill"),
+      };
+
       // Visibility check (#567) — the package contents endpoint must
       // not be more permissive than the metadata endpoint. Load the
       // skill first and reject inaccessible private skills with the
-      // same `SKILL_NOT_FOUND` shape `/skills/:idOrName` uses.
+      // same `SKILL_NOT_FOUND` shape `/skills/:idOrName` uses. Kept as
+      // defense-in-depth on top of the service-level gate (#806).
       const skill = await skillService.getSkill(idOrName);
-      if (skill.isPrivate) {
-        const authCtx = c.get("auth");
-        // `requirePermission` above guarantees authCtx is set.
-        if (!authCtx) {
-          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
-        }
-        const memberships = await readUserOrgMemberships(c);
-        const actor = {
-          userId: authCtx.userId,
-          memberships,
-          isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
-        };
-        if (!canReadSkill(skill, actor)) {
-          throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
-        }
+      if (skill.isPrivate && !canReadSkill(skill, actor)) {
+        throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
       }
 
-      const result = await skillService.getSkillJson(idOrName, version);
+      const result = await skillService.getSkillJson(idOrName, actor, version);
       // Programmatic pull — closest signal to the north-star metric.
       // Fire-and-forget; the analytics service swallows its own errors.
       const authCtx = c.get("auth");

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -1,0 +1,133 @@
+/**
+ * #806 — object-level authorization (BOLA / OWASP API1) for
+ * `SkillService.getSkillJson`.
+ *
+ * The package-contents path used to download + return any skill's full
+ * source (incl. embedded secrets) with no visibility check. These tests
+ * lock the gate in at the service layer so every caller — playground,
+ * mirror, the `/json` route — is protected by one policy:
+ *
+ *   - private skill + stranger actor → `skill_not_found`, NO download
+ *   - SYSTEM_ACTOR / owner / platform admin → succeed
+ *   - public skill → succeeds for any actor
+ *
+ * Run as a Bun unit test: the only repo method reached before the
+ * visibility gate is `findByGuid`, so the deny cases need no storage.
+ * The allow cases use an in-memory zip served via a `data:` URL so the
+ * download + extraction runs hermetically (no MinIO, no network).
+ */
+
+import { describe, expect, it } from "bun:test";
+import JSZip from "jszip";
+import { SkillService } from "./service";
+import { SYSTEM_ACTOR, type ActorContext } from "./authorize";
+import type { SkillRepository } from "./repository";
+import type { SkillVersionRepository } from "./skillVersionRepository";
+import type { IStorageClient } from "../../../clients/storageClient";
+import type { SkillDocument } from "../../../shared/types/index";
+import { AppError } from "../../../shared/types/index";
+
+const SECRET_BODY = "SECRET_FROM_PACKAGE_b91c";
+
+/** Build a one-file zip and hand it back as a fetchable `data:` URL. */
+async function zipDataUrl(): Promise<string> {
+  const zip = new JSZip();
+  zip.file("SKILL.md", `# demo\n${SECRET_BODY}`);
+  const buf = await zip.generateAsync({ type: "uint8array" });
+  return `data:application/zip;base64,${Buffer.from(buf).toString("base64")}`;
+}
+
+/** Minimal SkillDocument carrying just the fields getSkillJson reads. */
+function makeSkillDoc(overrides: Partial<SkillDocument> = {}): SkillDocument {
+  return {
+    guid: "guid-1",
+    name: "demo-skill",
+    description: "A demo skill.",
+    metadata: {} as SkillDocument["metadata"],
+    storageKey: "skills/guid-1/1.0.zip",
+    latestVersion: "1.0",
+    createdBy: "owner-1",
+    isPrivate: true,
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    ...overrides,
+  } as SkillDocument;
+}
+
+function makeService(skill: SkillDocument, presignedUrl: string): SkillService {
+  const skillRepo = {
+    findByGuid: async (guid: string) => (guid === skill.guid ? skill : null),
+    findByName: async (name: string) => (name === skill.name ? skill : null),
+  } as unknown as SkillRepository;
+  const skillVersionRepo = {} as unknown as SkillVersionRepository;
+  const storageClient = {
+    getPresignedUrl: async () => ({ presignedUrl, expiresAt: new Date().toISOString() }),
+  } as unknown as IStorageClient;
+  return new SkillService({
+    skillRepo,
+    skillVersionRepo,
+    storageClient,
+    storageBucketResolver: async () => "test-bucket",
+  });
+}
+
+const STRANGER: ActorContext = { userId: "stranger", memberships: [], isPlatformAdmin: false };
+const OWNER: ActorContext = { userId: "owner-1", memberships: [], isPlatformAdmin: false };
+const ADMIN: ActorContext = { userId: "admin-1", memberships: [], isPlatformAdmin: true };
+
+describe("SkillService.getSkillJson — object-level authorization (#806)", () => {
+  it("private skill + stranger actor throws skill_not_found before any download", async () => {
+    let downloaded = false;
+    const storageClient = {
+      getPresignedUrl: async () => {
+        downloaded = true;
+        return { presignedUrl: "http://unused", expiresAt: "" };
+      },
+    } as unknown as IStorageClient;
+    const skill = makeSkillDoc({ isPrivate: true });
+    const service = new SkillService({
+      skillRepo: {
+        findByGuid: async () => skill,
+        findByName: async () => null,
+      } as unknown as SkillRepository,
+      skillVersionRepo: {} as unknown as SkillVersionRepository,
+      storageClient,
+      storageBucketResolver: async () => "test-bucket",
+    });
+
+    let thrown: unknown;
+    try {
+      await service.getSkillJson("guid-1", STRANGER);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("skill_not_found");
+    // Gate runs before storage — no presigned URL was ever requested.
+    expect(downloaded).toBe(false);
+  });
+
+  it("private skill succeeds for SYSTEM_ACTOR and returns package contents", async () => {
+    const service = makeService(makeSkillDoc({ isPrivate: true }), await zipDataUrl());
+    const result = await service.getSkillJson("guid-1", SYSTEM_ACTOR);
+    expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
+  });
+
+  it("private skill succeeds for the author", async () => {
+    const service = makeService(makeSkillDoc({ isPrivate: true, createdBy: "owner-1" }), await zipDataUrl());
+    const result = await service.getSkillJson("guid-1", OWNER);
+    expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
+  });
+
+  it("private skill succeeds for a platform admin", async () => {
+    const service = makeService(makeSkillDoc({ isPrivate: true }), await zipDataUrl());
+    const result = await service.getSkillJson("guid-1", ADMIN);
+    expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
+  });
+
+  it("public skill succeeds for any actor (including a stranger)", async () => {
+    const service = makeService(makeSkillDoc({ isPrivate: false }), await zipDataUrl());
+    const result = await service.getSkillJson("guid-1", STRANGER);
+    expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
+  });
+});

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -14,6 +14,7 @@ import { AppError } from "../../../shared/types/index";
 import { fetchSkillFromGitHub, parseGithubUrl, type GitHubPullInput } from "./utils/githubPull";
 import { computeVersionDiff, type VersionDiffResult } from "./utils/versionDiff";
 import { isReservedVerb } from "../../../shared/reservedVerbs";
+import { canReadSkill, type ActorContext } from "./authorize";
 
 /**
  * Convert the stored hex `skillHash` into npm-style Subresource Integrity
@@ -1140,9 +1141,16 @@ export class SkillService {
    *
    * When `version` is omitted the response is the latest package — same
    * as before.
+   *
+   * #806 — object-level authorization (BOLA / OWASP API1). `actor` is a
+   * REQUIRED arg: the loaded skill doc is run through `canReadSkill`
+   * before any storage download, so a private skill the actor cannot
+   * read surfaces as `skill_not_found` instead of leaking its package
+   * (incl. embedded secrets). Trusted server jobs pass `SYSTEM_ACTOR`.
    */
   async getSkillJson(
     idOrName: string,
+    actor: ActorContext,
     version?: string,
   ): Promise<{
     name: string;
@@ -1157,6 +1165,17 @@ export class SkillService {
       skill = await this.skillRepo.findByName(idOrName);
     }
     if (!skill) {
+      throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+    }
+
+    // 1.5 Object-level authorization (#806, BOLA / OWASP API1). The
+    //      package-contents path must not be more permissive than the
+    //      metadata path: a private skill the actor cannot read is
+    //      denied here, before any storage download, with the same
+    //      `skill_not_found` shape so existence isn't leaked. Never log
+    //      file contents or secrets — only ids.
+    if (!canReadSkill(skill, actor)) {
+      logger.info({ idOrName, actorUserId: actor.userId }, "getSkillJson visibility denied");
       throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
     }
 

--- a/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
@@ -22,6 +22,7 @@ import { MirrorService, type MirrorSettingsReader } from "./mirrorService";
 import type { GitHubMirrorClient, TreeEntry } from "./githubMirrorClient";
 import type { SkillRepository } from "../crud/repository";
 import type { SkillService } from "../crud/service";
+import type { ActorContext } from "../crud/authorize";
 import type { SkillDocument } from "../../../shared/types/index";
 import type { MirrorSection } from "../../settings/sections/mirror";
 
@@ -156,9 +157,11 @@ function makeFakeSkillService(
   filesByGuid: Record<string, Record<string, string>>,
 ): SkillService {
   return {
-    getSkillJson: mock(async (idOrName: string) => ({
+    // Signature mirrors the #806 service change: (idOrName, actor, version?).
+    getSkillJson: mock(async (idOrName: string, _actor: ActorContext, _version?: string) => ({
       name: "demo-skill",
       description: "A test skill.",
+      version: "1.0",
       metadata: { category: "plain" },
       files: filesByGuid[idOrName] ?? {},
     })),

--- a/ornn-api/src/domains/skills/mirror/mirrorService.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.ts
@@ -28,6 +28,7 @@ import { GitHubAppAuth } from "./githubAppAuth";
 import { GitHubMirrorClient, type TreeEntry } from "./githubMirrorClient";
 import type { SkillRepository } from "../crud/repository";
 import type { SkillService } from "../crud/service";
+import { SYSTEM_ACTOR } from "../crud/authorize";
 import type { SkillDocument } from "../../../shared/types/index";
 import type { MirrorSection } from "../../settings/sections/mirror";
 
@@ -353,8 +354,10 @@ export class MirrorService {
    */
   private async buildSkillFolder(skill: SkillDocument): Promise<Map<string, string>> {
     // Reuse the existing `/skills/:id/json` extraction so we don't
-    // duplicate ZIP logic. Pulls latest version.
-    const json = await this.deps.skillService.getSkillJson(skill.guid);
+    // duplicate ZIP logic. Pulls latest version. Mirror is a trusted
+    // server job, so it reads with SYSTEM_ACTOR (#806) — the eligibility
+    // filter already guarantees only fully-public skills reach here.
+    const json = await this.deps.skillService.getSkillJson(skill.guid, SYSTEM_ACTOR);
     const out = new Map<string, string>();
     for (const [path, content] of Object.entries(json.files)) {
       // Drop README.md from the package if any, since we're writing


### PR DESCRIPTION
Closes #806

Automated change by `/auto` (run `20260604T053431Z-72549`, runner `auto-runner-20260604T053431Z-72549-iter1`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
