### PR TITLE
[Bug] Reject path-traversal skill names on the skip_validation import path

### DIFF
--- a/.changeset/auto-807-skill-name-traversal.md
+++ b/.changeset/auto-807-skill-name-traversal.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Reject path-traversal skill names on the `skip_validation` import path. The lenient frontmatter extractor now enforces the same kebab-case name rule as the strict path, and the GitHub-mirror folder builder refuses unsafe names, preventing a crafted skill name from writing outside its own folder in the public mirror.

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -131,3 +131,65 @@ describe("SkillService.getSkillJson — object-level authorization (#806)", () =
     expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
   });
 });
+
+/**
+ * #807 (CWE-22) — `extractSkillInfoLenient` is the `skip_validation=true`
+ * import path. It used to accept ANY non-empty `name`, including
+ * `../evil` / `/etc/passwd` / `..`, which then flowed into the public-
+ * mirror blob paths and could escape the skill's own `<name>/` subtree.
+ * The lenient path must now enforce the SAME kebab-case rule the strict
+ * Zod schema enforces.
+ *
+ * The method is private; we reach it via a cast (the file already casts
+ * deps to stubs elsewhere). It's a pure transform — no storage / repo
+ * call happens before the name guard — so empty stubs are sufficient.
+ */
+describe("SkillService.extractSkillInfoLenient — kebab-case name guard (#807)", () => {
+  function makeLenientService(): SkillService {
+    return new SkillService({
+      skillRepo: {} as unknown as SkillRepository,
+      skillVersionRepo: {} as unknown as SkillVersionRepository,
+      storageClient: {} as unknown as IStorageClient,
+      storageBucketResolver: async () => "test-bucket",
+    });
+  }
+
+  /** Call the private method through a typed cast. */
+  function callLenient(raw: Record<string, unknown>): { name: string } {
+    const svc = makeLenientService() as unknown as {
+      extractSkillInfoLenient: (r: Record<string, unknown>) => { name: string };
+    };
+    return svc.extractSkillInfoLenient(raw);
+  }
+
+  const TRAVERSAL_NAMES = [
+    "../evil",
+    "/etc/passwd",
+    "..",
+    "a/b",
+    "a\\b",
+    "Foo",
+    "a.b",
+    "-lead",
+    "a".repeat(65),
+  ];
+
+  for (const name of TRAVERSAL_NAMES) {
+    it(`rejects ${JSON.stringify(name)} with frontmatter_validation_failed`, () => {
+      let thrown: unknown;
+      try {
+        callLenient({ name });
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AppError);
+      expect((thrown as AppError).code).toBe("frontmatter_validation_failed");
+      expect((thrown as AppError).statusCode).toBe(400);
+    });
+  }
+
+  it("accepts a valid kebab-case name and returns it unchanged", () => {
+    const result = callLenient({ name: "valid-skill-1" });
+    expect(result.name).toBe("valid-skill-1");
+  });
+});

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -30,7 +30,11 @@ function hexToIntegrity(hex: string): string {
   }
   return `sha256-${Buffer.from(bytes).toString("base64")}`;
 }
-import { validateSkillFrontmatter } from "../../../shared/schemas/skillFrontmatter";
+import {
+  validateSkillFrontmatter,
+  SKILL_NAME_REGEX,
+  SKILL_NAME_MAX,
+} from "../../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../../shared/utils/zip";
 import { parseVersion, isGreater } from "./version";
 import { diffSkillInterface, type InterfaceChange } from "./interfaceDiff";
@@ -1536,6 +1540,19 @@ export class SkillService {
         "name: required (cannot be derived under skipValidation either)",
       );
     }
+    // #807 (CWE-22): the strict path rejects non-kebab-case names via the
+    // Zod schema; the lenient path bypassed it, so a crafted name (`../`,
+    // `/etc/passwd`, `..`) flowed straight into the public-mirror blob
+    // paths and could escape the skill's own `<name>/` subtree. Enforce
+    // the SAME kebab-case rule here so `skipValidation` can never widen
+    // the name surface beyond the strict path.
+    if (name.length > SKILL_NAME_MAX || !SKILL_NAME_REGEX.test(name)) {
+      logger.warn({ name }, "skipValidation: rejecting non-kebab-case skill name");
+      throw AppError.badRequest(
+        "frontmatter_validation_failed",
+        `name: must be kebab-case (^[a-z0-9][a-z0-9-]*$, <= ${SKILL_NAME_MAX} chars)`,
+      );
+    }
     const description =
       typeof raw.description === "string" ? raw.description : "";
     const version =
@@ -1699,10 +1716,12 @@ export class SkillService {
     const allPaths = Object.keys(zip.files);
     const { rootFolderName, rootEntries, getFile } = resolveZipRoot(zip, allPaths);
 
-    const KEBAB_RE = /^[a-z0-9][a-z0-9-]*$/;
+    // #807: reuse the canonical kebab-case rule (was a duplicate local
+    // regex) so folder-name validation can never drift from the name rule
+    // enforced on the create/import path.
     const ALLOWED_ROOT = new Set(["SKILL.md", "scripts", "references", "assets"]);
 
-    if (rootFolderName && !KEBAB_RE.test(rootFolderName)) {
+    if (rootFolderName && !SKILL_NAME_REGEX.test(rootFolderName)) {
       violations.push({
         rule: "folder-name-kebab-case",
         message: `Package folder name "${rootFolderName}" must be kebab-case.`,

--- a/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
@@ -340,3 +340,63 @@ describe("MirrorService idempotency", () => {
     expect(result.unchanged).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe("MirrorService path-traversal guard (#807, CWE-22)", () => {
+  it("removeSkill throws on a traversal name before touching the mirror", async () => {
+    const { github, calls } = makeFakeGithub({
+      currentTree: [
+        { path: "../evil/SKILL.md", mode: "100644", type: "blob", sha: "x" },
+      ],
+    });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([]),
+      skillService: makeFakeSkillService({}),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+    // `removeSkill(name)` reaches `commitSkillFolderChange` directly with
+    // the raw name — the guard at the top must reject it.
+    await expect(svc.removeSkill("../evil")).rejects.toThrow(/unsafe mirror skill folder name/i);
+    // Nothing was written to the mirror.
+    expect(calls.trees.length).toBe(0);
+    expect(calls.commits.length).toBe(0);
+    expect(calls.tags.length).toBe(0);
+  });
+
+  it("reconcileAll skips a malformed-name skill but still mirrors the good one", async () => {
+    const goodSkill = makeSkill({ guid: "g-good", name: "good-skill", isPrivate: false });
+    // Malformed name that would escape its subtree if interpolated.
+    const badSkill = makeSkill({ guid: "g-bad", name: "../escape", isPrivate: false });
+    const { github, calls } = makeFakeGithub();
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([goodSkill, badSkill]),
+      skillService: makeFakeSkillService({
+        "g-good": { "SKILL.md": "# good" },
+        "g-bad": { "SKILL.md": "# bad" },
+      }),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+    // The whole sweep must NOT abort because of one poisoned row.
+    const result = await svc.reconcileAll();
+
+    // Every path written stays inside a safe `<name>/` prefix — nothing
+    // escapes via `../`, and the bad skill's name appears in no path.
+    for (const tree of calls.trees) {
+      for (const entry of tree.entries) {
+        expect(entry.path).not.toContain("..");
+        expect(entry.path.startsWith("../escape")).toBe(false);
+      }
+    }
+    // The good skill WAS mirrored (its SKILL.md got uploaded).
+    const goodMirrored = calls.blobs.some((b) => b.content === "# good");
+    expect(goodMirrored).toBe(true);
+    // The bad skill's content never reached the mirror.
+    const badMirrored = calls.blobs.some((b) => b.content === "# bad");
+    expect(badMirrored).toBe(false);
+    // The sweep produced a commit (the good skill is a real add).
+    expect(result.added).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/ornn-api/src/domains/skills/mirror/mirrorService.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.ts
@@ -31,6 +31,7 @@ import type { SkillService } from "../crud/service";
 import { SYSTEM_ACTOR } from "../crud/authorize";
 import type { SkillDocument } from "../../../shared/types/index";
 import type { MirrorSection } from "../../settings/sections/mirror";
+import { SKILL_NAME_REGEX, SKILL_NAME_MAX } from "../../../shared/schemas/skillFrontmatter";
 
 const logger = createLogger("mirrorService");
 
@@ -260,6 +261,16 @@ export class MirrorService {
     const desired = new Map<string, string>(); // path → content
     const skillByName = new Map<string, { guid: string; version: string }>();
     for (const skill of eligible) {
+      // #807 (CWE-22): skip — do NOT abort — a row whose name would
+      // escape its `<name>/` subtree. One poisoned row must not stop the
+      // whole sweep from mirroring every other (safe) skill.
+      if (!SKILL_NAME_REGEX.test(skill.name) || skill.name.length > SKILL_NAME_MAX) {
+        logger.error(
+          { guid: skill.guid, name: skill.name },
+          "reconcileAll: skipping skill with unsafe folder name",
+        );
+        continue;
+      }
       skillByName.set(skill.name, { guid: skill.guid, version: skill.latestVersion });
       const folder = await this.buildSkillFolder(skill);
       for (const [relPath, content] of folder) {
@@ -473,12 +484,31 @@ export class MirrorService {
    * reconcile (first-push bootstrap). Callers use the return value to
    * decide whether to stamp `mirrorSync` on the DB.
    */
+  /**
+   * Defense-in-depth (#807, CWE-22): the create/import path already
+   * rejects non-kebab-case names, but a row that predates that fix (or
+   * one written by some future path) could still carry a name like
+   * `../evil` or `a/b`. Every site that interpolates `skill.name` into a
+   * mirror blob path runs this guard first so a poisoned name can never
+   * escape its own `<name>/` subtree in the public mirror repo.
+   */
+  private assertSafeSkillFolder(name: string): void {
+    if (!SKILL_NAME_REGEX.test(name) || name.length > SKILL_NAME_MAX) {
+      logger.error({ name }, "mirror: refusing unsafe skill folder name");
+      throw new Error(`Unsafe mirror skill folder name: ${name}`);
+    }
+  }
+
   private async commitSkillFolderChange(
     client: GitHubMirrorClient,
     skillName: string,
     desired: Map<string, string> | null,
     op: "publish" | "remove",
   ): Promise<{ sha: string; committedAt: Date } | null> {
+    // Guard before any path interpolation. Throwing is correct here: the
+    // call is scoped to a single skill (publishSkill / removeSkill), so a
+    // bad name fails just that operation, never a batch.
+    this.assertSafeSkillFolder(skillName);
     const headCommit = await client.getDefaultBranchHead();
     if (!headCommit) {
       // First-ever push — bootstrap requires an initial commit. Defer

--- a/ornn-api/src/shared/schemas/skillFrontmatter.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.ts
@@ -161,9 +161,21 @@ export const refinedMetadataSchema = metadataSchema.superRefine((data, ctx) => {
  */
 export const SKILL_VERSION_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
+/**
+ * Canonical skill-name shape: kebab-case, must start with a lowercase
+ * letter or digit. Single source of truth — consumed by the strict
+ * frontmatter schema, the lenient (`skipValidation`) extractor, the ZIP
+ * folder-name check, and the GitHub-mirror folder-name guard. This regex
+ * already rejects `/`, `\`, `.`, `..`, a leading `-`, and uppercase, so
+ * a skill name can never escape its `<name>/` subtree on the public
+ * mirror (CWE-22 path traversal, #807).
+ */
+export const SKILL_NAME_REGEX = /^[a-z0-9][a-z0-9-]*$/;
+export const SKILL_NAME_MAX = 64;
+
 // Full frontmatter schema
 export const skillFrontmatterSchema = z.object({
-  name: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/, "Name must be kebab-case"),
+  name: z.string().min(1).max(SKILL_NAME_MAX).regex(SKILL_NAME_REGEX, "Name must be kebab-case"),
   description: z.string().min(1).max(1024),
   // YAML parses `version: 0.1` (unquoted) as a float and `1.0` as an
   // integer `1`, which both lose the intended two-digit shape. We require


### PR DESCRIPTION
Closes #807

Automated change by `/auto` (run `20260604T053431Z-72549`, runner `auto-runner-20260604T053431Z-72549-iter2`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
