### PR TITLE
[Bug] Atomically reserve quota to prevent concurrent over-cap (TOCTOU)

### DIFF
--- a/.changeset/auto-808-quota-toctou.md
+++ b/.changeset/auto-808-quota-toctou.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Close a quota time-of-check/time-of-use race: the per-user/surface quota is now reserved atomically at check time (a conditional increment guarded by the cap) instead of being read first and charged after the LLM call, so concurrent requests can no longer exceed the cap. Failed or aborted calls release the reservation.

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -105,18 +105,13 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
 
       logger.info({ userId: authCtx.userId, messageCount: parsed.messages.length }, "Chat request");
 
-      // Quota check — rejects with 429 BEFORE any LLM cost is incurred.
-      // Admins bypass via permission inside the service.
-      const decision = await quotaService.checkAllowed({
-        userId: authCtx.userId,
-        permissions: authCtx.permissions,
-        surface: "playground",
-      });
-      if (!decision.allowed) throwQuotaError(decision);
-
       // Resolve the model — explicit `modelId` (validated against the
       // surface's enabled list) or the admin-set default. 503 when no
-      // models are enabled for the playground surface.
+      // models are enabled for the playground surface. This (and the
+      // org-membership read below) run BEFORE the quota reserve so a
+      // model/auth failure can't strand a reserved slot (#808) — both
+      // are pure reads that touch no LLM, so "429 before LLM cost" still
+      // holds.
       const resolution = await llmProvidersService.resolveModel({
         surface: "playground",
         // exactOptionalPropertyTypes (#657)
@@ -138,6 +133,20 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
         memberships,
         isPlatformAdmin: authCtx.permissions.includes("ornn:admin:skill"),
       };
+
+      // Quota reserve — atomically claims a slot under the cap guard and
+      // rejects with 429 BEFORE any LLM cost is incurred (#808). Runs
+      // last among the pre-stream awaits: from here to the producer's
+      // `finally` (which always calls chargeOnCompletion) nothing can
+      // throw, so a reserved slot is always reconciled (committed on
+      // success, released on system_error/abort). Admins bypass inside
+      // the service and take no reservation.
+      const decision = await quotaService.checkAllowed({
+        userId: authCtx.userId,
+        permissions: authCtx.permissions,
+        surface: "playground",
+      });
+      if (!decision.allowed) throwQuotaError(decision);
 
       // Record a `playground` pull if the chat is bound to a skill. The
       // chat service loads the skill internally; we duplicate the lookup

--- a/ornn-api/src/domains/quota/repository.test.ts
+++ b/ornn-api/src/domains/quota/repository.test.ts
@@ -1,8 +1,9 @@
 /**
- * QuotaRepository UT-QUOTAREPO-001..007 against an in-memory Mongo.
+ * QuotaRepository UT-QUOTAREPO-001..010 against an in-memory Mongo.
  *
- * Exercises the persistence layer (atomic $inc, upsert idempotence,
- * chronological lifetime, append-only audit, indexes).
+ * Exercises the persistence layer: the atomic cap-guarded reserve
+ * (#808 TOCTOU fix), per-model commit, slot release, upsert idempotence,
+ * chronological lifetime, append-only audit, indexes.
  *
  * @module domains/quota/repository.test
  */
@@ -11,7 +12,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:tes
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { MongoClient, type Db } from "mongodb";
 import { QuotaRepository } from "./repository";
-import { bucketId } from "./types";
+import { bucketId, type QuotaBucketDoc } from "./types";
 
 let mongo: MongoMemoryServer;
 let client: MongoClient;
@@ -37,103 +38,256 @@ beforeEach(async () => {
   await db.collection("quota_grants_audit").deleteMany({});
 });
 
-describe("UT-QUOTAREPO-001 incrementUsed creates new bucket", () => {
-  test("upsert creates doc with monthStart/monthEnd, defaults, used=1", async () => {
-    const now = new Date(Date.UTC(2026, 4, 15));
-    const b = await repo.incrementUsed({
+const NOW = new Date(Date.UTC(2026, 4, 15));
+const MARKER = "2026-05";
+
+/** Seed a bucket directly so a test can start from a precise counter. */
+async function seedBucket(overrides: Partial<QuotaBucketDoc>): Promise<void> {
+  const _id = bucketId("u1", "playground", MARKER);
+  await db.collection<QuotaBucketDoc>("quota_buckets").insertOne({
+    _id,
+    userId: "u1",
+    surface: "playground",
+    monthMarker: MARKER,
+    monthStart: new Date(Date.UTC(2026, 4, 1)),
+    monthEnd: new Date(Date.UTC(2026, 5, 1)),
+    defaultAllotment: 100,
+    adminGrant: 0,
+    used: 0,
+    usedByModel: {},
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  });
+}
+
+describe("UT-QUOTAREPO-001 reserveSlot creates new bucket on first touch", () => {
+  test("first reserve inserts doc with monthStart/monthEnd, defaults, used=1", async () => {
+    const ok = await repo.reserveSlot({
       userId: "u1",
       surface: "playground",
-      modelId: "gpt-4o",
-      defaultAllotment: 100,
-      now,
+      effectiveDefault: 100,
+      now: NOW,
     });
-    expect(b.userId).toBe("u1");
-    expect(b.surface).toBe("playground");
-    expect(b.monthMarker).toBe("2026-05");
-    expect(b.monthStart.toISOString()).toBe("2026-05-01T00:00:00.000Z");
-    expect(b.monthEnd.toISOString()).toBe("2026-06-01T00:00:00.000Z");
-    expect(b.defaultAllotment).toBe(100);
-    expect(b.adminGrant).toBe(0);
-    expect(b.used).toBe(1);
-    expect(b.usedByModel["gpt-4o"]).toBe(1);
+    expect(ok).toBe(true);
+    const b = await repo.findBucket("u1", "playground", MARKER);
+    expect(b?.userId).toBe("u1");
+    expect(b?.surface).toBe("playground");
+    expect(b?.monthMarker).toBe(MARKER);
+    expect(b?.monthStart.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    expect(b?.monthEnd.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    expect(b?.defaultAllotment).toBe(100);
+    expect(b?.adminGrant).toBe(0);
+    expect(b?.used).toBe(1);
+    expect(b?.usedByModel).toEqual({});
+  });
+
+  test("effectiveDefault < 1 denies and creates nothing", async () => {
+    const ok = await repo.reserveSlot({
+      userId: "u1",
+      surface: "playground",
+      effectiveDefault: 0,
+      now: NOW,
+    });
+    expect(ok).toBe(false);
+    expect(await repo.findBucket("u1", "playground", MARKER)).toBeNull();
   });
 });
 
-describe("UT-QUOTAREPO-002 upsert is idempotent on _id", () => {
-  test("two increments share the same _id; second hit increments used", async () => {
-    const now = new Date(Date.UTC(2026, 4, 15));
-    const id = bucketId("u1", "playground", "2026-05");
-    await repo.incrementUsed({
+describe("UT-QUOTAREPO-002 reserveSlot honours the cap on an existing bucket", () => {
+  test("reserve allowed below cap, denied at cap; used never exceeds cap", async () => {
+    // cap = effectiveDefault(100) + adminGrant(0) = 100.
+    await seedBucket({ used: 99 });
+    const first = await repo.reserveSlot({
       userId: "u1",
       surface: "playground",
-      modelId: "m",
-      defaultAllotment: 100,
-      now,
+      effectiveDefault: 100,
+      now: NOW,
     });
-    await repo.incrementUsed({
+    expect(first).toBe(true); // used 99 -> 100
+    const second = await repo.reserveSlot({
       userId: "u1",
       surface: "playground",
-      modelId: "m",
-      defaultAllotment: 100,
-      now,
+      effectiveDefault: 100,
+      now: NOW,
     });
-    const docs = await db
-      .collection("quota_buckets")
-      .find({ userId: "u1", surface: "playground" })
-      .toArray();
-    expect(docs.length).toBe(1);
-    expect(docs[0]!._id as unknown as string).toBe(id);
-    expect((docs[0]! as unknown as { used: number }).used).toBe(2);
+    expect(second).toBe(false); // 100 == cap, denied
+    expect((await repo.findBucket("u1", "playground", MARKER))?.used).toBe(100);
+  });
+
+  test("adminGrant lifts the cap", async () => {
+    await seedBucket({ used: 100, adminGrant: 5 });
+    const ok = await repo.reserveSlot({
+      userId: "u1",
+      surface: "playground",
+      effectiveDefault: 100,
+      now: NOW,
+    });
+    expect(ok).toBe(true); // cap now 105, used 100 -> 101
+    expect((await repo.findBucket("u1", "playground", MARKER))?.used).toBe(101);
   });
 });
 
-describe("UT-QUOTAREPO-003 incrementUsed atomic under concurrency", () => {
-  test("50 parallel increments → used==50", async () => {
-    const now = new Date(Date.UTC(2026, 4, 15));
-    await Promise.all(
-      Array.from({ length: 50 }, () =>
-        repo.incrementUsed({
+describe("UT-QUOTAREPO-003 reserveSlot is atomic under concurrency (TOCTOU)", () => {
+  test("K=20 parallel reserves at used=cap-1 → exactly 1 wins, used==cap", async () => {
+    const cap = 100;
+    await seedBucket({ used: cap - 1, defaultAllotment: cap });
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () =>
+        repo.reserveSlot({
           userId: "u1",
           surface: "playground",
-          modelId: "gpt-4o",
-          defaultAllotment: 1000,
-          now,
+          effectiveDefault: cap,
+          now: NOW,
         }),
       ),
     );
-    const b = await repo.findBucket("u1", "playground", "2026-05");
-    expect(b?.used).toBe(50);
-    expect(b?.usedByModel["gpt-4o"]).toBe(50);
+
+    const granted = results.filter((r) => r === true).length;
+    expect(granted).toBe(1);
+    expect(results.filter((r) => r === false).length).toBe(19);
+    const b = await repo.findBucket("u1", "playground", MARKER);
+    expect(b?.used).toBe(cap); // never cap+1
+  });
+
+  test("K=20 parallel reserves on first touch (no bucket) → 1 creates, rest race the cap", async () => {
+    // effectiveDefault 1 means exactly one slot total. The insert race
+    // (E11000) must collapse to a single winner.
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () =>
+        repo.reserveSlot({
+          userId: "u1",
+          surface: "playground",
+          effectiveDefault: 1,
+          now: NOW,
+        }),
+      ),
+    );
+    expect(results.filter((r) => r === true).length).toBe(1);
+    expect((await repo.findBucket("u1", "playground", MARKER))?.used).toBe(1);
   });
 });
 
-describe("UT-QUOTAREPO-004 incrementUsed updates used + usedByModel together", () => {
-  test("single op writes both fields atomically", async () => {
-    const now = new Date(Date.UTC(2026, 4, 15));
-    await repo.incrementUsed({
+describe("UT-QUOTAREPO-004 releaseSlot refunds a reservation", () => {
+  test("reserve then release returns used to baseline", async () => {
+    await seedBucket({ used: 50 });
+    await repo.reserveSlot({
+      userId: "u1",
+      surface: "playground",
+      effectiveDefault: 100,
+      now: NOW,
+    });
+    expect((await repo.findBucket("u1", "playground", MARKER))?.used).toBe(51);
+    await repo.releaseSlot({ userId: "u1", surface: "playground", now: NOW });
+    expect((await repo.findBucket("u1", "playground", MARKER))?.used).toBe(50);
+  });
+
+  test("releaseSlot at used=0 is a no-op (floored, never negative)", async () => {
+    await seedBucket({ used: 0 });
+    await repo.releaseSlot({ userId: "u1", surface: "playground", now: NOW });
+    expect((await repo.findBucket("u1", "playground", MARKER))?.used).toBe(0);
+  });
+
+  test("releaseSlot on a missing bucket is a no-op", async () => {
+    await repo.releaseSlot({ userId: "ghost", surface: "playground", now: NOW });
+    expect(await repo.findBucket("ghost", "playground", MARKER)).toBeNull();
+  });
+});
+
+describe("UT-QUOTAREPO-005 commitModel records usedByModel without touching used", () => {
+  test("commit increments usedByModel.<id>; used unchanged", async () => {
+    await seedBucket({ used: 1 });
+    await repo.commitModel({
       userId: "u1",
       surface: "playground",
       modelId: "gpt-4o",
-      defaultAllotment: 100,
-      now,
+      now: NOW,
     });
-    await repo.incrementUsed({
-      userId: "u1",
-      surface: "playground",
-      modelId: "claude-sonnet",
-      defaultAllotment: 100,
-      now,
-    });
-    const b = await repo.findBucket("u1", "playground", "2026-05");
+    const b = await repo.findBucket("u1", "playground", MARKER);
+    expect(b?.used).toBe(1); // reserve already bumped this — commit must not
+    expect(b?.usedByModel["gpt-4o"]).toBe(1);
+  });
+
+  test("two commits with different models tally separately", async () => {
+    await seedBucket({ used: 2 });
+    await repo.commitModel({ userId: "u1", surface: "playground", modelId: "gpt-4o", now: NOW });
+    await repo.commitModel({ userId: "u1", surface: "playground", modelId: "claude-sonnet", now: NOW });
+    const b = await repo.findBucket("u1", "playground", MARKER);
     expect(b?.used).toBe(2);
     expect(b?.usedByModel["gpt-4o"]).toBe(1);
     expect(b?.usedByModel["claude-sonnet"]).toBe(1);
   });
+
+  test("null modelId routes to __unknown__ sentinel", async () => {
+    await seedBucket({ used: 1 });
+    await repo.commitModel({ userId: "u1", surface: "playground", modelId: null, now: NOW });
+    expect((await repo.findBucket("u1", "playground", MARKER))?.usedByModel["__unknown__"]).toBe(1);
+  });
 });
 
-describe("UT-QUOTAREPO-005 appendGrantAudit inserts row with all spec fields", () => {
+describe("UT-QUOTAREPO-006 reserve + commit models the full charge lifecycle", () => {
+  test("reserve then commit → used=1, usedByModel.<id>=1 (matches legacy increment)", async () => {
+    await repo.reserveSlot({ userId: "u1", surface: "playground", effectiveDefault: 100, now: NOW });
+    await repo.commitModel({ userId: "u1", surface: "playground", modelId: "gpt-4o", now: NOW });
+    const b = await repo.findBucket("u1", "playground", MARKER);
+    expect(b?.used).toBe(1);
+    expect(b?.usedByModel["gpt-4o"]).toBe(1);
+  });
+});
+
+describe("UT-QUOTAREPO-007 findLifetime sorts asc by monthMarker", () => {
+  test("3 buckets seeded out of order → returned chronologically", async () => {
+    const months = [
+      { marker: "2026-04", date: new Date(Date.UTC(2026, 3, 15)) },
+      { marker: "2026-06", date: new Date(Date.UTC(2026, 5, 15)) },
+      { marker: "2026-05", date: new Date(Date.UTC(2026, 4, 15)) },
+    ];
+    for (const { date } of months) {
+      await repo.reserveSlot({
+        userId: "u1",
+        surface: "playground",
+        effectiveDefault: 100,
+        now: date,
+      });
+    }
+    const lifetime = await repo.findLifetime("u1", "playground");
+    expect(lifetime.map((b) => b.monthMarker)).toEqual(["2026-04", "2026-05", "2026-06"]);
+  });
+});
+
+describe("UT-QUOTAREPO-008 findLifetime returns [] for new user", () => {
+  test("empty array, not null", async () => {
+    const lifetime = await repo.findLifetime("nobody", "playground");
+    expect(lifetime).toEqual([]);
+  });
+});
+
+describe("incrementAdminGrant is atomic", () => {
+  test("two parallel grants accumulate to sum", async () => {
+    await Promise.all([
+      repo.incrementAdminGrant({
+        userId: "u1",
+        surface: "playground",
+        amount: 5,
+        defaultAllotment: 100,
+        now: NOW,
+      }),
+      repo.incrementAdminGrant({
+        userId: "u1",
+        surface: "playground",
+        amount: 7,
+        defaultAllotment: 100,
+        now: NOW,
+      }),
+    ]);
+    const b = await repo.findBucket("u1", "playground", MARKER);
+    expect(b?.adminGrant).toBe(12);
+  });
+});
+
+describe("UT-QUOTAREPO-005a appendGrantAudit inserts row with all spec fields", () => {
   test("audit row carries admin + target + month details", async () => {
-    const now = new Date(Date.UTC(2026, 4, 15));
     const id = await repo.appendGrantAudit({
       adminUserId: "a1",
       adminEmail: "a@x.test",
@@ -142,8 +296,8 @@ describe("UT-QUOTAREPO-005 appendGrantAudit inserts row with all spec fields", (
       surface: "playground",
       amount: 5,
       note: "initial",
-      monthMarker: "2026-05",
-      createdAt: now,
+      monthMarker: MARKER,
+      createdAt: NOW,
     });
     const row = await db
       .collection("quota_grants_audit")
@@ -153,59 +307,7 @@ describe("UT-QUOTAREPO-005 appendGrantAudit inserts row with all spec fields", (
     expect(row?.surface).toBe("playground");
     expect(row?.amount).toBe(5);
     expect(row?.note).toBe("initial");
-    expect(row?.monthMarker).toBe("2026-05");
-  });
-});
-
-describe("UT-QUOTAREPO-006 findLifetime sorts asc by monthMarker", () => {
-  test("3 buckets seeded out of order → returned chronologically", async () => {
-    const months = [
-      { marker: "2026-04", date: new Date(Date.UTC(2026, 3, 15)) },
-      { marker: "2026-06", date: new Date(Date.UTC(2026, 5, 15)) },
-      { marker: "2026-05", date: new Date(Date.UTC(2026, 4, 15)) },
-    ];
-    for (const { date } of months) {
-      await repo.incrementUsed({
-        userId: "u1",
-        surface: "playground",
-        modelId: "m",
-        defaultAllotment: 100,
-        now: date,
-      });
-    }
-    const lifetime = await repo.findLifetime("u1", "playground");
-    expect(lifetime.map((b) => b.monthMarker)).toEqual(["2026-04", "2026-05", "2026-06"]);
-  });
-});
-
-describe("UT-QUOTAREPO-007 findLifetime returns [] for new user", () => {
-  test("empty array, not null", async () => {
-    const lifetime = await repo.findLifetime("nobody", "playground");
-    expect(lifetime).toEqual([]);
-  });
-});
-
-describe("incrementAdminGrant is atomic", () => {
-  test("two parallel grants accumulate to sum", async () => {
-    const now = new Date(Date.UTC(2026, 4, 15));
-    await Promise.all([
-      repo.incrementAdminGrant({
-        userId: "u1",
-        surface: "playground",
-        amount: 5,
-        defaultAllotment: 100,
-        now,
-      }),
-      repo.incrementAdminGrant({
-        userId: "u1",
-        surface: "playground",
-        amount: 7,
-        defaultAllotment: 100,
-        now,
-      }),
-    ]);
-    const b = await repo.findBucket("u1", "playground", "2026-05");
-    expect(b?.adminGrant).toBe(12);
+    expect(row?.monthMarker).toBe(MARKER);
   });
 });
 
@@ -220,7 +322,7 @@ describe("listGrantAudit pagination + filter", () => {
         targetUserId: `u${i}`,
         surface: "playground",
         amount: 1,
-        monthMarker: "2026-05",
+        monthMarker: MARKER,
         createdAt: new Date(base + i * 1000),
       });
     }
@@ -237,7 +339,7 @@ describe("listGrantAudit pagination + filter", () => {
       targetUserId: "uA",
       surface: "playground",
       amount: 1,
-      monthMarker: "2026-05",
+      monthMarker: MARKER,
       createdAt: new Date(),
     });
     await repo.appendGrantAudit({
@@ -247,7 +349,7 @@ describe("listGrantAudit pagination + filter", () => {
       targetUserId: "uB",
       surface: "playground",
       amount: 1,
-      monthMarker: "2026-05",
+      monthMarker: MARKER,
       createdAt: new Date(),
     });
     const res = await repo.listGrantAudit({ page: 1, pageSize: 50, targetUserId: "uA" });

--- a/ornn-api/src/domains/quota/repository.ts
+++ b/ornn-api/src/domains/quota/repository.ts
@@ -2,14 +2,19 @@
  * Mongo persistence for the calendar-month quota bucket model.
  *
  *   `quota_buckets`        — one document per (userId, surface,
- *                            monthMarker). Atomic `$inc` on `used` /
- *                            `usedByModel` / `adminGrant`.
+ *                            monthMarker). `used` doubles as the
+ *                            reservation counter: `reserveSlot` does a
+ *                            cap-guarded atomic `$inc` (the TOCTOU fix,
+ *                            #808), `commitModel` records the per-model
+ *                            tally, `releaseSlot` refunds on failure.
+ *                            `adminGrant` has its own atomic `$inc`.
  *   `quota_grants_audit`   — append-only history of admin grants
  *                            (replaces the old drainable ledger).
  *
  * @module domains/quota/repository
  */
 
+import { MongoServerError } from "mongodb";
 import type { Collection, Db } from "mongodb";
 import { randomUUID } from "node:crypto";
 import { createLogger } from "../../shared/logger";
@@ -24,11 +29,31 @@ import {
 
 const logger = createLogger("quotaRepository");
 
-export interface UpsertChargeParams {
+/** Mongo duplicate-key error code (E11000). */
+const DUPLICATE_KEY_CODE = 11000;
+
+export interface ReserveSlotParams {
+  userId: string;
+  surface: Surface;
+  /**
+   * The runtime-effective default (`max(stored, currentSettingsDefault)`).
+   * Combined with the bucket's `adminGrant` this forms the cap the
+   * reservation is guarded against: `used < adminGrant + effectiveDefault`.
+   */
+  effectiveDefault: number;
+  now?: Date;
+}
+
+export interface CommitModelParams {
   userId: string;
   surface: Surface;
   modelId: string | null | undefined;
-  defaultAllotment: number;
+  now?: Date;
+}
+
+export interface ReleaseSlotParams {
+  userId: string;
+  surface: Surface;
   now?: Date;
 }
 
@@ -98,39 +123,101 @@ export class QuotaRepository {
   }
 
   /**
-   * Atomically increment `used` and `usedByModel.<id>`. Upserts a fresh
-   * bucket on first touch with the spec defaults — `$setOnInsert` keeps
-   * existing buckets untouched. Returns the after-state for callers
-   * who want to log resulting counters.
+   * Atomically reserve one slot by bumping `used`, guarded by the cap
+   * (`used < adminGrant + effectiveDefault`). This is the time-of-check =
+   * time-of-use fix (#808): N concurrent requests at `used = cap-1` race
+   * on the same conditional `$inc`, so at most one wins — the rest see
+   * the guard fail and are denied. `used` doubles as the reservation
+   * counter; the per-model tally is recorded later by `commitModel` and
+   * a failed run refunds via `releaseSlot`.
+   *
+   * Returns `true` when a slot was reserved, `false` when the cap is hit.
+   *
+   * First-touch (no bucket yet) is handled by an insert with `used = 1`;
+   * a lost insert race (E11000) retries the guarded update.
    */
-  async incrementUsed(params: UpsertChargeParams): Promise<QuotaBucketDoc> {
+  async reserveSlot(params: ReserveSlotParams): Promise<boolean> {
     const now = params.now ?? new Date();
     const { monthMarker, monthStart, monthEnd } = monthBounds(now);
     const id = bucketId(params.userId, params.surface, monthMarker);
-    const modelKey = escapeModelKey(params.modelId);
 
-    const result = await this.buckets.findOneAndUpdate(
-      { _id: id },
-      {
-        $inc: { used: 1, [`usedByModel.${modelKey}`]: 1 },
-        $set: { updatedAt: now },
-        $setOnInsert: {
-          userId: params.userId,
-          surface: params.surface,
-          monthMarker,
-          monthStart,
-          monthEnd,
-          defaultAllotment: params.defaultAllotment,
-          adminGrant: 0,
-          createdAt: now,
+    // Cap-guarded conditional increment on an existing bucket. `$expr`
+    // lets the cap reference the doc's own `adminGrant`, so an admin
+    // grant applied mid-month is respected without re-reading first.
+    const guardedUpdate = () =>
+      this.buckets.findOneAndUpdate(
+        {
+          _id: id,
+          $expr: { $lt: ["$used", { $add: ["$adminGrant", params.effectiveDefault] }] },
         },
-      },
-      { upsert: true, returnDocument: "after" },
-    );
-    if (!result) {
-      throw new Error(`incrementUsed: upsert returned null for ${id}`);
+        { $inc: { used: 1 }, $set: { updatedAt: now } },
+        { returnDocument: "after" },
+      );
+
+    const updated = await guardedUpdate();
+    if (updated) return true;
+
+    // No match: either the bucket exists and is at/over cap, or it
+    // doesn't exist yet. A zero (or negative) cap can never admit the
+    // first request, so don't bother creating a bucket.
+    if (params.effectiveDefault < 1) return false;
+
+    try {
+      await this.buckets.insertOne({
+        _id: id,
+        userId: params.userId,
+        surface: params.surface,
+        monthMarker,
+        monthStart,
+        monthEnd,
+        defaultAllotment: params.effectiveDefault,
+        adminGrant: 0,
+        used: 1,
+        usedByModel: {},
+        createdAt: now,
+        updatedAt: now,
+      });
+      return true;
+    } catch (err) {
+      // Lost the insert race — another concurrent reserve created the
+      // bucket first. Fall back to the guarded update and honour the cap.
+      if (err instanceof MongoServerError && err.code === DUPLICATE_KEY_CODE) {
+        const retry = await guardedUpdate();
+        return !!retry;
+      }
+      throw err;
     }
-    return result;
+  }
+
+  /**
+   * Record the per-model tally for a committed run. The slot's `used`
+   * counter was already bumped by `reserveSlot`, so this only touches
+   * `usedByModel.<id>` — it must NOT bump `used` again.
+   */
+  async commitModel(params: CommitModelParams): Promise<void> {
+    const now = params.now ?? new Date();
+    const { monthMarker } = monthBounds(now);
+    const id = bucketId(params.userId, params.surface, monthMarker);
+    const modelKey = escapeModelKey(params.modelId);
+    await this.buckets.updateOne(
+      { _id: id },
+      { $inc: { [`usedByModel.${modelKey}`]: 1 }, $set: { updatedAt: now } },
+    );
+  }
+
+  /**
+   * Refund a reserved slot (e.g. the LLM call failed with a system
+   * error or the client aborted). Decrements `used`, floored at 0 via
+   * the `used > 0` guard so a double-release can never drive it negative.
+   */
+  async releaseSlot(params: ReleaseSlotParams): Promise<void> {
+    const now = params.now ?? new Date();
+    const { monthMarker } = monthBounds(now);
+    const id = bucketId(params.userId, params.surface, monthMarker);
+    await this.buckets.updateOne(
+      { _id: id, used: { $gt: 0 } },
+      { $inc: { used: -1 }, $set: { updatedAt: now } },
+    );
   }
 
   /**

--- a/ornn-api/src/domains/quota/service.test.ts
+++ b/ornn-api/src/domains/quota/service.test.ts
@@ -32,44 +32,76 @@ class FakeRepo {
       .sort((a, b) => a.monthMarker.localeCompare(b.monthMarker));
   }
 
-  async incrementUsed(p: {
+  /**
+   * In-memory mirror of the atomic cap-guarded reserve. JS runs this
+   * body to completion without interleaving (no `await` between the
+   * read and the write), so it is serialized the same way Mongo's
+   * single-document `findOneAndUpdate` is — at most one reserve per
+   * slot wins.
+   */
+  async reserveSlot(p: {
     userId: string;
     surface: Surface;
-    modelId: string | null | undefined;
-    defaultAllotment: number;
+    effectiveDefault: number;
     now?: Date;
   }) {
     const now = p.now ?? new Date();
     const { monthMarker, monthStart, monthEnd } = monthBounds(now);
     const id = bucketId(p.userId, p.surface, monthMarker);
     const existing = this.buckets.get(id);
+    if (existing) {
+      const cap = existing.adminGrant + p.effectiveDefault;
+      if (existing.used >= cap) return false;
+      this.buckets.set(id, { ...existing, used: existing.used + 1, updatedAt: now });
+      return true;
+    }
+    if (p.effectiveDefault < 1) return false;
+    this.buckets.set(id, {
+      _id: id,
+      userId: p.userId,
+      surface: p.surface,
+      monthMarker,
+      monthStart,
+      monthEnd,
+      defaultAllotment: p.effectiveDefault,
+      adminGrant: 0,
+      used: 1,
+      usedByModel: {},
+      createdAt: now,
+      updatedAt: now,
+    });
+    return true;
+  }
+
+  async commitModel(p: {
+    userId: string;
+    surface: Surface;
+    modelId: string | null | undefined;
+    now?: Date;
+  }) {
+    const now = p.now ?? new Date();
+    const { monthMarker } = monthBounds(now);
+    const id = bucketId(p.userId, p.surface, monthMarker);
+    const existing = this.buckets.get(id);
+    if (!existing) return;
     const modelKey = p.modelId && p.modelId.length > 0 ? p.modelId : "__unknown__";
-    const next: QuotaBucketDoc = existing
-      ? {
-          ...existing,
-          used: existing.used + 1,
-          usedByModel: {
-            ...existing.usedByModel,
-            [modelKey]: (existing.usedByModel[modelKey] ?? 0) + 1,
-          },
-          updatedAt: now,
-        }
-      : {
-          _id: id,
-          userId: p.userId,
-          surface: p.surface,
-          monthMarker,
-          monthStart,
-          monthEnd,
-          defaultAllotment: p.defaultAllotment,
-          adminGrant: 0,
-          used: 1,
-          usedByModel: { [modelKey]: 1 },
-          createdAt: now,
-          updatedAt: now,
-        };
-    this.buckets.set(id, next);
-    return next;
+    this.buckets.set(id, {
+      ...existing,
+      usedByModel: {
+        ...existing.usedByModel,
+        [modelKey]: (existing.usedByModel[modelKey] ?? 0) + 1,
+      },
+      updatedAt: now,
+    });
+  }
+
+  async releaseSlot(p: { userId: string; surface: Surface; now?: Date }) {
+    const now = p.now ?? new Date();
+    const { monthMarker } = monthBounds(now);
+    const id = bucketId(p.userId, p.surface, monthMarker);
+    const existing = this.buckets.get(id);
+    if (!existing || existing.used <= 0) return;
+    this.buckets.set(id, { ...existing, used: existing.used - 1, updatedAt: now });
   }
 
   async incrementAdminGrant(p: {
@@ -180,8 +212,8 @@ describe("UT-QUOTA-002 first-call shows clean snapshot", () => {
   });
 });
 
-describe("UT-QUOTA-003 allowed when under cap", () => {
-  test("used < default+grant → allowed", async () => {
+describe("UT-QUOTA-003 allowed when under cap (reserves the slot)", () => {
+  test("used < default+grant → allowed; checkAllowed reserves (used++)", async () => {
     const { service, repo } = build();
     const now = new Date(Date.UTC(2026, 4, 15));
     repo.buckets.set("u1:playground:2026-05", {
@@ -205,6 +237,8 @@ describe("UT-QUOTA-003 allowed when under cap", () => {
       now,
     });
     expect(d.allowed).toBe(true);
+    // The check IS the reserve now (#808): the slot is claimed up front.
+    expect(repo.buckets.get("u1:playground:2026-05")?.used).toBe(51);
   });
 });
 
@@ -234,6 +268,8 @@ describe("UT-QUOTA-004 blocked when at cap", () => {
     });
     expect(d.allowed).toBe(false);
     if (!d.allowed) expect(d.message).toContain("playground");
+    // A denied reserve must not over-count past the cap.
+    expect(repo.buckets.get("u1:playground:2026-05")?.used).toBe(100);
   });
 });
 
@@ -265,10 +301,11 @@ describe("UT-QUOTA-005 admin grant lifts ceiling", () => {
   });
 });
 
-describe("UT-QUOTA-006 charge success increments used+usedByModel", () => {
-  test("used+=1 and usedByModel.<id>+=1", async () => {
+describe("UT-QUOTA-006 reserve+success commits used+usedByModel", () => {
+  test("reserve bumps used to 1; success commit records usedByModel.<id>", async () => {
     const { service, repo } = build();
     const now = new Date(Date.UTC(2026, 4, 15));
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now });
     await service.chargeOnCompletion({
       userId: "u1",
       permissions: [],
@@ -283,9 +320,10 @@ describe("UT-QUOTA-006 charge success increments used+usedByModel", () => {
   });
 });
 
-describe("UT-QUOTA-007 skill_error charges 1", () => {
-  test("used+=1 on skill_error", async () => {
+describe("UT-QUOTA-007 reserve+skill_error keeps the slot consumed", () => {
+  test("used stays 1 on skill_error (chargeable — ran the skill)", async () => {
     const { service, repo } = build();
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground" });
     await service.chargeOnCompletion({
       userId: "u1",
       permissions: [],
@@ -296,22 +334,25 @@ describe("UT-QUOTA-007 skill_error charges 1", () => {
   });
 });
 
-describe("UT-QUOTA-008 system_error charges 0", () => {
-  test("DB unchanged on system_error", async () => {
+describe("UT-QUOTA-008 reserve+system_error releases the slot", () => {
+  test("used returns to 0 on system_error (refund — never reached skill)", async () => {
     const { service, repo } = build();
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground" });
+    expect([...repo.buckets.values()][0]?.used).toBe(1);
     await service.chargeOnCompletion({
       userId: "u1",
       permissions: [],
       surface: "playground",
       outcome: "system_error",
     });
-    expect(repo.buckets.size).toBe(0);
+    expect([...repo.buckets.values()][0]?.used).toBe(0);
   });
 });
 
 describe("UT-QUOTA-009 unknown modelId routes to __unknown__", () => {
-  test("missing modelId → usedByModel.__unknown__: 1", async () => {
+  test("missing modelId on commit → usedByModel.__unknown__: 1", async () => {
     const { service, repo } = build();
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground" });
     await service.chargeOnCompletion({
       userId: "u1",
       permissions: [],
@@ -322,25 +363,70 @@ describe("UT-QUOTA-009 unknown modelId routes to __unknown__", () => {
   });
 });
 
+describe("UT-QUOTA-009a checkAllowed denies once the cap is reached", () => {
+  test("repeated reserves on a cap-1 default exhaust then deny", async () => {
+    const { service, repo } = build({ defaultPg: 2 });
+    const now = new Date(Date.UTC(2026, 4, 15));
+    const d1 = await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now });
+    const d2 = await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now });
+    const d3 = await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now });
+    expect(d1.allowed).toBe(true);
+    expect(d2.allowed).toBe(true);
+    expect(d3.allowed).toBe(false);
+    // Cap is 2 — the third reserve must not push used to 3.
+    expect(repo.buckets.get("u1:playground:2026-05")?.used).toBe(2);
+  });
+});
+
+describe("UT-QUOTA-009b admin bypass reserves and releases nothing", () => {
+  test("admin checkAllowed + chargeOnCompletion (both outcomes) leave no bucket", async () => {
+    const { service, repo } = build();
+    const d = await service.checkAllowed({
+      userId: "admin",
+      permissions: [ADMIN_PERM],
+      surface: "playground",
+    });
+    expect(d.allowed).toBe(true);
+    if (d.allowed) expect(d.isAdminBypass).toBe(true);
+    await service.chargeOnCompletion({
+      userId: "admin",
+      permissions: [ADMIN_PERM],
+      surface: "playground",
+      outcome: "system_error",
+    });
+    await service.chargeOnCompletion({
+      userId: "admin",
+      permissions: [ADMIN_PERM],
+      surface: "playground",
+      outcome: "success",
+    });
+    expect(repo.buckets.size).toBe(0);
+  });
+});
+
+describe("UT-QUOTA-010 release then reserve frees the slot again", () => {
+  test("a system_error refund lets a later request through at the cap", async () => {
+    const { service, repo } = build({ defaultPg: 1 });
+    const now = new Date(Date.UTC(2026, 4, 15));
+    // Consume the single slot.
+    expect((await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now })).allowed).toBe(true);
+    // Second is denied at the cap.
+    expect((await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now })).allowed).toBe(false);
+    // First run fails with a system error → slot released.
+    await service.chargeOnCompletion({ userId: "u1", permissions: [], surface: "playground", outcome: "system_error", now });
+    expect(repo.buckets.get("u1:playground:2026-05")?.used).toBe(0);
+    // Now a fresh request is admitted again.
+    expect((await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now })).allowed).toBe(true);
+  });
+});
+
 describe("UT-QUOTA-011 boundary millisecond rollover", () => {
   test("Jun 1 00:00:00.000Z creates new June bucket; May untouched", async () => {
     const { service, repo } = build();
     const may = new Date(Date.UTC(2026, 4, 31, 23, 59, 59, 999));
-    await service.chargeOnCompletion({
-      userId: "u1",
-      permissions: [],
-      surface: "playground",
-      outcome: "success",
-      now: may,
-    });
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now: may });
     const jun = new Date(Date.UTC(2026, 5, 1, 0, 0, 0, 0));
-    await service.chargeOnCompletion({
-      userId: "u1",
-      permissions: [],
-      surface: "playground",
-      outcome: "success",
-      now: jun,
-    });
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now: jun });
     const mayBucket = repo.buckets.get("u1:playground:2026-05");
     const junBucket = repo.buckets.get("u1:playground:2026-06");
     expect(mayBucket?.used).toBe(1);
@@ -352,13 +438,7 @@ describe("UT-QUOTA-012 last millisecond of May → 2026-05", () => {
   test("monthMarker stays May at 23:59:59.999", async () => {
     const { service, repo } = build();
     const may = new Date(Date.UTC(2026, 4, 31, 23, 59, 59, 999));
-    await service.chargeOnCompletion({
-      userId: "u1",
-      permissions: [],
-      surface: "playground",
-      outcome: "success",
-      now: may,
-    });
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now: may });
     expect(repo.buckets.has("u1:playground:2026-05")).toBe(true);
   });
 });
@@ -536,21 +616,9 @@ describe("UT-QUOTA-023 year boundary rollover", () => {
   test("Dec 31 23:59:59.999Z → 2026; Jan 1 00:00Z → 2027", async () => {
     const { service, repo } = build();
     const dec = new Date(Date.UTC(2026, 11, 31, 23, 59, 59, 999));
-    await service.chargeOnCompletion({
-      userId: "u1",
-      permissions: [],
-      surface: "playground",
-      outcome: "success",
-      now: dec,
-    });
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now: dec });
     const jan = new Date(Date.UTC(2027, 0, 1, 0, 0, 0, 0));
-    await service.chargeOnCompletion({
-      userId: "u1",
-      permissions: [],
-      surface: "playground",
-      outcome: "success",
-      now: jan,
-    });
+    await service.checkAllowed({ userId: "u1", permissions: [], surface: "playground", now: jan });
     expect(repo.buckets.has("u1:playground:2026-12")).toBe(true);
     expect(repo.buckets.has("u1:playground:2027-01")).toBe(true);
   });

--- a/ornn-api/src/domains/quota/service.ts
+++ b/ornn-api/src/domains/quota/service.ts
@@ -2,9 +2,13 @@
  * Quota policy on the calendar-month bucket model.
  *
  *   - Admins (`ornn:admin:skill`) bypass entirely.
- *   - `checkAllowed` reads the current-month bucket. Pure read; no upsert.
- *   - `chargeOnCompletion` upserts the bucket and atomically increments
- *     `used` and `usedByModel.<id>`. `system_error` outcomes are no-ops.
+ *   - `checkAllowed` atomically *reserves* a slot (#808): a cap-guarded
+ *     `$inc` on `used`, so concurrent requests at the cap boundary can't
+ *     all pass the check and over-spend. Returns the allow/deny decision.
+ *   - `chargeOnCompletion` reconciles the reservation by outcome:
+ *     `system_error` (incl. abort) → release (refund the slot);
+ *     `success` / `skill_error` → commit the per-model tally. `used`
+ *     was already bumped at reserve time and is not touched again.
  *   - `grant` adds to `adminGrant` for the current month and appends an
  *     audit row. Negative grants rejected (out of scope for v1).
  *   - Default allotment is settings-driven; runtime computes
@@ -76,6 +80,16 @@ export class QuotaService {
       : def.defaultSkillGenMonthly;
   }
 
+  /**
+   * Atomically reserve a slot before the LLM call. The reservation IS
+   * the charge — it bumps `used` under a cap guard so concurrent
+   * requests at the boundary can't all be admitted (#808, CWE-367).
+   * A reservation that doesn't reach a chargeable outcome is refunded
+   * by `chargeOnCompletion` (`system_error`/abort → release).
+   *
+   * Admins bypass entirely: no reservation is taken and none is
+   * released, so their runs never touch a bucket.
+   */
   async checkAllowed(params: {
     userId: string;
     permissions: readonly string[] | undefined;
@@ -86,18 +100,38 @@ export class QuotaService {
       return { allowed: true, isAdminBypass: true };
     }
     const now = params.now ?? new Date();
-    const { monthMarker } = monthBounds(now);
-    const [bucket, currentDefault] = await Promise.all([
-      this.repo.findBucket(params.userId, params.surface, monthMarker),
-      this.resolveDefault(params.surface),
-    ]);
-    const stored = bucket?.defaultAllotment ?? 0;
+    // The bucket stores the first-touch default; the runtime-effective
+    // default may be higher if the admin raised it mid-month. The repo
+    // guards against `adminGrant + effectiveDefault`, reading the bucket's
+    // own `adminGrant` inside the atomic update.
+    const currentDefault = await this.resolveDefault(params.surface);
+    const existing = await this.repo.findBucket(
+      params.userId,
+      params.surface,
+      monthBounds(now).monthMarker,
+    );
+    const stored = existing?.defaultAllotment ?? 0;
     const effectiveDefault = Math.max(stored, currentDefault);
-    const adminGrant = bucket?.adminGrant ?? 0;
-    const used = bucket?.used ?? 0;
-    if (used < effectiveDefault + adminGrant) {
+
+    const reserved = await this.repo.reserveSlot({
+      userId: params.userId,
+      surface: params.surface,
+      effectiveDefault,
+      now,
+    });
+
+    if (reserved) {
+      logger.info(
+        { userId: params.userId, surface: params.surface },
+        "Quota slot reserved",
+      );
       return { allowed: true, isAdminBypass: false };
     }
+
+    logger.info(
+      { userId: params.userId, surface: params.surface },
+      "Quota denied — cap reached",
+    );
     return {
       allowed: false,
       isAdminBypass: false,
@@ -106,6 +140,15 @@ export class QuotaService {
     };
   }
 
+  /**
+   * Reconcile a reservation once the run terminates. The slot was
+   * already taken at `checkAllowed` time, so this never bumps `used`:
+   *  - `system_error` (LLM timeout, infra 5xx, client abort) → release
+   *    the slot (refund), since the request never reached the skill.
+   *  - `success` / `skill_error` → commit the per-model tally; the slot
+   *    stays consumed.
+   * Admins took no reservation, so this is a no-op for them.
+   */
   async chargeOnCompletion(params: {
     userId: string;
     permissions: readonly string[] | undefined;
@@ -115,14 +158,25 @@ export class QuotaService {
     now?: Date;
   }): Promise<void> {
     if (this.isAdmin(params.permissions)) return;
-    if (params.outcome === "system_error") return;
     const now = params.now ?? new Date();
-    const def = await this.resolveDefault(params.surface);
-    await this.repo.incrementUsed({
+
+    if (params.outcome === "system_error") {
+      await this.repo.releaseSlot({
+        userId: params.userId,
+        surface: params.surface,
+        now,
+      });
+      logger.info(
+        { userId: params.userId, surface: params.surface, outcome: params.outcome },
+        "Quota reservation released",
+      );
+      return;
+    }
+
+    await this.repo.commitModel({
       userId: params.userId,
       surface: params.surface,
       modelId: params.modelId,
-      defaultAllotment: def,
       now,
     });
     logger.debug(

--- a/ornn-api/src/domains/skills/generation/routes.ts
+++ b/ornn-api/src/domains/skills/generation/routes.ts
@@ -69,9 +69,17 @@ async function resolveKeepAliveMs(
 }
 
 /**
- * Run quota check + model resolution for a skill-gen request. Returns
+ * Run model resolution + quota reserve for a skill-gen request. Returns
  * the resolved model id; throws the appropriate AppError when either
- * gate fails (quota → 429, models → 503/4xx).
+ * gate fails (models → 503/4xx, quota → 429).
+ *
+ * Order is load-bearing (#808): model resolution runs FIRST so a
+ * resolution failure can't strand a reserved quota slot. `resolveModel`
+ * is a pure catalog read (no LLM), so reserving last still keeps the
+ * "429 before any LLM cost" guarantee. Once `checkAllowed` reserves,
+ * every caller threads the result straight into `streamGenerationEvents`,
+ * whose `finally` always reconciles the reservation (commit on success,
+ * release on system_error/abort).
  */
 async function preflight(
   c: Context<{ Variables: AuthVariables }>,
@@ -80,12 +88,6 @@ async function preflight(
   requestedModelId: string | undefined,
 ): Promise<{ modelId: string; userId: string; permissions: readonly string[] | undefined }> {
   const authCtx = getAuth(c);
-  const decision = await quotaService.checkAllowed({
-    userId: authCtx.userId,
-    permissions: authCtx.permissions,
-    surface: "skillGen",
-  });
-  if (!decision.allowed) throwQuotaError(decision);
 
   const resolution = await llmProvidersService.resolveModel({
     surface: "skillGen",
@@ -93,6 +95,14 @@ async function preflight(
     ...(requestedModelId !== undefined ? { requested: requestedModelId } : {}),
   });
   if (resolution.kind !== "ok") throwModelResolutionError(resolution);
+
+  const decision = await quotaService.checkAllowed({
+    userId: authCtx.userId,
+    permissions: authCtx.permissions,
+    surface: "skillGen",
+  });
+  if (!decision.allowed) throwQuotaError(decision);
+
   return { modelId: resolution.modelId, userId: authCtx.userId, permissions: authCtx.permissions };
 }
 


### PR DESCRIPTION
Closes #808

Automated change by `/auto` (run `20260604T053431Z-72549`, runner `auto-runner-20260604T053431Z-72549-iter3`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
