### PR TITLE
[Bug] Add a per-user rate limit to POST /playground/chat

### DIFF
--- a/.changeset/auto-809-playground-chat-rate-limit.md
+++ b/.changeset/auto-809-playground-chat-rate-limit.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add per-user rate limit (20/min) to POST /playground/chat (#809).

--- a/ornn-api/src/domains/playground/routes.test.ts
+++ b/ornn-api/src/domains/playground/routes.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Route-level wiring test for the playground chat rate limit (#809).
+ *
+ * Pins that `POST /playground/chat` carries the per-user 20/min limiter
+ * (same cap + class as `/skills/generate`). The limiter's own behaviour
+ * (RFC 9239 headers, per-user keying, window reset) is owned by
+ * `middleware/rateLimit.test.ts` — this test only asserts the limiter is
+ * mounted on this route, ahead of `validateBody`, so the 21st request
+ * 429s before Zod and before any LLM cost.
+ *
+ * @module domains/playground/routes.test
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { AppError, buildProblemJsonBody } from "../../shared/types/index";
+import { __resetRateLimitForTests } from "../../middleware/rateLimit";
+import { createPlaygroundRoutes, type PlaygroundRoutesConfig } from "./routes";
+
+function makeApp() {
+  const app = new Hono();
+  // Upstream auth stub. `nyxidAuthMiddleware` + `requirePermission` only
+  // READ `c.get("auth")`; the real middleware never overwrites it, so this
+  // stub survives into the route chain and satisfies both.
+  app.use("*", async (c, next) => {
+    c.set(
+      "auth" as never,
+      { userId: "u1", permissions: ["ornn:playground:use"] } as never,
+    );
+    await next();
+  });
+
+  // Mount the real route. Services are never reached: the 429 fires inside
+  // rateLimit, ahead of validateBody, so the empty config is never touched.
+  app.route("/", createPlaygroundRoutes({} as unknown as PlaygroundRoutesConfig));
+
+  // Translate AppError → problem+json like the global handler does.
+  app.onError((err, c) => {
+    if (err instanceof AppError) {
+      const body = buildProblemJsonBody({
+        statusCode: err.statusCode,
+        code: err.code,
+        message: err.message,
+        instance: c.req.path,
+        requestId: null,
+      });
+      return c.json(body, err.statusCode as never, {
+        "Content-Type": "application/problem+json",
+      });
+    }
+    return c.json({ error: { code: "internal_error", message: String(err) } }, 500);
+  });
+
+  return app;
+}
+
+describe("POST /playground/chat rate limit (#809)", () => {
+  beforeEach(() => __resetRateLimitForTests());
+
+  test("429s the 21st per-user request before validateBody", async () => {
+    const app = makeApp();
+    const req = () =>
+      app.request("/playground/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // Invalid body — but rateLimit trips before Zod, so the cap is
+        // reached on raw request count regardless of body shape.
+        body: "{}",
+      });
+
+    // Exhaust the 20/min cap.
+    for (let i = 0; i < 20; i++) {
+      await req();
+    }
+
+    // 21st request is denied by the limiter.
+    const denied = await req();
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get("RateLimit-Limit")).toBe("20");
+    expect(denied.headers.get("RateLimit-Remaining")).toBe("0");
+    expect(denied.headers.get("Retry-After")).not.toBeNull();
+    const body = (await denied.json()) as { code: string };
+    expect(body.code).toBe("rate_limited");
+  });
+});

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -22,6 +22,7 @@ import {
   readUserOrgMemberships,
 } from "../../middleware/nyxidAuth";
 import { validateBody, getValidatedBody } from "../../middleware/validate";
+import { rateLimit } from "../../middleware/rateLimit";
 import { createLogger } from "../../shared/logger";
 const logger = createLogger("playgroundRoutes");
 
@@ -98,6 +99,11 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
   app.post(
     "/playground/chat",
     requirePermission("ornn:playground:use"),
+    // Rate limit (#809): per-user 20/min, same cap as skills-generate
+    // (generation/routes.ts) — playground chat runs an LLM call per request,
+    // same cost class. Mounted before validateBody so a flood of malformed
+    // bodies still 429s before Zod (and before any LLM cost).
+    rateLimit({ windowMs: 60_000, max: 20, label: "playground-chat" }),
     validateBody(chatRequestSchema, "VALIDATION_ERROR"),
     async (c) => {
       const authCtx = getAuth(c);


### PR DESCRIPTION
Closes #809

Automated change by `/auto` (run `20260604T074750Z-90075`, runner `auto-runner-20260604T074750Z-90075-91180-28280`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
