### PR TITLE
[Bug] Bound pagination page to stop unbounded MongoDB skip()

### DIFF
--- a/.changeset/auto-810-bound-skip-dos.md
+++ b/.changeset/auto-810-bound-skip-dos.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Bound unbounded MongoDB skip() pagination (CWE-770): page ceiling + maxTimeMS on public skill queries (#810).

--- a/ornn-api/src/domains/admin/quota/routes.ts
+++ b/ornn-api/src/domains/admin/quota/routes.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../middleware/nyxidAuth";
 import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import { AppError } from "../../../shared/types/index";
+import { MAX_PAGE } from "../../../shared/cursor";
 import type { UserDirectoryRepository } from "../../users/repository";
 import type { QuotaService } from "../../quota/service";
 import {
@@ -239,7 +240,9 @@ export function createAdminQuotaRoutes(
     auth,
     requirePermission(QUOTA_ADMIN_PERMISSION),
     async (c) => {
-      const page = Math.max(1, Number(c.req.query("page")) || 1);
+      // Clamp to MAX_PAGE so a huge ?page= can't drive an unbounded
+      // `.skip()` scan in the grant-audit query (CWE-770, #810).
+      const page = Math.min(MAX_PAGE, Math.max(1, Number(c.req.query("page")) || 1));
       const pageSize = Math.min(200, Math.max(1, Number(c.req.query("pageSize")) || 50));
       const targetUserId = c.req.query("userId") || undefined;
       const adminUserId = c.req.query("adminUserId") || undefined;

--- a/ornn-api/src/domains/redemption-codes/me-routes.ts
+++ b/ornn-api/src/domains/redemption-codes/me-routes.ts
@@ -24,6 +24,7 @@ import { validateBody, getValidatedBody } from "../../middleware/validate";
 import { AppError } from "../../shared/types/index";
 import type { RedemptionCodeService } from "./service";
 import { redeemSchema, type RedeemInput, type RedemptionCodeDoc } from "./types";
+import { MAX_PAGE } from "../../shared/cursor";
 
 const logger = createLogger("meRedemptionCodeRoutes");
 
@@ -130,7 +131,9 @@ export function createMeRedemptionCodesRoutes(
   // GET /me/redemption-codes/history
   app.get("/me/redemption-codes/history", auth, async (c) => {
     const authCtx = getAuth(c);
-    const page = Math.max(1, Number(c.req.query("page")) || 1);
+    // Clamp to MAX_PAGE so a huge ?page= can't drive an unbounded
+    // `.skip()` scan in the redeemed-code history query (CWE-770, #810).
+    const page = Math.min(MAX_PAGE, Math.max(1, Number(c.req.query("page")) || 1));
     const pageSize = Math.min(
       HISTORY_PAGE_SIZE_MAX,
       Math.max(1, Number(c.req.query("pageSize")) || HISTORY_PAGE_SIZE_DEFAULT),

--- a/ornn-api/src/domains/skills/crud/repository.ts
+++ b/ornn-api/src/domains/skills/crud/repository.ts
@@ -129,6 +129,14 @@ export interface ExtraFilters {
 export class SkillRepository {
   private readonly collection: Collection;
 
+  /**
+   * Server-side cap on paginated reads. Bounds the worst-case
+   * `.skip()` scan + its paired `countDocuments` so a deep page (even
+   * within the clamped page ceiling) can't tie up a Mongo worker for
+   * an unbounded stretch (CWE-770, #810). Mirrors admin/routes.ts.
+   */
+  private static readonly MAX_QUERY_MS = 5_000;
+
   constructor(db: Db) {
     this.collection = db.collection("skills");
   }
@@ -337,13 +345,16 @@ export class SkillRepository {
     applyScope(matchStage, scope, currentUserId, userOrgIds);
     applyExtraFilters(matchStage, { nyxidServiceId: serviceId });
 
-    const total = await this.collection.countDocuments(matchStage);
+    const total = await this.collection.countDocuments(matchStage, {
+      maxTimeMS: SkillRepository.MAX_QUERY_MS,
+    });
     const offset = (page - 1) * pageSize;
     const docs = await this.collection
       .find(matchStage)
       .sort({ createdOn: -1 })
       .skip(offset)
       .limit(pageSize)
+      .maxTimeMS(SkillRepository.MAX_QUERY_MS)
       .toArray();
     return { skills: docs.map((d) => mapDoc(d)!), total };
   }
@@ -381,9 +392,17 @@ export class SkillRepository {
 
     applyExtraFilters(matchStage, extraFilters);
 
-    const total = await this.collection.countDocuments(matchStage);
+    const total = await this.collection.countDocuments(matchStage, {
+      maxTimeMS: SkillRepository.MAX_QUERY_MS,
+    });
     const offset = (page - 1) * pageSize;
-    const docs = await this.collection.find(matchStage).sort({ createdOn: -1 }).skip(offset).limit(pageSize).toArray();
+    const docs = await this.collection
+      .find(matchStage)
+      .sort({ createdOn: -1 })
+      .skip(offset)
+      .limit(pageSize)
+      .maxTimeMS(SkillRepository.MAX_QUERY_MS)
+      .toArray();
 
     return { skills: docs.map((d) => mapDoc(d)!), total };
   }
@@ -408,9 +427,17 @@ export class SkillRepository {
 
     applyExtraFilters(matchStage, extraFilters);
 
-    const total = await this.collection.countDocuments(matchStage);
+    const total = await this.collection.countDocuments(matchStage, {
+      maxTimeMS: SkillRepository.MAX_QUERY_MS,
+    });
     const offset = (page - 1) * pageSize;
-    const docs = await this.collection.find(matchStage).sort({ createdOn: -1 }).skip(offset).limit(pageSize).toArray();
+    const docs = await this.collection
+      .find(matchStage)
+      .sort({ createdOn: -1 })
+      .skip(offset)
+      .limit(pageSize)
+      .maxTimeMS(SkillRepository.MAX_QUERY_MS)
+      .toArray();
 
     return { skills: docs.map((d) => mapDoc(d)!), total };
   }

--- a/ornn-api/src/domains/skills/search/routes.test.ts
+++ b/ornn-api/src/domains/skills/search/routes.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the skill-search route's pagination bounds (CWE-770, #810).
+ *
+ * The `?page=` query param feeds an offset-based `.skip()` underneath.
+ * Without an upper bound a caller could request `?page=999999999` and
+ * drive a multi-second collection scan. `searchQuerySchema.page` now
+ * carries `.max(MAX_PAGE)`, so the request is rejected at the
+ * `validateQuery` layer with a 400 `invalid_query` BEFORE the handler
+ * (and the service) ever runs.
+ *
+ * The stub services here are intentionally inert: the 400 case never
+ * reaches them, and the positive-control 200 case only exercises
+ * `searchService.search` (which returns an empty result set).
+ *
+ * @module domains/skills/search/routes.test
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { createSearchRoutes } from "./routes";
+import type { SearchService } from "./service";
+import type { SkillRepository } from "../crud/repository";
+import {
+  AppError,
+  buildProblemJsonBody,
+  type SkillSearchResponse,
+} from "../../../shared/types/index";
+import { __resetRateLimitForTests } from "../../../middleware/rateLimit";
+
+/**
+ * Mount the real search routes with stub deps under a Hono app whose
+ * onError mirrors the global handler (AppError → problem+json). Only
+ * `searchService.search` is ever called (positive-control path); the
+ * 400 path short-circuits in `validateQuery`.
+ */
+function makeApp(searchImpl?: SearchService["search"]) {
+  const searchService = {
+    search:
+      searchImpl ??
+      (async (): Promise<SkillSearchResponse> => {
+        throw new Error("search() should not be called when validation rejects");
+      }),
+  } as unknown as SearchService;
+
+  // skillRepo is never touched on the /skill-search path — the route
+  // only calls searchService.search. A bare cast keeps the wiring light.
+  const skillRepo = {} as unknown as SkillRepository;
+
+  const app = new Hono();
+  app.route("/", createSearchRoutes({ searchService, skillRepo }));
+  app.onError((err, c) => {
+    if (err instanceof AppError) {
+      const body = buildProblemJsonBody({
+        statusCode: err.statusCode,
+        code: err.code,
+        message: err.message,
+        instance: c.req.path,
+        requestId: null,
+      });
+      return c.json(body, err.statusCode as never, {
+        "Content-Type": "application/problem+json",
+      });
+    }
+    return c.json({ error: { code: "internal_error", message: String(err) } }, 500);
+  });
+  return app;
+}
+
+describe("GET /skill-search — page bound (CWE-770, #810)", () => {
+  beforeEach(() => __resetRateLimitForTests());
+  afterEach(() => __resetRateLimitForTests());
+
+  test("rejects ?page=999999999 with 400 invalid_query", async () => {
+    const app = makeApp();
+    const res = await app.request("/skill-search?page=999999999");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_query");
+  });
+
+  test("accepts ?page=10000 (the ceiling) — does not 400 at validation", async () => {
+    const emptyResult: SkillSearchResponse = {
+      searchMode: "keyword",
+      searchScope: "public",
+      total: 0,
+      totalPages: 0,
+      page: 10_000,
+      pageSize: 9,
+      items: [],
+    };
+    const app = makeApp(async () => emptyResult);
+    const res = await app.request("/skill-search?page=10000");
+    expect(res.status).toBe(200);
+    expect(res.status).not.toBe(400);
+    const body = (await res.json()) as { data: { items: unknown[] }; error: unknown };
+    expect(body.error).toBeNull();
+    expect(body.data.items).toEqual([]);
+  });
+});

--- a/ornn-api/src/domains/skills/search/routes.ts
+++ b/ornn-api/src/domains/skills/search/routes.ts
@@ -19,7 +19,7 @@ import {
 import { validateQuery, getValidatedQuery } from "../../../middleware/validate";
 import { AppError } from "../../../shared/types/index";
 import { createLogger } from "../../../shared/logger";
-import { decodeCursor, buildNextCursor } from "../../../shared/cursor";
+import { decodeCursor, buildNextCursor, MAX_PAGE } from "../../../shared/cursor";
 import { rateLimit } from "../../../middleware/rateLimit";
 const logger = createLogger("skillSearchRoutes");
 
@@ -32,7 +32,7 @@ const searchQuerySchema = z.object({
   query: z.string().max(2000).optional(),
   mode: z.enum(["keyword", "semantic"]).optional().default("keyword"),
   scope: z.enum(["public", "private", "mixed", "shared-with-me", "mine"]).optional().default("private"),
-  page: z.coerce.number().int().min(1).optional().default(1),
+  page: z.coerce.number().int().min(1).max(MAX_PAGE).optional().default(1),
   pageSize: z.coerce.number().int().min(1).max(100).optional().default(9),
   /**
    * Cursor-based pagination per CONVENTIONS.md §4.3 (#457). Opaque

--- a/ornn-api/src/shared/cursor.test.ts
+++ b/ornn-api/src/shared/cursor.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { encodeCursor, decodeCursor, buildNextCursor } from "./cursor";
+import { encodeCursor, decodeCursor, buildNextCursor, MAX_PAGE } from "./cursor";
 
 describe("encodeCursor + decodeCursor round-trip", () => {
   test("encodes + decodes a page payload losslessly", () => {
@@ -39,6 +39,12 @@ describe("encodeCursor + decodeCursor round-trip", () => {
     expect(decodeCursor(Buffer.from('{"page":-1}', "utf-8").toString("base64url"))).toBeNull();
     // page is 0
     expect(decodeCursor(Buffer.from('{"page":0}', "utf-8").toString("base64url"))).toBeNull();
+    // page at the ceiling is still valid (CWE-770 #810)
+    expect(decodeCursor(encodeCursor({ page: MAX_PAGE }))).toEqual({ page: MAX_PAGE });
+    // page one past the ceiling → null
+    expect(decodeCursor(encodeCursor({ page: MAX_PAGE + 1 }))).toBeNull();
+    // forged huge page → null (the unbounded-`.skip()` DoS vector)
+    expect(decodeCursor(Buffer.from('{"page":999999999}', "utf-8").toString("base64url"))).toBeNull();
   });
 });
 

--- a/ornn-api/src/shared/cursor.ts
+++ b/ornn-api/src/shared/cursor.ts
@@ -16,6 +16,10 @@
  * @module shared/cursor
  */
 
+// Ceiling bounds `.skip()` so a forged cursor can't drive a multi-second
+// collection scan (CWE-770, #810).
+export const MAX_PAGE = 10_000;
+
 export interface CursorPayload {
   /** 1-indexed page number — what the underlying offset query reads. */
   page: number;
@@ -29,7 +33,9 @@ export function encodeCursor(payload: CursorPayload): string {
 /**
  * Decode an opaque cursor. Returns `null` for any malformed input —
  * the route layer then surfaces a 400 `invalid_cursor` so an old
- * client doesn't end up paginating from page 1 silently.
+ * client doesn't end up paginating from page 1 silently. A page above
+ * `MAX_PAGE` is also rejected so a forged cursor can't drive an
+ * unbounded `.skip()` (CWE-770, #810).
  */
 export function decodeCursor(raw: string | undefined): CursorPayload | null {
   if (!raw || typeof raw !== "string" || raw.length === 0) return null;
@@ -38,7 +44,7 @@ export function decodeCursor(raw: string | undefined): CursorPayload | null {
     const parsed = JSON.parse(json) as unknown;
     if (!parsed || typeof parsed !== "object") return null;
     const page = (parsed as { page?: unknown }).page;
-    if (typeof page !== "number" || !Number.isInteger(page) || page < 1) return null;
+    if (typeof page !== "number" || !Number.isInteger(page) || page < 1 || page > MAX_PAGE) return null;
     return { page };
   } catch {
     return null;


### PR DESCRIPTION
Closes #810

Automated change by `/auto` (run `20260604T074750Z-90075`, runner `auto-runner-20260604T074750Z-90075-93822-3237`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
