### PR TITLE
[Bug] Re-resolve outbound hosts at fetch time for SSRF (DNS-rebind) parity

### DIFF
--- a/.changeset/auto-811-ssrf-dns-rebind-parity.md
+++ b/.changeset/auto-811-ssrf-dns-rebind-parity.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Close DNS-rebind SSRF gap: route chrono-storage, chrono-sandbox, and all NyxID/LLM-gateway outbound requests through a shared fetch-time assertPublicResolvedAddress preflight (#811).

--- a/ornn-api/src/clients/llmModelListClient.ts
+++ b/ornn-api/src/clients/llmModelListClient.ts
@@ -38,10 +38,8 @@ import type {
   LlmProviderAuth,
 } from "../domains/settings/llmProviders/types";
 import type { ModelListFetcher } from "../domains/settings/llmProviders/service";
-import {
-  assertPublicResolvedAddress,
-  SsrfRefusalError,
-} from "../infra/url";
+import { safeFetch } from "../infra/safeFetch";
+import { SsrfRefusalError } from "../infra/url";
 
 const logger = createLogger("llmModelListClient");
 
@@ -76,27 +74,6 @@ function redactCredentials(body: string): string {
     .replace(/"(access_token|api_key|apiKey|token)"\s*:\s*"[^"]*"/g, '"$1":"[REDACTED]"');
 }
 
-/**
- * Pre-flight SSRF check + AbortSignal wrapper around `fetch`. Centralised
- * so the model-list and OAuth2 token-exchange paths share one
- * implementation.
- */
-async function safeFetch(
-  url: string,
-  init: RequestInit,
-): Promise<Response> {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error(`Invalid URL: '${url}'`);
-  }
-  await assertPublicResolvedAddress(parsed.hostname);
-
-  const signal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
-  return fetch(url, { ...init, signal });
-}
-
 export class LlmModelListClient implements ModelListFetcher {
   /**
    * Fetch the upstream catalog. Returns `[{ id, displayName }]` —
@@ -119,7 +96,10 @@ export class LlmModelListClient implements ModelListFetcher {
 
     let resp: Response;
     try {
-      resp = await safeFetch(args.modelListUrl, { headers });
+      resp = await safeFetch(args.modelListUrl, {
+        headers,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
     } catch (err) {
       // Distinguish SSRF refusal (operator-actionable) from generic
       // transport failures so the admin "Refresh" toast can render
@@ -219,6 +199,7 @@ export class LlmModelListClient implements ModelListFetcher {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
           body: body.toString(),
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         });
       } catch (err) {
         if (err instanceof SsrfRefusalError) {

--- a/ornn-api/src/clients/nyxid/base.ts
+++ b/ornn-api/src/clients/nyxid/base.ts
@@ -17,6 +17,7 @@
  */
 
 import { createLogger } from "../../shared/logger";
+import { safeFetch } from "../../infra/safeFetch";
 const logger = createLogger("nyxidSaTokenProvider");
 
 /**
@@ -82,7 +83,7 @@ export class NyxidSaTokenProvider {
       client_id: clientId,
       client_secret: clientSecret,
     });
-    const resp = await fetch(tokenUrl, {
+    const resp = await safeFetch(tokenUrl, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: body.toString(),

--- a/ornn-api/src/clients/nyxid/llm.ts
+++ b/ornn-api/src/clients/nyxid/llm.ts
@@ -25,6 +25,7 @@
  */
 
 import { createLogger } from "../../shared/logger";
+import { safeFetch } from "../../infra/safeFetch";
 import type { ApiFormat } from "../../domains/settings/llmProviders/types";
 import type { NyxidSaTokenProvider } from "./base";
 
@@ -375,7 +376,7 @@ export class NyxLlmClient {
         ? buildChatCompletionBody(params, true)
         : buildResponsesBody(params, true);
 
-    const response = await fetch(`${gatewayUrl}${path}`, {
+    const response = await safeFetch(`${gatewayUrl}${path}`, {
       method: "POST",
       headers: {
         "Authorization": authHeader,
@@ -424,7 +425,7 @@ export class NyxLlmClient {
         ? buildChatCompletionBody(params, false)
         : buildResponsesBody(params, false);
 
-    const response = await fetch(`${gatewayUrl}${path}`, {
+    const response = await safeFetch(`${gatewayUrl}${path}`, {
       method: "POST",
       headers: {
         "Authorization": authHeader,

--- a/ornn-api/src/clients/nyxid/llmCatalog.ts
+++ b/ornn-api/src/clients/nyxid/llmCatalog.ts
@@ -17,6 +17,7 @@
  */
 
 import { createLogger } from "../../shared/logger";
+import { safeFetch } from "../../infra/safeFetch";
 import type { NyxidConfigResolver, NyxidSaTokenProvider } from "./base";
 
 const logger = createLogger("nyxLlmCatalogClient");
@@ -72,7 +73,7 @@ export class NyxLlmCatalogClient {
   async listUpstreamModels(): Promise<UpstreamModel[]> {
     const url = await this.resolveUrl();
     const token = await this.saTokenProvider.getAccessToken();
-    const resp = await fetch(url, {
+    const resp = await safeFetch(url, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!resp.ok) {

--- a/ornn-api/src/clients/nyxid/orgs.ts
+++ b/ornn-api/src/clients/nyxid/orgs.ts
@@ -12,6 +12,7 @@
  */
 
 import { createLogger } from "../../shared/logger";
+import { safeFetch } from "../../infra/safeFetch";
 import type { NyxidConfigResolver, NyxidSaTokenProvider } from "./base";
 
 const logger = createLogger("nyxidOrgsClient");
@@ -75,7 +76,7 @@ export class NyxidOrgsClient {
   async listUserOrgs(userAccessToken: string): Promise<OrgMembership[]> {
     const baseUrl = await this.resolveBaseUrl();
     const url = `${baseUrl}/api/v1/orgs`;
-    const resp = await fetch(url, {
+    const resp = await safeFetch(url, {
       headers: { Authorization: `Bearer ${userAccessToken}` },
     });
     if (!resp.ok) {
@@ -137,7 +138,7 @@ export class NyxidOrgsClient {
     const url = `${baseUrl}/api/v1/orgs/${encodeURIComponent(orgUserId)}/members`;
     let resp: Response;
     try {
-      resp = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+      resp = await safeFetch(url, { headers: { Authorization: `Bearer ${token}` } });
     } catch (err) {
       logger.warn({ err, orgUserId }, "NyxID listOrgMembers fetch threw");
       return [];

--- a/ornn-api/src/clients/nyxid/service.ts
+++ b/ornn-api/src/clients/nyxid/service.ts
@@ -14,6 +14,7 @@
  */
 
 import { createLogger } from "../../shared/logger";
+import { safeFetch } from "../../infra/safeFetch";
 import type { NyxidConfigResolver } from "./base";
 
 const logger = createLogger("nyxidServiceClient");
@@ -99,7 +100,7 @@ export class NyxidServiceClient {
     }
     try {
       const baseUrl = await this.resolveBaseUrl();
-      const resp = await fetch(`${baseUrl}/api/v1/services`, {
+      const resp = await safeFetch(`${baseUrl}/api/v1/services`, {
         headers: { Authorization: `Bearer ${userAccessToken}` },
       });
       if (!resp.ok) {
@@ -187,7 +188,7 @@ export class NyxidServiceClient {
     }
     try {
       const baseUrl = await this.resolveBaseUrl();
-      const resp = await fetch(`${baseUrl}/api/v1/services`, {
+      const resp = await safeFetch(`${baseUrl}/api/v1/services`, {
         headers: { Authorization: `Bearer ${saToken}` },
       });
       if (!resp.ok) {

--- a/ornn-api/src/clients/nyxid/ssrf.test.ts
+++ b/ornn-api/src/clients/nyxid/ssrf.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for #811: the NyxID-family clients route every outbound request
+ * through `safeFetch`, closing the DNS-rebind gap for both the
+ * SA token-exchange path (`base.ts`) and the `baseApiUrl` service calls
+ * (`service.ts`). A NyxID host that rebinds to 169.254.169.254 at fetch
+ * time is refused before the client_secret / bearer token is sent.
+ *
+ * dns is stubbed before the client imports so the shared preflight
+ * (bound in `url.ts` at module load) sees the rebind. Asserting the
+ * `globalThis.fetch` spy recorded zero calls proves the swap is live for
+ * both the token path and a `baseApiUrl` sibling.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// `mock.module` is process-global and `url.ts` binds the dns namespace
+// at first load, so the stub cannot be cleanly torn down per-file. We
+// therefore make it host-aware: ONLY the rebind hostname resolves to
+// the cloud-metadata address; every other host (including the public
+// hostnames sibling tests like llm.test.ts / service.test.ts use)
+// resolves to a benign public IP, so the leaked mock is harmless.
+const REBIND_HOST = "rebind.test";
+mock.module("node:dns/promises", () => ({
+  lookup: async (host: string) =>
+    host === REBIND_HOST
+      ? [{ address: "169.254.169.254", family: 4 }]
+      : [{ address: "93.184.216.34", family: 4 }],
+}));
+
+const { NyxidSaTokenProvider } = await import("./base");
+const { NyxidServiceClient } = await import("./service");
+const { SsrfRefusalError } = await import("../../infra/url");
+
+const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
+const originalFetch = globalThis.fetch;
+const originalAllowlist = process.env[ALLOWLIST_ENV];
+
+let fetchCalls: string[];
+
+beforeEach(() => {
+  fetchCalls = [];
+  delete process.env[ALLOWLIST_ENV];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    fetchCalls.push(url);
+    return new Response(JSON.stringify({ access_token: "tok", services: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalAllowlist === undefined) delete process.env[ALLOWLIST_ENV];
+  else process.env[ALLOWLIST_ENV] = originalAllowlist;
+});
+
+describe("NyxidSaTokenProvider SSRF preflight (#811)", () => {
+  function makeProvider() {
+    return new NyxidSaTokenProvider(async () => ({
+      tokenUrl: "http://rebind.test/oauth/token",
+      clientId: "cid",
+      clientSecret: "secret",
+    }));
+  }
+
+  it("getAccessToken() refuses a rebound token host before posting client_secret", async () => {
+    await expect(makeProvider().getAccessToken()).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("allowlisted token host passes the preflight and reaches fetch", async () => {
+    process.env[ALLOWLIST_ENV] = "rebind.test";
+    const token = await makeProvider().getAccessToken();
+    expect(token).toBe("tok");
+    expect(fetchCalls).toEqual(["http://rebind.test/oauth/token"]);
+  });
+});
+
+describe("NyxidServiceClient SSRF preflight (#811) — baseApiUrl sibling", () => {
+  function makeClient() {
+    return new NyxidServiceClient({
+      resolver: async () => ({ baseApiUrl: "http://rebind.test" }),
+    });
+  }
+
+  it("listServicesForCaller() refuses a rebound baseApiUrl before sending the bearer token", async () => {
+    // listServicesForCaller fail-soft-catches errors and returns []; we
+    // assert via the fetch spy that the network call never fired and the
+    // refusal short-circuited the request.
+    const out = await makeClient().listServicesForCaller("user-token");
+    expect(out).toEqual([]);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("listActiveServiceIdsAsPlatform() refuses a rebound baseApiUrl (SA path)", async () => {
+    const ids = await makeClient().listActiveServiceIdsAsPlatform("sa-token");
+    // Fail-soft returns null when the SSRF refusal is caught.
+    expect(ids).toBeNull();
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("allowlisted baseApiUrl passes the preflight and reaches fetch", async () => {
+    process.env[ALLOWLIST_ENV] = "rebind.test";
+    await makeClient().listServicesForCaller("user-token");
+    expect(fetchCalls).toEqual(["http://rebind.test/api/v1/services"]);
+  });
+});

--- a/ornn-api/src/clients/nyxid/userServices.ts
+++ b/ornn-api/src/clients/nyxid/userServices.ts
@@ -21,6 +21,7 @@
  */
 
 import { createLogger } from "../../shared/logger";
+import { safeFetch } from "../../infra/safeFetch";
 import type { NyxidConfigResolver } from "./base";
 
 const logger = createLogger("nyxidUserServicesClient");
@@ -76,7 +77,7 @@ export class NyxidUserServicesClient {
   async listUserServices(userAccessToken: string): Promise<UserService[]> {
     const baseUrl = await this.resolveBaseUrl();
     const url = `${baseUrl}/api/v1/user-services`;
-    const resp = await fetch(url, {
+    const resp = await safeFetch(url, {
       headers: { Authorization: `Bearer ${userAccessToken}` },
     });
     if (!resp.ok) {

--- a/ornn-api/src/clients/sandboxClient.test.ts
+++ b/ornn-api/src/clients/sandboxClient.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for #811: SandboxClient outbound calls route through `safeFetch`.
+ * A chrono-sandbox host that rebinds to a private/metadata address at
+ * fetch time is refused before the SA bearer token leaves the process.
+ *
+ * dns is stubbed → 169.254.169.254 before the client import so the
+ * shared preflight (bound in `url.ts` at load) catches the rebind. The
+ * zero-fetch-call assertion proves the swap is live.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// `mock.module` is process-global and `url.ts` binds the dns namespace
+// at first load, so the stub cannot be cleanly torn down per-file. We
+// therefore make it host-aware: ONLY the rebind hostname resolves to
+// the cloud-metadata address; every other host resolves to a benign
+// public IP, so the leaked mock is harmless to sibling tests.
+const REBIND_HOST = "rebind.test";
+mock.module("node:dns/promises", () => ({
+  lookup: async (host: string) =>
+    host === REBIND_HOST
+      ? [{ address: "169.254.169.254", family: 4 }]
+      : [{ address: "93.184.216.34", family: 4 }],
+}));
+
+const { SandboxClient } = await import("./sandboxClient");
+const { SsrfRefusalError } = await import("../infra/url");
+
+const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
+const originalFetch = globalThis.fetch;
+const originalAllowlist = process.env[ALLOWLIST_ENV];
+
+let fetchCalls: string[];
+
+beforeEach(() => {
+  fetchCalls = [];
+  delete process.env[ALLOWLIST_ENV];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    fetchCalls.push(url);
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalAllowlist === undefined) delete process.env[ALLOWLIST_ENV];
+  else process.env[ALLOWLIST_ENV] = originalAllowlist;
+});
+
+function makeClient() {
+  return new SandboxClient({
+    resolver: async () => ({ baseUrl: "http://rebind.test" }),
+    getAccessToken: async () => "sa-token-xyz",
+  });
+}
+
+/** Drain an async generator to force the underlying request to fire. */
+async function drain(gen: AsyncGenerator<unknown>): Promise<void> {
+  for await (const _ of gen) {
+    /* discard */
+  }
+}
+
+describe("SandboxClient SSRF preflight (#811)", () => {
+  it("execute() (POST path) refuses a rebound host before issuing the request", async () => {
+    await expect(
+      makeClient().execute({ script: "print(1)", language: "python" }),
+    ).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("deleteSession() refuses a rebound host before issuing the request", async () => {
+    await expect(makeClient().deleteSession("s1")).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("listSessions() refuses a rebound host before issuing the request", async () => {
+    await expect(makeClient().listSessions()).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("executeStream() (SSE path) refuses a rebound host before issuing the request", async () => {
+    await expect(
+      drain(makeClient().executeStream({ script: "print(1)", language: "python" })),
+    ).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("allowlisted host passes the preflight and reaches fetch", async () => {
+    process.env[ALLOWLIST_ENV] = "rebind.test";
+    const res = await makeClient().execute({ script: "print(1)", language: "python" });
+    expect(res.success).toBe(true);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]).toBe("http://rebind.test/execute");
+  });
+});

--- a/ornn-api/src/clients/sandboxClient.ts
+++ b/ornn-api/src/clients/sandboxClient.ts
@@ -5,6 +5,7 @@
  */
 
 import { createLogger } from "../shared/logger";
+import { safeFetch } from "../infra/safeFetch";
 const logger = createLogger("sandboxClient");
 
 // ── Shared types ──────────────────────────────────────────────────────
@@ -296,7 +297,7 @@ export class SandboxClient {
 
     const baseUrl = await this.resolveBaseUrl();
     const auth = await this.authHeaders();
-    const response = await fetch(`${baseUrl}/sessions/${sessionId}`, {
+    const response = await safeFetch(`${baseUrl}/sessions/${sessionId}`, {
       method: "DELETE",
       headers: auth,
     });
@@ -315,7 +316,7 @@ export class SandboxClient {
 
     const baseUrl = await this.resolveBaseUrl();
     const auth = await this.authHeaders();
-    const response = await fetch(`${baseUrl}/sessions`, { headers: auth });
+    const response = await safeFetch(`${baseUrl}/sessions`, { headers: auth });
     if (!response.ok) {
       const text = await response.text().catch(() => "");
       throw new Error(`List sessions failed (${response.status}): ${text}`);
@@ -329,7 +330,7 @@ export class SandboxClient {
   private async post<T>(path: string, body: Record<string, unknown>): Promise<T> {
     const baseUrl = await this.resolveBaseUrl();
     const auth = await this.authHeaders();
-    const response = await fetch(`${baseUrl}${path}`, {
+    const response = await safeFetch(`${baseUrl}${path}`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...auth },
       body: JSON.stringify(body),
@@ -347,7 +348,7 @@ export class SandboxClient {
   private async *streamSSE(path: string, body: Record<string, unknown>): AsyncGenerator<StreamEvent> {
     const baseUrl = await this.resolveBaseUrl();
     const auth = await this.authHeaders();
-    const response = await fetch(`${baseUrl}${path}`, {
+    const response = await safeFetch(`${baseUrl}${path}`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...auth },
       body: JSON.stringify(body),

--- a/ornn-api/src/clients/storageClient.test.ts
+++ b/ornn-api/src/clients/storageClient.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for #811: StorageClient outbound calls route through `safeFetch`,
+ * so a chrono-storage host that resolves to a private/metadata address
+ * at fetch time is refused BEFORE the SA bearer token is sent.
+ *
+ * We stub `node:dns/promises` → 169.254.169.254 (cloud metadata) before
+ * importing the client so the shared `assertPublicResolvedAddress`
+ * (bound in `url.ts` at load) sees the rebind. The assertion that the
+ * `globalThis.fetch` spy recorded zero calls is what proves the swap is
+ * live — revert `fetch`→`safeFetch` and these tests fail.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// `mock.module` is process-global and `url.ts` binds the dns namespace
+// at first load, so the stub cannot be cleanly torn down per-file. We
+// therefore make it host-aware: ONLY the rebind hostname resolves to
+// the cloud-metadata address; every other host (including the public
+// hostnames sibling tests use) resolves to a benign public IP. That way
+// the leaked mock is harmless to `llm.test.ts` / `service.test.ts`.
+const REBIND_HOST = "rebind.test";
+mock.module("node:dns/promises", () => ({
+  lookup: async (host: string) =>
+    host === REBIND_HOST
+      ? [{ address: "169.254.169.254", family: 4 }]
+      : [{ address: "93.184.216.34", family: 4 }],
+}));
+
+const { StorageClient } = await import("./storageClient");
+const { SsrfRefusalError } = await import("../infra/url");
+
+const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
+const originalFetch = globalThis.fetch;
+const originalAllowlist = process.env[ALLOWLIST_ENV];
+
+let fetchCalls: string[];
+
+beforeEach(() => {
+  fetchCalls = [];
+  delete process.env[ALLOWLIST_ENV];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    fetchCalls.push(url);
+    return new Response(JSON.stringify({ data: { url: "x" } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalAllowlist === undefined) delete process.env[ALLOWLIST_ENV];
+  else process.env[ALLOWLIST_ENV] = originalAllowlist;
+});
+
+function makeClient() {
+  return new StorageClient({
+    resolver: async () => ({ baseUrl: "http://rebind.test", bucket: "b" }),
+    getAccessToken: async () => "sa-token-xyz",
+  });
+}
+
+describe("StorageClient SSRF preflight (#811)", () => {
+  it("upload() refuses a rebound host before issuing the request", async () => {
+    await expect(
+      makeClient().upload("b", "k", new Uint8Array([1]), "text/plain"),
+    ).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("delete() refuses a rebound host before issuing the request", async () => {
+    await expect(makeClient().delete("b", "k")).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("getPresignedUrl() refuses a rebound host before issuing the request", async () => {
+    await expect(makeClient().getPresignedUrl("b", "k")).rejects.toBeInstanceOf(
+      SsrfRefusalError,
+    );
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("copy() refuses a rebound host before issuing the request", async () => {
+    await expect(makeClient().copy("b", "s", "d")).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("allowlisted host passes the preflight and reaches fetch", async () => {
+    process.env[ALLOWLIST_ENV] = "rebind.test";
+    const out = await makeClient().upload("b", "k", new Uint8Array([1]), "text/plain");
+    expect(out).toEqual({ url: "x" });
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]).toContain("http://rebind.test/api/buckets/b/objects");
+  });
+});

--- a/ornn-api/src/clients/storageClient.ts
+++ b/ornn-api/src/clients/storageClient.ts
@@ -5,6 +5,7 @@
  */
 
 import { createLogger } from "../shared/logger";
+import { safeFetch } from "../infra/safeFetch";
 const logger = createLogger("storageClient");
 
 export interface IStorageClient {
@@ -67,7 +68,7 @@ export class StorageClient implements IStorageClient {
     const url = `${baseUrl}/api/buckets/${bucket}/objects?${params.toString()}`;
 
     const auth = await this.authHeaders();
-    const res = await fetch(url, {
+    const res = await safeFetch(url, {
       method: "POST",
       headers: { "Content-Type": contentType, ...auth },
       body: data as unknown as BodyInit,
@@ -90,7 +91,7 @@ export class StorageClient implements IStorageClient {
     const url = `${baseUrl}/api/buckets/${bucket}/objects?${params.toString()}`;
 
     const auth = await this.authHeaders();
-    const res = await fetch(url, { method: "DELETE", headers: auth });
+    const res = await safeFetch(url, { method: "DELETE", headers: auth });
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");
@@ -114,7 +115,7 @@ export class StorageClient implements IStorageClient {
     const url = `${baseUrl}/api/buckets/${bucket}/presigned-url?${params.toString()}`;
 
     const auth = await this.authHeaders();
-    const res = await fetch(url, { method: "GET", headers: auth });
+    const res = await safeFetch(url, { method: "GET", headers: auth });
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");
@@ -131,7 +132,7 @@ export class StorageClient implements IStorageClient {
     const url = `${baseUrl}/api/buckets/${bucket}/objects/copy`;
 
     const auth = await this.authHeaders();
-    const res = await fetch(url, {
+    const res = await safeFetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...auth },
       body: JSON.stringify({ sourceKey, destKey }),

--- a/ornn-api/src/infra/safeFetch.test.ts
+++ b/ornn-api/src/infra/safeFetch.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for #811: the shared SSRF-preflight `safeFetch` primitive.
+ *
+ * `safeFetch` re-resolves the outbound host at fetch time via
+ * `assertPublicResolvedAddress` (which calls `dns.lookup`) and refuses
+ * private/loopback/link-local resolutions BEFORE the real `fetch` —
+ * the DNS-rebind defense. We stub `node:dns/promises` so a public
+ * hostname resolves to the cloud-metadata address `169.254.169.254`
+ * and assert the wrapper rejects without ever issuing the network call.
+ *
+ * `url.ts` binds `dns` at module load (`import * as dns from
+ * "node:dns/promises"`), so the `mock.module` MUST be installed before
+ * the modules under test are imported — hence the top-level mock +
+ * dynamic `import()` (same idiom as mirror/scheduler.test.ts).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Install the dns mock BEFORE importing the module under test so
+// `url.ts` binds the stub at load time. `mock.module` is process-global
+// and `url.ts` binds the dns namespace once, so the stub cannot be
+// cleanly torn down per-file — we therefore make it host-aware: ONLY
+// the rebind hostname resolves to the cloud-metadata address; every
+// other host resolves to a benign public IP, so the leaked stub is
+// harmless to sibling tests that hit real public hostnames.
+const REBIND_HOST = "evil.example.com";
+mock.module("node:dns/promises", () => ({
+  lookup: async (host: string) =>
+    host === REBIND_HOST
+      ? [{ address: "169.254.169.254", family: 4 }]
+      : [{ address: "93.184.216.34", family: 4 }],
+}));
+
+const { safeFetch } = await import("./safeFetch");
+const { SsrfRefusalError } = await import("./url");
+
+const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
+const originalFetch = globalThis.fetch;
+const originalAllowlist = process.env[ALLOWLIST_ENV];
+
+let fetchCalls: string[];
+
+beforeEach(() => {
+  fetchCalls = [];
+  delete process.env[ALLOWLIST_ENV];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    fetchCalls.push(url);
+    return new Response("ok", { status: 200 });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalAllowlist === undefined) delete process.env[ALLOWLIST_ENV];
+  else process.env[ALLOWLIST_ENV] = originalAllowlist;
+});
+
+describe("safeFetch — DNS-rebind preflight (#811)", () => {
+  it("rejects with SsrfRefusalError and never calls fetch when the host resolves to a private address", async () => {
+    await expect(safeFetch("http://evil.example.com/x")).rejects.toBeInstanceOf(
+      SsrfRefusalError,
+    );
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("lets the request through (fetch IS called) when the host is operator-allowlisted — DNS resolution skipped", async () => {
+    process.env[ALLOWLIST_ENV] = "evil.example.com";
+    const res = await safeFetch("http://evil.example.com/x");
+    expect(res.status).toBe(200);
+    expect(fetchCalls).toEqual(["http://evil.example.com/x"]);
+  });
+
+  it("lets the request through for a literal public IP (upstream already vetted the literal — no re-resolution)", async () => {
+    const res = await safeFetch("http://93.184.216.34/x");
+    expect(res.status).toBe(200);
+    expect(fetchCalls).toEqual(["http://93.184.216.34/x"]);
+  });
+
+  it("forwards the init object verbatim to fetch", async () => {
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedInit = init;
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    const init: RequestInit = { method: "POST", headers: { "X-Test": "1" }, body: "payload" };
+    await safeFetch("http://93.184.216.34/x", init);
+    expect(capturedInit).toBe(init);
+  });
+
+  it("throws on an invalid URL before resolving or fetching", async () => {
+    await expect(safeFetch("not a url")).rejects.toThrow(/Invalid URL/);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/ornn-api/src/infra/safeFetch.ts
+++ b/ornn-api/src/infra/safeFetch.ts
@@ -1,0 +1,29 @@
+/**
+ * SSRF-preflight fetch wrapper (#811).
+ *
+ * The single shared primitive that re-resolves an outbound host at
+ * fetch time and refuses private/loopback/link-local targets — the
+ * DNS-rebind defense that complements write-time `validatePublicUrl`.
+ * Every outbound client (chrono-storage, chrono-sandbox, NyxID,
+ * LLM gateway, model-list) routes through this so a public host that
+ * later flips its DNS to 169.254.169.254 / RFC1918 is caught before
+ * the bearer/SA token is sent.
+ *
+ * Intentionally a thin wrapper: NO timeout (callers that need one pass
+ * their own `init.signal`); credential redaction / response parsing
+ * stay in the individual clients.
+ *
+ * @module infra/safeFetch
+ */
+import { assertPublicResolvedAddress } from "./url";
+
+export async function safeFetch(url: string, init?: RequestInit): Promise<Response> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: '${url}'`);
+  }
+  await assertPublicResolvedAddress(parsed.hostname);
+  return fetch(url, init);
+}


### PR DESCRIPTION
Closes #811

Automated change by `/auto` (run `20260604T074750Z-90075`, runner `auto-runner-20260604T074750Z-90075-96171-30984`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
