### PR TITLE
[Bug] Skip idempotency capture for SSE/streaming responses

### DIFF
--- a/.changeset/auto-812-idempotency-sse-passthrough.md
+++ b/.changeset/auto-812-idempotency-sse-passthrough.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Idempotency middleware skips capture for streaming (text/event-stream) responses so SSE streams are delivered unbuffered and never persisted (#812).

--- a/ornn-api/src/middleware/idempotency.test.ts
+++ b/ornn-api/src/middleware/idempotency.test.ts
@@ -100,6 +100,31 @@ describe("idempotency middleware (#459)", () => {
     expect(second.headers.get("Location")).toBe("/v1/skills/abc");
   });
 
+  test("SSE responses are passed through unbuffered and never persisted (#812, CWE-770)", async () => {
+    const { app, counter } = makeApp(
+      () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+              controller.enqueue(new TextEncoder().encode("data: two\n\n"));
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream; charset=utf-8" } },
+        ),
+    );
+    const headers = { "Idempotency-Key": "sse-key" };
+    const first = await app.request("/api/v1/skills", { method: "POST", headers });
+    expect(first.status).toBe(200);
+    expect(first.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+    expect(await first.text()).toBe("data: one\n\ndata: two\n\n");
+    expect(await db.collection("idempotency_keys").countDocuments()).toBe(0);
+    const second = await app.request("/api/v1/skills", { method: "POST", headers });
+    expect(counter.value).toBe(2); // handler re-ran, not replayed
+    expect(second.headers.get("Idempotency-Replay")).toBe(null);
+  });
+
   test("different users with the same key DON'T collide (per-user scoping)", async () => {
     const { app, counter } = makeApp((c) =>
       new Response(JSON.stringify({ id: c.value }), {

--- a/ornn-api/src/middleware/idempotency.ts
+++ b/ornn-api/src/middleware/idempotency.ts
@@ -192,6 +192,15 @@ export function idempotencyMiddleware(config: IdempotencyConfig): MiddlewareHand
     try {
       const responseHeaders = captureHeaders(res);
       const contentType = responseHeaders["content-type"] ?? "";
+      // CWE-770 (#812): never buffer/persist a streaming body. SSE responses
+      // are unbounded; clone().text() would tee + drain the live stream into
+      // memory and persist a frozen blob that replays incorrectly. Pass the
+      // live stream through untouched. startsWith — prod emits
+      // "text/event-stream; charset=utf-8" (playground/routes.ts), so === misses it.
+      if (contentType.startsWith("text/event-stream")) {
+        logger.debug({ id, path }, "Idempotency skip: streaming response not cached");
+        return;
+      }
       let body: string;
       let encoding: "utf-8" | "base64";
       if (contentType.startsWith("application/") || contentType.startsWith("text/")) {


### PR DESCRIPTION
Closes #812

Automated change by `/auto` (run `20260604T074750Z-90075`, runner `auto-runner-20260604T074750Z-90075-99590-12574`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
