### PR TITLE
[Bug] Key anonymous rate limits on a trusted client IP, not raw XFF

### DIFF
--- a/.changeset/auto-813-rate-limit-xff-trusted-hop.md
+++ b/.changeset/auto-813-rate-limit-xff-trusted-hop.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Rate-limit keys anonymous traffic on a trusted-position X-Forwarded-For hop (configurable via ORNN_TRUSTED_PROXY_HOPS), not the spoofable leftmost token (#813, CWE-348).

--- a/deployment/.env.sample.ornn
+++ b/deployment/.env.sample.ornn
@@ -17,6 +17,7 @@ MAX_PACKAGE_SIZE_BYTES=<max-package-size>
 ALLOWED_ORIGINS=<comma-separated-origins, e.g. https://app.ornn.xyz,http://localhost:5173>
 ORNN_PUBLIC_ORIGIN=<e.g. https://ornn.chrono-ai.fun>
 ORNN_URL_ALLOWLIST_CIDR=<comma-separated, e.g. nyxid-backend,mongodb,10.0.0.0/8,127.0.0.0/8>
+ORNN_TRUSTED_PROXY_HOPS=<trusted appending proxies in front of ornn-api beyond the immediate peer; default 0 = key the connecting peer's appended IP>
 AGENTSEAL_PYTHON=/opt/agentseal/bin/python
 AGENTSEAL_SCRIPT=/opt/agentseal/scan_skill.py
 ENCRYPTION_KEY=<32+ char passphrase, e.g. openssl rand -hex 32>

--- a/deployment/ornn-api/deployment.yaml
+++ b/deployment/ornn-api/deployment.yaml
@@ -54,6 +54,8 @@ spec:
               value: "${ORNN_PUBLIC_ORIGIN}"
             - name: ORNN_URL_ALLOWLIST_CIDR
               value: "${ORNN_URL_ALLOWLIST_CIDR}"
+            - name: ORNN_TRUSTED_PROXY_HOPS
+              value: "${ORNN_TRUSTED_PROXY_HOPS}"
             - name: AGENTSEAL_PYTHON
               value: "${AGENTSEAL_PYTHON}"
             - name: AGENTSEAL_SCRIPT

--- a/ornn-api/src/middleware/rateLimit.test.ts
+++ b/ornn-api/src/middleware/rateLimit.test.ts
@@ -145,3 +145,91 @@ describe("rateLimit middleware (#439 + #460)", () => {
     expect(r3.status).toBe(429);
   });
 });
+
+/**
+ * Anonymous (no-auth) keying — the spoofable-XFF surface (#813, CWE-348).
+ *
+ * The leftmost X-Forwarded-For token is client-controlled: an attacker
+ * can rotate it per request to shard the per-IP bucket and bypass the
+ * cap. The fix keys on a trusted token counted from the RIGHT (proxies
+ * append), configurable via ORNN_TRUSTED_PROXY_HOPS. These tests build
+ * a bare app with NO auth stub so `defaultKeyBy` falls through to the
+ * IP branch.
+ */
+describe("rateLimit middleware — anonymous XFF keying (#813)", () => {
+  beforeEach(() => __resetRateLimitForTests());
+
+  // Bare app: no auth stub, so defaultKeyBy hits the x-forwarded-for path.
+  function makeAnonApp(opts: { windowMs?: number; max?: number; label?: string }) {
+    const app = new Hono();
+    app.use(
+      "*",
+      rateLimit({
+        windowMs: opts.windowMs ?? 60_000,
+        max: opts.max ?? 2,
+        label: opts.label ?? "ip",
+      }),
+    );
+    app.get("/", (c) => c.json({ ok: true }));
+    app.onError((err, c) => {
+      if (err instanceof AppError) {
+        const body = buildProblemJsonBody({
+          statusCode: err.statusCode,
+          code: err.code,
+          message: err.message,
+          instance: c.req.path,
+          requestId: null,
+        });
+        return c.json(body, err.statusCode as never, {
+          "Content-Type": "application/problem+json",
+        });
+      }
+      return c.json({ error: { code: "internal_error", message: String(err) } }, 500);
+    });
+    return app;
+  }
+
+  test("anonymous: distinct spoofed leftmost XFF + same trusted hop share one bucket", async () => {
+    // Default hops=0 → trusted token is the rightmost "9.9.9.9", shared by
+    // all three. The distinct leftmost tokens are client-prepended spoofs
+    // and MUST NOT shard the bucket.
+    const app = makeAnonApp({ windowMs: 60_000, max: 2, label: "ip" });
+    const r1 = await app.request("/", { headers: { "x-forwarded-for": "1.1.1.1, 9.9.9.9" } });
+    const r2 = await app.request("/", { headers: { "x-forwarded-for": "2.2.2.2, 9.9.9.9" } });
+    const r3 = await app.request("/", { headers: { "x-forwarded-for": "3.3.3.3, 9.9.9.9" } });
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(429); // shared bucket exhausted at max=2
+  });
+
+  test("anonymous: distinct trusted hop → separate buckets", async () => {
+    // Different rightmost (trusted) token → genuinely different clients →
+    // independent buckets. max=1 means each is allowed exactly once.
+    const app = makeAnonApp({ windowMs: 60_000, max: 1, label: "ip" });
+    const a = await app.request("/", { headers: { "x-forwarded-for": "1.1.1.1, 8.8.8.8" } });
+    const b = await app.request("/", { headers: { "x-forwarded-for": "1.1.1.1, 9.9.9.9" } });
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200); // different trusted token → not the same bucket
+  });
+
+  test("respects ORNN_TRUSTED_PROXY_HOPS (counts from the right)", async () => {
+    // With hops=1 the trusted token is len-2 = "7.7.7.7" for all three
+    // requests, even though both the leftmost spoof AND the rightmost peer
+    // token differ per request. Proves the index is computed from the right.
+    const prev = process.env.ORNN_TRUSTED_PROXY_HOPS;
+    process.env.ORNN_TRUSTED_PROXY_HOPS = "1";
+    try {
+      const app = makeAnonApp({ windowMs: 60_000, max: 2, label: "ip" });
+      const r1 = await app.request("/", { headers: { "x-forwarded-for": "a, 7.7.7.7, peer1" } });
+      const r2 = await app.request("/", { headers: { "x-forwarded-for": "b, 7.7.7.7, peer2" } });
+      const r3 = await app.request("/", { headers: { "x-forwarded-for": "c, 7.7.7.7, peer3" } });
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+      expect(r3.status).toBe(429); // all keyed on "7.7.7.7" → bucket exhausted
+    } finally {
+      // Restore so the env var doesn't leak into sibling tests.
+      if (prev === undefined) delete process.env.ORNN_TRUSTED_PROXY_HOPS;
+      else process.env.ORNN_TRUSTED_PROXY_HOPS = prev;
+    }
+  });
+});

--- a/ornn-api/src/middleware/rateLimit.ts
+++ b/ornn-api/src/middleware/rateLimit.ts
@@ -21,9 +21,11 @@
  *
  * Mount order: must run AFTER `proxyAuthSetup` so `auth.userId` is
  * available for keying. When auth is missing (public endpoints), the
- * key falls back to the proxy-forwarded IP. Without IP either,
- * everyone shares the "anonymous" bucket — a fail-safe for the rare
- * truly-public path.
+ * key falls back to a trusted-position `x-forwarded-for` token —
+ * counted from the right per `ORNN_TRUSTED_PROXY_HOPS` so a client-
+ * prepended leftmost token can't shard the bucket (CWE-348, #813).
+ * Without a usable token, everyone shares the "anonymous" bucket — a
+ * fail-safe for the rare truly-public path.
  *
  * @module middleware/rateLimit
  */
@@ -33,6 +35,19 @@ import { AppError } from "../shared/types/index";
 import { createLogger } from "../shared/logger";
 
 const logger = createLogger("rateLimit");
+
+const TRUSTED_HOPS_ENV = "ORNN_TRUSTED_PROXY_HOPS";
+/**
+ * Number of trusted proxies that append to X-Forwarded-For in front of
+ * ornn-api, beyond the immediate connecting peer. Default 0 = key on the
+ * peer-appended (rightmost) token. The real client IP sits `hops` tokens
+ * from the right; counting from the right defeats client-prepended spoof
+ * tokens. Operators set this to match their ingress topology (#813).
+ */
+function readTrustedProxyHops(): number {
+  const raw = Number(process.env[TRUSTED_HOPS_ENV]);
+  return Number.isInteger(raw) && raw >= 0 ? raw : 0; // default/clamp on unset/NaN/negative/non-int
+}
 
 export interface RateLimitConfig {
   /** Window length in milliseconds. */
@@ -85,10 +100,23 @@ function cleanupExpired(now: number): void {
 function defaultKeyBy(c: Context): string {
   const auth = (c.get as unknown as (k: "auth") => { userId?: string } | undefined)("auth");
   if (auth?.userId) return `user:${auth.userId}`;
-  // Trust proxy-forwarded IP — production traffic comes through
-  // NyxID's reverse proxy which sets `x-forwarded-for`.
-  const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
-  if (ip) return `ip:${ip}`;
+  // XFF arrives as `client, …prepended…, realClient, proxy1, …` (proxies
+  // APPEND). Key on the trusted hop counted from the RIGHT so a client-
+  // prepended leftmost token cannot shard the bucket (CWE-348, #813).
+  const xff = c.req.header("x-forwarded-for");
+  if (xff) {
+    const tokens = xff.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
+    const idx = tokens.length - 1 - readTrustedProxyHops();
+    // idx < 0 means the chain is shorter than the configured trusted-hop
+    // count (misconfig or a request that skipped the proxy chain): we cannot
+    // identify a trusted token, so bucket together rather than trust a
+    // client-controlled token. CRITICAL: do NOT clamp to tokens[0] — that is
+    // the spoofable leftmost token (the exact bug). Fail safe to a shared bucket.
+    if (idx >= 0) {
+      const ip = tokens[idx];
+      if (ip) return `ip:${ip}`;
+    }
+  }
   return "anonymous";
 }
 


### PR DESCRIPTION
Closes #813

Automated change by `/auto` (run `20260604T074750Z-90075`, runner `auto-runner-20260604T074750Z-90075-2099-19829`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
