### PR TITLE
[Misc] Redact token/clientSecret/privateKey/accessToken in Pino logs

### DIFF
--- a/.changeset/auto-817-pino-redact-secrets.md
+++ b/.changeset/auto-817-pino-redact-secrets.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Harden log redaction: token, accessToken, userAccessToken, clientSecret and privateKey are now censored in all Pino logger roots (shared logger, bootstrap, entrypoint), sourced from a single exported REDACT_PATHS constant.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -147,6 +147,10 @@ import { buildSpec } from "./openapi/specBuilder";
 // Error handler
 import { AppError, buildProblemJsonBody } from "./shared/types/index";
 
+// Shared redaction list — single source of truth for sensitive log
+// fields, shared with index.ts and the createLogger factory.
+import { REDACT_PATHS } from "./shared/logger";
+
 export interface BootstrapResult {
   app: Hono;
   shutdown: () => Promise<void>;
@@ -156,15 +160,7 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   const logger = pino({
     level: config.logLevel,
     ...(config.logPretty ? { transport: { target: "pino-pretty" } } : {}),
-    redact: {
-      paths: [
-        "req.headers.authorization",
-        "req.headers[\"x-api-key\"]",
-        "*.password",
-        "*.secret",
-        "*.apiKey",
-      ],
-    },
+    redact: { paths: REDACT_PATHS },
   }).child({ service: "ornn-api" });
 
   logger.info("Bootstrapping ornn-api service...");

--- a/ornn-api/src/index.ts
+++ b/ornn-api/src/index.ts
@@ -5,6 +5,7 @@
 
 import { loadConfig, ConfigError, type SkillConfig } from "./infra/config";
 import { bootstrap } from "./bootstrap";
+import { REDACT_PATHS } from "./shared/logger";
 import pino from "pino";
 
 let config: SkillConfig;
@@ -23,6 +24,7 @@ try {
 const logger = pino({
   level: config.logLevel,
   ...(config.logPretty ? { transport: { target: "pino-pretty" } } : {}),
+  redact: { paths: REDACT_PATHS },
 }).child({ service: "ornn-api" });
 
 logger.info({ port: config.port }, "ornn-api starting");

--- a/ornn-api/src/shared/logger.test.ts
+++ b/ornn-api/src/shared/logger.test.ts
@@ -13,7 +13,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { createLogger } from "./logger";
+import { Writable } from "node:stream";
+import pino from "pino";
+import { createLogger, REDACT_PATHS } from "./logger";
 
 describe("createLogger (#575)", () => {
   test("returns a logger bound to the module name", () => {
@@ -61,5 +63,61 @@ describe("createLogger (#575)", () => {
     const child = parent.child({ requestId: "req_test" });
     expect(child).toBeDefined();
     expect(typeof child.info).toBe("function");
+  });
+
+  test("REDACT_PATHS censors token-family secrets at depth-2 (#817)", () => {
+    // Build our OWN pino instance from the exported constant + a
+    // minimal capture stream, deliberately avoiding pino-pretty and any
+    // env/import-order coupling. This makes the assertion fully
+    // order-independent — it behaves identically in a scoped `bun test
+    // src/shared/` run and in the single-process full suite (the trap
+    // that broke #816's CI).
+    //
+    // The `*.field` redaction wildcard matches EXACTLY one level, so we
+    // log a depth-2 object (`user.token`, ...). A depth-1 or depth-3
+    // payload would NOT match and the test would silently pass without
+    // proving anything.
+    const chunks: string[] = [];
+    const captureStream = new Writable({
+      write(chunk, _enc, cb) {
+        chunks.push(chunk.toString());
+        cb();
+      },
+    });
+    const logger = pino({ redact: { paths: REDACT_PATHS } }, captureStream);
+
+    logger.info(
+      {
+        user: {
+          token: "RAW_T",
+          accessToken: "RAW_AT",
+          userAccessToken: "RAW_UAT",
+          clientSecret: "RAW_CS",
+          privateKey: "RAW_PK",
+        },
+      },
+      "redaction check",
+    );
+
+    const serialized = chunks.join("");
+    const parsed = JSON.parse(serialized);
+
+    expect(parsed.user.token).toBe("[Redacted]");
+    expect(parsed.user.accessToken).toBe("[Redacted]");
+    expect(parsed.user.userAccessToken).toBe("[Redacted]");
+    expect(parsed.user.clientSecret).toBe("[Redacted]");
+    expect(parsed.user.privateKey).toBe("[Redacted]");
+
+    // Belt-and-braces: no raw secret value survives anywhere in the
+    // serialized line, not just under the expected keys.
+    for (const sentinel of [
+      "RAW_T",
+      "RAW_AT",
+      "RAW_UAT",
+      "RAW_CS",
+      "RAW_PK",
+    ]) {
+      expect(serialized).not.toContain(sentinel);
+    }
   });
 });

--- a/ornn-api/src/shared/logger.ts
+++ b/ornn-api/src/shared/logger.ts
@@ -13,6 +13,12 @@
  *      all of that — a misconfigured handler logging req headers
  *      would leak bearer tokens.
  *
+ * `REDACT_PATHS` (exported below) is the single source of truth for
+ * the redaction list. Both other pino roots — `bootstrap.ts`'s
+ * request/response logger and `index.ts`'s startup logger — import it
+ * rather than re-declaring their own list, so adding a sensitive field
+ * here covers every logger in the process at once.
+ *
  * `createLogger(moduleName)` returns a child of a single process-wide
  * pino root configured with both — every consumer inherits both knobs
  * for free.
@@ -51,16 +57,23 @@ export type { Logger };
 const LEVEL = process.env.LOG_LEVEL ?? "info";
 
 /**
- * Default redaction rules. Mirrors the bootstrap pino exactly so
- * module loggers can't accidentally log a bearer token. Adding new
- * sensitive fields here updates every logger in the codebase.
+ * Default redaction rules — the single source of truth for log
+ * redaction across the whole service. Imported by `bootstrap.ts` and
+ * `index.ts` so every pino root shares one list; module loggers
+ * created via `createLogger()` inherit it too. Adding a sensitive
+ * field here updates every logger in the codebase.
  */
-const REDACT_PATHS = [
+export const REDACT_PATHS = [
   "req.headers.authorization",
   'req.headers["x-api-key"]',
   "*.password",
   "*.secret",
   "*.apiKey",
+  "*.token",
+  "*.accessToken",
+  "*.userAccessToken",
+  "*.clientSecret",
+  "*.privateKey",
 ];
 
 /**


### PR DESCRIPTION
Closes #817

Automated change by `/auto` (run `20260604T121112Z-15019`, runner `auto-runner-20260604T121112Z-15019-15019-30412`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
