### PR TITLE
[Bug] Reject traversal/dot segments in GitHub owner/repo identifiers (mirror + pull)

### DIFF
--- a/.changeset/auto-818-github-identifier-hardening.md
+++ b/.changeset/auto-818-github-identifier-hardening.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Harden GitHub identifier validation: mirror settings owner/repo now enforce the same naming rules as the mirror routes (shared constants), and repo pull identifiers reject "." / ".." path-traversal segments.

--- a/ornn-api/src/domains/settings/sections/mirror.ts
+++ b/ornn-api/src/domains/settings/sections/mirror.ts
@@ -15,6 +15,7 @@
  */
 import { z } from "zod";
 import { CronExpressionParser } from "cron-parser";
+import { OWNER_RE, REPO_RE } from "../../../shared/githubNaming";
 import type { SectionMeta } from "./index";
 
 /**
@@ -44,8 +45,12 @@ const cronSchedule = z
 
 export const mirrorSchema = z.object({
   enabled: z.boolean(),
-  owner: z.string(),
-  repo: z.string(),
+  owner: z.string().refine((v) => v === "" || OWNER_RE.test(v), {
+    message: "must be a valid GitHub owner or empty",
+  }),
+  repo: z.string().refine((v) => v === "" || REPO_RE.test(v), {
+    message: "must be a valid GitHub repo name or empty",
+  }),
   branch: z.string(),
   appId: z.string(),
   installationId: z.string(),

--- a/ornn-api/src/domains/settings/sections/sections.test.ts
+++ b/ornn-api/src/domains/settings/sections/sections.test.ts
@@ -335,6 +335,35 @@ describe("section schemas", () => {
     expect(mirrorSection.defaults.reconcileSchedule).toBe("0 2 * * *");
   });
 
+  it("UT-SCHEMA-MIRROR-005: owner/repo enforce GitHub naming, empty stays valid (#818)", () => {
+    // Path-traversal / slash-bearing repo rejected by REPO_RE.
+    expect(
+      mirrorSection.schema.safeParse({
+        ...mirrorSection.defaults,
+        owner: "ChronoAIProject",
+        repo: "a/../b",
+      }).success,
+    ).toBe(false);
+    // Empty owner + empty repo = unset state, still valid.
+    expect(
+      mirrorSection.schema.safeParse({
+        ...mirrorSection.defaults,
+        owner: "",
+        repo: "",
+      }).success,
+    ).toBe(true);
+    // Dotted + dashed repo names are valid GitHub repos.
+    for (const repo of ["repo.name", "repo-1"]) {
+      expect(
+        mirrorSection.schema.safeParse({
+          ...mirrorSection.defaults,
+          owner: "ChronoAIProject",
+          repo,
+        }).success,
+      ).toBe(true);
+    }
+  });
+
   // -------- telemetry --------
   it("telemetry schema accepts placeholder defaults", () => {
     expect(

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
@@ -92,6 +92,18 @@ describe("normalizeRepoIdentifier", () => {
     expect(() => normalizeRepoIdentifier("acme/s kill")).toThrow();
     expect(() => normalizeRepoIdentifier("acme/skill#branch")).toThrow();
   });
+  test("rejects path-traversal segments (#818)", () => {
+    expect(() => normalizeRepoIdentifier("owner/..")).toThrow(
+      /Invalid GitHub repo/,
+    );
+    expect(() => normalizeRepoIdentifier("../repo")).toThrow(
+      /Invalid GitHub repo/,
+    );
+  });
+  test("accepts dotted / dashed repo names", () => {
+    expect(normalizeRepoIdentifier("owner/repo.name")).toBe("owner/repo.name");
+    expect(normalizeRepoIdentifier("owner/repo-1")).toBe("owner/repo-1");
+  });
 });
 
 describe("normalizePath", () => {

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.ts
@@ -16,6 +16,7 @@
 
 import JSZip from "jszip";
 import { createLogger } from "../../../../shared/logger";
+import { hasUnsafeSegment } from "../../../../shared/githubNaming";
 const logger = createLogger("githubSkillPull");
 
 export interface GitHubPullInput {
@@ -63,7 +64,10 @@ const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
 /** Validates `owner/name` and strips any trailing whitespace. */
 export function normalizeRepoIdentifier(repo: string): string {
   const trimmed = repo.trim();
-  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(trimmed)) {
+  if (
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(trimmed) ||
+    hasUnsafeSegment(trimmed)
+  ) {
     throw new Error(
       `Invalid GitHub repo identifier '${repo}'. Expected 'owner/name'.`,
     );

--- a/ornn-api/src/domains/skills/mirror/routes.ts
+++ b/ornn-api/src/domains/skills/mirror/routes.ts
@@ -40,6 +40,7 @@ import {
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
 import { isMidMaskSentinel, midMaskSecret } from "../../../infra/crypto";
+import { OWNER_RE, REPO_RE } from "../../../shared/githubNaming";
 import type { MirrorService, ReconcileResult } from "./mirrorService";
 import type { MirrorScheduler, ScheduledRunStatus } from "./scheduler";
 import type { SettingsService, SettingsActor } from "../../settings/types";
@@ -52,13 +53,12 @@ const logger = createLogger("mirrorRoutes");
 /**
  * GitHub naming validation.
  *
- *   owner: alphanumeric + dashes; can't start or end with a dash; 1–39 chars.
- *   repo:  alphanumeric + dot/dash/underscore; 1–100 chars.
+ *   owner / repo: see `shared/githubNaming` (OWNER_RE / REPO_RE) — the
+ *          single source of truth shared with the mirror settings section
+ *          and the repo-pull path.
  *   branch: any non-empty string up to 250 chars (git's actual limit is
  *          looser but we want a sane upper bound and disallow control chars).
  */
-const OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
-const REPO_RE = /^[A-Za-z0-9._-]{1,100}$/;
 // eslint-disable-next-line no-control-regex -- intentional: rejects branch names containing C0 control chars or DEL.
 const BRANCH_RE = /^[^\x00-\x1f\x7f]{1,250}$/;
 const APP_ID_RE = /^[0-9]{1,15}$/;

--- a/ornn-api/src/shared/githubNaming.test.ts
+++ b/ornn-api/src/shared/githubNaming.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for shared GitHub naming validation.
+ *
+ * @module shared/githubNaming.test
+ */
+
+import { describe, expect, it } from "bun:test";
+import { OWNER_RE, REPO_RE, hasUnsafeSegment } from "./githubNaming";
+
+describe("OWNER_RE", () => {
+  it("accepts a plain owner", () => {
+    expect(OWNER_RE.test("owner")).toBe(true);
+  });
+
+  it("rejects the empty string", () => {
+    expect(OWNER_RE.test("")).toBe(false);
+  });
+
+  it("rejects a leading-hyphen owner", () => {
+    expect(OWNER_RE.test("-owner")).toBe(false);
+  });
+});
+
+describe("REPO_RE", () => {
+  it("accepts repo.name with a dot", () => {
+    expect(REPO_RE.test("repo.name")).toBe(true);
+  });
+
+  it("accepts repo-1 with a dash", () => {
+    expect(REPO_RE.test("repo-1")).toBe(true);
+  });
+
+  it("rejects a value containing a slash", () => {
+    expect(REPO_RE.test("a/b")).toBe(false);
+  });
+
+  it("rejects a value over 100 chars", () => {
+    expect(REPO_RE.test("a".repeat(101))).toBe(false);
+  });
+});
+
+describe("hasUnsafeSegment", () => {
+  it("flags a trailing .. segment", () => {
+    expect(hasUnsafeSegment("owner/..")).toBe(true);
+  });
+
+  it("flags a leading .. segment", () => {
+    expect(hasUnsafeSegment("../repo")).toBe(true);
+  });
+
+  it("flags a dot-prefixed (hidden) segment", () => {
+    expect(hasUnsafeSegment(".hidden")).toBe(true);
+  });
+
+  it("flags a dot-suffixed (trailing-dot) segment", () => {
+    expect(hasUnsafeSegment("trail.")).toBe(true);
+  });
+
+  it("allows a normal owner/repo.name identifier", () => {
+    expect(hasUnsafeSegment("owner/repo.name")).toBe(false);
+  });
+});

--- a/ornn-api/src/shared/githubNaming.ts
+++ b/ornn-api/src/shared/githubNaming.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared GitHub owner/repo naming validation.
+ *
+ * Single source of truth for the GitHub identifier charset + length rules
+ * so the mirror routes, the mirror settings section, and the repo-pull
+ * path all enforce the same shape.
+ *
+ *   owner: alphanumeric + dashes; can't start or end with a dash; 1–39 chars.
+ *   repo:  alphanumeric + dot/dash/underscore; 1–100 chars.
+ *
+ * Note: passing the charset/length regexes does NOT mean an identifier is
+ * safe to splice into a filesystem path or URL — a `repo` segment can be
+ * `..` or `.` and still match `REPO_RE`. Callers that build paths must
+ * additionally reject path-traversal segments via {@link hasUnsafeSegment}.
+ *
+ * @module shared/githubNaming
+ */
+
+export const OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+export const REPO_RE = /^[A-Za-z0-9._-]{1,100}$/;
+
+/**
+ * True when any slash-delimited segment of `s` is a path-traversal or
+ * hidden-segment hazard: exactly `.`/`..`, or starts/ends with a dot
+ * (e.g. `.hidden`, `trail.`). Use this to reject identifiers that would
+ * otherwise pass the charset regexes but are unsafe to splice into a
+ * filesystem path.
+ */
+export function hasUnsafeSegment(s: string): boolean {
+  return s
+    .split("/")
+    .some(
+      (seg) =>
+        seg === "." ||
+        seg === ".." ||
+        seg.startsWith(".") ||
+        seg.endsWith("."),
+    );
+}


### PR DESCRIPTION
Closes #818

Automated change by `/auto` (run `20260604T121112Z-15019`, runner `auto-runner-20260604T121112Z-15019-15019-40118`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
