### PR TITLE
[Bug] Clamp playground sandbox timeout_secs to the advertised 1-600 range

### DIFF
--- a/.changeset/auto-819-clamp-sandbox-timeout.md
+++ b/.changeset/auto-819-clamp-sandbox-timeout.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Clamp the playground sandbox timeout_secs to the advertised 1-600 range and default non-numeric values to 60s.

--- a/ornn-api/src/domains/playground/chatService.test.ts
+++ b/ornn-api/src/domains/playground/chatService.test.ts
@@ -520,3 +520,44 @@ describe("PlaygroundChatService — skill-load authorization (#806)", () => {
     expect(toolResult!.result).toContain(SECRET_MARKER);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #819 — model-supplied timeout_secs is coerced + clamped to 1-600 before it
+// reaches the sandbox client. The clamp lives at the single chokepoint in
+// runSandboxToolCall, so asserting on the session-execute path is sufficient.
+// ---------------------------------------------------------------------------
+
+describe("PlaygroundChatService — sandbox timeout clamp (#819)", () => {
+  const cases: Array<{ label: string; input: unknown; expected: number }> = [
+    { label: "0 clamps up to the 1s floor", input: 0, expected: 1 },
+    { label: "-5 clamps up to the 1s floor", input: -5, expected: 1 },
+    // The tool-call args are JSON-serialized by makeToolCallEvents exactly as
+    // the real LLM stream emits them, and JSON.stringify coerces a literal NaN
+    // to null (-> Number(null) === 0, not NaN). A non-numeric *string* is the
+    // value that actually survives that boundary and reaches the service as a
+    // NaN under Number(...), so it is the faithful trigger for the 60s fallback.
+    { label: "non-numeric input falls back to the 60s default", input: "not-a-number", expected: 60 },
+    { label: "10_000 clamps down to the 600s ceiling", input: 10_000, expected: 600 },
+  ];
+
+  for (const { label, input, expected } of cases) {
+    it(label, async () => {
+      const sandbox = makeSandboxClient({});
+      const service = makeService(
+        [
+          makeToolCallEvents({
+            name: "execute_in_sandbox",
+            args: { script: "x", language: "python", timeout_secs: input as never },
+          }),
+          STOP_EVENTS,
+        ],
+        sandbox,
+      );
+
+      await drain(service.chat("u1", { messages: [{ role: "user", content: "go" }] }));
+
+      expect(sandbox.calls.sessionExecute).toHaveLength(1);
+      expect(sandbox.calls.sessionExecute[0]!.params.timeoutSecs).toBe(expected);
+    });
+  }
+});

--- a/ornn-api/src/domains/playground/chatService.ts
+++ b/ornn-api/src/domains/playground/chatService.ts
@@ -174,7 +174,7 @@ When calling execute_in_sandbox:
 - env: the user-provided environment variables (already in context)
 - output_type: from metadata (text or file)
 - retrieve_files: glob patterns for output files (e.g. ["*.png", "*.jpg"])
-- timeout_secs: 120 (default)
+- timeout_secs: 60 (default, clamped to 1-600)
 
 Be concise. Act, don't explain.`;
 
@@ -594,7 +594,14 @@ export class PlaygroundChatService {
     const dependencies = (args.dependencies as string[]) ?? [];
     const retrieveFiles = (args.retrieve_files as string[]) ?? [];
     const inputFiles = (args.input_files as Array<{ path: string; content: string }>) ?? [];
-    const timeoutSecs = (args.timeout_secs as number) ?? 120;
+    // #819 — coerce + clamp the model-supplied timeout before it reaches the
+    // sandbox client. Computed once here; flows into the session path and both
+    // one-shot fallbacks, so this is the single chokepoint for this value.
+    // Non-numeric / NaN falls back to the documented 60s default.
+    const rawTimeout = Number(args.timeout_secs);
+    const timeoutSecs = Number.isFinite(rawTimeout)
+      ? Math.min(600, Math.max(1, Math.trunc(rawTimeout)))
+      : 60;
 
     let sessionId = sandboxSessions.get(language);
 


### PR DESCRIPTION
Closes #819

Automated change by `/auto` (run `20260604T121112Z-15019`, runner `auto-runner-20260604T121112Z-15019-15019-51230`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
