### PR TITLE
[Misc] Remove the unused requireOwnerOrAdmin authz helper

### DIFF
--- a/.changeset/auto-820-remove-dead-authz-helper.md
+++ b/.changeset/auto-820-remove-dead-authz-helper.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Remove the unused requireOwnerOrAdmin authz middleware (dead code; the live skill-ownership policy is canManageSkill).

--- a/ornn-api/src/middleware/nyxidAuth.ts
+++ b/ornn-api/src/middleware/nyxidAuth.ts
@@ -262,25 +262,6 @@ export function requirePermission(...required: string[]) {
 }
 
 /**
- * Allows access if user owns the resource or has ornn:admin:skill permission.
- */
-export function requireOwnerOrAdmin(getResourceOwnerId: (c: Context) => Promise<string>) {
-  return async (c: Context<{ Variables: AuthVariables }>, next: Next) => {
-    const auth = c.get("auth");
-    if (!auth) {
-      throw new AppError(401, "auth_missing", "Not authenticated");
-    }
-
-    const ownerId = await getResourceOwnerId(c);
-    if (auth.userId !== ownerId && !auth.permissions.includes("ornn:admin:skill")) {
-      throw new AppError(403, "forbidden", "You can only operate on your own resources");
-    }
-
-    await next();
-  };
-}
-
-/**
  * Helper to get auth context from request. Throws if not authenticated.
  */
 export function getAuth(c: Context<{ Variables: AuthVariables }>): AuthContext {


### PR DESCRIPTION
Closes #820

Automated change by `/auto` (run `20260604T121112Z-15019`, runner `auto-runner-20260604T121112Z-15019-15019-63007`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
