### PR TITLE
[Docs] Correct the stale ENCRYPTION_KEY dev-sentinel claim in config doc

### DIFF
--- a/.changeset/auto-821-encryption-key-jsdoc.md
+++ b/.changeset/auto-821-encryption-key-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Correct the SkillConfig.encryptionKey JSDoc to match the enforced contract (mandatory ≥32 chars, no dev fallback, fail-fast at boot) and add tests pinning loadConfig() ConfigError behavior.

--- a/ornn-api/src/infra/config.test.ts
+++ b/ornn-api/src/infra/config.test.ts
@@ -14,17 +14,26 @@ import { ConfigError, loadConfig } from "./config";
 
 const VALID_KEY = "test-encryption-key-32-chars-min-12345";
 
-let envSnapshot: NodeJS.ProcessEnv;
+// Per-key save/restore (the #816 class). Never rebind process.env — that
+// leaks set-but-not-snapshotted state into sibling test files. Capture the
+// ORIGINAL value of exactly the keys this file touches (undefined vs string)
+// once, mutate via direct assignment per case, then restore each key
+// individually in afterEach. Same idiom as safeFetch.test.ts.
+const ORIGINAL_ENCRYPTION_KEY = process.env.ENCRYPTION_KEY;
+const ORIGINAL_MONGODB_URI = process.env.MONGODB_URI;
 
 beforeEach(() => {
-  envSnapshot = { ...process.env };
   // Seed every required var EXCEPT ENCRYPTION_KEY so failures attribute
   // to the key under test, not to an unrelated missing var.
   process.env.MONGODB_URI = "mongodb://localhost:27017";
 });
 
 afterEach(() => {
-  process.env = envSnapshot;
+  if (ORIGINAL_ENCRYPTION_KEY === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = ORIGINAL_ENCRYPTION_KEY;
+
+  if (ORIGINAL_MONGODB_URI === undefined) delete process.env.MONGODB_URI;
+  else process.env.MONGODB_URI = ORIGINAL_MONGODB_URI;
 });
 
 describe("loadConfig — ENCRYPTION_KEY", () => {
@@ -52,6 +61,42 @@ describe("loadConfig — ENCRYPTION_KEY", () => {
         (err as ConfigError).issues.some((i) => i.path.includes("ENCRYPTION_KEY")),
       ).toBe(true);
     }
+  });
+
+  test("throws ConfigError when ENCRYPTION_KEY is exactly 31 chars (boundary)", () => {
+    const KEY_31 = "a".repeat(31);
+    expect(KEY_31.length).toBe(31);
+    process.env.ENCRYPTION_KEY = KEY_31;
+    try {
+      loadConfig();
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      expect(
+        (err as ConfigError).issues.some((i) => i.path.includes("ENCRYPTION_KEY")),
+      ).toBe(true);
+    }
+  });
+
+  test("throws ConfigError when ENCRYPTION_KEY is the empty string (envsubst footgun)", () => {
+    process.env.ENCRYPTION_KEY = "";
+    try {
+      loadConfig();
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      expect(
+        (err as ConfigError).issues.some((i) => i.path.includes("ENCRYPTION_KEY")),
+      ).toBe(true);
+    }
+  });
+
+  test("loads config when ENCRYPTION_KEY is exactly 32 chars (boundary)", () => {
+    const KEY_32 = "a".repeat(32);
+    expect(KEY_32.length).toBe(32);
+    process.env.ENCRYPTION_KEY = KEY_32;
+    const config = loadConfig();
+    expect(config.encryptionKey).toBe(KEY_32);
   });
 
   test("loads config when ENCRYPTION_KEY is ≥32 chars", () => {

--- a/ornn-api/src/infra/config.test.ts
+++ b/ornn-api/src/infra/config.test.ts
@@ -1,0 +1,62 @@
+/**
+ * loadConfig() env-validation tests (#821).
+ *
+ * Locks the ENCRYPTION_KEY contract the interface + schema JSDoc now
+ * claim: mandatory, ≥32 chars, NO dev fallback, fail-fast with a
+ * structured ConfigError. Asserts on ConfigError identity + the
+ * ZodIssue path (not message text, which is brittle).
+ *
+ * @module infra/config.test
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ConfigError, loadConfig } from "./config";
+
+const VALID_KEY = "test-encryption-key-32-chars-min-12345";
+
+let envSnapshot: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  envSnapshot = { ...process.env };
+  // Seed every required var EXCEPT ENCRYPTION_KEY so failures attribute
+  // to the key under test, not to an unrelated missing var.
+  process.env.MONGODB_URI = "mongodb://localhost:27017";
+});
+
+afterEach(() => {
+  process.env = envSnapshot;
+});
+
+describe("loadConfig — ENCRYPTION_KEY", () => {
+  test("throws ConfigError when ENCRYPTION_KEY is unset", () => {
+    delete process.env.ENCRYPTION_KEY;
+    try {
+      loadConfig();
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      expect(
+        (err as ConfigError).issues.some((i) => i.path.includes("ENCRYPTION_KEY")),
+      ).toBe(true);
+    }
+  });
+
+  test("throws ConfigError when ENCRYPTION_KEY is shorter than 32 chars", () => {
+    process.env.ENCRYPTION_KEY = "too-short";
+    try {
+      loadConfig();
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      expect(
+        (err as ConfigError).issues.some((i) => i.path.includes("ENCRYPTION_KEY")),
+      ).toBe(true);
+    }
+  });
+
+  test("loads config when ENCRYPTION_KEY is ≥32 chars", () => {
+    process.env.ENCRYPTION_KEY = VALID_KEY;
+    const config = loadConfig();
+    expect(config.encryptionKey).toBe(VALID_KEY);
+  });
+});

--- a/ornn-api/src/infra/config.ts
+++ b/ornn-api/src/infra/config.ts
@@ -74,12 +74,7 @@ export interface SkillConfig {
    */
   readonly ornnPublicOrigin: string;
 
-  /**
-   * Master passphrase for AES-256-GCM at-rest secret encryption (LLM
-   * provider apiKey, future operator-pasted secrets). Falls back to a
-   * dev sentinel when `ENCRYPTION_KEY` is unset — production deployments
-   * MUST override.
-   */
+  /** Master passphrase for AES-256-GCM at-rest secret encryption. Required, ≥32 chars; boot fails with ConfigError if missing/short. See ENCRYPTION_KEY in envSchema for full rationale. */
   readonly encryptionKey: string;
 }
 


### PR DESCRIPTION
Closes #821

Automated change by `/auto` (run `20260604T121112Z-15019`, runner `auto-runner-20260604T121112Z-15019-15019-77881`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
