### PR TITLE
[Misc] Quota reservation follow-ups (follow-up to #808)

### DIFF
--- a/.changeset/auto-827-quota-reservation-followups.md
+++ b/.changeset/auto-827-quota-reservation-followups.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Thread the quota reservation timestamp through to charge-on-completion so per-model analytics reconcile against the reserved month bucket (fixes a benign month-boundary straddle). Add route-level integration tests covering model-resolution failure (used unchanged) and aborted/errored streams (slot released). Note for consumers: /me/quota remaining reflects in-flight reservations — used is bumped at reserve time and refunded on system-error/abort.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -156,7 +156,23 @@ export interface BootstrapResult {
   shutdown: () => Promise<void>;
 }
 
-export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
+/**
+ * Test-only dependency overrides. Production callers pass nothing — the
+ * single optional second argument lets integration tests substitute the
+ * `NyxLlmClient` with an in-process fake (see `tests/mocks/llmGateway.ts`)
+ * so quota-charge / per-model accounting flows run without real network
+ * IO. The override, when present, replaces the single `nyxLlmClient` that
+ * the playground, skill-gen, search, and audit domains all share.
+ */
+export interface BootstrapOverrides {
+  /** Substitute the shared LLM gateway client (integration tests only). */
+  llmClient?: NyxLlmClient;
+}
+
+export async function bootstrap(
+  config: SkillConfig,
+  overrides?: BootstrapOverrides,
+): Promise<BootstrapResult> {
   const logger = pino({
     level: config.logLevel,
     ...(config.logPretty ? { transport: { target: "pino-pretty" } } : {}),
@@ -432,10 +448,12 @@ export async function bootstrap(config: SkillConfig): Promise<BootstrapResult> {
   // selection still resolves through this single client. Backend-eng-2
   // will swap this for a per-surface provider lookup once the
   // `llm_providers` collection ships.
-  const nyxLlmClient = new NyxLlmClient({
-    resolver: async () => resolveLlmProviderForSurface("playground"),
-    saTokenProvider,
-  });
+  const nyxLlmClient =
+    overrides?.llmClient ??
+    new NyxLlmClient({
+      resolver: async () => resolveLlmProviderForSurface("playground"),
+      saTokenProvider,
+    });
 
   // ---- Repositories ----
   const skillRepo = new SkillRepository(db);

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -141,10 +141,18 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
       // throw, so a reserved slot is always reconciled (committed on
       // success, released on system_error/abort). Admins bypass inside
       // the service and take no reservation.
+      // Capture the reservation instant so the eventual charge lands in
+      // the SAME calendar-month bucket the slot was reserved against
+      // (#827). Without this, a run that starts at 23:59:59 on the last
+      // day of a month and finishes after the UTC rollover would commit
+      // its per-model tally to the next month's bucket while `used` was
+      // bumped in the previous one — a benign but confusing straddle.
+      const reservedAt = new Date();
       const decision = await quotaService.checkAllowed({
         userId: authCtx.userId,
         permissions: authCtx.permissions,
         surface: "playground",
+        now: reservedAt,
       });
       if (!decision.allowed) throwQuotaError(decision);
 
@@ -275,6 +283,10 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
               surface: "playground",
               outcome,
               modelId: resolvedModelId,
+              // Reconcile against the reserved month bucket (#827), not
+              // wall-clock-now, so a month-boundary straddle commits/
+              // releases the slot it actually reserved.
+              now: reservedAt,
             })
             .catch((err) => {
               logger.warn(

--- a/ornn-api/src/domains/quota/routes.ts
+++ b/ornn-api/src/domains/quota/routes.ts
@@ -30,6 +30,9 @@ export function createQuotaRoutes(
   const auth = nyxidAuthMiddleware();
 
   app.get("/me/quota", auth, async (c) => {
+    // `remaining` here reflects in-flight reservations: `used` is bumped
+    // at reserve time (before the LLM call) and refunded on
+    // system-error/abort. See `SurfaceSnapshot.remaining` in types.ts.
     const authCtx = getAuth(c);
     const snapshot = await quotaService.getSnapshot({
       userId: authCtx.userId,

--- a/ornn-api/src/domains/quota/service.test.ts
+++ b/ornn-api/src/domains/quota/service.test.ts
@@ -612,6 +612,41 @@ describe("UT-QUOTA-021 snapshot has no daily/expiresAt", () => {
   });
 });
 
+describe("UT-QUOTA-024 charge reconciles against the reserved month bucket", () => {
+  test("reserve in May, charge with the May reservedAt (wall-clock June) → May bucket charged, no June bucket", async () => {
+    const { service, repo } = build({ defaultPg: 5 });
+    // Reservation taken at the very last second of May.
+    const reservedAt = new Date(Date.UTC(2026, 4, 31, 23, 59, 59, 0));
+    await service.checkAllowed({
+      userId: "u1",
+      permissions: [],
+      surface: "playground",
+      now: reservedAt,
+    });
+    // The May bucket now holds the reservation.
+    expect(repo.buckets.get("u1:playground:2026-05")?.used).toBe(1);
+
+    // The run finishes after the UTC month rollover. #827: the route
+    // threads the reservation instant (`reservedAt`, still May) into the
+    // charge so the per-model commit lands in the SAME bucket the slot
+    // was reserved against — NOT a fresh June bucket keyed by wall-clock.
+    await service.chargeOnCompletion({
+      userId: "u1",
+      permissions: [],
+      surface: "playground",
+      outcome: "success",
+      modelId: "gpt-4o",
+      now: reservedAt,
+    });
+
+    const mayBucket = repo.buckets.get("u1:playground:2026-05");
+    expect(mayBucket?.used).toBe(1);
+    expect(mayBucket?.usedByModel["gpt-4o"]).toBe(1);
+    // No June bucket was created — the charge did not straddle the boundary.
+    expect(repo.buckets.has("u1:playground:2026-06")).toBe(false);
+  });
+});
+
 describe("UT-QUOTA-023 year boundary rollover", () => {
   test("Dec 31 23:59:59.999Z → 2026; Jan 1 00:00Z → 2027", async () => {
     const { service, repo } = build();

--- a/ornn-api/src/domains/quota/types.ts
+++ b/ornn-api/src/domains/quota/types.ts
@@ -77,6 +77,12 @@ export interface SurfaceSnapshot {
   defaultAllotment: number;
   adminGrant: number;
   used: number;
+  /**
+   * Reflects in-flight reservations — `used` is bumped at reserve time
+   * (before the LLM call), so `remaining` already accounts for runs
+   * currently streaming. A run that ends in system_error/abort releases
+   * its slot, raising `remaining` back.
+   */
   remaining: number;
   warningThreshold: number;
   warning: boolean;

--- a/ornn-api/src/domains/skills/generation/routes.ts
+++ b/ornn-api/src/domains/skills/generation/routes.ts
@@ -86,7 +86,12 @@ async function preflight(
   quotaService: QuotaService,
   llmProvidersService: LlmProvidersService,
   requestedModelId: string | undefined,
-): Promise<{ modelId: string; userId: string; permissions: readonly string[] | undefined }> {
+): Promise<{
+  modelId: string;
+  userId: string;
+  permissions: readonly string[] | undefined;
+  reservedAt: Date;
+}> {
   const authCtx = getAuth(c);
 
   const resolution = await llmProvidersService.resolveModel({
@@ -96,14 +101,24 @@ async function preflight(
   });
   if (resolution.kind !== "ok") throwModelResolutionError(resolution);
 
+  // Capture the reservation instant so the charge lands in the SAME
+  // month bucket the slot was reserved against (#827) — see the
+  // playground route for the boundary-straddle rationale.
+  const reservedAt = new Date();
   const decision = await quotaService.checkAllowed({
     userId: authCtx.userId,
     permissions: authCtx.permissions,
     surface: "skillGen",
+    now: reservedAt,
   });
   if (!decision.allowed) throwQuotaError(decision);
 
-  return { modelId: resolution.modelId, userId: authCtx.userId, permissions: authCtx.permissions };
+  return {
+    modelId: resolution.modelId,
+    userId: authCtx.userId,
+    permissions: authCtx.permissions,
+    reservedAt,
+  };
 }
 
 /**
@@ -124,6 +139,12 @@ async function streamGenerationEvents(
     permissions: readonly string[] | undefined;
     /** Resolved model id used for the LLM call — flows into `usedByModel`. */
     modelId: string;
+    /**
+     * Reservation instant captured at `preflight` time (#827). Threaded
+     * into `chargeOnCompletion` as `now` so the commit/release reconciles
+     * against the month bucket the slot was reserved in, not wall-clock.
+     */
+    reservedAt: Date;
   },
 ) {
   c.header("Cache-Control", "no-cache");
@@ -158,6 +179,8 @@ async function streamGenerationEvents(
             surface: "skillGen",
             outcome,
             modelId: chargeAfter.modelId,
+            // Reconcile against the reserved month bucket (#827).
+            now: chargeAfter.reservedAt,
           })
           .catch((err) => {
             logger.warn(
@@ -311,7 +334,7 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
               pf.modelId,
             ),
             keepAliveMs,
-            { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId },
+            { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId, reservedAt: pf.reservedAt },
           );
         }
 
@@ -344,7 +367,7 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
         c,
         generationService.generateStream(query, signal, pf.modelId),
         keepAliveMs,
-        { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId },
+        { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId, reservedAt: pf.reservedAt },
       );
     },
   );
@@ -461,7 +484,7 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
           pf.modelId,
         ),
         keepAliveMs,
-        { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId },
+        { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId, reservedAt: pf.reservedAt },
       );
     },
   );
@@ -516,7 +539,7 @@ export function createGenerationRoutes(config: GenerationRoutesConfig): Hono<{ V
           pf.modelId,
         ),
         keepAliveMs,
-        { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId },
+        { quotaService, userId: pf.userId, permissions: pf.permissions, modelId: pf.modelId, reservedAt: pf.reservedAt },
       );
     },
   );

--- a/ornn-api/tests/integration/harness.ts
+++ b/ornn-api/tests/integration/harness.ts
@@ -18,6 +18,7 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 import { MongoClient, type Db } from "mongodb";
 import { bootstrap } from "../../src/bootstrap";
 import type { SkillConfig } from "../../src/infra/config";
+import type { NyxLlmClient } from "../../src/clients/nyxid/llm";
 import type { Hono } from "hono";
 
 export interface Harness {
@@ -65,6 +66,17 @@ export function authHeaders(auth: SimAuth): Record<string, string> {
   };
 }
 
+/**
+ * Optional per-harness dependency overrides. Mirrors `BootstrapOverrides`
+ * — the only knob today is swapping the shared `NyxLlmClient` for an
+ * in-process fake (`tests/mocks/llmGateway.ts`) so charge-path tests run
+ * the real route → service → quota wiring without touching the network.
+ */
+export interface StartHarnessOptions {
+  /** Substitute the shared LLM gateway client. */
+  llmClient?: NyxLlmClient;
+}
+
 let cached: Harness | null = null;
 
 /**
@@ -74,9 +86,18 @@ let cached: Harness | null = null;
  * Mongo takes ~2s each time, so sharing one instance per `bun test` run
  * is worth the isolation trade-off. Individual tests MUST clean up any
  * state they seed via the `db` handle.
+ *
+ * When `opts.llmClient` is set the cache is SKIPPED and a fresh,
+ * non-shared harness is built — an override harness wires a different LLM
+ * client, so handing back the shared default-harness instance would be
+ * wrong. Override harnesses are not shared; the caller owns its lifecycle
+ * and MUST `cleanup()` it.
  */
-export async function startHarness(): Promise<Harness> {
-  if (cached) return cached;
+export async function startHarness(
+  opts?: StartHarnessOptions,
+): Promise<Harness> {
+  const useOverride = !!opts?.llmClient;
+  if (cached && !useOverride) return cached;
 
   const mongo = await MongoMemoryServer.create();
   const mongoUri = mongo.getUri();
@@ -107,7 +128,11 @@ export async function startHarness(): Promise<Harness> {
     agentsealEnabled: false,
   };
 
-  const { app, shutdown } = await bootstrap(config);
+  const { app, shutdown } = await bootstrap(
+    config,
+    // exactOptionalPropertyTypes (#657): only attach the key when set.
+    opts?.llmClient ? { llmClient: opts.llmClient } : undefined,
+  );
 
   // Separate client for test-side seeding. Bootstrap holds its own
   // internal client; closing ours does not affect it.
@@ -123,10 +148,12 @@ export async function startHarness(): Promise<Harness> {
       await client.close().catch(() => {});
       await shutdown().catch(() => {});
       await mongo.stop().catch(() => {});
-      cached = null;
+      // Only the shared default harness lives in `cached`; an override
+      // harness was never stored there, so don't clobber the shared one.
+      if (!useOverride) cached = null;
     },
   };
 
-  cached = harness;
+  if (!useOverride) cached = harness;
   return harness;
 }

--- a/ornn-api/tests/integration/playground_charge.test.ts
+++ b/ornn-api/tests/integration/playground_charge.test.ts
@@ -3,20 +3,19 @@
  *
  * End-to-end flow tests for the playground surface charging path:
  *   - At-cap user → 429 with QUOTA_EXCEEDED
+ *   - Model-resolution failure (no models enabled) → 503, no bucket row
  *   - Successful stream → bucket.used += 1, usedByModel[model] += 1
  *   - skill_error stream → bucket.used += 1
- *   - system_error stream → bucket unchanged
+ *   - system_error stream → bucket released back to baseline
+ *   - Abort mid-stream → bucket released back to baseline
  *   - Admin caller → no quota check, no charge
  *
  * The test seeds the `quota_buckets` collection directly (bypasses the
- * quota service constructor) so we can pin the start state. The mock
- * LLM gateway controls outcome via `installLlmGatewayMock`.
- *
- * NOTE: Round 1 implementation may still wire through the legacy
- * `user_quotas` collection while backend-engineer's quota service
- * rewrite lands. These tests assert against the *new* `quota_buckets`
- * shape; if they fail with collection-not-found until Round 2, that's
- * the expected blocker — not a test bug.
+ * quota service constructor) so we can pin the start state. The charge-
+ * path cases inject the in-process `installLlmGatewayMock()` via the
+ * harness `llmClient` seam so the real route → chat service → quota
+ * wiring runs without touching the network, and the mock controls the
+ * outcome (success / skill_error / system_error).
  *
  * @module tests/integration/playground_charge.test
  */
@@ -24,6 +23,8 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { startHarness, type Harness, authHeaders } from "./harness";
 import { resetCollections } from "./cleanup";
+import { installLlmGatewayMock } from "../mocks/llmGateway";
+import type { NyxLlmClient } from "../../src/clients/nyxid/llm";
 
 let h: Harness;
 
@@ -36,7 +37,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await resetCollections(h.db, ["quota_buckets", "platform_settings"]);
+  await resetCollections(h.db, ["quota_buckets", "platform_settings", "llm_providers"]);
 });
 
 const userAuth = (userId: string, isAdmin = false) =>
@@ -48,19 +49,94 @@ const userAuth = (userId: string, isAdmin = false) =>
       : ["ornn:playground:use"],
   });
 
+/**
+ * Seed one provider with a single model enabled for the playground
+ * surface so `resolveModel({ surface: "playground" })` returns `ok`.
+ * The injected mock LLM client ignores gateway/auth, so the seed only
+ * needs to satisfy the catalog resolver, not a real upstream.
+ */
+async function seedPlaygroundModel(db: Harness["db"], modelId: string): Promise<void> {
+  const now = new Date();
+  await db.collection("llm_providers").insertOne({
+    _id: "prov-playground",
+    name: "test-provider",
+    gatewayUrl: "https://gw.test.invalid",
+    modelListUrl: "https://gw.test.invalid/models",
+    apiFormat: "responses",
+    auth: { kind: "apiKey", apiKeyEnc: "" },
+    models: [
+      {
+        id: modelId,
+        displayName: modelId,
+        enabledForPlayground: true,
+        enabledForSkillGen: false,
+        defaultForPlayground: true,
+        defaultForSkillGen: false,
+        removed: false,
+        firstSeenAt: now,
+        lastSyncedAt: now,
+      },
+    ],
+    maxOutputTokens: 8192,
+    defaultTemperature: 0.7,
+    createdAt: now,
+    updatedAt: now,
+    updatedBy: "test",
+  });
+}
+
+const monthMarker = () => new Date().toISOString().slice(0, 7);
+
+/** Drain an SSE response body to completion so the producer task ends. */
+async function drainBody(res: Response): Promise<void> {
+  const reader = res.body?.getReader();
+  if (!reader) return;
+  for (let done = false; !done; ) {
+    ({ done } = await reader.read());
+  }
+}
+
+/**
+ * Poll the bucket until `predicate` holds or the bounded retry budget is
+ * exhausted. The producer's `finally` fires `chargeOnCompletion` after
+ * the response stream closes; it is not awaitable from the route, so we
+ * poll rather than race a fixed sleep — keeps the assertion deterministic.
+ */
+async function waitForBucket(
+  db: Harness["db"],
+  filter: Record<string, unknown>,
+  predicate: (doc: Record<string, unknown> | null) => boolean,
+  { tries = 100, intervalMs = 10 } = {},
+): Promise<Record<string, unknown> | null> {
+  for (let i = 0; i < tries; i++) {
+    const doc = (await db.collection("quota_buckets").findOne(filter)) as
+      | Record<string, unknown>
+      | null;
+    if (predicate(doc)) return doc;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return (await db.collection("quota_buckets").findOne(filter)) as
+    | Record<string, unknown>
+    | null;
+}
+
 describe("IT-PLAYGROUND-QUOTA-DENY", () => {
   test("user at cap → 429 QUOTA_EXCEEDED", async () => {
-    const monthMarker = new Date().toISOString().slice(0, 7);
+    const mm = monthMarker();
+    await seedPlaygroundModel(h.db, "gpt-test");
+    // Pin used == cap. `effectiveDefault = max(stored, settingsDefault)`;
+    // the playground settings default is 200, so the stored allotment
+    // must be >= 200 for `used` to be at the effective cap.
     await h.db.collection("quota_buckets").insertOne({
-      _id: `u-cap:playground:${monthMarker}`,
+      _id: `u-cap:playground:${mm}`,
       userId: "u-cap",
       surface: "playground",
-      monthMarker,
+      monthMarker: mm,
       monthStart: new Date(),
       monthEnd: new Date(),
-      defaultAllotment: 5,
+      defaultAllotment: 200,
       adminGrant: 0,
-      used: 5,
+      used: 200,
       usedByModel: {},
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -71,45 +147,187 @@ describe("IT-PLAYGROUND-QUOTA-DENY", () => {
       headers: { ...userAuth("u-cap"), "Content-Type": "application/json" },
       body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
     });
-    // The user is at cap. The route must reject pre-charge. Accept
-    // any non-2xx — 429 is the spec-correct quota surface; 503 is
-    // the fail-closed "no LLM provider configured" surface (which
-    // fires before quota when settings aren't seeded). A 2xx here
-    // would mean the call actually ran the LLM despite a full bucket.
-    expect(res.status).toBeGreaterThanOrEqual(400);
+    // The user is at cap; the route must reject pre-charge with 429
+    // (model resolution succeeds here because a model is seeded).
+    expect(res.status).toBe(429);
+  });
+});
+
+describe("IT-PLAYGROUND-MODEL-RESOLUTION-FAIL", () => {
+  test("no models enabled → 503 and NO bucket row for the user", async () => {
+    // No provider seeded → resolveModel returns no-models-enabled → 503,
+    // before quota reserve, so the user's bucket must never be created.
+    const res = await h.app.request("/api/v1/playground/chat", {
+      method: "POST",
+      headers: { ...userAuth("u-nomodels"), "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(res.status).toBe(503);
+    const buckets = await h.db
+      .collection("quota_buckets")
+      .find({ userId: "u-nomodels", surface: "playground" })
+      .toArray();
+    expect(buckets.length).toBe(0);
   });
 });
 
 describe("IT-ADMIN-BYPASS-PLAYGROUND", () => {
   test("admin caller skips quota check (no bucket created)", async () => {
+    await seedPlaygroundModel(h.db, "gpt-test");
     const res = await h.app.request("/api/v1/playground/chat", {
       method: "POST",
       headers: { ...userAuth("u-admin", true), "Content-Type": "application/json" },
       body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
     });
-    // The chat call may fail because no LLM provider is configured in
-    // the test settings — acceptable: we're asserting the QUOTA gate
-    // didn't reject the admin pre-LLM (no 429), and no bucket row
-    // got upserted on this surface.
+    // Admins bypass the quota gate (no 429) and no bucket is created.
     expect(res.status).not.toBe(429);
     const buckets = await h.db
       .collection("quota_buckets")
       .find({ userId: "u-admin", surface: "playground" })
       .toArray();
-    // Admins bypass; no bucket should be created on their behalf.
     expect(buckets.length).toBe(0);
   });
 });
 
-describe("IT-PLAYGROUND-CHARGE-* (smoke)", () => {
-  test.todo("success outcome charges 1 + usedByModel[model] += 1", () => {
-    // Requires the LlmGateway mock to be installed in bootstrap. The
-    // round-1 harness doesn't yet expose a mock-injection seam — this
-    // test ships as a TODO so the assertion exists in the suite and a
-    // later round can flip the .todo to .test once the seam is wired.
+describe("IT-PLAYGROUND-CHARGE-* (via injected LLM mock)", () => {
+  test("success outcome charges 1 + usedByModel[model] += 1", async () => {
+    const { client, handle } = installLlmGatewayMock({
+      outcome: "success",
+      modelId: "gpt-test",
+      text: "hello",
+    });
+    const oh = await startHarness({ llmClient: client as NyxLlmClient });
+    try {
+      await resetCollections(oh.db, ["quota_buckets", "platform_settings", "llm_providers"]);
+      await seedPlaygroundModel(oh.db, "gpt-test");
+
+      const res = await oh.app.request("/api/v1/playground/chat", {
+        method: "POST",
+        headers: { ...userAuth("u-ok"), "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+      });
+      expect(res.status).toBe(200);
+      await drainBody(res);
+      expect(handle.callCount()).toBeGreaterThan(0);
+
+      const mm = monthMarker();
+      const bucket = await waitForBucket(
+        oh.db,
+        { _id: `u-ok:playground:${mm}` },
+        (d) => !!d && (d.usedByModel as Record<string, number>)?.["gpt-test"] === 1,
+      );
+      expect(bucket?.used).toBe(1);
+      expect((bucket?.usedByModel as Record<string, number>)["gpt-test"]).toBe(1);
+    } finally {
+      await oh.cleanup();
+    }
   });
 
-  test.todo("skill_error outcome charges 1");
+  test("skill_error outcome charges 1", async () => {
+    const { client } = installLlmGatewayMock({
+      outcome: "skill_error",
+      modelId: "gpt-test",
+      text: "partial",
+    });
+    const oh = await startHarness({ llmClient: client as NyxLlmClient });
+    try {
+      await resetCollections(oh.db, ["quota_buckets", "platform_settings", "llm_providers"]);
+      await seedPlaygroundModel(oh.db, "gpt-test");
 
-  test.todo("system_error outcome charges 0");
+      const res = await oh.app.request("/api/v1/playground/chat", {
+        method: "POST",
+        headers: { ...userAuth("u-skillerr"), "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+      });
+      expect(res.status).toBe(200);
+      await drainBody(res);
+
+      const mm = monthMarker();
+      const bucket = await waitForBucket(
+        oh.db,
+        { _id: `u-skillerr:playground:${mm}` },
+        (d) => !!d && (d.used as number) === 1,
+      );
+      expect(bucket?.used).toBe(1);
+    } finally {
+      await oh.cleanup();
+    }
+  });
+
+  test("system_error outcome leaves used unchanged (slot released)", async () => {
+    const { client } = installLlmGatewayMock({
+      outcome: "system_error",
+      modelId: "gpt-test",
+    });
+    const oh = await startHarness({ llmClient: client as NyxLlmClient });
+    try {
+      await resetCollections(oh.db, ["quota_buckets", "platform_settings", "llm_providers"]);
+      await seedPlaygroundModel(oh.db, "gpt-test");
+
+      const res = await oh.app.request("/api/v1/playground/chat", {
+        method: "POST",
+        headers: { ...userAuth("u-syserr"), "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+      });
+      expect(res.status).toBe(200);
+      await drainBody(res);
+
+      const mm = monthMarker();
+      // Reserve bumped used to 1; system_error releases it back to 0.
+      const bucket = await waitForBucket(
+        oh.db,
+        { _id: `u-syserr:playground:${mm}` },
+        (d) => !!d && (d.used as number) === 0,
+      );
+      expect(bucket?.used).toBe(0);
+    } finally {
+      await oh.cleanup();
+    }
+  });
+});
+
+describe("IT-PLAYGROUND-ABORT", () => {
+  test("abort mid-stream releases the reserved slot (used back to baseline)", async () => {
+    // Slow the mock stream so the abort lands while the producer is still
+    // pumping. Outcome=success, but the client aborts before `finish`.
+    const { client } = installLlmGatewayMock({
+      outcome: "success",
+      modelId: "gpt-test",
+      text: "streaming...",
+    });
+    const oh = await startHarness({ llmClient: client as NyxLlmClient });
+    try {
+      await resetCollections(oh.db, ["quota_buckets", "platform_settings", "llm_providers"]);
+      await seedPlaygroundModel(oh.db, "gpt-test");
+
+      const controller = new AbortController();
+      const resPromise = oh.app.request("/api/v1/playground/chat", {
+        method: "POST",
+        headers: { ...userAuth("u-abort"), "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+        signal: controller.signal,
+      });
+
+      const res = await resPromise;
+      expect(res.status).toBe(200);
+      // Begin draining, then abort mid-stream.
+      const reader = res.body?.getReader();
+      // Read the first chunk (the stream-open pad frame) then abort.
+      await reader?.read().catch(() => {});
+      controller.abort();
+      await reader?.cancel().catch(() => {});
+
+      const mm = monthMarker();
+      // The producer's abort handler closes the writer; its `finally`
+      // charges with outcome=system_error → release → used back to 0.
+      const bucket = await waitForBucket(
+        oh.db,
+        { _id: `u-abort:playground:${mm}` },
+        (d) => !!d && (d.used as number) === 0,
+      );
+      expect(bucket?.used).toBe(0);
+    } finally {
+      await oh.cleanup();
+    }
+  });
 });

--- a/ornn-api/tests/integration/playground_charge.test.ts
+++ b/ornn-api/tests/integration/playground_charge.test.ts
@@ -21,10 +21,16 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
 import { startHarness, type Harness, authHeaders } from "./harness";
 import { resetCollections } from "./cleanup";
 import { installLlmGatewayMock } from "../mocks/llmGateway";
 import type { NyxLlmClient } from "../../src/clients/nyxid/llm";
+import {
+  createPlaygroundRoutes,
+  type PlaygroundRoutesConfig,
+} from "../../src/domains/playground/routes";
+import type { PlaygroundChatEvent } from "../../src/shared/types/index";
 
 let h: Harness;
 
@@ -223,7 +229,17 @@ describe("IT-PLAYGROUND-CHARGE-* (via injected LLM mock)", () => {
     }
   });
 
-  test("skill_error outcome charges 1", async () => {
+  test("completed run with dropped unknown error event still charges 1 (playground has no skill_error mapping — see follow-up)", async () => {
+    // NOTE: the mock's `skill_error` outcome yields a `response.error` +
+    // `response.completed{finishReason:"skill_error"}`, but the playground
+    // chat service's event union does not recognize those shapes — they
+    // are dropped as unknown events. The run therefore terminates on the
+    // service's own `finish{finishReason:"stop"}`, so the route records a
+    // SUCCESS-shaped completion. There is no skill_error event path on the
+    // playground surface today; this case asserts that a completed run
+    // (with the error frame silently dropped) still commits a +1 charge —
+    // identical to the success case. Wiring a real playground skill_error
+    // outcome is a separate product follow-up, intentionally out of scope.
     const { client } = installLlmGatewayMock({
       outcome: "skill_error",
       modelId: "gpt-test",
@@ -288,12 +304,16 @@ describe("IT-PLAYGROUND-CHARGE-* (via injected LLM mock)", () => {
 
 describe("IT-PLAYGROUND-ABORT", () => {
   test("abort mid-stream releases the reserved slot (used back to baseline)", async () => {
-    // Slow the mock stream so the abort lands while the producer is still
-    // pumping. Outcome=success, but the client aborts before `finish`.
+    // `delayMs` parks the mock producer on a real timer between stream
+    // events (after `response.created`, before `response.completed`), so
+    // the abort below lands deterministically while the generator is
+    // suspended mid-stream — by control flow, not back-pressure luck.
+    // Outcome would be success, but the client aborts before `finish`.
     const { client } = installLlmGatewayMock({
       outcome: "success",
       modelId: "gpt-test",
       text: "streaming...",
+      delayMs: 50,
     });
     const oh = await startHarness({ llmClient: client as NyxLlmClient });
     try {
@@ -329,5 +349,104 @@ describe("IT-PLAYGROUND-ABORT", () => {
     } finally {
       await oh.cleanup();
     }
+  });
+});
+
+/**
+ * IT-PLAYGROUND-RESERVEDAT-THREADING — route-wiring guard (#827).
+ *
+ * The route captures a single `reservedAt = new Date()` and MUST thread
+ * that SAME instant into BOTH `quotaService.checkAllowed({ now })` (reserve)
+ * AND `quotaService.chargeOnCompletion({ now })` (commit/release). Without
+ * it, a run that straddles a UTC month boundary reserves in one month's
+ * bucket and reconciles against another. The route calls `new Date()`
+ * internally, so the instant can't be pinned from outside — instead this
+ * test stubs the quota service and captures the `now` arg of each call,
+ * then asserts they are the SAME `Date` instance. Deleting `now:` from
+ * either call site makes that call default to its own `new Date()`, so the
+ * two captured instants diverge and this test fails.
+ *
+ * This is a pure route-wiring unit test (no DB harness): it mounts the real
+ * `createPlaygroundRoutes` with stubbed collaborators, mirroring the auth-
+ * stub technique in `src/domains/playground/routes.test.ts`. Playground-only
+ * is acceptable here — the generation routes have no comparable stub harness
+ * (their routes.test mounts the full app), so a mirror is out of scope.
+ */
+describe("IT-PLAYGROUND-RESERVEDAT-THREADING (route wiring #827)", () => {
+  test("checkAllowed and chargeOnCompletion receive the SAME reserve instant", async () => {
+    let reserveNow: Date | undefined;
+    let chargeNow: Date | undefined;
+
+    const quotaService = {
+      checkAllowed: async (params: { now?: Date }) => {
+        reserveNow = params.now;
+        return { allowed: true, isAdminBypass: false } as const;
+      },
+      chargeOnCompletion: async (params: { now?: Date }) => {
+        chargeNow = params.now;
+      },
+    };
+
+    const chatService = {
+      async *chat(): AsyncGenerator<PlaygroundChatEvent> {
+        // Complete cleanly so the route flips outcome to "success" and
+        // reaches the `finally` that calls chargeOnCompletion.
+        yield { type: "finish", finishReason: "stop" };
+      },
+    };
+
+    const llmProvidersService = {
+      resolveModel: async () => ({
+        kind: "ok" as const,
+        modelId: "gpt-test",
+        displayName: "gpt-test",
+        providerId: "prov-test",
+      }),
+    };
+
+    const config = {
+      chatService,
+      quotaService,
+      llmProvidersService,
+      keepAliveIntervalMsResolver: async () => 15_000,
+    } as unknown as PlaygroundRoutesConfig;
+
+    const app = new Hono();
+    // Upstream auth stub — the real `nyxidAuthMiddleware` only READS
+    // `c.get("auth")`, so this survives into the route chain and satisfies
+    // both it and `requirePermission`.
+    app.use("*", async (c, next) => {
+      c.set(
+        "auth" as never,
+        { userId: "u-thread", permissions: ["ornn:playground:use"] } as never,
+      );
+      await next();
+    });
+    app.route("/", createPlaygroundRoutes(config));
+
+    // Route module mounts at `/playground/chat`; the `/api/v1` prefix is
+    // added in bootstrap, not here, so request the bare path.
+    const res = await app.request("/playground/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(res.status).toBe(200);
+    // Drain so the producer's `finally` (chargeOnCompletion) runs.
+    await drainBody(res);
+
+    // The charge fires from the producer's `finally` after the stream
+    // closes; poll until it's observed rather than racing a fixed sleep.
+    for (let i = 0; i < 200 && chargeNow === undefined; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    expect(reserveNow).toBeInstanceOf(Date);
+    expect(chargeNow).toBeInstanceOf(Date);
+    // Load-bearing: same instant, threaded from the route's single
+    // `reservedAt`. Strict identity — dropping `now:` from either call
+    // makes one default to its own `new Date()` and breaks this.
+    expect(chargeNow).toBe(reserveNow as Date);
+    expect((chargeNow as Date).getTime()).toBe((reserveNow as Date).getTime());
   });
 });

--- a/ornn-api/tests/integration/skillgen_charge.test.ts
+++ b/ornn-api/tests/integration/skillgen_charge.test.ts
@@ -229,10 +229,14 @@ describe("IT-SKILLGEN-CHARGE-* (via injected LLM mock)", () => {
 
 describe("IT-SKILLGEN-ABORT", () => {
   test("abort mid-stream releases the reserved slot (used back to baseline)", async () => {
+    // `delayMs` parks the mock producer on a real timer between stream
+    // events so the abort lands deterministically while the generator is
+    // suspended mid-stream — by control flow, not back-pressure luck.
     const { client } = installLlmGatewayMock({
       outcome: "success",
       modelId: "gpt-test",
       text: VALID_SKILL_JSON,
+      delayMs: 50,
     });
     const oh = await startHarness({ llmClient: client as NyxLlmClient });
     try {

--- a/ornn-api/tests/integration/skillgen_charge.test.ts
+++ b/ornn-api/tests/integration/skillgen_charge.test.ts
@@ -1,7 +1,17 @@
 /**
- * IT-SKILLGEN-QUOTA-DENY + IT-SKILLGEN-* charge path mirrors of the
- * playground charge tests. Same contract — different surface and
- * different route prefix.
+ * IT-SKILLGEN-QUOTA-DENY + IT-SKILLGEN-* charge-path mirrors of the
+ * playground charge tests. Same contract — different surface and route
+ * prefix.
+ *
+ *   - At-cap user → 429
+ *   - Model-resolution failure (no models enabled) → 503, no bucket row
+ *   - Successful generation → bucket.used += 1
+ *   - system_error generation → bucket released back to baseline
+ *   - Abort mid-stream → bucket released back to baseline
+ *
+ * Charge-path cases inject the in-process `installLlmGatewayMock()` via
+ * the harness `llmClient` seam so the route → generation service → quota
+ * wiring runs without network IO.
  *
  * @module tests/integration/skillgen_charge.test
  */
@@ -9,6 +19,8 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { startHarness, type Harness, authHeaders } from "./harness";
 import { resetCollections } from "./cleanup";
+import { installLlmGatewayMock } from "../mocks/llmGateway";
+import type { NyxLlmClient } from "../../src/clients/nyxid/llm";
 
 let h: Harness;
 
@@ -21,22 +33,105 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await resetCollections(h.db, ["quota_buckets", "platform_settings"]);
+  await resetCollections(h.db, ["quota_buckets", "platform_settings", "llm_providers"]);
 });
+
+const buildAuth = (userId: string) =>
+  authHeaders({
+    userId,
+    email: `${userId}@test.invalid`,
+    permissions: ["ornn:skill:build"],
+  });
+
+/**
+ * Valid generated-skill JSON — passes `generatedSkillSchema` so the
+ * service emits `generation_complete` (success outcome) on the first
+ * stream pass, with no retry round-trip.
+ */
+const VALID_SKILL_JSON = JSON.stringify({
+  name: "test-skill",
+  description: "A test skill generated for the integration charge test.",
+  category: "plain",
+  tags: ["test", "integration"],
+  readmeBody:
+    "This is a generated test skill body long enough to clear the fifty character minimum readme length requirement.",
+});
+
+/** Seed one provider with a model enabled for the skillGen surface. */
+async function seedSkillGenModel(db: Harness["db"], modelId: string): Promise<void> {
+  const now = new Date();
+  await db.collection("llm_providers").insertOne({
+    _id: "prov-skillgen",
+    name: "test-provider",
+    gatewayUrl: "https://gw.test.invalid",
+    modelListUrl: "https://gw.test.invalid/models",
+    apiFormat: "responses",
+    auth: { kind: "apiKey", apiKeyEnc: "" },
+    models: [
+      {
+        id: modelId,
+        displayName: modelId,
+        enabledForPlayground: false,
+        enabledForSkillGen: true,
+        defaultForPlayground: false,
+        defaultForSkillGen: true,
+        removed: false,
+        firstSeenAt: now,
+        lastSyncedAt: now,
+      },
+    ],
+    maxOutputTokens: 8192,
+    defaultTemperature: 0.7,
+    createdAt: now,
+    updatedAt: now,
+    updatedBy: "test",
+  });
+}
+
+const monthMarker = () => new Date().toISOString().slice(0, 7);
+
+async function drainBody(res: Response): Promise<void> {
+  const reader = res.body?.getReader();
+  if (!reader) return;
+  for (let done = false; !done; ) {
+    ({ done } = await reader.read());
+  }
+}
+
+async function waitForBucket(
+  db: Harness["db"],
+  filter: Record<string, unknown>,
+  predicate: (doc: Record<string, unknown> | null) => boolean,
+  { tries = 100, intervalMs = 10 } = {},
+): Promise<Record<string, unknown> | null> {
+  for (let i = 0; i < tries; i++) {
+    const doc = (await db.collection("quota_buckets").findOne(filter)) as
+      | Record<string, unknown>
+      | null;
+    if (predicate(doc)) return doc;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return (await db.collection("quota_buckets").findOne(filter)) as
+    | Record<string, unknown>
+    | null;
+}
 
 describe("IT-SKILLGEN-QUOTA-DENY", () => {
   test("user at skillGen cap → 429", async () => {
-    const monthMarker = new Date().toISOString().slice(0, 7);
+    const mm = monthMarker();
+    await seedSkillGenModel(h.db, "gpt-test");
+    // skillGen settings default is 50 (see sections/skillGen.ts); pin
+    // stored allotment >= that so `used` sits at the effective cap.
     await h.db.collection("quota_buckets").insertOne({
-      _id: `u-cap:skillGen:${monthMarker}`,
+      _id: `u-cap:skillGen:${mm}`,
       userId: "u-cap",
       surface: "skillGen",
-      monthMarker,
+      monthMarker: mm,
       monthStart: new Date(),
       monthEnd: new Date(),
-      defaultAllotment: 3,
+      defaultAllotment: 1000,
       adminGrant: 0,
-      used: 3,
+      used: 1000,
       usedByModel: {},
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -44,20 +139,130 @@ describe("IT-SKILLGEN-QUOTA-DENY", () => {
 
     const res = await h.app.request("/api/v1/skills/generate", {
       method: "POST",
-      headers: {
-        ...authHeaders({
-          userId: "u-cap",
-          email: "u-cap@test.invalid",
-          permissions: ["ornn:skill:build"],
-        }),
-        "Content-Type": "application/json",
-      },
+      headers: { ...buildAuth("u-cap"), "Content-Type": "application/json" },
       body: JSON.stringify({ prompt: "hello" }),
     });
-    // Accept any non-2xx — see playground_charge.test for rationale.
-    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBe(429);
+  });
+});
+
+describe("IT-SKILLGEN-MODEL-RESOLUTION-FAIL", () => {
+  test("no models enabled → 503 and NO bucket row for the user", async () => {
+    const res = await h.app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { ...buildAuth("u-nomodels"), "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "hello" }),
+    });
+    expect(res.status).toBe(503);
+    const buckets = await h.db
+      .collection("quota_buckets")
+      .find({ userId: "u-nomodels", surface: "skillGen" })
+      .toArray();
+    expect(buckets.length).toBe(0);
+  });
+});
+
+describe("IT-SKILLGEN-CHARGE-* (via injected LLM mock)", () => {
+  test("successful skill-gen run charges +1 on bucket.used", async () => {
+    const { client } = installLlmGatewayMock({
+      outcome: "success",
+      modelId: "gpt-test",
+      text: VALID_SKILL_JSON,
+    });
+    const oh = await startHarness({ llmClient: client as NyxLlmClient });
+    try {
+      await resetCollections(oh.db, ["quota_buckets", "platform_settings", "llm_providers"]);
+      await seedSkillGenModel(oh.db, "gpt-test");
+
+      const res = await oh.app.request("/api/v1/skills/generate", {
+        method: "POST",
+        headers: { ...buildAuth("u-ok"), "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: "build me a skill" }),
+      });
+      expect(res.status).toBe(200);
+      await drainBody(res);
+
+      const mm = monthMarker();
+      const bucket = await waitForBucket(
+        oh.db,
+        { _id: `u-ok:skillGen:${mm}` },
+        (d) => !!d && (d.used as number) === 1,
+      );
+      expect(bucket?.used).toBe(1);
+      expect((bucket?.usedByModel as Record<string, number>)["gpt-test"]).toBe(1);
+    } finally {
+      await oh.cleanup();
+    }
   });
 
-  test.todo("successful skill-gen run charges +1 on bucket.used");
-  test.todo("system_error skill-gen run charges 0");
+  test("system_error skill-gen run charges 0 (slot released)", async () => {
+    const { client } = installLlmGatewayMock({
+      outcome: "system_error",
+      modelId: "gpt-test",
+    });
+    const oh = await startHarness({ llmClient: client as NyxLlmClient });
+    try {
+      await resetCollections(oh.db, ["quota_buckets", "platform_settings", "llm_providers"]);
+      await seedSkillGenModel(oh.db, "gpt-test");
+
+      const res = await oh.app.request("/api/v1/skills/generate", {
+        method: "POST",
+        headers: { ...buildAuth("u-syserr"), "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: "build me a skill" }),
+      });
+      expect(res.status).toBe(200);
+      await drainBody(res);
+
+      const mm = monthMarker();
+      // Reserve bumped used to 1; system_error releases it back to 0.
+      const bucket = await waitForBucket(
+        oh.db,
+        { _id: `u-syserr:skillGen:${mm}` },
+        (d) => !!d && (d.used as number) === 0,
+      );
+      expect(bucket?.used).toBe(0);
+    } finally {
+      await oh.cleanup();
+    }
+  });
+});
+
+describe("IT-SKILLGEN-ABORT", () => {
+  test("abort mid-stream releases the reserved slot (used back to baseline)", async () => {
+    const { client } = installLlmGatewayMock({
+      outcome: "success",
+      modelId: "gpt-test",
+      text: VALID_SKILL_JSON,
+    });
+    const oh = await startHarness({ llmClient: client as NyxLlmClient });
+    try {
+      await resetCollections(oh.db, ["quota_buckets", "platform_settings", "llm_providers"]);
+      await seedSkillGenModel(oh.db, "gpt-test");
+
+      const controller = new AbortController();
+      const res = await oh.app.request("/api/v1/skills/generate", {
+        method: "POST",
+        headers: { ...buildAuth("u-abort"), "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: "build me a skill" }),
+        signal: controller.signal,
+      });
+      expect(res.status).toBe(200);
+      const reader = res.body?.getReader();
+      await reader?.read().catch(() => {});
+      controller.abort();
+      await reader?.cancel().catch(() => {});
+
+      const mm = monthMarker();
+      // Aborted stream → generation service never emits generation_complete
+      // → outcome stays system_error → slot released → used back to 0.
+      const bucket = await waitForBucket(
+        oh.db,
+        { _id: `u-abort:skillGen:${mm}` },
+        (d) => !!d && (d.used as number) === 0,
+      );
+      expect(bucket?.used).toBe(0);
+    } finally {
+      await oh.cleanup();
+    }
+  });
 });

--- a/ornn-api/tests/mocks/llmGateway.ts
+++ b/ornn-api/tests/mocks/llmGateway.ts
@@ -31,6 +31,16 @@ export interface LlmGatewayMockOptions {
   modelId?: string;
   /** Optional text to emit as a single delta before the finish event. */
   text?: string;
+  /**
+   * Per-yield pause (ms) injected into `stream()` AFTER the opening
+   * `response.created` event and before each subsequent event. Gives the
+   * abort tests a deterministic window to cancel mid-stream by control
+   * flow rather than back-pressure luck: the producer parks on a real
+   * timer, so a `controller.abort()` fired after the first chunk always
+   * lands while the generator is suspended inside the stream. `0` (the
+   * default) still yields a macrotask boundary via `setTimeout(_, 0)`.
+   */
+  delayMs?: number;
 }
 
 export interface LlmGatewayMockHandle {
@@ -62,21 +72,31 @@ export function installLlmGatewayMock(
     if (cfg.outcome === "system_error") {
       throw new Error("LLM_TRANSPORT_FAIL: simulated upstream 5xx");
     }
+    // Awaitable inter-event pause. Defaults to a bare macrotask boundary
+    // (`setTimeout(_, 0)`) so every yield cooperatively suspends the
+    // generator; abort tests bump `delayMs` so the producer is reliably
+    // parked between `response.created` and `response.completed` when
+    // `controller.abort()` fires.
+    const pause = () =>
+      new Promise<void>((resolve) => setTimeout(resolve, cfg.delayMs ?? 0));
     yield {
       type: "response.created",
       response: { model: cfg.modelId ?? params.model },
     } as ResponsesApiStreamEvent;
+    await pause();
     if (cfg.text) {
       yield {
         type: "response.output_text.delta",
         delta: cfg.text,
       } as ResponsesApiStreamEvent;
+      await pause();
     }
     if (cfg.outcome === "skill_error") {
       yield {
         type: "response.error",
         error: { message: "simulated skill-side failure" },
       } as ResponsesApiStreamEvent;
+      await pause();
     }
     yield {
       type: "response.completed",


### PR DESCRIPTION
Closes #827

Automated change by `/auto` (run `20260604T121112Z-15019`, runner `auto-runner-20260604T121112Z-15019-15019-95512`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
