### PR TITLE
[Bug] Re-validate redirect hops in safeFetch to close the SSRF redirect bypass (follow-up to #811)

### DIFF
--- a/.changeset/auto-832-safefetch-redirect-ssrf.md
+++ b/.changeset/auto-832-safefetch-redirect-ssrf.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Close an SSRF redirect-hop bypass: safeFetch now follows redirects via a bounded manual loop that re-validates each hop's host against the public-address guard and strips cross-host credentials, instead of blindly following 3xx to unvalidated targets.

--- a/ornn-api/src/clients/llmModelListClient.ssrf.test.ts
+++ b/ornn-api/src/clients/llmModelListClient.ssrf.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for #832: `LlmModelListClient` routes BOTH of its outbound
+ * sites through `safeFetch`, so each is refused when its host rebinds to
+ * 169.254.169.254 at fetch time:
+ *
+ *   1. The model-list URL fetch (`fetch({ modelListUrl, auth })`).
+ *   2. The OAuth2 `tokenUrl` client_credentials exchange, taken when
+ *      `auth.kind === "tokenUrl"` — an explicitly named site because it
+ *      POSTs `client_secret` to an operator-supplied host. The refusal
+ *      MUST fire before the secret leaves the process.
+ *
+ * The client catches `SsrfRefusalError` and rethrows it as-is, so the
+ * caller still sees the refusal type. We assert the fetch spy recorded
+ * zero calls for the refused site.
+ *
+ * dns is stubbed before the client imports so the shared preflight
+ * (bound in `url.ts` at module load) sees the rebind — same host-aware
+ * idiom as the nyxid ssrf tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type {
+  ApiFormat,
+  LlmProviderAuth,
+} from "../domains/settings/llmProviders/types";
+
+const REBIND_HOST = "rebind.test";
+mock.module("node:dns/promises", () => ({
+  lookup: async (host: string) =>
+    host === REBIND_HOST
+      ? [{ address: "169.254.169.254", family: 4 }]
+      : [{ address: "93.184.216.34", family: 4 }],
+}));
+
+const { LlmModelListClient } = await import("./llmModelListClient");
+const { SsrfRefusalError } = await import("../infra/url");
+
+const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
+const originalFetch = globalThis.fetch;
+const originalAllowlist = process.env[ALLOWLIST_ENV];
+
+let fetchCalls: string[];
+
+beforeEach(() => {
+  fetchCalls = [];
+  delete process.env[ALLOWLIST_ENV];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    fetchCalls.push(url);
+    return new Response(JSON.stringify({ data: [], access_token: "tok" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalAllowlist === undefined) delete process.env[ALLOWLIST_ENV];
+  else process.env[ALLOWLIST_ENV] = originalAllowlist;
+});
+
+const apiFormat: ApiFormat = "responses";
+
+describe("LlmModelListClient SSRF preflight (#832)", () => {
+  it("refuses a rebound modelListUrl before reading the catalog", async () => {
+    const auth: LlmProviderAuth = { kind: "apiKey", apiKey: "secret-key" };
+    await expect(
+      new LlmModelListClient().fetch({
+        modelListUrl: "http://rebind.test/v1/models",
+        apiFormat,
+        auth,
+      }),
+    ).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("refuses a rebound OAuth2 tokenUrl before POSTing client_secret", async () => {
+    // Named site: the auth.kind === "tokenUrl" client_credentials
+    // exchange. tokenUrl rebinds to the metadata host — the preflight
+    // must refuse before `client_secret` is posted. The model-list URL
+    // is a benign public host that is never reached because auth header
+    // construction fails first.
+    const auth: LlmProviderAuth = {
+      kind: "tokenUrl",
+      tokenUrl: "http://rebind.test/oauth/token",
+      clientId: "cid",
+      clientSecret: "super-secret",
+    };
+    await expect(
+      new LlmModelListClient().fetch({
+        modelListUrl: "http://public-models.example.com/v1/models",
+        apiFormat,
+        auth,
+      }),
+    ).rejects.toBeInstanceOf(SsrfRefusalError);
+    // Neither the token endpoint nor the model-list endpoint was hit.
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/ornn-api/src/clients/nyxid/llm.ssrf.test.ts
+++ b/ornn-api/src/clients/nyxid/llm.ssrf.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for #832: the LLM gateway client (`NyxLlmClient`) routes every
+ * outbound call through `safeFetch`, so a gateway host that rebinds to
+ * 169.254.169.254 at fetch time is refused before the bearer token is
+ * sent on the wire.
+ *
+ * Both surfaces — `complete()` (non-streaming) and `stream()` (SSE) —
+ * are named call-sites. We inject a working SA token provider so the
+ * refusal lands at the GATEWAY fetch (the site under test), not the SA
+ * token exchange, and assert the `globalThis.fetch` spy recorded zero
+ * calls (the refusal short-circuits before any network I/O).
+ *
+ * dns is stubbed before the client imports so the shared preflight
+ * (bound in `url.ts` at module load) sees the rebind — same host-aware
+ * idiom as `ssrf.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { NyxidSaTokenProvider } from "./base";
+
+const REBIND_HOST = "rebind.test";
+mock.module("node:dns/promises", () => ({
+  lookup: async (host: string) =>
+    host === REBIND_HOST
+      ? [{ address: "169.254.169.254", family: 4 }]
+      : [{ address: "93.184.216.34", family: 4 }],
+}));
+
+const { NyxLlmClient } = await import("./llm");
+const { SsrfRefusalError } = await import("../../infra/url");
+
+const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
+const originalFetch = globalThis.fetch;
+const originalAllowlist = process.env[ALLOWLIST_ENV];
+
+let fetchCalls: string[];
+
+beforeEach(() => {
+  fetchCalls = [];
+  delete process.env[ALLOWLIST_ENV];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    fetchCalls.push(url);
+    return new Response(JSON.stringify({ output: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalAllowlist === undefined) delete process.env[ALLOWLIST_ENV];
+  else process.env[ALLOWLIST_ENV] = originalAllowlist;
+});
+
+// Working SA token provider — the bearer is ready BEFORE the gateway
+// fetch, so any refusal must come from the gateway preflight, proving
+// the token never hits the wire.
+const stubSa = {
+  getAccessToken: async () => "sa-token",
+} as unknown as NyxidSaTokenProvider;
+
+function makeClient() {
+  return new NyxLlmClient({
+    resolver: async () => ({
+      gatewayUrl: "http://rebind.test",
+      apiKey: "",
+      apiFormat: "responses" as const,
+    }),
+    saTokenProvider: stubSa,
+  });
+}
+
+const params = {
+  model: "gpt-x",
+  input: [{ role: "user" as const, content: "hi" }],
+};
+
+describe("NyxLlmClient SSRF preflight (#832) — LLM gateway sites", () => {
+  it("complete() refuses a rebound gatewayUrl before sending the bearer", async () => {
+    await expect(makeClient().complete(params)).rejects.toBeInstanceOf(
+      SsrfRefusalError,
+    );
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("stream() refuses a rebound gatewayUrl before sending the bearer", async () => {
+    const iter = makeClient().stream(params);
+    // `stream` is an async generator — the refusal surfaces on first
+    // pull, before any SSE frame is read.
+    await expect((async () => {
+      for await (const _ of iter) {
+        /* unreachable — refusal throws before the first event */
+      }
+    })()).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/ornn-api/src/clients/nyxid/ssrf.test.ts
+++ b/ornn-api/src/clients/nyxid/ssrf.test.ts
@@ -29,6 +29,9 @@ mock.module("node:dns/promises", () => ({
 
 const { NyxidSaTokenProvider } = await import("./base");
 const { NyxidServiceClient } = await import("./service");
+const { NyxidOrgsClient } = await import("./orgs");
+const { NyxidUserServicesClient } = await import("./userServices");
+const { NyxLlmCatalogClient } = await import("./llmCatalog");
 const { SsrfRefusalError } = await import("../../infra/url");
 
 const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
@@ -106,5 +109,81 @@ describe("NyxidServiceClient SSRF preflight (#811) — baseApiUrl sibling", () =
     process.env[ALLOWLIST_ENV] = "rebind.test";
     await makeClient().listServicesForCaller("user-token");
     expect(fetchCalls).toEqual(["http://rebind.test/api/v1/services"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #832 — per-call-site SSRF smoke tests. Each named outbound site must
+// route through `safeFetch`, so a rebound resolver host is refused before
+// the network call (and before any bearer/credential is sent). We assert
+// the fetch spy recorded ZERO calls; the surfaced behaviour matches each
+// client's documented contract (throw on fail-closed reads, [] on
+// fail-soft reads).
+// ---------------------------------------------------------------------------
+
+describe("NyxidOrgsClient SSRF preflight (#832) — orgs sites", () => {
+  // listUserOrgs is fail-closed (throws); listOrgMembers is fail-soft
+  // (returns [] and logs). A working SA token provider is injected so
+  // the listOrgMembers refusal lands at the /members fetch, not the SA
+  // token exchange.
+  const stubSa = {
+    getAccessToken: async () => "sa-token",
+  } as unknown as InstanceType<typeof NyxidSaTokenProvider>;
+
+  function makeClient() {
+    return new NyxidOrgsClient({
+      resolver: async () => ({ baseApiUrl: "http://rebind.test" }),
+      saTokenProvider: stubSa,
+    });
+  }
+
+  it("listUserOrgs() refuses a rebound baseApiUrl before sending the user bearer", async () => {
+    await expect(makeClient().listUserOrgs("user-token")).rejects.toBeInstanceOf(
+      SsrfRefusalError,
+    );
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("listOrgMembers() refuses a rebound baseApiUrl (fail-soft []) before sending the SA bearer", async () => {
+    const out = await makeClient().listOrgMembers("org-user-id");
+    expect(out).toEqual([]);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("NyxidUserServicesClient SSRF preflight (#832) — user-services site", () => {
+  function makeClient() {
+    return new NyxidUserServicesClient({
+      resolver: async () => ({ baseApiUrl: "http://rebind.test" }),
+    });
+  }
+
+  it("listUserServices() refuses a rebound baseApiUrl before sending the user bearer", async () => {
+    await expect(
+      makeClient().listUserServices("user-token"),
+    ).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("NyxLlmCatalogClient SSRF preflight (#832) — catalog site", () => {
+  // A working SA token provider is injected so the refusal lands at the
+  // catalog `/models` fetch (the named site), not the token exchange.
+  const stubSa = {
+    getAccessToken: async () => "sa-token",
+  } as unknown as InstanceType<typeof NyxidSaTokenProvider>;
+
+  function makeClient() {
+    return new NyxLlmCatalogClient({
+      resolver: async () => ({ baseApiUrl: "http://rebind.test" }),
+      saTokenProvider: stubSa,
+    });
+  }
+
+  it("listUpstreamModels() refuses a rebound catalog host before reading the model list", async () => {
+    await expect(makeClient().listUpstreamModels()).rejects.toBeInstanceOf(
+      SsrfRefusalError,
+    );
+    expect(fetchCalls).toHaveLength(0);
   });
 });

--- a/ornn-api/src/infra/safeFetch.test.ts
+++ b/ornn-api/src/infra/safeFetch.test.ts
@@ -1,5 +1,6 @@
 /**
- * Tests for #811: the shared SSRF-preflight `safeFetch` primitive.
+ * Tests for #811 (SSRF-preflight) + #832 (redirect-hop hardening) for
+ * the shared `safeFetch` primitive.
  *
  * `safeFetch` re-resolves the outbound host at fetch time via
  * `assertPublicResolvedAddress` (which calls `dns.lookup`) and refuses
@@ -7,6 +8,11 @@
  * the DNS-rebind defense. We stub `node:dns/promises` so a public
  * hostname resolves to the cloud-metadata address `169.254.169.254`
  * and assert the wrapper rejects without ever issuing the network call.
+ *
+ * #832 forces `redirect: "manual"` and follows 3xx ourselves in a
+ * bounded loop, re-validating EACH hop's host. The redirect tests use a
+ * scripted per-URL fetch queue (keyed by URL, not call order) so a host
+ * can return a 302 once and a 200 next, without order-fragility.
  *
  * `url.ts` binds `dns` at module load (`import * as dns from
  * "node:dns/promises"`), so the `mock.module` MUST be installed before
@@ -20,10 +26,11 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 // `url.ts` binds the stub at load time. `mock.module` is process-global
 // and `url.ts` binds the dns namespace once, so the stub cannot be
 // cleanly torn down per-file — we therefore make it host-aware: ONLY
-// the rebind hostname resolves to the cloud-metadata address; every
+// the rebind hostnames resolve to the cloud-metadata address; every
 // other host resolves to a benign public IP, so the leaked stub is
 // harmless to sibling tests that hit real public hostnames.
 const REBIND_HOST = "evil.example.com";
+const METADATA_HOST = "169.254.169.254";
 mock.module("node:dns/promises", () => ({
   lookup: async (host: string) =>
     host === REBIND_HOST
@@ -40,13 +47,37 @@ const originalAllowlist = process.env[ALLOWLIST_ENV];
 
 let fetchCalls: string[];
 
+/**
+ * Scripted per-URL response queue. Map a URL to an array of Responses;
+ * each call to that URL shifts the next one (the last one sticks once
+ * the queue is drained). Keyed by URL — no order-fragility across hosts.
+ */
+let scriptedResponses: Map<string, Response[]>;
+
+function urlOf(input: RequestInfo | URL): string {
+  return typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+}
+
+/** A 302 redirect Response pointing at `location`. */
+function redirect302(location: string): Response {
+  return new Response(null, { status: 302, headers: { location } });
+}
+
 beforeEach(() => {
   fetchCalls = [];
+  scriptedResponses = new Map();
   delete process.env[ALLOWLIST_ENV];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
-    const url =
-      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = urlOf(input);
     fetchCalls.push(url);
+    const queue = scriptedResponses.get(url);
+    if (queue && queue.length > 0) {
+      return queue.length > 1 ? queue.shift()! : queue[0]!;
+    }
     return new Response("ok", { status: 200 });
   }) as typeof fetch;
 });
@@ -78,7 +109,10 @@ describe("safeFetch — DNS-rebind preflight (#811)", () => {
     expect(fetchCalls).toEqual(["http://93.184.216.34/x"]);
   });
 
-  it("forwards the init object verbatim to fetch", async () => {
+  it("forwards init structurally and sets redirect:manual (#832)", async () => {
+    // #832 spreads init to inject `redirect: "manual"`, so the forwarded
+    // object is no longer reference-identical. Assert the load-bearing
+    // fields survive the spread AND that manual-redirect is forced on.
     let capturedInit: RequestInit | undefined;
     globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       capturedInit = init;
@@ -86,11 +120,96 @@ describe("safeFetch — DNS-rebind preflight (#811)", () => {
     }) as typeof fetch;
     const init: RequestInit = { method: "POST", headers: { "X-Test": "1" }, body: "payload" };
     await safeFetch("http://93.184.216.34/x", init);
-    expect(capturedInit).toBe(init);
+    expect(capturedInit).toMatchObject({
+      method: "POST",
+      headers: { "X-Test": "1" },
+      body: "payload",
+    });
+    expect(capturedInit?.redirect).toBe("manual");
   });
 
   it("throws on an invalid URL before resolving or fetching", async () => {
     await expect(safeFetch("not a url")).rejects.toThrow(/Invalid URL/);
     expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("safeFetch — bounded manual redirect follow (#832)", () => {
+  it("refuses a first-hop 302 → metadata host; second fetch never fires", async () => {
+    // hop1 (public host) returns a 302 pointing at the cloud-metadata
+    // address. The loop re-validates the redirect target before its
+    // fetch — `evil.example.com` resolves to 169.254.169.254 so the
+    // SECOND fetch never fires.
+    const hop1 = "http://public-a.example.com/start";
+    scriptedResponses.set(hop1, [redirect302("http://evil.example.com/")]);
+
+    await expect(safeFetch(hop1)).rejects.toBeInstanceOf(SsrfRefusalError);
+    // Only the first hop's fetch fired; the metadata target was refused
+    // by the preflight before its network call.
+    expect(fetchCalls).toEqual([hop1]);
+  });
+
+  it("refuses a 302 to a literal metadata IP; second fetch never fires", async () => {
+    // A redirect straight to the literal 169.254.169.254 is caught by
+    // the per-hop URL guard (private IP literal) before its fetch.
+    const hop1 = "http://public-a.example.com/start";
+    scriptedResponses.set(hop1, [redirect302(`http://${METADATA_HOST}/latest/meta-data/`)]);
+
+    await expect(safeFetch(hop1)).rejects.toBeInstanceOf(SsrfRefusalError);
+    expect(fetchCalls).toEqual([hop1]);
+  });
+
+  it("follows a same-host PUBLIC 302 and returns the final 200", async () => {
+    // Criterion 2: a legitimate public redirect still succeeds. Same
+    // host, so credentials (if any) are preserved.
+    const hop1 = "http://public-a.example.com/start";
+    const hop2 = "http://public-a.example.com/final";
+    scriptedResponses.set(hop1, [redirect302(hop2)]);
+    scriptedResponses.set(hop2, [new Response("done", { status: 200 })]);
+
+    const res = await safeFetch(hop1);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("done");
+    expect(fetchCalls).toEqual([hop1, hop2]);
+  });
+
+  it("strips Authorization on a cross-host PUBLIC redirect", async () => {
+    // hop1 (hostA) carries an Authorization header and 302s to hostB —
+    // both public. The follow must NOT carry the bearer token to hostB.
+    const hop1 = "http://public-a.example.com/start";
+    const hop2 = "http://public-b.example.com/final";
+    scriptedResponses.set(hop1, [redirect302(hop2)]);
+    scriptedResponses.set(hop2, [new Response("done", { status: 200 })]);
+
+    let hop2Init: RequestInit | undefined;
+    const baseFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (urlOf(input) === hop2) hop2Init = init;
+      return baseFetch(input, init);
+    }) as typeof fetch;
+
+    const res = await safeFetch(hop1, {
+      headers: { Authorization: "Bearer secret-token", "X-Keep": "1" },
+    });
+    expect(res.status).toBe(200);
+    expect(fetchCalls).toEqual([hop1, hop2]);
+
+    // The Authorization header must be gone on the cross-host hop;
+    // non-sensitive headers are preserved.
+    const hop2Headers = new Headers(hop2Init?.headers as HeadersInit);
+    expect(hop2Headers.has("authorization")).toBe(false);
+    expect(hop2Headers.get("x-keep")).toBe("1");
+  });
+
+  it("throws after MAX_REDIRECTS on a self-redirect loop", async () => {
+    // Self-redirect loop on a public host — every hop returns a 302 to
+    // itself. The loop caps at MAX_REDIRECTS (5) + the initial attempt,
+    // so at most 6 fetch calls before the limit error.
+    const loopUrl = "http://public-loop.example.com/spin";
+    scriptedResponses.set(loopUrl, [redirect302(loopUrl)]);
+
+    await expect(safeFetch(loopUrl)).rejects.toThrow(/Too many redirects/);
+    expect(fetchCalls.length).toBeLessThanOrEqual(6);
+    expect(fetchCalls.every((u) => u === loopUrl)).toBe(true);
   });
 });

--- a/ornn-api/src/infra/safeFetch.ts
+++ b/ornn-api/src/infra/safeFetch.ts
@@ -1,5 +1,5 @@
 /**
- * SSRF-preflight fetch wrapper (#811).
+ * SSRF-preflight fetch wrapper (#811, redirect-hop hardening #832).
  *
  * The single shared primitive that re-resolves an outbound host at
  * fetch time and refuses private/loopback/link-local targets — the
@@ -9,21 +9,164 @@
  * later flips its DNS to 169.254.169.254 / RFC1918 is caught before
  * the bearer/SA token is sent.
  *
- * Intentionally a thin wrapper: NO timeout (callers that need one pass
- * their own `init.signal`); credential redaction / response parsing
- * stay in the individual clients.
+ * Redirect handling (#832): the underlying `fetch` default is
+ * `redirect: "follow"`, which transparently chases 3xx `Location`
+ * headers to whatever host the upstream names — including
+ * `http://169.254.169.254/`. That re-opens the exact rebind hole the
+ * preflight closes: we validate the FIRST hop, then `fetch` follows a
+ * 302 to the metadata host without any further check. We close this by
+ * forcing `redirect: "manual"` and following redirects ourselves in a
+ * bounded loop, re-running `assertPublicResolvedAddress` against EACH
+ * hop's host before issuing its request. A redirect to a private /
+ * metadata address therefore throws `SsrfRefusalError` on the hop that
+ * names it, exactly like a first-hop rebind.
+ *
+ * Cross-host credential stripping: when a redirect crosses to a
+ * different host, sensitive request headers (`authorization`, `cookie`,
+ * `proxy-authorization`) are dropped before following — a 302 from a
+ * legitimate gateway to a third-party host must not leak the caller's
+ * bearer token. Same-host redirects keep the headers (they're staying
+ * within the trust boundary the caller already authorized).
+ *
+ * Non-goals (deliberate):
+ *   - NO RFC 7231 method downgrade on 301/302/303. The method and body
+ *     are re-passed as-is on every hop. No current caller relies on a
+ *     POST→GET downgrade, and re-issuing the original method is the
+ *     safer default for our API-to-API traffic (a redirected POST that
+ *     silently became a GET would drop the body and confuse callers).
+ *   - NO timeout here (callers that need one pass their own
+ *     `init.signal`); credential redaction / response parsing stay in
+ *     the individual clients.
  *
  * @module infra/safeFetch
  */
-import { assertPublicResolvedAddress } from "./url";
+import { createLogger } from "../shared/logger";
+import { assertPublicResolvedAddress, isPrivateHost, SsrfRefusalError } from "./url";
+
+const logger = createLogger("safeFetch");
+
+/** Cap on followed redirects before we give up (a loop or a chain). */
+const MAX_REDIRECTS = 5;
+
+/**
+ * Request headers stripped when a redirect crosses to a different host.
+ * Lowercase — comparison is case-insensitive. These carry the caller's
+ * credentials and must never follow a 3xx to an unrelated origin.
+ */
+const SENSITIVE_HEADERS = ["authorization", "cookie", "proxy-authorization"];
+
+const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
+
+/**
+ * True if `host` is on the operator allowlist (exact hostname match).
+ * Mirrors the hostname fast-path in `assertPublicResolvedAddress` so a
+ * redirect-hop literal-IP guard honours the same operator override.
+ */
+function isAllowlistedHost(host: string): boolean {
+  const raw = process.env[ALLOWLIST_ENV] ?? "";
+  const lower = host.toLowerCase();
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .some((entry) => entry.length > 0 && entry === lower);
+}
+
+/**
+ * Normalize `init.headers` (Headers | Record | [k,v][] | undefined) into
+ * a plain object, delete `keys` case-insensitively, and return a new
+ * `RequestInit` carrying the cleaned headers. Does not mutate the input.
+ */
+function stripSensitiveHeaders(init: RequestInit, keys: ReadonlyArray<string>): RequestInit {
+  const lowerKeys = new Set(keys.map((k) => k.toLowerCase()));
+  const cleaned: Record<string, string> = {};
+  const source = init.headers;
+  if (source instanceof Headers) {
+    source.forEach((value, name) => {
+      if (!lowerKeys.has(name.toLowerCase())) cleaned[name] = value;
+    });
+  } else if (Array.isArray(source)) {
+    for (const [name, value] of source) {
+      if (!lowerKeys.has(name.toLowerCase())) cleaned[name] = value;
+    }
+  } else if (source) {
+    for (const [name, value] of Object.entries(source)) {
+      if (!lowerKeys.has(name.toLowerCase())) cleaned[name] = value;
+    }
+  }
+  return { ...init, headers: cleaned };
+}
 
 export async function safeFetch(url: string, init?: RequestInit): Promise<Response> {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error(`Invalid URL: '${url}'`);
+  let currentUrl = url;
+  // Force manual redirect handling — we re-validate each hop ourselves
+  // instead of letting `fetch` chase 3xx to unvalidated hosts (#832).
+  let currentInit: RequestInit = { ...init, redirect: "manual" };
+  let prevHost: string | null = null;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    let parsed: URL;
+    try {
+      parsed = new URL(currentUrl);
+    } catch {
+      throw new Error(`Invalid URL: '${currentUrl}'`);
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(`Refusing non-http(s) URL: '${currentUrl}'`);
+    }
+
+    logger.debug({ hop, host: parsed.hostname }, "safeFetch hop");
+
+    // Redirect targets (hop > 0) never passed write-time
+    // `validatePublicUrl`, so a `Location: http://169.254.169.254/`
+    // would slip past `assertPublicResolvedAddress`'s literal-IP
+    // fast-path (which assumes the literal was already vetted upstream).
+    // Guard literal private/loopback/link-local IPs explicitly on each
+    // redirect hop, honouring the operator allowlist. The first hop
+    // keeps relying on the write-time guard so literal PUBLIC IPs (an
+    // already-vetted upstream target) still work.
+    if (hop > 0 && isPrivateHost(parsed.hostname) && !isAllowlistedHost(parsed.hostname)) {
+      throw new SsrfRefusalError(parsed.hostname, parsed.hostname);
+    }
+
+    // Re-resolve and re-check EACH hop's host — first hop AND every
+    // redirect target. Throws SsrfRefusalError on a private resolution;
+    // we intentionally do NOT catch it so the refusal propagates to the
+    // caller exactly as a first-hop rebind would.
+    await assertPublicResolvedAddress(parsed.hostname);
+
+    // A cross-host redirect must not carry the caller's credentials to a
+    // host they did not authorize. `prevHost === null` is the first hop
+    // (no redirect yet) — leave headers untouched there.
+    if (prevHost !== null && parsed.hostname !== prevHost) {
+      currentInit = stripSensitiveHeaders(currentInit, SENSITIVE_HEADERS);
+    }
+
+    const res = await fetch(currentUrl, currentInit);
+
+    // Not a redirect (or a redirect with no Location) — this is the
+    // final response.
+    if (res.status < 300 || res.status >= 400) return res;
+    const loc = res.headers.get("location");
+    if (!loc) return res;
+
+    // Drain the redirect response body so the connection can be reused
+    // and we don't leak a dangling stream.
+    res.body?.cancel();
+
+    const nextUrl = new URL(loc, currentUrl).toString();
+    const nextHost = new URL(nextUrl).hostname;
+    if (nextHost !== parsed.hostname && !isPrivateHost(nextHost)) {
+      // Cross-host follow is the only redirect class worth an info log
+      // (a same-host redirect is routine). Suppress the log for a target
+      // we're about to refuse on the next hop (private/metadata) so the
+      // record reads "refused", not "following". NEVER log header /
+      // token values — only the from/to hosts.
+      logger.info({ from: parsed.hostname, to: nextHost }, "safeFetch following cross-host redirect");
+    }
+    prevHost = parsed.hostname;
+    currentUrl = nextUrl;
   }
-  await assertPublicResolvedAddress(parsed.hostname);
-  return fetch(url, init);
+
+  logger.warn({ url, max: MAX_REDIRECTS }, "safeFetch exceeded redirect limit");
+  throw new Error(`Too many redirects (>${MAX_REDIRECTS}) for '${url}'`);
 }


### PR DESCRIPTION
Closes #832

Automated change by `/auto` (run `20260604T121112Z-15019`, runner `auto-runner-20260604T121112Z-15019-15019-99841`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
