### PR TITLE
[Bug] setSkillPermissions returns spurious 403 when org memberships are unresolved (follow-up to #815)

### DIFF
--- a/.changeset/auto-842-org-membership-unresolved.md
+++ b/.changeset/auto-842-org-membership-unresolved.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+setSkillPermissions now distinguishes an unresolved org-membership read (forwarded token absent or NyxID unreachable) from a confirmed non-membership: sharing a skill into an org while memberships are unresolved returns a retryable 503 org_membership_unavailable instead of a misleading 403 not_org_member. Confirmed non-members still get 403. Read-path visibility is unchanged (still fail-soft).

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -96,6 +96,7 @@ Optional: `detail`, `errors[]`.
 | `resource_conflict` | 409 | State conflict (duplicate, concurrent modification, etc.) |
 | `rate_limited` | 429 | Caller exceeded rate limit |
 | `upstream_unavailable` | 502 / 503 | Dependency (NyxID, LLM, sandbox, ...) failed |
+| `org_membership_unavailable` | 503 | NyxID org-membership lookup unresolved — forwarded token absent or lookup failed. Retryable |
 | `internal_error` | 500 | Unhandled server error |
 
 New codes require convention-doc update. Handlers MUST NOT invent ad-hoc codes.

--- a/ornn-api/src/domains/playground/chatService.test.ts
+++ b/ornn-api/src/domains/playground/chatService.test.ts
@@ -120,7 +120,7 @@ const DEFAULTS_RESOLVER = async () => ({
 // fallback was dropped). `isPlatformAdmin: true` preserves the old
 // SYSTEM_ACTOR-bypass intent for the session/env/timeout tests that
 // don't exercise object-level authorization.
-const TEST_ACTOR: ActorContext = { userId: "u1", memberships: [], isPlatformAdmin: true };
+const TEST_ACTOR: ActorContext = { userId: "u1", memberships: [], isPlatformAdmin: true, membershipsResolved: true };
 
 interface SandboxCalls {
   createSession: Array<{ params: CreateSessionParams }>;
@@ -433,15 +433,16 @@ describe("PlaygroundChatService — env value isolation (#721)", () => {
 // these tests exercise the production policy end-to-end through chat().
 // ---------------------------------------------------------------------------
 
-const STRANGER: ActorContext = { userId: "stranger", memberships: [], isPlatformAdmin: false };
-const OWNER: ActorContext = { userId: "owner-1", memberships: [], isPlatformAdmin: false };
-const SHARED_USER: ActorContext = { userId: "shared-1", memberships: [], isPlatformAdmin: false };
+const STRANGER: ActorContext = { userId: "stranger", memberships: [], isPlatformAdmin: false, membershipsResolved: true };
+const OWNER: ActorContext = { userId: "owner-1", memberships: [], isPlatformAdmin: false, membershipsResolved: true };
+const SHARED_USER: ActorContext = { userId: "shared-1", memberships: [], isPlatformAdmin: false, membershipsResolved: true };
 const ORG_MEMBER: ActorContext = {
   userId: "someone-else",
   memberships: [{ userId: "org-9", role: "member", displayName: "Org Nine" }],
   isPlatformAdmin: false,
+  membershipsResolved: true,
 };
-const ADMIN: ActorContext = { userId: "admin-1", memberships: [], isPlatformAdmin: true };
+const ADMIN: ActorContext = { userId: "admin-1", memberships: [], isPlatformAdmin: true, membershipsResolved: true };
 
 /** True if any emitted event's serialized form contains the secret marker. */
 function leaksMarker(events: PlaygroundChatEvent[]): boolean {

--- a/ornn-api/src/domains/skills/crud/authorize.test.ts
+++ b/ornn-api/src/domains/skills/crud/authorize.test.ts
@@ -3,8 +3,9 @@
  * caller's object-level authorization actor from a request (#826).
  *
  * `buildActorContext(c)` consumes exactly two context keys:
- *   - `c.get("auth")` (via `getAuth`)            → throws 401 when absent
- *   - `c.get("getUserOrgMemberships")` (lazy)    → memberships passthrough
+ *   - `c.get("auth")` (via `getAuth`)                       → throws 401 when absent
+ *   - `c.get("getUserOrgMembershipResolution")` (lazy)      → memberships +
+ *     resolved/unresolved discriminant passthrough (#842)
  *
  * Each case stubs a minimal fake Hono context — a plain `{ get }` cast to
  * the Context type — wiring only those two keys. No env mutation, no DB,
@@ -18,25 +19,38 @@ import {
   type AuthContext,
   type AuthVariables,
   type OrgMembershipFact,
+  type OrgMembershipResolution,
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
 
-/** Build a fake Hono context exposing only the keys buildActorContext reads. */
+/**
+ * Build a fake Hono context exposing only the keys buildActorContext reads.
+ *
+ * `resolution` mirrors what `nyxidOrgLookupMiddleware` would memoize. When
+ * omitted the resolution getter is unmounted, so `buildActorContext` falls
+ * back to the helper's `{ status: "resolved", memberships: [] }` default
+ * (the "middleware not mounted" path).
+ */
 function fakeContext(opts: {
   auth?: AuthContext;
-  memberships?: OrgMembershipFact[];
+  resolution?: OrgMembershipResolution;
 }): Context<{ Variables: AuthVariables }> {
   const getter =
-    opts.memberships !== undefined
-      ? async () => opts.memberships as OrgMembershipFact[]
+    opts.resolution !== undefined
+      ? async () => opts.resolution as OrgMembershipResolution
       : undefined;
   const store: Record<string, unknown> = {
     auth: opts.auth,
-    getUserOrgMemberships: getter,
+    getUserOrgMembershipResolution: getter,
   };
   return {
     get: (key: string) => store[key],
   } as unknown as Context<{ Variables: AuthVariables }>;
+}
+
+/** Convenience: a resolved resolution carrying the given memberships. */
+function resolved(memberships: OrgMembershipFact[]): OrgMembershipResolution {
+  return { status: "resolved", memberships };
 }
 
 function authWith(permissions: string[]): AuthContext {
@@ -51,20 +65,20 @@ function authWith(permissions: string[]): AuthContext {
 
 describe("buildActorContext", () => {
   it("(a) flags platform admin when caller holds ornn:admin:skill", async () => {
-    const c = fakeContext({ auth: authWith(["ornn:admin:skill"]), memberships: [] });
+    const c = fakeContext({ auth: authWith(["ornn:admin:skill"]), resolution: resolved([]) });
     const actor = await buildActorContext(c);
     expect(actor.isPlatformAdmin).toBe(true);
     expect(actor.userId).toBe("user-1");
   });
 
   it("(b) does not flag platform admin without ornn:admin:skill", async () => {
-    const c = fakeContext({ auth: authWith(["ornn:skill:read"]), memberships: [] });
+    const c = fakeContext({ auth: authWith(["ornn:skill:read"]), resolution: resolved([]) });
     const actor = await buildActorContext(c);
     expect(actor.isPlatformAdmin).toBe(false);
   });
 
   it("(c) throws 401 AppError when unauthenticated (no auth on context)", async () => {
-    const c = fakeContext({ memberships: [] });
+    const c = fakeContext({ resolution: resolved([]) });
     let thrown: unknown;
     try {
       await buildActorContext(c);
@@ -80,8 +94,35 @@ describe("buildActorContext", () => {
       { userId: "org-a", role: "admin", displayName: "Org A" },
       { userId: "org-b", role: "member", displayName: "Org B" },
     ];
-    const c = fakeContext({ auth: authWith([]), memberships });
+    const c = fakeContext({ auth: authWith([]), resolution: resolved(memberships) });
     const actor = await buildActorContext(c);
     expect(actor.memberships).toEqual(memberships);
+  });
+
+  it("(e) marks membershipsResolved true on a resolved lookup (#842)", async () => {
+    const c = fakeContext({ auth: authWith([]), resolution: resolved([]) });
+    const actor = await buildActorContext(c);
+    // Resolved-empty is still resolved: caller is a member of nothing.
+    expect(actor.membershipsResolved).toBe(true);
+    expect(actor.memberships).toEqual([]);
+  });
+
+  it("(f) marks membershipsResolved false + memberships [] on an unresolved lookup (#842)", async () => {
+    const c = fakeContext({
+      auth: authWith([]),
+      resolution: { status: "unresolved", reason: "lookup_failed", memberships: [] },
+    });
+    const actor = await buildActorContext(c);
+    expect(actor.membershipsResolved).toBe(false);
+    expect(actor.memberships).toEqual([]);
+  });
+
+  it("(g) defaults to resolved-empty when the resolution getter is unmounted (#842)", async () => {
+    // No `resolution` wired → middleware-not-mounted path. Must NOT flip to
+    // unresolved, so unrelated tests don't suddenly 503 on a share write.
+    const c = fakeContext({ auth: authWith([]) });
+    const actor = await buildActorContext(c);
+    expect(actor.membershipsResolved).toBe(true);
+    expect(actor.memberships).toEqual([]);
   });
 });

--- a/ornn-api/src/domains/skills/crud/authorize.ts
+++ b/ornn-api/src/domains/skills/crud/authorize.ts
@@ -29,7 +29,7 @@
 import type { Context } from "hono";
 import {
   getAuth,
-  readUserOrgMemberships,
+  readUserOrgMembershipResolution,
   type AuthVariables,
   type OrgMembershipFact,
 } from "../../../middleware/nyxidAuth";
@@ -48,10 +48,29 @@ export interface ActorContext {
   userId: string;
   memberships: OrgMembershipFact[];
   isPlatformAdmin: boolean;
+  /**
+   * Whether the org-membership lookup resolved authoritatively (#842).
+   * `true` when NyxID answered (including a 200-empty list); `false` when
+   * the lookup was unresolved (no forwarded token / NyxID unreachable).
+   * Write gates that share a skill into orgs must distinguish an empty
+   * `memberships` that means "member of nothing" (resolved) from one that
+   * means "we couldn't ask" (unresolved) — the latter is a retryable 503,
+   * not a 403. Read gates ignore this field (they fail soft regardless).
+   */
+  membershipsResolved: boolean;
 }
 
-/** Internal/system caller — bypasses visibility (mirror, server-side jobs). */
-export const SYSTEM_ACTOR: ActorContext = { userId: "__system__", memberships: [], isPlatformAdmin: true };
+/**
+ * Internal/system caller — bypasses visibility (mirror, server-side jobs).
+ * `membershipsResolved: true` so system callers are never treated as having
+ * an unresolved org lookup.
+ */
+export const SYSTEM_ACTOR: ActorContext = {
+  userId: "__system__",
+  memberships: [],
+  isPlatformAdmin: true,
+  membershipsResolved: true,
+};
 
 /**
  * Build the caller's object-level authorization actor from the request.
@@ -63,11 +82,16 @@ export async function buildActorContext(
   c: Context<{ Variables: AuthVariables }>,
 ): Promise<ActorContext> {
   const auth = getAuth(c);
-  const memberships = await readUserOrgMemberships(c);
+  // Resolution-aware read (#842): carry whether NyxID answered so the write
+  // gate can tell "member of nothing" (resolved) from "couldn't ask"
+  // (unresolved). `.memberships` is the same fail-soft `[]` the read path
+  // already used for both cases, so read callers are unaffected.
+  const resolution = await readUserOrgMembershipResolution(c);
   return {
     userId: auth.userId,
-    memberships,
+    memberships: resolution.memberships,
     isPlatformAdmin: auth.permissions.includes("ornn:admin:skill"),
+    membershipsResolved: resolution.status === "resolved",
   };
 }
 

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -71,9 +71,9 @@ function makeService(skill: SkillDocument, presignedUrl: string): SkillService {
   });
 }
 
-const STRANGER: ActorContext = { userId: "stranger", memberships: [], isPlatformAdmin: false };
-const OWNER: ActorContext = { userId: "owner-1", memberships: [], isPlatformAdmin: false };
-const ADMIN: ActorContext = { userId: "admin-1", memberships: [], isPlatformAdmin: true };
+const STRANGER: ActorContext = { userId: "stranger", memberships: [], isPlatformAdmin: false, membershipsResolved: true };
+const OWNER: ActorContext = { userId: "owner-1", memberships: [], isPlatformAdmin: false, membershipsResolved: true };
+const ADMIN: ActorContext = { userId: "admin-1", memberships: [], isPlatformAdmin: true, membershipsResolved: true };
 
 describe("SkillService.getSkillJson — object-level authorization (#806)", () => {
   it("private skill + stranger actor throws skill_not_found before any download", async () => {
@@ -248,7 +248,7 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
       makeSkillDoc({ guid: "guid-1", createdBy: "owner-1", isPrivate: true }),
     );
     // Caller owns the skill (passes the route gate) but is a member of no org.
-    const actor: ActorContext = { userId: "owner-1", memberships: [], isPlatformAdmin: false };
+    const actor: ActorContext = { userId: "owner-1", memberships: [], isPlatformAdmin: false, membershipsResolved: true };
 
     let thrown: unknown;
     try {
@@ -276,6 +276,7 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
       userId: "owner-1",
       memberships: [{ userId: "org-A", role: "member", displayName: "" }],
       isPlatformAdmin: false,
+      membershipsResolved: true,
     };
 
     const result = await service.setSkillPermissions(
@@ -293,7 +294,7 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
       makeSkillDoc({ guid: "guid-1", createdBy: "owner-1", isPrivate: true }),
     );
     // Admin has zero memberships but the bypass lets them share into org-A.
-    const actor: ActorContext = { userId: "admin-1", memberships: [], isPlatformAdmin: true };
+    const actor: ActorContext = { userId: "admin-1", memberships: [], isPlatformAdmin: true, membershipsResolved: true };
 
     const result = await service.setSkillPermissions(
       "guid-1",
@@ -319,7 +320,142 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
       userId: "u2",
       memberships: [{ userId: "org-X", role: "member", displayName: "" }],
       isPlatformAdmin: false,
+      membershipsResolved: true,
     };
     expect(canReadSkill(skill, orgMember)).toBe(false);
+  });
+
+  /**
+   * #842 — unresolved org-membership read.
+   *
+   * The #815 gate above intersects `sharedWithOrgs` against the caller's
+   * `memberships`. When the org-membership lookup is UNRESOLVED (forwarded
+   * token absent or NyxID unreachable) `memberships` is empty for a
+   * non-membership reason — so the #815 intersection would 403 a legitimate
+   * member. `setSkillPermissions` instead fails closed with a retryable 503
+   * `org_membership_unavailable`, but only when the caller actually shares
+   * into an org. A public / user-only change needs no membership data and
+   * succeeds even while the lookup is unresolved. A resolved-not-member share
+   * still gets the #815 403, naming only the offending org id(s).
+   */
+  it("(a) unresolved lookup + sharing into an org → 503 org_membership_unavailable, no write", async () => {
+    const { service, state } = makePermissionsService(
+      makeSkillDoc({ guid: "guid-1", createdBy: "owner-1", isPrivate: true }),
+    );
+    // Owner passes the route gate, but the org lookup never resolved — empty
+    // memberships here means "couldn't ask", not "member of nothing".
+    const actor: ActorContext = {
+      userId: "owner-1",
+      memberships: [],
+      isPlatformAdmin: false,
+      membershipsResolved: false,
+    };
+
+    let thrown: unknown;
+    try {
+      await service.setSkillPermissions(
+        "guid-1",
+        "owner-1",
+        { isPrivate: true, sharedWithUsers: [], sharedWithOrgs: ["org-X"] },
+        actor,
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("org_membership_unavailable");
+    expect((thrown as AppError).statusCode).toBe(503);
+    // Fails closed before persistence — nothing was written.
+    expect(state.updateCalled).toBe(false);
+  });
+
+  it("(b) unresolved lookup + NOT sharing into any org → succeeds", async () => {
+    const { service, state } = makePermissionsService(
+      makeSkillDoc({ guid: "guid-1", createdBy: "owner-1", isPrivate: true }),
+    );
+    // Lookup unresolved, but the caller only flips visibility / shares with a
+    // user — no org data is needed, so the write proceeds.
+    const actor: ActorContext = {
+      userId: "owner-1",
+      memberships: [],
+      isPlatformAdmin: false,
+      membershipsResolved: false,
+    };
+
+    const result = await service.setSkillPermissions(
+      "guid-1",
+      "owner-1",
+      { isPrivate: false, sharedWithUsers: ["friend-1"], sharedWithOrgs: [] },
+      actor,
+    );
+    expect(state.updateCalled).toBe(true);
+    expect(result.isPrivate).toBe(false);
+    expect(result.sharedWithOrgs).toEqual([]);
+  });
+
+  it("(c) resolved-not-member + sharing into an org → 403 not_org_member naming the org", async () => {
+    const { service, state } = makePermissionsService(
+      makeSkillDoc({ guid: "guid-1", createdBy: "owner-1", isPrivate: true }),
+    );
+    // Lookup resolved authoritatively: caller belongs to no org. Sharing into
+    // org-X is a genuine non-membership → the #815 403, not a 503.
+    const actor: ActorContext = {
+      userId: "owner-1",
+      memberships: [],
+      isPlatformAdmin: false,
+      membershipsResolved: true,
+    };
+
+    let thrown: unknown;
+    try {
+      await service.setSkillPermissions(
+        "guid-1",
+        "owner-1",
+        { isPrivate: true, sharedWithUsers: [], sharedWithOrgs: ["org-X"] },
+        actor,
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("not_org_member");
+    expect((thrown as AppError).statusCode).toBe(403);
+    expect((thrown as AppError).message).toContain("org-X");
+    expect(state.updateCalled).toBe(false);
+  });
+
+  it("(d) resolved partial membership → atomic 403 naming ONLY the non-member org", async () => {
+    const { service, state } = makePermissionsService(
+      makeSkillDoc({ guid: "guid-1", createdBy: "owner-1", isPrivate: true }),
+    );
+    // Member of org-A only; tries to share into [org-A, org-B]. The whole
+    // write is rejected atomically (org-A is NOT persisted) and the message
+    // names only the offending org-B, not org-A.
+    const actor: ActorContext = {
+      userId: "owner-1",
+      memberships: [{ userId: "org-A", role: "member", displayName: "" }],
+      isPlatformAdmin: false,
+      membershipsResolved: true,
+    };
+
+    let thrown: unknown;
+    try {
+      await service.setSkillPermissions(
+        "guid-1",
+        "owner-1",
+        { isPrivate: true, sharedWithUsers: [], sharedWithOrgs: ["org-A", "org-B"] },
+        actor,
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("not_org_member");
+    expect((thrown as AppError).statusCode).toBe(403);
+    const msg = (thrown as AppError).message;
+    expect(msg).toContain("org-B");
+    expect(msg).not.toContain("org-A");
+    // Atomic — no partial persistence of the member org.
+    expect(state.updateCalled).toBe(false);
   });
 });

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -512,6 +512,23 @@ export class SkillService {
     // isMemberOfOrg is membership-only (does not consider platform admin), so
     // gate the whole check behind the admin bypass.
     if (!actor.isPlatformAdmin) {
+      // #842: an unresolved org-membership lookup (forwarded token absent or
+      // NyxID unreachable) leaves `memberships` empty for a non-membership
+      // reason. Validating a share into orgs against that empty list would
+      // wrongly 403 a legitimate member, so fail closed with a retryable 503
+      // instead — but only when the caller actually asked to share into an
+      // org. A public / user-only change (empty sharedWithOrgs) needs no
+      // membership data and proceeds even while the lookup is unresolved.
+      if (sharedWithOrgs.length > 0 && !actor.membershipsResolved) {
+        logger.warn(
+          { guid, userId },
+          "Org membership unresolved; cannot validate share into orgs (#842)",
+        );
+        throw AppError.serviceUnavailable(
+          "org_membership_unavailable",
+          "Could not verify your organization memberships right now. Retry shortly.",
+        );
+      }
       const nonMember = sharedWithOrgs.filter((orgId) => !isMemberOfOrg(actor, orgId));
       if (nonMember.length > 0) {
         logger.warn({ guid, userId, nonMember }, "Rejected skill share into non-member org(s) (#815)");

--- a/ornn-api/src/middleware/nyxidAuth.test.ts
+++ b/ornn-api/src/middleware/nyxidAuth.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Getter-level tests for the org-membership lookup middleware (#842).
+ *
+ * `nyxidOrgLookupMiddleware` attaches two lazy getters that share ONE memo
+ * cell and ONE NyxID round-trip:
+ *   - `getUserOrgMemberships`            → fail-soft `OrgMembershipFact[]`
+ *   - `getUserOrgMembershipResolution`   → resolved/unresolved discriminant
+ *
+ * These tests pin the discriminant branches, the single-round-trip sharing,
+ * and the read-path fail-soft regression guard (read still `[]`-returns in
+ * every unresolved case). No env mutation, no import-order coupling: each
+ * case builds a fresh Hono app and a fresh fake `OrgMembershipSource`, so the
+ * suite is order-independent (the #816 lesson).
+ *
+ * @module middleware/nyxidAuth.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import {
+  nyxidOrgLookupMiddleware,
+  readUserOrgMemberships,
+  readUserOrgMembershipResolution,
+  type AuthContext,
+  type AuthVariables,
+  type OrgMembershipResolution,
+  type OrgMembershipFact,
+  type OrgMembershipSource,
+} from "./nyxidAuth";
+
+/** An auth context with an optional forwarded access token. */
+function authWith(token?: string): AuthContext {
+  return {
+    userId: "user-1",
+    email: "u@example.com",
+    displayName: "User One",
+    roles: [],
+    permissions: [],
+    ...(token !== undefined ? { userAccessToken: token } : {}),
+  };
+}
+
+/**
+ * Build a fake org source. `listUserOrgs` either returns the supplied rows or
+ * throws. `calls` counts how many times NyxID was actually hit so we can
+ * assert the single-round-trip memo.
+ */
+function fakeOrgs(
+  behaviour:
+    | { kind: "ok"; rows: Array<{ userId: string; role: string; displayName: string }> }
+    | { kind: "throw" },
+): { source: OrgMembershipSource; calls: () => number } {
+  let count = 0;
+  const source: OrgMembershipSource = {
+    listUserOrgs: async () => {
+      count += 1;
+      if (behaviour.kind === "throw") {
+        throw new Error("nyxid down");
+      }
+      return behaviour.rows;
+    },
+  };
+  return { source, calls: () => count };
+}
+
+/**
+ * Run the lookup middleware against a single request whose auth context is
+ * `auth` (or absent when undefined), then hand the live Hono context to
+ * `inspect` so the test can call the getters with the real memo wiring.
+ */
+async function withContext(
+  orgs: OrgMembershipSource,
+  auth: AuthContext | undefined,
+  inspect: (c: import("hono").Context<{ Variables: AuthVariables }>) => Promise<void>,
+): Promise<void> {
+  const app = new Hono<{ Variables: AuthVariables }>();
+  if (auth) {
+    app.use("*", async (c, next) => {
+      c.set("auth", auth);
+      await next();
+    });
+  }
+  app.use("*", nyxidOrgLookupMiddleware(orgs));
+  app.get("/", async (c) => {
+    await inspect(c);
+    return c.json({ ok: true });
+  });
+  const res = await app.request("/");
+  expect(res.status).toBe(200);
+}
+
+describe("nyxidOrgLookupMiddleware getters (#842)", () => {
+  test("no forwarded token → unresolved/no_token, memberships []", async () => {
+    const { source, calls } = fakeOrgs({ kind: "ok", rows: [] });
+    await withContext(source, authWith(undefined), async (c) => {
+      const resolution = await readUserOrgMembershipResolution(c);
+      expect(resolution.status).toBe("unresolved");
+      expect((resolution as Extract<OrgMembershipResolution, { status: "unresolved" }>).reason).toBe(
+        "no_token",
+      );
+      expect(resolution.memberships).toEqual([]);
+      // No token → NyxID was never asked.
+      expect(calls()).toBe(0);
+      // Read fail-soft regression guard.
+      expect(await readUserOrgMemberships(c)).toEqual([]);
+    });
+  });
+
+  test("listUserOrgs throws → unresolved/lookup_failed, memberships []", async () => {
+    const { source } = fakeOrgs({ kind: "throw" });
+    await withContext(source, authWith("tok-1"), async (c) => {
+      const resolution = await readUserOrgMembershipResolution(c);
+      expect(resolution.status).toBe("unresolved");
+      expect((resolution as Extract<OrgMembershipResolution, { status: "unresolved" }>).reason).toBe(
+        "lookup_failed",
+      );
+      expect(resolution.memberships).toEqual([]);
+      // Read fail-soft regression guard: still [] on a failed lookup.
+      expect(await readUserOrgMemberships(c)).toEqual([]);
+    });
+  });
+
+  test("200-empty → resolved with empty memberships (member of nothing)", async () => {
+    const { source } = fakeOrgs({ kind: "ok", rows: [] });
+    await withContext(source, authWith("tok-1"), async (c) => {
+      const resolution = await readUserOrgMembershipResolution(c);
+      expect(resolution.status).toBe("resolved");
+      expect(resolution.memberships).toEqual([]);
+      // Read path agrees.
+      expect(await readUserOrgMemberships(c)).toEqual([]);
+    });
+  });
+
+  test("200-with-orgs → resolved, filtered to admin + member roles", async () => {
+    const { source } = fakeOrgs({
+      kind: "ok",
+      rows: [
+        { userId: "org-a", role: "admin", displayName: "Org A" },
+        { userId: "org-b", role: "member", displayName: "Org B" },
+        // Viewers are non-members for Ornn — filtered out.
+        { userId: "org-c", role: "viewer", displayName: "Org C" },
+      ],
+    });
+    await withContext(source, authWith("tok-1"), async (c) => {
+      const resolution = await readUserOrgMembershipResolution(c);
+      expect(resolution.status).toBe("resolved");
+      const expected: OrgMembershipFact[] = [
+        { userId: "org-a", role: "admin", displayName: "Org A" },
+        { userId: "org-b", role: "member", displayName: "Org B" },
+      ];
+      expect(resolution.memberships).toEqual(expected);
+      expect(await readUserOrgMemberships(c)).toEqual(expected);
+    });
+  });
+
+  test("both getters share ONE NyxID round-trip", async () => {
+    const { source, calls } = fakeOrgs({
+      kind: "ok",
+      rows: [{ userId: "org-a", role: "admin", displayName: "Org A" }],
+    });
+    await withContext(source, authWith("tok-1"), async (c) => {
+      // Hit both getters, twice each, in mixed order.
+      await readUserOrgMemberships(c);
+      await readUserOrgMembershipResolution(c);
+      await readUserOrgMembershipResolution(c);
+      await readUserOrgMemberships(c);
+      // Memoized — NyxID was asked exactly once.
+      expect(calls()).toBe(1);
+    });
+  });
+});

--- a/ornn-api/src/middleware/nyxidAuth.ts
+++ b/ornn-api/src/middleware/nyxidAuth.ts
@@ -60,6 +60,30 @@ export interface OrgMembershipFact {
   displayName: string;
 }
 
+/**
+ * First-class resolved/unresolved signal for the org-membership lookup (#842).
+ *
+ * The plain `getUserOrgMemberships` getter fails soft to `[]` for both
+ * "caller genuinely has no orgs" and "we couldn't ask NyxID" — fine for
+ * read visibility (a missed share just hides a skill), dangerous for the
+ * write gate (a missed lookup would look like "you're a member of nothing"
+ * and reject a legitimate share with a misleading 403). This discriminated
+ * union lets write paths distinguish the two:
+ *
+ *   - `resolved`   — NyxID answered (including a 200-empty list). The
+ *                    `memberships` array is authoritative.
+ *   - `unresolved` — we never got an authoritative answer: either no
+ *                    forwarded token (`no_token`) or the lookup threw
+ *                    (`lookup_failed`). `memberships` is always `[]` and
+ *                    MUST NOT be treated as "member of nothing".
+ *
+ * Note: a successful lookup that returns zero orgs is `resolved`, not
+ * `unresolved` — the caller really is a member of no org.
+ */
+export type OrgMembershipResolution =
+  | { status: "resolved"; memberships: OrgMembershipFact[] }
+  | { status: "unresolved"; reason: "no_token" | "lookup_failed"; memberships: [] };
+
 export type AuthVariables = {
   auth: AuthContext;
   /**
@@ -75,6 +99,14 @@ export type AuthVariables = {
    *     of a specific org.
    */
   getUserOrgMemberships?: () => Promise<OrgMembershipFact[]>;
+  /**
+   * Lazy getter for the same lookup as `getUserOrgMemberships`, but carrying
+   * the resolved/unresolved signal (#842). Shares the SAME memo cell and SAME
+   * single NyxID round-trip as `getUserOrgMemberships` — calling either getter
+   * (or both) hits NyxID at most once per request. Write gates that must not
+   * mistake an unresolved lookup for "member of nothing" read this one.
+   */
+  getUserOrgMembershipResolution?: () => Promise<OrgMembershipResolution>;
 };
 
 // ---------------------------------------------------------------------------
@@ -288,52 +320,84 @@ export interface OrgMembershipSource {
 }
 
 /**
- * Build a middleware that attaches a lazy `getUserOrgMemberships` getter to
- * the request context. The getter:
- *   - Memoizes within a single request so multiple downstream calls share
- *     one NyxID round-trip.
- *   - Returns `[]` for anonymous callers, callers without a forwarded
- *     access token, or when the NyxID call errors out (fail-soft).
- *   - Filters to admin + member roles only (viewers are non-members for Ornn).
+ * Build a middleware that attaches the lazy org-membership getters to the
+ * request context. Two getters share ONE memo cell and ONE NyxID round-trip:
+ *   - `getUserOrgMemberships` → fail-soft `OrgMembershipFact[]` (`[]` for
+ *     anonymous callers, no forwarded token, or a lookup error). The legacy
+ *     read API — unchanged signature, unchanged fail-soft behaviour.
+ *   - `getUserOrgMembershipResolution` → the same lookup carrying the
+ *     resolved/unresolved discriminant (#842) for write gates that must not
+ *     mistake an unresolved lookup for "member of nothing".
+ *
+ * The single resolve runs at most once per request and both getters await it.
+ *   - no forwarded token            → unresolved / `no_token`     / `[]`
+ *   - `listUserOrgs` throws         → unresolved / `lookup_failed`/ `[]`
+ *     (warn-logged, same as before)
+ *   - success (incl. 200-empty)     → resolved (filtered to admin + member)
  *
  * Mount this AFTER `proxyAuthSetup()` so `auth.userAccessToken` is populated.
  */
 export function nyxidOrgLookupMiddleware(orgs: OrgMembershipSource) {
   return createMiddleware<{ Variables: AuthVariables }>(async (c, next) => {
-    let cache: OrgMembershipFact[] | null = null;
-    c.set("getUserOrgMemberships", async () => {
+    // Single shared memo cell: the first getter to run resolves it, the
+    // second reuses it — so at most one NyxID round-trip per request even
+    // when both the read path and the write gate ask.
+    let cache: OrgMembershipResolution | null = null;
+    const resolve = async (): Promise<OrgMembershipResolution> => {
       if (cache) return cache;
       const auth = c.get("auth");
       const token = auth?.userAccessToken;
       if (!token) {
-        cache = [];
+        cache = { status: "unresolved", reason: "no_token", memberships: [] };
         return cache;
       }
       try {
         const raw = await orgs.listUserOrgs(token);
-        cache = raw
+        const memberships = raw
           .filter((m) => m.role === "admin" || m.role === "member")
           .map((m) => ({
             userId: m.userId,
             role: m.role as "admin" | "member",
             displayName: m.displayName,
           }));
+        // Resolved even when the filtered list is empty: NyxID answered
+        // authoritatively that the caller belongs to no (admin/member) org.
+        cache = { status: "resolved", memberships };
       } catch (err) {
         logger.warn(
           { err: (err as Error).message, userId: auth.userId },
           "Org lookup failed; treating user as no-org",
         );
-        cache = [];
+        cache = { status: "unresolved", reason: "lookup_failed", memberships: [] };
       }
       return cache;
-    });
+    };
+    c.set("getUserOrgMembershipResolution", resolve);
+    c.set("getUserOrgMemberships", async () => (await resolve()).memberships);
     await next();
   });
 }
 
 /**
+ * Resolution convenience helper (#842). Returns the resolved/unresolved
+ * signal. When the middleware wasn't mounted (tests that don't wire the
+ * getter) this returns `{ status: "resolved", memberships: [] }` so unrelated
+ * tests behave as a caller-with-no-orgs rather than flipping into the
+ * unresolved (503) branch.
+ */
+export async function readUserOrgMembershipResolution(
+  c: Context<{ Variables: AuthVariables }>,
+): Promise<OrgMembershipResolution> {
+  const getter = c.get("getUserOrgMembershipResolution");
+  if (!getter) return { status: "resolved", memberships: [] };
+  return getter();
+}
+
+/**
  * Memberships convenience helper — returns an empty array when the middleware
- * wasn't mounted (tests) or the caller has none.
+ * wasn't mounted (tests) or the caller has none. Fail-soft to `[]` in every
+ * case, including an unresolved lookup: the read path stays exactly as before
+ * (#842 only adds a separate resolution-aware helper for write gates).
  */
 export async function readUserOrgMemberships(
   c: Context<{ Variables: AuthVariables }>,


### PR DESCRIPTION
Closes #842

Automated change by `/auto` (run `20260604T121112Z-15019`, runner `auto-runner-20260604T121112Z-15019-15019-10547`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
