### PR TITLE
chore: [Misc] test(api): skills/mirror unit tests — raise src/domains/skills/

### DIFF
--- a/.changeset/test-872-mirror-coverage.md
+++ b/.changeset/test-872-mirror-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add unit test coverage for the GitHub mirror auth, REST client, and admin routes (#872)

--- a/ornn-api/src/domains/skills/mirror/githubAppAuth.test.ts
+++ b/ornn-api/src/domains/skills/mirror/githubAppAuth.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for GitHubAppAuth (#872).
+ *
+ * Exercises the two-step GitHub App auth flow without touching the
+ * network: `fetch` is swapped for an in-test stub that records the
+ * outbound request and returns a per-test scripted Response. The RSA
+ * private key is generated fresh at runtime (PKCS#8 PEM) so no key
+ * literal is ever committed and `createSign` runs against a real key.
+ *
+ * Coverage:
+ *   - installation-token caching (1 mint shared across calls)
+ *   - re-mint when the cached token is inside REFRESH_SLACK_MS of expiry
+ *   - error surfaces: non-ok mint, missing token, missing/NaN expires_at
+ *   - JWT shape: 3 dot-segments, RS256 header, iss=appId, ~9-min window
+ *   - base64url segments contain no `+` / `/` / `=`
+ *   - garbage private key throws at sign time
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { GitHubAppAuth } from "./githubAppAuth";
+
+const APP_ID = "123456";
+const INSTALLATION_ID = "7890";
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+const originalFetch = globalThis.fetch;
+let captured: CapturedRequest[];
+let fetchHandler: () => Promise<Response> | Response;
+
+beforeEach(() => {
+  captured = [];
+  fetchHandler = () => new Response("no handler", { status: 500 });
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    captured.push({ url, init });
+    return fetchHandler();
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makePkcs8Pem(): string {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+}
+
+function tokenResponse(token: string, expiresAt: string): Response {
+  return new Response(JSON.stringify({ token, expires_at: expiresAt }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** ISO timestamp `seconds` from now (negative = in the past). */
+function isoFromNow(seconds: number): string {
+  return new Date(Date.now() + seconds * 1000).toISOString();
+}
+
+function makeAuth(privateKey = makePkcs8Pem()): GitHubAppAuth {
+  return new GitHubAppAuth({
+    appId: APP_ID,
+    privateKey,
+    installationId: INSTALLATION_ID,
+  });
+}
+
+function b64urlDecode(seg: string): string {
+  return Buffer.from(seg, "base64url").toString("utf-8");
+}
+
+describe("GitHubAppAuth.getInstallationToken — caching", () => {
+  it("mints once and serves the cache on a second call within the slack window", async () => {
+    // expires_at one hour out → comfortably outside the 5-min refresh slack.
+    fetchHandler = () => tokenResponse("ghs_token_1", isoFromNow(3600));
+    const auth = makeAuth();
+
+    const first = await auth.getInstallationToken();
+    const second = await auth.getInstallationToken();
+
+    expect(first).toBe("ghs_token_1");
+    expect(second).toBe("ghs_token_1");
+    expect(captured.length).toBe(1);
+  });
+
+  it("re-mints when the cached token is inside REFRESH_SLACK_MS (5 min) of expiry", async () => {
+    // First mint expires in ~4 minutes — inside the 5-min refresh slack, so
+    // the second call must re-mint rather than serve the stale cache.
+    let call = 0;
+    fetchHandler = () => {
+      call += 1;
+      return call === 1
+        ? tokenResponse("ghs_near_expiry", isoFromNow(4 * 60))
+        : tokenResponse("ghs_fresh", isoFromNow(3600));
+    };
+    const auth = makeAuth();
+
+    const first = await auth.getInstallationToken();
+    const second = await auth.getInstallationToken();
+
+    expect(first).toBe("ghs_near_expiry");
+    expect(second).toBe("ghs_fresh");
+    expect(captured.length).toBe(2);
+  });
+});
+
+describe("GitHubAppAuth.getInstallationToken — error surfaces", () => {
+  it("throws with the status code when the mint call is non-ok", async () => {
+    fetchHandler = () =>
+      new Response("forbidden", { status: 403, headers: {} });
+    const auth = makeAuth();
+    await expect(auth.getInstallationToken()).rejects.toThrow(/403/);
+  });
+
+  it("throws when the response is missing the token field", async () => {
+    fetchHandler = () =>
+      new Response(JSON.stringify({ expires_at: isoFromNow(3600) }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const auth = makeAuth();
+    await expect(auth.getInstallationToken()).rejects.toThrow(
+      /missing required fields/,
+    );
+  });
+
+  it("throws when the response is missing expires_at", async () => {
+    fetchHandler = () =>
+      new Response(JSON.stringify({ token: "ghs_x" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const auth = makeAuth();
+    await expect(auth.getInstallationToken()).rejects.toThrow(
+      /missing required fields/,
+    );
+  });
+
+  it("throws when expires_at is not a parseable date (NaN)", async () => {
+    fetchHandler = () =>
+      new Response(JSON.stringify({ token: "ghs_x", expires_at: "not-a-date" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const auth = makeAuth();
+    await expect(auth.getInstallationToken()).rejects.toThrow(/Invalid expires_at/);
+  });
+
+  it("throws at sign time when the private key is garbage", async () => {
+    // Should fail before any fetch happens.
+    fetchHandler = () => tokenResponse("ghs_unreached", isoFromNow(3600));
+    const auth = makeAuth("-----BEGIN PRIVATE KEY-----\nnot a real key\n-----END PRIVATE KEY-----");
+    await expect(auth.getInstallationToken()).rejects.toThrow();
+    expect(captured.length).toBe(0);
+  });
+});
+
+describe("GitHubAppAuth — signed JWT shape", () => {
+  it("sends a 3-segment RS256 JWT with iss=appId and a ~9-minute window", async () => {
+    fetchHandler = () => tokenResponse("ghs_token", isoFromNow(3600));
+    const auth = makeAuth();
+    await auth.getInstallationToken();
+
+    expect(captured.length).toBe(1);
+    const authHeader = (captured[0]!.init?.headers as Record<string, string>)
+      .Authorization!;
+    expect(authHeader.startsWith("Bearer ")).toBe(true);
+    const jwt = authHeader.slice("Bearer ".length);
+
+    const segments = jwt.split(".");
+    expect(segments.length).toBe(3);
+
+    const header = JSON.parse(b64urlDecode(segments[0]!)) as {
+      alg: string;
+      typ: string;
+    };
+    expect(header.alg).toBe("RS256");
+    expect(header.typ).toBe("JWT");
+
+    const payload = JSON.parse(b64urlDecode(segments[1]!)) as {
+      iss: string;
+      iat: number;
+      exp: number;
+    };
+    expect(payload.iss).toBe(APP_ID);
+    // iat leans back 30s, exp is +9min → the window from iat to exp is
+    // ~9min30s. Assert it lands in a tolerant 9–10 minute band.
+    const windowSec = payload.exp - payload.iat;
+    expect(windowSec).toBeGreaterThanOrEqual(9 * 60);
+    expect(windowSec).toBeLessThanOrEqual(10 * 60);
+  });
+
+  it("emits base64url segments with no +, / or = characters", async () => {
+    fetchHandler = () => tokenResponse("ghs_token", isoFromNow(3600));
+    const auth = makeAuth();
+    await auth.getInstallationToken();
+
+    const authHeader = (captured[0]!.init?.headers as Record<string, string>)
+      .Authorization!;
+    const jwt = authHeader.slice("Bearer ".length);
+    for (const seg of jwt.split(".")) {
+      expect(seg.includes("+")).toBe(false);
+      expect(seg.includes("/")).toBe(false);
+      expect(seg.includes("=")).toBe(false);
+    }
+  });
+});

--- a/ornn-api/src/domains/skills/mirror/githubMirrorClient.test.ts
+++ b/ornn-api/src/domains/skills/mirror/githubMirrorClient.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Tests for GitHubMirrorClient (#872).
+ *
+ * The client is the thin REST wrapper over GitHub's Git Data API. Tests
+ * swap `globalThis.fetch` for a recording stub and inject a fake
+ * `GitHubAppAuth` (returns a fixed token, never touches the network) plus
+ * a fixed `resolveTarget`. Each method is checked for: correct HTTP verb +
+ * path, request body shape, happy-path SHA extraction, and the error /
+ * missing-field surfaces.
+ *
+ * Coverage:
+ *   - getDefaultBranchHead: 200→sha / 404→null / 500→throws
+ *   - updateDefaultBranch: PATCH {sha, force:true} + non-ok throws
+ *   - createBranchRef: POST refs/heads/<branch>
+ *   - getRecursiveTree: happy / truncated→throws / non-ok→throws
+ *   - createTree: base_tree set when baseTree given / omitted when not /
+ *                 missing sha throws
+ *   - createBlob: base64-encoded body / missing sha throws
+ *   - createCommit: {message, tree, parents} / missing sha throws
+ *   - createAnnotatedTag: tag→ref two-step / non-ok at either step throws
+ *   - getCommitTreeSha: tree.sha / missing tree throws
+ *   - api() shared headers + Content-Type only when a body is present
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { GitHubMirrorClient } from "./githubMirrorClient";
+import type { GitHubAppAuth } from "./githubAppAuth";
+
+const OWNER = "ChronoAIProject";
+const REPO = "ornn-skills";
+const BRANCH = "main";
+const TOKEN = "tok";
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+const originalFetch = globalThis.fetch;
+let captured: CapturedRequest[];
+let fetchHandler: () => Promise<Response> | Response;
+
+beforeEach(() => {
+  captured = [];
+  fetchHandler = () => new Response("no handler", { status: 500 });
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    captured.push({ url, init });
+    return fetchHandler();
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makeClient(): GitHubMirrorClient {
+  const fakeAuth = {
+    getInstallationToken: async () => TOKEN,
+  } as unknown as GitHubAppAuth;
+  return new GitHubMirrorClient(fakeAuth, async () => ({
+    owner: OWNER,
+    repo: REPO,
+    defaultBranch: BRANCH,
+  }));
+}
+
+function json(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Parse the JSON body the client posted on the Nth captured request. */
+function bodyOf(idx: number): Record<string, unknown> {
+  const raw = captured[idx]!.init?.body;
+  return JSON.parse(String(raw)) as Record<string, unknown>;
+}
+
+function headersOf(idx: number): Record<string, string> {
+  return captured[idx]!.init?.headers as Record<string, string>;
+}
+
+describe("GitHubMirrorClient — Refs", () => {
+  it("getDefaultBranchHead returns the SHA on 200", async () => {
+    fetchHandler = () => json({ object: { sha: "abc123" } });
+    const sha = await makeClient().getDefaultBranchHead();
+    expect(sha).toBe("abc123");
+    expect(captured[0]!.url).toBe(
+      `https://api.github.com/repos/${OWNER}/${REPO}/git/ref/heads/${BRANCH}`,
+    );
+    expect(captured[0]!.init?.method).toBe("GET");
+  });
+
+  it("getDefaultBranchHead returns null on 404 (fresh empty repo)", async () => {
+    fetchHandler = () => new Response("not found", { status: 404 });
+    const sha = await makeClient().getDefaultBranchHead();
+    expect(sha).toBeNull();
+  });
+
+  it("getDefaultBranchHead throws on 500", async () => {
+    fetchHandler = () => new Response("boom", { status: 500 });
+    await expect(makeClient().getDefaultBranchHead()).rejects.toThrow(/500/);
+  });
+
+  it("updateDefaultBranch PATCHes {sha, force:true}", async () => {
+    fetchHandler = () => json({});
+    await makeClient().updateDefaultBranch("deadbeef");
+    expect(captured[0]!.url).toBe(
+      `https://api.github.com/repos/${OWNER}/${REPO}/git/refs/heads/${BRANCH}`,
+    );
+    expect(captured[0]!.init?.method).toBe("PATCH");
+    expect(bodyOf(0)).toEqual({ sha: "deadbeef", force: true });
+  });
+
+  it("updateDefaultBranch throws when non-ok", async () => {
+    fetchHandler = () => new Response("nope", { status: 422 });
+    await expect(makeClient().updateDefaultBranch("x")).rejects.toThrow(/422/);
+  });
+
+  it("createBranchRef POSTs refs/heads/<branch>", async () => {
+    fetchHandler = () => json({});
+    await makeClient().createBranchRef("seedsha");
+    expect(captured[0]!.url).toBe(
+      `https://api.github.com/repos/${OWNER}/${REPO}/git/refs`,
+    );
+    expect(captured[0]!.init?.method).toBe("POST");
+    expect(bodyOf(0)).toEqual({ ref: `refs/heads/${BRANCH}`, sha: "seedsha" });
+  });
+});
+
+describe("GitHubMirrorClient — Trees", () => {
+  it("getRecursiveTree returns the entries on the happy path", async () => {
+    const tree = [
+      { path: "a.txt", mode: "100644" as const, type: "blob" as const, sha: "s1" },
+    ];
+    fetchHandler = () => json({ tree, truncated: false });
+    const out = await makeClient().getRecursiveTree("treesha");
+    expect(out).toEqual(tree);
+    expect(captured[0]!.url).toBe(
+      `https://api.github.com/repos/${OWNER}/${REPO}/git/trees/treesha?recursive=1`,
+    );
+  });
+
+  it("getRecursiveTree throws when GitHub flags the tree truncated", async () => {
+    fetchHandler = () => json({ tree: [], truncated: true });
+    await expect(makeClient().getRecursiveTree("big")).rejects.toThrow(
+      /truncated|100k|exceeded/i,
+    );
+  });
+
+  it("getRecursiveTree throws on non-ok", async () => {
+    fetchHandler = () => new Response("x", { status: 404 });
+    await expect(makeClient().getRecursiveTree("missing")).rejects.toThrow(/404/);
+  });
+
+  it("createTree sets base_tree when baseTree is provided", async () => {
+    fetchHandler = () => json({ sha: "newtree" });
+    const entries = [
+      { path: "f", mode: "100644" as const, type: "blob" as const, sha: "b1" },
+    ];
+    const sha = await makeClient().createTree(entries, "basesha");
+    expect(sha).toBe("newtree");
+    const body = bodyOf(0);
+    expect(body.base_tree).toBe("basesha");
+    expect(body.tree).toEqual(entries);
+  });
+
+  it("createTree omits base_tree when no base is provided", async () => {
+    fetchHandler = () => json({ sha: "newtree" });
+    await makeClient().createTree([], null);
+    const body = bodyOf(0);
+    expect("base_tree" in body).toBe(false);
+  });
+
+  it("createTree throws when the response has no sha", async () => {
+    fetchHandler = () => json({});
+    await expect(makeClient().createTree([], null)).rejects.toThrow(/no SHA/);
+  });
+});
+
+describe("GitHubMirrorClient — Blobs", () => {
+  it("createBlob base64-encodes the content body", async () => {
+    fetchHandler = () => json({ sha: "blobsha" });
+    const sha = await makeClient().createBlob("hello world");
+    expect(sha).toBe("blobsha");
+    const body = bodyOf(0);
+    expect(body.encoding).toBe("base64");
+    expect(body.content).toBe(Buffer.from("hello world", "utf-8").toString("base64"));
+  });
+
+  it("createBlob throws when the response has no sha", async () => {
+    fetchHandler = () => json({});
+    await expect(makeClient().createBlob("x")).rejects.toThrow(/no SHA/);
+  });
+});
+
+describe("GitHubMirrorClient — Commits + tags", () => {
+  it("createCommit POSTs {message, tree, parents}", async () => {
+    fetchHandler = () => json({ sha: "commitsha" });
+    const sha = await makeClient().createCommit({
+      message: "sync",
+      treeSha: "t1",
+      parents: ["p1"],
+    });
+    expect(sha).toBe("commitsha");
+    expect(bodyOf(0)).toEqual({ message: "sync", tree: "t1", parents: ["p1"] });
+  });
+
+  it("createCommit throws when the response has no sha", async () => {
+    fetchHandler = () => json({});
+    await expect(
+      makeClient().createCommit({ message: "m", treeSha: "t", parents: [] }),
+    ).rejects.toThrow(/no SHA/);
+  });
+
+  it("createAnnotatedTag creates the tag object then the ref (two-step)", async () => {
+    let call = 0;
+    fetchHandler = () => {
+      call += 1;
+      return call === 1 ? json({ sha: "tagsha" }) : json({});
+    };
+    await makeClient().createAnnotatedTag({
+      tagName: "sync-2026",
+      message: "snapshot",
+      objectSha: "commitsha",
+    });
+    expect(captured.length).toBe(2);
+    // Step 1: create tag object.
+    expect(captured[0]!.url).toBe(
+      `https://api.github.com/repos/${OWNER}/${REPO}/git/tags`,
+    );
+    expect(bodyOf(0)).toEqual({
+      tag: "sync-2026",
+      message: "snapshot",
+      object: "commitsha",
+      type: "commit",
+    });
+    // Step 2: point a tag ref at the tag object's sha.
+    expect(captured[1]!.url).toBe(
+      `https://api.github.com/repos/${OWNER}/${REPO}/git/refs`,
+    );
+    expect(bodyOf(1)).toEqual({ ref: "refs/tags/sync-2026", sha: "tagsha" });
+  });
+
+  it("createAnnotatedTag throws when the tag-object step fails", async () => {
+    fetchHandler = () => new Response("bad", { status: 422 });
+    await expect(
+      makeClient().createAnnotatedTag({ tagName: "t", message: "m", objectSha: "o" }),
+    ).rejects.toThrow(/422/);
+    expect(captured.length).toBe(1);
+  });
+
+  it("createAnnotatedTag throws when the ref step fails", async () => {
+    let call = 0;
+    fetchHandler = () => {
+      call += 1;
+      return call === 1 ? json({ sha: "tagsha" }) : new Response("dup", { status: 422 });
+    };
+    await expect(
+      makeClient().createAnnotatedTag({ tagName: "t", message: "m", objectSha: "o" }),
+    ).rejects.toThrow(/422/);
+    expect(captured.length).toBe(2);
+  });
+
+  it("getCommitTreeSha returns tree.sha", async () => {
+    fetchHandler = () => json({ tree: { sha: "treesha" } });
+    const sha = await makeClient().getCommitTreeSha("commitsha");
+    expect(sha).toBe("treesha");
+    expect(captured[0]!.url).toBe(
+      `https://api.github.com/repos/${OWNER}/${REPO}/git/commits/commitsha`,
+    );
+  });
+
+  it("getCommitTreeSha throws when the commit has no tree", async () => {
+    fetchHandler = () => json({});
+    await expect(makeClient().getCommitTreeSha("c")).rejects.toThrow(/no tree/);
+  });
+});
+
+describe("GitHubMirrorClient — api() headers", () => {
+  it("stamps the shared GitHub headers + bearer token on every call", async () => {
+    fetchHandler = () => json({ object: { sha: "x" } });
+    await makeClient().getDefaultBranchHead();
+    const h = headersOf(0);
+    expect(h.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(h.Accept).toBe("application/vnd.github+json");
+    expect(h["X-GitHub-Api-Version"]).toBe("2022-11-28");
+    expect(h["User-Agent"]).toBe("ornn-api-mirror");
+  });
+
+  it("sets Content-Type only when a request body is present", async () => {
+    // GET (no body) → no Content-Type.
+    fetchHandler = () => json({ object: { sha: "x" } });
+    await makeClient().getDefaultBranchHead();
+    expect(headersOf(0)["Content-Type"]).toBeUndefined();
+
+    // POST (with body) → Content-Type: application/json.
+    captured = [];
+    fetchHandler = () => json({ sha: "s" });
+    await makeClient().createBlob("data");
+    expect(headersOf(0)["Content-Type"]).toBe("application/json");
+  });
+});

--- a/ornn-api/src/domains/skills/mirror/routes.test.ts
+++ b/ornn-api/src/domains/skills/mirror/routes.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Route-level tests for the GitHub mirror routes (#872).
+ *
+ * Mounts `createMirrorRoutes` on a bare Hono app, stubs the upstream
+ * auth context (production wires this via proxyAuthSetup) and supplies
+ * hand-rolled fakes for the four collaborators (settingsService,
+ * skillRepo, mirrorService, mirrorScheduler). The fakes record the
+ * arguments the routes pass them so we can assert on the actor shape,
+ * the abandon-confirm stamp clear, and the sentinel handling without a
+ * real DB.
+ *
+ * Coverage:
+ *   - GET /github/repo: coords + enabled, no credentials, no auth needed
+ *   - POST /github/repo validation: enabled / owner / repo / branch /
+ *     appId / installationId / appPrivateKey type+regex rejections
+ *   - appPrivateKey sentinel handling: mid-mask preserves, "" clears,
+ *     fresh PEM validates + stores
+ *   - abandon-confirm: 409 without confirm, success + stamp clear with it
+ *   - response masks appPrivateKey; putSection receives the auth actor
+ *   - 403 when permissions lack ornn:admin:skill
+ *   - reconcile: 503 disabled / 503 unconfigured / 202 happy / 409 running
+ *   - status: scheduler-backed serialized run + counts, null-scheduler
+ *     never_run block
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { generateKeyPairSync } from "node:crypto";
+import { createMirrorRoutes, type MirrorRoutesConfig } from "./routes";
+import { midMaskSecret, isMidMaskSentinel } from "../../../infra/crypto";
+import { buildProblemJsonBody } from "../../../shared/types/index";
+import type { MirrorSection } from "../../settings/sections/mirror";
+import type { SettingsActor, PutSectionResult } from "../../settings/types";
+import type { ReconcileResult } from "./mirrorService";
+import type { ScheduledRunStatus } from "./scheduler";
+
+const ADMIN_PERM = "ornn:admin:skill";
+
+function freshPem(): string {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+}
+
+const defaultSection: MirrorSection = {
+  enabled: true,
+  owner: "ChronoAIProject",
+  repo: "ornn-skills",
+  branch: "main",
+  appId: "123456",
+  installationId: "7890",
+  appPrivateKey: "stored-private-key-value-1234567890",
+  reconcileSchedule: "0 2 * * *",
+};
+
+// ---- Fakes -----------------------------------------------------------
+
+interface PutCall {
+  id: string;
+  value: MirrorSection;
+  actor: SettingsActor;
+}
+
+class FakeSettings {
+  putCalls: PutCall[] = [];
+  constructor(private section: MirrorSection) {}
+  async getMirror(): Promise<MirrorSection> {
+    return this.section;
+  }
+  async putSection<T>(
+    id: string,
+    value: T,
+    actor: SettingsActor,
+  ): Promise<PutSectionResult<T>> {
+    this.putCalls.push({ id, value: value as MirrorSection, actor });
+    this.section = value as MirrorSection;
+    return { value, changedFields: [] };
+  }
+}
+
+interface MirrorCounts {
+  eligible: number;
+  synced: number;
+  lagging: number;
+  neverSynced: number;
+  oldestUnsyncedAt: Date | null;
+}
+
+class FakeSkillRepo {
+  clearCalled = 0;
+  constructor(private counts: MirrorCounts) {}
+  async getMirrorCounts(): Promise<MirrorCounts> {
+    return this.counts;
+  }
+  async clearAllMirrorSyncStamps(): Promise<void> {
+    this.clearCalled += 1;
+  }
+}
+
+interface RuntimeState {
+  enabled: boolean;
+  configured: boolean;
+  owner: string;
+  repo: string;
+  branch: string;
+}
+
+class FakeMirrorService {
+  reconcileCalled = 0;
+  constructor(
+    private runtime: RuntimeState,
+    private reconcileResult: ReconcileResult = {
+      added: 0,
+      updated: 0,
+      removed: 0,
+      unchanged: 0,
+    },
+  ) {}
+  async getRuntimeState(): Promise<RuntimeState> {
+    return this.runtime;
+  }
+  async reconcileAll(): Promise<ReconcileResult> {
+    this.reconcileCalled += 1;
+    return this.reconcileResult;
+  }
+}
+
+class FakeScheduler {
+  constructor(private status: ScheduledRunStatus) {}
+  async getScheduledRunStatus(): Promise<ScheduledRunStatus> {
+    return this.status;
+  }
+}
+
+// ---- App builder -----------------------------------------------------
+
+function buildApp(
+  cfg: Partial<MirrorRoutesConfig>,
+  opts: { authenticated?: boolean; permissions?: string[] } = {},
+): Hono {
+  const { authenticated = true, permissions = [ADMIN_PERM] } = opts;
+  const full: MirrorRoutesConfig = {
+    mirrorService:
+      (cfg.mirrorService as MirrorRoutesConfig["mirrorService"]) ??
+      (new FakeMirrorService({
+        enabled: true,
+        configured: true,
+        owner: "o",
+        repo: "r",
+        branch: "main",
+      }) as unknown as MirrorRoutesConfig["mirrorService"]),
+    settingsService:
+      (cfg.settingsService as MirrorRoutesConfig["settingsService"]) ??
+      (new FakeSettings(defaultSection) as unknown as MirrorRoutesConfig["settingsService"]),
+    skillRepo:
+      (cfg.skillRepo as MirrorRoutesConfig["skillRepo"]) ??
+      (new FakeSkillRepo({
+        eligible: 0,
+        synced: 0,
+        lagging: 0,
+        neverSynced: 0,
+        oldestUnsyncedAt: null,
+      }) as unknown as MirrorRoutesConfig["skillRepo"]),
+    mirrorScheduler:
+      (cfg.mirrorScheduler as MirrorRoutesConfig["mirrorScheduler"]) ?? null,
+  };
+
+  const app = new Hono();
+  if (authenticated) {
+    app.use("*", async (c, next) => {
+      c.set("auth" as never, {
+        userId: "u-admin",
+        email: "admin@test.local",
+        displayName: "Admin",
+        permissions,
+      } as never);
+      await next();
+    });
+  }
+  app.route("/api/v1", createMirrorRoutes(full));
+  app.onError((err, c) => {
+    const code = (err as { code?: string }).code ?? "internal_error";
+    const status = (err as { statusCode?: number }).statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode: status,
+      code,
+      message: err.message,
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, status as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  return app;
+}
+
+// ---- GET /github/repo ------------------------------------------------
+
+describe("GET /github/repo", () => {
+  it("returns coords + enabled, no credentials, and needs no auth", async () => {
+    const settings = new FakeSettings(defaultSection);
+    const app = buildApp(
+      { settingsService: settings as unknown as MirrorRoutesConfig["settingsService"] },
+      { authenticated: false },
+    );
+    const res = await app.request("/api/v1/github/repo");
+    expect(res.status).toBe(200);
+    const parsed = (await res.json()) as { data: Record<string, unknown> };
+    expect(parsed.data).toEqual({
+      owner: "ChronoAIProject",
+      repo: "ornn-skills",
+      branch: "main",
+      enabled: true,
+    });
+    // Sensitive fields never leak on the public read.
+    expect("appId" in parsed.data).toBe(false);
+    expect("appPrivateKey" in parsed.data).toBe(false);
+    expect("installationId" in parsed.data).toBe(false);
+  });
+});
+
+// ---- POST /github/repo: validation -----------------------------------
+
+async function postRepo(
+  body: unknown,
+  opts: { permissions?: string[]; settings?: FakeSettings; skillRepo?: FakeSkillRepo } = {},
+) {
+  const settings = opts.settings ?? new FakeSettings(defaultSection);
+  const skillRepo =
+    opts.skillRepo ??
+    new FakeSkillRepo({
+      eligible: 0,
+      synced: 0,
+      lagging: 0,
+      neverSynced: 0,
+      oldestUnsyncedAt: null,
+    });
+  const app = buildApp(
+    {
+      settingsService: settings as unknown as MirrorRoutesConfig["settingsService"],
+      skillRepo: skillRepo as unknown as MirrorRoutesConfig["skillRepo"],
+    },
+    opts.permissions ? { permissions: opts.permissions } : {},
+  );
+  const res = await app.request("/api/v1/github/repo", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { res, settings, skillRepo };
+}
+
+describe("POST /github/repo — validation rejections (400)", () => {
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ["non-boolean enabled", { enabled: "yes" }],
+    ["bad owner", { owner: "-bad-owner-" }],
+    ["bad repo", { repo: "no spaces allowed" }],
+    ["bad branch (control char)", { branch: "feat\u0001ure" }],
+    ["bad appId (non-digit)", { appId: "abc" }],
+    ["bad installationId (non-digit)", { installationId: "12x" }],
+    ["non-string appPrivateKey", { appPrivateKey: 12345 }],
+  ];
+  for (const [label, body] of cases) {
+    it(`rejects ${label}`, async () => {
+      const { res } = await postRepo(body);
+      expect(res.status).toBe(400);
+    });
+  }
+});
+
+// ---- POST /github/repo: appPrivateKey sentinel handling --------------
+
+describe("POST /github/repo — appPrivateKey sentinel handling", () => {
+  it("mid-mask sentinel preserves the stored key", async () => {
+    const settings = new FakeSettings(defaultSection);
+    const masked = midMaskSecret(defaultSection.appPrivateKey);
+    const { res } = await postRepo({ appPrivateKey: masked }, { settings });
+    expect(res.status).toBe(200);
+    expect(settings.putCalls[0]!.value.appPrivateKey).toBe(
+      defaultSection.appPrivateKey,
+    );
+  });
+
+  it('empty string clears the stored key', async () => {
+    const settings = new FakeSettings(defaultSection);
+    const { res } = await postRepo({ appPrivateKey: "" }, { settings });
+    expect(res.status).toBe(200);
+    expect(settings.putCalls[0]!.value.appPrivateKey).toBe("");
+  });
+
+  it("a fresh real PEM validates and is stored", async () => {
+    const settings = new FakeSettings(defaultSection);
+    const pem = freshPem();
+    const { res } = await postRepo({ appPrivateKey: pem }, { settings });
+    expect(res.status).toBe(200);
+    expect(settings.putCalls[0]!.value.appPrivateKey).toBe(pem.trim());
+  });
+});
+
+// ---- POST /github/repo: abandon-confirm ------------------------------
+
+describe("POST /github/repo — abandon-confirm on coord change", () => {
+  it("returns 409 when changing coords would abandon stamped skills without confirm", async () => {
+    const settings = new FakeSettings(defaultSection);
+    const skillRepo = new FakeSkillRepo({
+      eligible: 5,
+      synced: 3,
+      lagging: 1,
+      neverSynced: 1,
+      oldestUnsyncedAt: null,
+    });
+    const { res } = await postRepo({ owner: "NewOwner" }, { settings, skillRepo });
+    expect(res.status).toBe(409);
+    expect(skillRepo.clearCalled).toBe(0);
+    expect(settings.putCalls.length).toBe(0);
+  });
+
+  it("succeeds + clears stamps when confirmAbandonOldRepo is true", async () => {
+    const settings = new FakeSettings(defaultSection);
+    const skillRepo = new FakeSkillRepo({
+      eligible: 5,
+      synced: 3,
+      lagging: 1,
+      neverSynced: 1,
+      oldestUnsyncedAt: null,
+    });
+    const { res } = await postRepo(
+      { owner: "NewOwner", confirmAbandonOldRepo: true },
+      { settings, skillRepo },
+    );
+    expect(res.status).toBe(200);
+    expect(skillRepo.clearCalled).toBe(1);
+    expect(settings.putCalls[0]!.value.owner).toBe("NewOwner");
+  });
+});
+
+// ---- POST /github/repo: response + actor + permission ----------------
+
+describe("POST /github/repo — response masking, actor, permission gate", () => {
+  it("mid-masks appPrivateKey in the response body (never plaintext)", async () => {
+    const settings = new FakeSettings(defaultSection);
+    const { res } = await postRepo({ enabled: false }, { settings });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text.includes(defaultSection.appPrivateKey)).toBe(false);
+    const parsed = JSON.parse(text) as { data: { appPrivateKey: string } };
+    expect(isMidMaskSentinel(parsed.data.appPrivateKey)).toBe(true);
+  });
+
+  it("passes the auth actor through to putSection", async () => {
+    const settings = new FakeSettings(defaultSection);
+    const { res } = await postRepo({ enabled: false }, { settings });
+    expect(res.status).toBe(200);
+    expect(settings.putCalls[0]!.actor).toEqual({
+      userId: "u-admin",
+      email: "admin@test.local",
+      displayName: "Admin",
+    });
+  });
+
+  it("returns 403 when the caller lacks ornn:admin:skill", async () => {
+    const { res } = await postRepo({ enabled: false }, { permissions: ["ornn:read"] });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---- POST /admin/mirror/reconcile ------------------------------------
+
+describe("POST /admin/mirror/reconcile", () => {
+  async function reconcile(runtime: RuntimeState) {
+    const svc = new FakeMirrorService(runtime);
+    const app = buildApp({
+      mirrorService: svc as unknown as MirrorRoutesConfig["mirrorService"],
+    });
+    const res = await app.request("/api/v1/admin/mirror/reconcile", {
+      method: "POST",
+    });
+    return { res, svc };
+  }
+
+  it("returns 503 when the mirror is disabled", async () => {
+    const { res } = await reconcile({
+      enabled: false,
+      configured: true,
+      owner: "o",
+      repo: "r",
+      branch: "main",
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 when the mirror is unconfigured", async () => {
+    const { res } = await reconcile({
+      enabled: true,
+      configured: false,
+      owner: "o",
+      repo: "r",
+      branch: "main",
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 202 running on the happy path", async () => {
+    const { res } = await reconcile({
+      enabled: true,
+      configured: true,
+      owner: "o",
+      repo: "r",
+      branch: "main",
+    });
+    expect(res.status).toBe(202);
+    const parsed = (await res.json()) as { data: { status: string } };
+    expect(parsed.data.status).toBe("running");
+  });
+
+  it("returns 409 when a reconcile is already running", async () => {
+    // reconcileAll never settles → the run stays in `running` state so a
+    // second immediate kick hits the already-running 409 guard.
+    const svc = new FakeMirrorService({
+      enabled: true,
+      configured: true,
+      owner: "o",
+      repo: "r",
+      branch: "main",
+    });
+    const hold: { release: () => void } = { release: () => {} };
+    svc.reconcileAll = () =>
+      new Promise<ReconcileResult>((resolve) => {
+        hold.release = () =>
+          resolve({ added: 0, updated: 0, removed: 0, unchanged: 0 });
+      });
+    const app = buildApp({
+      mirrorService: svc as unknown as MirrorRoutesConfig["mirrorService"],
+    });
+    const first = await app.request("/api/v1/admin/mirror/reconcile", {
+      method: "POST",
+    });
+    expect(first.status).toBe(202);
+    const second = await app.request("/api/v1/admin/mirror/reconcile", {
+      method: "POST",
+    });
+    expect(second.status).toBe(409);
+    // Let the background run settle so it doesn't leak past the test.
+    hold.release();
+  });
+});
+
+// ---- GET /admin/mirror/status ----------------------------------------
+
+describe("GET /admin/mirror/status", () => {
+  it("serializes the scheduled run + counts when a scheduler is wired", async () => {
+    const lastRunAt = new Date("2026-06-05T02:00:00.000Z");
+    const lastFinishedAt = new Date("2026-06-05T02:01:00.000Z");
+    const oldestUnsyncedAt = new Date("2026-06-01T00:00:00.000Z");
+    const scheduler = new FakeScheduler({
+      status: "succeeded",
+      lastRunAt,
+      lastFinishedAt,
+      lastDurationMs: 60_000,
+      lastError: null,
+      nextRunAt: new Date("2026-06-06T02:00:00.000Z"),
+    });
+    const skillRepo = new FakeSkillRepo({
+      eligible: 10,
+      synced: 7,
+      lagging: 2,
+      neverSynced: 1,
+      oldestUnsyncedAt,
+    });
+    const app = buildApp({
+      mirrorScheduler: scheduler as unknown as MirrorRoutesConfig["mirrorScheduler"],
+      skillRepo: skillRepo as unknown as MirrorRoutesConfig["skillRepo"],
+    });
+    const res = await app.request("/api/v1/admin/mirror/status");
+    expect(res.status).toBe(200);
+    const parsed = (await res.json()) as {
+      data: {
+        counts: { eligible: number; oldestUnsyncedAt: string | null };
+        scheduledRun: { status: string; lastRunAt: string | null };
+        appPrivateKey: string;
+      };
+    };
+    expect(parsed.data.counts.eligible).toBe(10);
+    expect(parsed.data.counts.oldestUnsyncedAt).toBe(oldestUnsyncedAt.toISOString());
+    expect(parsed.data.scheduledRun.status).toBe("succeeded");
+    expect(parsed.data.scheduledRun.lastRunAt).toBe(lastRunAt.toISOString());
+    // App key is mid-masked here too.
+    expect(isMidMaskSentinel(parsed.data.appPrivateKey)).toBe(true);
+  });
+
+  it("reports a never_run scheduled block when the scheduler is null", async () => {
+    const app = buildApp({ mirrorScheduler: null });
+    const res = await app.request("/api/v1/admin/mirror/status");
+    expect(res.status).toBe(200);
+    const parsed = (await res.json()) as {
+      data: { scheduledRun: { status: string; lastRunAt: string | null } };
+    };
+    expect(parsed.data.scheduledRun.status).toBe("never_run");
+    expect(parsed.data.scheduledRun.lastRunAt).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #872

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-44016-19038`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
