### PR TITLE
chore: [Misc] test(api): skills/audit unit tests — raise src/domains/skills/a

### DIFF
--- a/.changeset/test-873-audit-coverage.md
+++ b/.changeset/test-873-audit-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add unit test coverage for the skill-audit module (prompts, repository, service, routes) (#873)

--- a/ornn-api/src/domains/skills/audit/parseAuditJson.test.ts
+++ b/ornn-api/src/domains/skills/audit/parseAuditJson.test.ts
@@ -98,4 +98,54 @@ describe("parseAuditJson", () => {
   test("returns null on non-JSON garbage", () => {
     expect(parseAuditJson("sorry, I cannot produce JSON today")).toBeNull();
   });
+
+  test("returns null on a bare number with no JSON object braces", () => {
+    // No `{`/`}` → the brace scan bails before JSON.parse runs.
+    expect(parseAuditJson("123")).toBeNull();
+  });
+
+  test("returns null on a bare null with no JSON object braces", () => {
+    expect(parseAuditJson("null")).toBeNull();
+  });
+
+  test("returns null when an object lacks a scores key", () => {
+    // Parses to an object, but `scores` is undefined → not an array → null.
+    expect(parseAuditJson('{ "x": 1 }')).toBeNull();
+  });
+
+  test("returns null when scores is not an array", () => {
+    const raw = JSON.stringify({ scores: { nope: true }, findings: [] });
+    expect(parseAuditJson(raw)).toBeNull();
+  });
+
+  test("skips score entries with a NaN score", () => {
+    const raw = JSON.stringify({
+      scores: [
+        { dimension: "security", score: "not-a-number", rationale: "" }, // NaN → skipped
+        { dimension: "code_quality", score: 8, rationale: "" },
+        { dimension: "documentation", score: 8, rationale: "" },
+        { dimension: "reliability", score: 8, rationale: "" },
+        { dimension: "permission_scope", score: 8, rationale: "" },
+      ],
+      findings: [],
+    });
+    // security got skipped (NaN) → a required dimension is missing → null.
+    expect(parseAuditJson(raw)).toBeNull();
+  });
+
+  test("treats a non-array findings field as empty", () => {
+    const raw = JSON.stringify({
+      scores: [
+        { dimension: "security", score: 8, rationale: "" },
+        { dimension: "code_quality", score: 8, rationale: "" },
+        { dimension: "documentation", score: 8, rationale: "" },
+        { dimension: "reliability", score: 8, rationale: "" },
+        { dimension: "permission_scope", score: 8, rationale: "" },
+      ],
+      findings: "oops not an array",
+    });
+    const parsed = parseAuditJson(raw)!;
+    expect(parsed).not.toBeNull();
+    expect(parsed.findings).toEqual([]);
+  });
 });

--- a/ornn-api/src/domains/skills/audit/prompts.test.ts
+++ b/ornn-api/src/domains/skills/audit/prompts.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the skill-audit LLM prompts (#873).
+ *
+ * Two contracts are pinned:
+ *   - `buildAuditUserPrompt` interpolates every field it is given
+ *     (skillName / version / metadataSummary / filesBundle) into the
+ *     returned string, so the LLM receives the full package context.
+ *   - `AUDIT_SYSTEM_PROMPT` names all five scoring dimensions. This is a
+ *     STRUCTURAL assertion (the parser keys off these exact names) — we
+ *     deliberately do NOT snapshot the whole literal so prose edits don't
+ *     break the test.
+ *
+ * @module domains/skills/audit/prompts.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AUDIT_SYSTEM_PROMPT, buildAuditUserPrompt } from "./prompts";
+import { AUDIT_DIMENSIONS } from "./types";
+
+describe("buildAuditUserPrompt", () => {
+  test("interpolates every supplied field into the prompt", () => {
+    const out = buildAuditUserPrompt({
+      skillName: "my-cool-skill",
+      version: "2.3.4",
+      metadataSummary: "category=devtools; runtimes=node; tags=a,b",
+      filesBundle: "// FILE: SKILL.md\nHello world bundle marker",
+    });
+
+    expect(out).toContain("my-cool-skill");
+    expect(out).toContain("2.3.4");
+    expect(out).toContain("category=devtools; runtimes=node; tags=a,b");
+    expect(out).toContain("// FILE: SKILL.md\nHello world bundle marker");
+    // Section headers the model relies on are present.
+    expect(out).toContain("## Identity");
+    expect(out).toContain("## Metadata summary");
+    expect(out).toContain("## Package files");
+  });
+
+  test("keeps empty fields as empty interpolations (no crash, no placeholder leak)", () => {
+    const out = buildAuditUserPrompt({
+      skillName: "",
+      version: "",
+      metadataSummary: "",
+      filesBundle: "",
+    });
+    // The template still renders its labels even when values are blank.
+    expect(out).toContain("- name: ");
+    expect(out).toContain("- version: ");
+    // No unreplaced template tokens.
+    expect(out).not.toContain("${");
+  });
+});
+
+describe("AUDIT_SYSTEM_PROMPT", () => {
+  test("names all five scoring dimensions", () => {
+    for (const dim of AUDIT_DIMENSIONS) {
+      expect(AUDIT_SYSTEM_PROMPT).toContain(dim);
+    }
+  });
+
+  test("documents the strict JSON output contract", () => {
+    // The parser strips fences and expects `scores` + `findings` keys —
+    // pin that the prompt actually instructs that shape.
+    expect(AUDIT_SYSTEM_PROMPT).toContain('"scores"');
+    expect(AUDIT_SYSTEM_PROMPT).toContain('"findings"');
+    expect(AUDIT_SYSTEM_PROMPT.length).toBeGreaterThan(100);
+  });
+});

--- a/ornn-api/src/domains/skills/audit/repository.test.ts
+++ b/ornn-api/src/domains/skills/audit/repository.test.ts
@@ -1,0 +1,260 @@
+/**
+ * AuditRepository unit tests (#873).
+ *
+ * Backed by mongodb-memory-server (mirrors the notifications repository
+ * test harness). The audit collection is append-only on insert
+ * (`createRunning` mints a UUID `_id`) and updated in place on
+ * complete/fail. Pins:
+ *   - ensureIndexes resolves
+ *   - createRunning persists a running placeholder + round-trips via mapDoc
+ *   - markCompleted transitions running → completed (null on unknown id)
+ *   - markFailed truncates errorMessage to 500 chars (null on unknown id)
+ *   - findLatestBySkillAndVersion is newest-first incl. running rows
+ *   - listBySkillGuid is newest-first across statuses
+ *   - findLatestCompletedPerVersion is one-per-version, completed-only
+ *   - findCachedByHash honours TTL + completed-only gate
+ *
+ * @module domains/skills/audit/repository.test
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { MongoClient, type Db } from "mongodb";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { AuditRepository, type CompleteAuditInput, type CreateRunningInput } from "./repository";
+import type { AuditScore, AuditFinding } from "./types";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: AuditRepository;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("audits_test");
+  repo = new AuditRepository(db);
+  await repo.ensureIndexes();
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("skill_audits").deleteMany({});
+});
+
+// ---- Fixtures --------------------------------------------------------
+
+function runningInput(overrides: Partial<CreateRunningInput> = {}): CreateRunningInput {
+  return {
+    skillGuid: "skill-1",
+    version: "1.0.0",
+    skillHash: "hash-abc",
+    model: "gpt-test",
+    triggeredBy: "user-1",
+    ...overrides,
+  };
+}
+
+const completedScores: AuditScore[] = [
+  { dimension: "security", score: 9, rationale: "ok" },
+  { dimension: "code_quality", score: 8, rationale: "ok" },
+  { dimension: "documentation", score: 7, rationale: "ok" },
+  { dimension: "reliability", score: 8, rationale: "ok" },
+  { dimension: "permission_scope", score: 9, rationale: "ok" },
+];
+
+const completedFindings: AuditFinding[] = [
+  { dimension: "security", severity: "warning", message: "watch out" },
+];
+
+const completeInput: CompleteAuditInput = {
+  verdict: "green",
+  overallScore: 8.2,
+  scores: completedScores,
+  findings: completedFindings,
+};
+
+/** Insert a running row, then force its createdAt so ordering is deterministic. */
+async function seedAt(
+  input: CreateRunningInput,
+  createdAt: Date,
+  patch: Record<string, unknown> = {},
+): Promise<string> {
+  const rec = await repo.createRunning(input);
+  await db
+    .collection("skill_audits")
+    .updateOne({ _id: rec._id as never }, { $set: { createdAt, ...patch } });
+  return rec._id;
+}
+
+describe("ensureIndexes", () => {
+  test("resolves without throwing", async () => {
+    await expect(repo.ensureIndexes()).resolves.toBeUndefined();
+  });
+});
+
+describe("createRunning", () => {
+  test("persists a running placeholder that round-trips through mapDoc", async () => {
+    const rec = await repo.createRunning(runningInput());
+    expect(rec.status).toBe("running");
+    expect(rec.verdict).toBe("yellow"); // placeholder
+    expect(rec.overallScore).toBe(0);
+    expect(rec.scores).toEqual([]);
+    expect(rec.findings).toEqual([]);
+    expect(rec.model).toBe("gpt-test");
+    expect(rec.triggeredBy).toBe("user-1");
+    expect(rec.createdAt).toBeInstanceOf(Date);
+    // _id is a UUID string, not an ObjectId.
+    expect(rec._id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe("markCompleted", () => {
+  test("transitions running → completed and returns the mapped record", async () => {
+    const running = await repo.createRunning(runningInput());
+    const completed = await repo.markCompleted(running._id, completeInput);
+    expect(completed).not.toBeNull();
+    expect(completed!.status).toBe("completed");
+    expect(completed!.verdict).toBe("green");
+    expect(completed!.overallScore).toBe(8.2);
+    expect(completed!.scores).toHaveLength(5);
+    expect(completed!.findings).toHaveLength(1);
+    expect(completed!.completedAt).toBeInstanceOf(Date);
+  });
+
+  test("returns null for an unknown id", async () => {
+    expect(await repo.markCompleted("does-not-exist", completeInput)).toBeNull();
+  });
+});
+
+describe("markFailed", () => {
+  test("truncates errorMessage to 500 chars", async () => {
+    const running = await repo.createRunning(runningInput());
+    const longMessage = "x".repeat(600);
+    const failed = await repo.markFailed(running._id, longMessage);
+    expect(failed).not.toBeNull();
+    expect(failed!.status).toBe("failed");
+    expect(failed!.errorMessage).toBeDefined();
+    expect(failed!.errorMessage!.length).toBe(500);
+    expect(failed!.completedAt).toBeInstanceOf(Date);
+  });
+
+  test("returns null for an unknown id", async () => {
+    expect(await repo.markFailed("does-not-exist", "boom")).toBeNull();
+  });
+});
+
+describe("findLatestBySkillAndVersion", () => {
+  test("returns the newest row, including running ones", async () => {
+    await seedAt(runningInput(), new Date("2026-01-01T00:00:00Z"));
+    const newerId = await seedAt(
+      runningInput(),
+      new Date("2026-02-01T00:00:00Z"),
+    );
+    const latest = await repo.findLatestBySkillAndVersion("skill-1", "1.0.0");
+    expect(latest).not.toBeNull();
+    expect(latest!._id).toBe(newerId);
+    expect(latest!.status).toBe("running");
+  });
+
+  test("returns null when no record exists", async () => {
+    expect(await repo.findLatestBySkillAndVersion("nope", "9.9.9")).toBeNull();
+  });
+});
+
+describe("listBySkillGuid", () => {
+  test("returns every status, newest first", async () => {
+    const oldId = await seedAt(
+      runningInput({ version: "1.0.0" }),
+      new Date("2026-01-01T00:00:00Z"),
+    );
+    const midId = await seedAt(
+      runningInput({ version: "1.1.0" }),
+      new Date("2026-02-01T00:00:00Z"),
+      { status: "failed", errorMessage: "boom" },
+    );
+    const newId = await seedAt(
+      runningInput({ version: "1.2.0" }),
+      new Date("2026-03-01T00:00:00Z"),
+      { status: "completed" },
+    );
+    const rows = await repo.listBySkillGuid("skill-1");
+    expect(rows.map((r) => r._id)).toEqual([newId, midId, oldId]);
+    expect(rows.map((r) => r.status)).toEqual(["completed", "failed", "running"]);
+  });
+});
+
+describe("findLatestCompletedPerVersion", () => {
+  test("keeps one completed row per version and excludes running/failed", async () => {
+    // version 1.0.0 — two completed; the newer wins.
+    await seedAt(
+      runningInput({ version: "1.0.0" }),
+      new Date("2026-01-01T00:00:00Z"),
+      { status: "completed", overallScore: 5 },
+    );
+    const v100Newer = await seedAt(
+      runningInput({ version: "1.0.0" }),
+      new Date("2026-02-01T00:00:00Z"),
+      { status: "completed", overallScore: 9 },
+    );
+    // version 2.0.0 — only running + failed → excluded entirely.
+    await seedAt(
+      runningInput({ version: "2.0.0" }),
+      new Date("2026-02-15T00:00:00Z"),
+    );
+    await seedAt(
+      runningInput({ version: "2.0.0" }),
+      new Date("2026-02-16T00:00:00Z"),
+      { status: "failed" },
+    );
+    // version 3.0.0 — one completed.
+    const v300 = await seedAt(
+      runningInput({ version: "3.0.0" }),
+      new Date("2026-03-01T00:00:00Z"),
+      { status: "completed" },
+    );
+
+    const rows = await repo.findLatestCompletedPerVersion("skill-1");
+    const byVersion = Object.fromEntries(rows.map((r) => [r.version, r]));
+    expect(Object.keys(byVersion).sort()).toEqual(["1.0.0", "3.0.0"]);
+    expect(byVersion["1.0.0"]!._id).toBe(v100Newer);
+    expect(byVersion["1.0.0"]!.overallScore).toBe(9);
+    expect(byVersion["3.0.0"]!._id).toBe(v300);
+    expect(byVersion["2.0.0"]).toBeUndefined();
+  });
+});
+
+describe("findCachedByHash", () => {
+  const maxAgeMs = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+  test("hits a completed row inside the TTL", async () => {
+    const recent = new Date(Date.now() - 60_000); // 1 min ago
+    const id = await seedAt(runningInput(), recent, { status: "completed" });
+    const hit = await repo.findCachedByHash("skill-1", "hash-abc", maxAgeMs);
+    expect(hit).not.toBeNull();
+    expect(hit!._id).toBe(id);
+  });
+
+  test("misses when the only matching row is older than maxAgeMs", async () => {
+    const stale = new Date(Date.now() - maxAgeMs - 60_000);
+    await seedAt(runningInput(), stale, { status: "completed" });
+    expect(await repo.findCachedByHash("skill-1", "hash-abc", maxAgeMs)).toBeNull();
+  });
+
+  test("misses when the matching row is not completed", async () => {
+    const recent = new Date(Date.now() - 60_000);
+    await seedAt(runningInput(), recent); // status stays running
+    expect(await repo.findCachedByHash("skill-1", "hash-abc", maxAgeMs)).toBeNull();
+  });
+});

--- a/ornn-api/src/domains/skills/audit/routes.test.ts
+++ b/ornn-api/src/domains/skills/audit/routes.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Route-level tests for the skill-audit routes (#873).
+ *
+ * Mounts `createAuditRoutes` on a bare Hono app, stubs the upstream auth
+ * context (production wires this via proxyAuthSetup), and supplies
+ * hand-rolled fakes for the two collaborators (auditService,
+ * skillService). The project onError → RFC 7807 mapping is replicated so
+ * thrown AppErrors surface with the right status.
+ *
+ * Coverage:
+ *   - GET  /skills/:id/audit          → 200 / 404 audit_not_found /
+ *     private-skill anon 404 / private + !canReadSkill 404
+ *   - GET  .../summary-by-version     → 200 / private 404
+ *   - GET  .../history                → 200 / ?version passthrough / private 404
+ *   - POST /skills/:id/audit          → owner 200 / admin 200 /
+ *     non-owner non-admin 403 / invalid body 400
+ *   - POST /admin/skills/:id/audit    → 200 with perm / 403 without
+ *
+ * @module domains/skills/audit/routes.test
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { createAuditRoutes, type AuditRoutesConfig } from "./routes";
+import { buildProblemJsonBody } from "../../../shared/types/index";
+import type { AuditRecord } from "./types";
+import type { SkillDetailResponse } from "../../../shared/types/index";
+
+const ADMIN_PERM = "ornn:admin:skill";
+const OWNER_ID = "owner-1";
+
+// ---- Fixtures --------------------------------------------------------
+
+function record(overrides: Partial<AuditRecord> = {}): AuditRecord {
+  return {
+    _id: "audit-1",
+    skillGuid: "skill-guid-1",
+    version: "1.0.0",
+    skillHash: "hash-1",
+    status: "completed",
+    verdict: "green",
+    overallScore: 8.2,
+    scores: [],
+    findings: [],
+    model: "gpt-test",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    completedAt: new Date("2026-01-01T00:01:00Z"),
+    triggeredBy: OWNER_ID,
+    ...overrides,
+  };
+}
+
+function skill(overrides: Partial<SkillDetailResponse> = {}): SkillDetailResponse {
+  return {
+    guid: "skill-guid-1",
+    name: "demo-skill",
+    description: "a demo",
+    license: null,
+    compatibility: null,
+    metadata: {},
+    tags: [],
+    skillHash: "hash-1",
+    presignedPackageUrl: "https://storage.test/skill.zip",
+    isPrivate: false,
+    createdBy: OWNER_ID,
+    createdOn: "2026-01-01T00:00:00Z",
+    updatedOn: "2026-01-01T00:00:00Z",
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+// ---- Fakes -----------------------------------------------------------
+
+class FakeAuditService {
+  audit: AuditRecord | null = record();
+  history: AuditRecord[] = [record()];
+  summary: Record<string, AuditRecord> = { "1.0.0": record() };
+  runResult: AuditRecord = record({ status: "running" });
+  listHistoryCalls: Array<{ idOrName: string; version?: string | undefined }> = [];
+  runAuditCalls: Array<{ idOrName: string; triggeredBy: string; force: boolean }> = [];
+
+  async getAudit(): Promise<AuditRecord | null> {
+    return this.audit;
+  }
+  async listHistory(idOrName: string, version?: string): Promise<ReadonlyArray<AuditRecord>> {
+    this.listHistoryCalls.push({ idOrName, version });
+    return this.history;
+  }
+  async summaryByVersion(): Promise<Record<string, AuditRecord>> {
+    return this.summary;
+  }
+  async runAudit(
+    idOrName: string,
+    opts: { triggeredBy: string; force?: boolean },
+  ): Promise<AuditRecord> {
+    this.runAuditCalls.push({ idOrName, triggeredBy: opts.triggeredBy, force: opts.force ?? false });
+    return this.runResult;
+  }
+}
+
+class FakeSkillService {
+  constructor(private s: SkillDetailResponse) {}
+  async getSkill(): Promise<SkillDetailResponse> {
+    return this.s;
+  }
+}
+
+// ---- App builder -----------------------------------------------------
+
+function buildApp(
+  cfg: { auditService?: FakeAuditService; skillService?: FakeSkillService },
+  opts: { authenticated?: boolean; userId?: string; permissions?: string[] } = {},
+): { app: Hono; auditService: FakeAuditService } {
+  const { authenticated = true, userId = OWNER_ID, permissions = [] } = opts;
+  const auditService = cfg.auditService ?? new FakeAuditService();
+  const skillService = cfg.skillService ?? new FakeSkillService(skill());
+
+  const full: AuditRoutesConfig = {
+    auditService: auditService as unknown as AuditRoutesConfig["auditService"],
+    skillService: skillService as unknown as AuditRoutesConfig["skillService"],
+  };
+
+  const app = new Hono();
+  if (authenticated) {
+    app.use("*", async (c, next) => {
+      c.set("auth" as never, {
+        userId,
+        email: `${userId}@test.local`,
+        displayName: userId,
+        roles: [],
+        permissions,
+      } as never);
+      await next();
+    });
+  }
+  app.route("/api/v1", createAuditRoutes(full));
+  app.onError((err, c) => {
+    const code = (err as { code?: string }).code ?? "internal_error";
+    const status = (err as { statusCode?: number }).statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode: status,
+      code,
+      message: err.message,
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, status as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  return { app, auditService };
+}
+
+// ---- GET /skills/:id/audit -------------------------------------------
+
+describe("GET /skills/:idOrName/audit", () => {
+  it("returns 200 with the audit record", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/audit");
+    expect(res.status).toBe(200);
+    const parsed = (await res.json()) as { data: { _id: string } };
+    expect(parsed.data._id).toBe("audit-1");
+  });
+
+  it("returns 404 audit_not_found when there is no audit", async () => {
+    const audit = new FakeAuditService();
+    audit.audit = null;
+    const { app } = buildApp({ auditService: audit }, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/audit");
+    expect(res.status).toBe(404);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("audit_not_found");
+  });
+
+  it("returns 404 skill_not_found for an anonymous caller on a private skill", async () => {
+    const skillSvc = new FakeSkillService(skill({ isPrivate: true }));
+    const { app } = buildApp({ skillService: skillSvc }, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/audit");
+    expect(res.status).toBe(404);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("skill_not_found");
+  });
+
+  it("returns 404 when an authed caller cannot read the private skill", async () => {
+    const skillSvc = new FakeSkillService(
+      skill({ isPrivate: true, createdBy: "someone-else" }),
+    );
+    const { app } = buildApp(
+      { skillService: skillSvc },
+      { authenticated: true, userId: "stranger", permissions: [] },
+    );
+    const res = await app.request("/api/v1/skills/demo-skill/audit");
+    expect(res.status).toBe(404);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("skill_not_found");
+  });
+});
+
+// ---- GET .../summary-by-version --------------------------------------
+
+describe("GET /skills/:idOrName/audit/summary-by-version", () => {
+  it("returns 200 with the per-version map", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/audit/summary-by-version");
+    expect(res.status).toBe(200);
+    const parsed = (await res.json()) as { data: { byVersion: Record<string, unknown> } };
+    expect(Object.keys(parsed.data.byVersion)).toContain("1.0.0");
+  });
+
+  it("returns 404 for an anonymous caller on a private skill", async () => {
+    const skillSvc = new FakeSkillService(skill({ isPrivate: true }));
+    const { app } = buildApp({ skillService: skillSvc }, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/audit/summary-by-version");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---- GET .../history -------------------------------------------------
+
+describe("GET /skills/:idOrName/audit/history", () => {
+  it("returns 200 with the items array", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/audit/history");
+    expect(res.status).toBe(200);
+    const parsed = (await res.json()) as { data: { items: unknown[] } };
+    expect(parsed.data.items).toHaveLength(1);
+  });
+
+  it("passes ?version through to the service", async () => {
+    const { app, auditService } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/audit/history?version=2.1.0");
+    expect(res.status).toBe(200);
+    expect(auditService.listHistoryCalls[0]!.version).toBe("2.1.0");
+  });
+
+  it("returns 404 for an anonymous caller on a private skill", async () => {
+    const skillSvc = new FakeSkillService(skill({ isPrivate: true }));
+    const { app } = buildApp({ skillService: skillSvc }, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/audit/history");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---- POST /skills/:id/audit ------------------------------------------
+
+describe("POST /skills/:idOrName/audit", () => {
+  it("returns 200 when the owner triggers", async () => {
+    const { app, auditService } = buildApp(
+      {},
+      { authenticated: true, userId: OWNER_ID, permissions: [] },
+    );
+    const res = await app.request("/api/v1/skills/demo-skill/audit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ force: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(auditService.runAuditCalls[0]!.triggeredBy).toBe(OWNER_ID);
+    expect(auditService.runAuditCalls[0]!.force).toBe(true);
+  });
+
+  it("returns 200 when a platform admin triggers on someone else's skill", async () => {
+    const skillSvc = new FakeSkillService(skill({ createdBy: "someone-else" }));
+    const { app } = buildApp(
+      { skillService: skillSvc },
+      { authenticated: true, userId: "admin-user", permissions: [ADMIN_PERM] },
+    );
+    const res = await app.request("/api/v1/skills/demo-skill/audit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 not_skill_owner for a non-owner non-admin", async () => {
+    const skillSvc = new FakeSkillService(skill({ createdBy: "someone-else" }));
+    const { app } = buildApp(
+      { skillService: skillSvc },
+      { authenticated: true, userId: "stranger", permissions: [] },
+    );
+    const res = await app.request("/api/v1/skills/demo-skill/audit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("not_skill_owner");
+  });
+
+  it("returns 400 for an invalid body (force not a boolean)", async () => {
+    const { app } = buildApp(
+      {},
+      { authenticated: true, userId: OWNER_ID, permissions: [] },
+    );
+    const res = await app.request("/api/v1/skills/demo-skill/audit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ force: "x" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---- POST /admin/skills/:id/audit ------------------------------------
+
+describe("POST /admin/skills/:idOrName/audit", () => {
+  it("returns 200 with the admin permission", async () => {
+    const { app, auditService } = buildApp(
+      {},
+      { authenticated: true, userId: "admin-user", permissions: [ADMIN_PERM] },
+    );
+    const res = await app.request("/api/v1/admin/skills/demo-skill/audit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ force: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(auditService.runAuditCalls[0]!.triggeredBy).toBe("admin-user");
+  });
+
+  it("returns 403 without the admin permission", async () => {
+    const { app } = buildApp(
+      {},
+      { authenticated: true, userId: "stranger", permissions: [] },
+    );
+    const res = await app.request("/api/v1/admin/skills/demo-skill/audit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/ornn-api/src/domains/skills/audit/service.test.ts
+++ b/ornn-api/src/domains/skills/audit/service.test.ts
@@ -1,0 +1,600 @@
+/**
+ * AuditService unit tests (#873).
+ *
+ * The service is fully DI-driven, so this suite hand-rolls fakes for
+ * every collaborator and never touches a real DB / network / LLM:
+ *   - skillService    → returns a SkillDetailResponse-shaped stub
+ *   - auditRepo       → records createRunning / markCompleted / markFailed
+ *   - llmClient       → installLlmGatewayMock (complete() → output_text)
+ *   - notification    → LOCAL typed recorder (the shared mock's
+ *                       notifyAuditCompleted signature doesn't match the
+ *                       real {ownerUserId,...} call site)
+ *   - storage/orgs    → minimal fakes
+ *   - globalThis.fetch → swapped to a Response wrapping a real JSZip zip
+ *
+ * `runAudit` finalizes in a fire-and-forget microtask; tests flush it
+ * with `flushFinalize()` before asserting on the recorder.
+ *
+ * @module domains/skills/audit/service.test
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import JSZip from "jszip";
+import { AuditService, type AuditServiceDeps } from "./service";
+import type {
+  AuditRecord,
+  AuditScore,
+  AuditFinding,
+  AuditVerdict,
+} from "./types";
+import type { CompleteAuditInput, CreateRunningInput } from "./repository";
+import type {
+  NyxLlmClient,
+  NyxLlmCompleteParams,
+  ResponsesApiOutput,
+} from "../../../clients/nyxid/llm";
+import type { SkillService } from "../crud/service";
+import type { NotificationService } from "../../notifications/service";
+import type { NyxidOrgsClient } from "../../../clients/nyxid/orgs";
+import type { IStorageClient } from "../../../clients/storageClient";
+import type { SkillDetailResponse } from "../../../shared/types/index";
+
+// ---- Local typed notification recorder -------------------------------
+//
+// Mirrors EXACTLY the two methods the service calls
+// (notifyAuditCompleted({ownerUserId,...}) +
+//  notifyAuditRiskyForConsumer({consumerUserId,...})). The shared
+// tests/mocks/notificationService.ts uses a different param shape and
+// would not typecheck against the real call sites.
+
+interface CompletedCall {
+  ownerUserId: string;
+  skillGuid: string;
+  skillName: string;
+  version: string;
+  verdict: AuditVerdict;
+  overallScore: number;
+}
+
+interface RiskyCall {
+  consumerUserId: string;
+  skillGuid: string;
+  skillName: string;
+  version: string;
+  verdict: "yellow" | "red";
+  overallScore: number;
+}
+
+class FakeNotificationService {
+  completed: CompletedCall[] = [];
+  risky: RiskyCall[] = [];
+  async notifyAuditCompleted(p: CompletedCall): Promise<void> {
+    this.completed.push(p);
+  }
+  async notifyAuditRiskyForConsumer(p: RiskyCall): Promise<void> {
+    this.risky.push(p);
+  }
+}
+
+// ---- Fake skill service ----------------------------------------------
+
+const VALID_SCORING_JSON = JSON.stringify({
+  scores: [
+    { dimension: "security", score: 9, rationale: "clean" },
+    { dimension: "code_quality", score: 8, rationale: "ok" },
+    { dimension: "documentation", score: 7, rationale: "ok" },
+    { dimension: "reliability", score: 8, rationale: "ok" },
+    { dimension: "permission_scope", score: 9, rationale: "ok" },
+  ],
+  findings: [],
+});
+
+// A scoring response whose lowest dimension forces a yellow/red verdict
+// so the consumer fan-out branch is exercised.
+const RISKY_SCORING_JSON = JSON.stringify({
+  scores: [
+    { dimension: "security", score: 1, rationale: "shell injection" },
+    { dimension: "code_quality", score: 3, rationale: "bad" },
+    { dimension: "documentation", score: 4, rationale: "thin" },
+    { dimension: "reliability", score: 4, rationale: "fragile" },
+    { dimension: "permission_scope", score: 3, rationale: "broad" },
+  ],
+  findings: [
+    { dimension: "security", severity: "critical", message: "rm -rf user input" },
+  ],
+});
+
+function baseSkill(overrides: Partial<SkillDetailResponse> = {}): SkillDetailResponse {
+  return {
+    guid: "skill-guid-1",
+    name: "demo-skill",
+    description: "a demo",
+    license: null,
+    compatibility: null,
+    metadata: { category: "devtools", runtimes: [{ runtime: "node" }] },
+    tags: ["alpha", "beta"],
+    skillHash: "hash-1",
+    presignedPackageUrl: "https://storage.test/skill.zip",
+    isPrivate: false,
+    createdBy: "owner-1",
+    createdOn: "2026-01-01T00:00:00Z",
+    updatedOn: "2026-01-01T00:00:00Z",
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+class FakeSkillService {
+  getSkillCalls: Array<{ idOrName: string; version?: string | undefined }> = [];
+  constructor(private skill: SkillDetailResponse) {}
+  setSkill(s: SkillDetailResponse) {
+    this.skill = s;
+  }
+  async getSkill(idOrName: string, version?: string): Promise<SkillDetailResponse> {
+    this.getSkillCalls.push({ idOrName, version });
+    return this.skill;
+  }
+}
+
+// ---- Fake audit repository -------------------------------------------
+
+class FakeAuditRepo {
+  createRunningCalls: CreateRunningInput[] = [];
+  markCompletedCalls: Array<{ auditId: string; result: CompleteAuditInput }> = [];
+  markFailedCalls: Array<{ auditId: string; errorMessage: string }> = [];
+  cached: AuditRecord | null = null;
+  latest: AuditRecord | null = null;
+  list: AuditRecord[] = [];
+  perVersion: AuditRecord[] = [];
+
+  async findCachedByHash(): Promise<AuditRecord | null> {
+    return this.cached;
+  }
+  async createRunning(input: CreateRunningInput): Promise<AuditRecord> {
+    this.createRunningCalls.push(input);
+    return {
+      _id: "audit-running-1",
+      skillGuid: input.skillGuid,
+      version: input.version,
+      skillHash: input.skillHash,
+      status: "running",
+      verdict: "yellow",
+      overallScore: 0,
+      scores: [],
+      findings: [],
+      model: input.model,
+      createdAt: new Date(),
+      triggeredBy: input.triggeredBy,
+    };
+  }
+  async markCompleted(auditId: string, result: CompleteAuditInput): Promise<AuditRecord | null> {
+    this.markCompletedCalls.push({ auditId, result });
+    return null;
+  }
+  async markFailed(auditId: string, errorMessage: string): Promise<AuditRecord | null> {
+    this.markFailedCalls.push({ auditId, errorMessage });
+    return null;
+  }
+  async findLatestBySkillAndVersion(): Promise<AuditRecord | null> {
+    return this.latest;
+  }
+  async listBySkillGuid(): Promise<ReadonlyArray<AuditRecord>> {
+    return this.list;
+  }
+  async findLatestCompletedPerVersion(): Promise<ReadonlyArray<AuditRecord>> {
+    return this.perVersion;
+  }
+}
+
+// ---- Fake storage / orgs ---------------------------------------------
+
+class FakeStorageClient {
+  async getPresignedUrl(): Promise<{ presignedUrl: string; expiresAt: string }> {
+    return { presignedUrl: "https://storage.test/skill.zip", expiresAt: "2026-01-01T01:00:00Z" };
+  }
+}
+
+class FakeOrgsClient {
+  membersByOrg = new Map<string, Array<{ userId: string }>>();
+  listOrgMembersCalls: string[] = [];
+  async listOrgMembers(orgId: string): Promise<Array<{ userId: string; displayName: string; role: "admin" | "member" }>> {
+    this.listOrgMembersCalls.push(orgId);
+    return (this.membersByOrg.get(orgId) ?? []).map((m) => ({
+      userId: m.userId,
+      displayName: m.userId,
+      role: "member" as const,
+    }));
+  }
+}
+
+// ---- Fake LLM client -------------------------------------------------
+//
+// Mirrors the tests/mocks/llmGateway.ts complete() shape
+// (`[{ type:"message", content:[{ type:"output_text", text }] }]`) but
+// stays inside src/ rootDir. Only complete() is exercised by the audit
+// pipeline; stream() is stubbed to satisfy the type.
+
+function makeLlmClient(text: string): NyxLlmClient {
+  const fake = {
+    async complete(_params: NyxLlmCompleteParams): Promise<ResponsesApiOutput[]> {
+      return [{ type: "message", content: [{ type: "output_text", text }] }];
+    },
+    async *stream(): AsyncIterable<never> {
+      // not used by the audit service
+    },
+  };
+  return fake as unknown as NyxLlmClient;
+}
+
+// ---- fetch swap ------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+
+interface FetchPlan {
+  ok: boolean;
+  status: number;
+  bytes: Uint8Array;
+  throws?: boolean;
+}
+
+let fetchPlan: FetchPlan;
+
+async function buildZip(files: Record<string, string>): Promise<Uint8Array> {
+  const zip = new JSZip();
+  for (const [name, content] of Object.entries(files)) {
+    zip.file(name, content);
+  }
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+beforeEach(() => {
+  const fakeFetch = async (): Promise<Response> => {
+    if (fetchPlan.throws) throw new Error("network down");
+    return new Response(fetchPlan.bytes as unknown as BodyInit, {
+      status: fetchPlan.status,
+      statusText: fetchPlan.ok ? "OK" : "Error",
+    });
+  };
+  globalThis.fetch = fakeFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---- helpers ---------------------------------------------------------
+
+/**
+ * Flush the fire-and-forget finalize chain. finalizeAudit + the nested
+ * fanOutNotifications both schedule via promise microtasks; a couple of
+ * macrotask ticks let them settle before assertions.
+ */
+async function flushFinalize(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+function buildService(
+  overrides: {
+    skill?: SkillDetailResponse;
+    llmText?: string;
+    notification?: FakeNotificationService;
+    orgs?: FakeOrgsClient;
+    repo?: FakeAuditRepo;
+    withNotification?: boolean;
+  } = {},
+): {
+  service: AuditService;
+  repo: FakeAuditRepo;
+  skillService: FakeSkillService;
+  notification: FakeNotificationService;
+  orgs: FakeOrgsClient;
+} {
+  const repo = overrides.repo ?? new FakeAuditRepo();
+  const skillService = new FakeSkillService(overrides.skill ?? baseSkill());
+  const notification = overrides.notification ?? new FakeNotificationService();
+  const orgs = overrides.orgs ?? new FakeOrgsClient();
+  const client = makeLlmClient(overrides.llmText ?? VALID_SCORING_JSON);
+
+  const deps: AuditServiceDeps = {
+    auditRepo: repo as unknown as AuditServiceDeps["auditRepo"],
+    skillService: skillService as unknown as SkillService,
+    storageClient: new FakeStorageClient() as unknown as IStorageClient,
+    storageBucketResolver: async () => "skills-bucket",
+    llmClient: client,
+    defaultsResolver: async () => ({
+      model: "gpt-test",
+      llmEnabled: true,
+      agentSealEnabled: false,
+      agentSealTimeoutMs: 1000,
+      riskThreshold: 5,
+    }),
+    cacheTtlMs: 30 * 24 * 60 * 60 * 1000,
+    ...(overrides.withNotification === false
+      ? {}
+      : {
+          notificationService: notification as unknown as NotificationService,
+          nyxidOrgsClient: orgs as unknown as NyxidOrgsClient,
+        }),
+  };
+
+  return { service: new AuditService(deps), repo, skillService, notification, orgs };
+}
+
+function completedRecord(overrides: Partial<AuditRecord> = {}): AuditRecord {
+  const scores: AuditScore[] = [
+    { dimension: "security", score: 9, rationale: "" },
+    { dimension: "code_quality", score: 8, rationale: "" },
+    { dimension: "documentation", score: 7, rationale: "" },
+    { dimension: "reliability", score: 8, rationale: "" },
+    { dimension: "permission_scope", score: 9, rationale: "" },
+  ];
+  const findings: AuditFinding[] = [];
+  return {
+    _id: "audit-1",
+    skillGuid: "skill-guid-1",
+    version: "1.0.0",
+    skillHash: "hash-1",
+    status: "completed",
+    verdict: "green",
+    overallScore: 8.2,
+    scores,
+    findings,
+    model: "gpt-test",
+    createdAt: new Date(),
+    completedAt: new Date(),
+    triggeredBy: "owner-1",
+    ...overrides,
+  };
+}
+
+// ---- getAudit --------------------------------------------------------
+
+describe("getAudit", () => {
+  test("returns a completed record", async () => {
+    const { service, repo } = buildService();
+    repo.latest = completedRecord();
+    const rec = await service.getAudit("demo-skill");
+    expect(rec).not.toBeNull();
+    expect(rec!.status).toBe("completed");
+  });
+
+  test("returns null when the latest record is still running", async () => {
+    const { service, repo } = buildService();
+    repo.latest = completedRecord({ status: "running" });
+    expect(await service.getAudit("demo-skill")).toBeNull();
+  });
+
+  test("returns null when no record exists", async () => {
+    const { service, repo } = buildService();
+    repo.latest = null;
+    expect(await service.getAudit("demo-skill")).toBeNull();
+  });
+});
+
+// ---- listHistory -----------------------------------------------------
+
+describe("listHistory", () => {
+  test("returns all records when no version filter is given", async () => {
+    const { service, repo } = buildService();
+    repo.list = [
+      completedRecord({ _id: "a", version: "1.0.0" }),
+      completedRecord({ _id: "b", version: "2.0.0" }),
+    ];
+    const items = await service.listHistory("demo-skill");
+    expect(items).toHaveLength(2);
+  });
+
+  test("filters by version when given", async () => {
+    const { service, repo } = buildService();
+    repo.list = [
+      completedRecord({ _id: "a", version: "1.0.0" }),
+      completedRecord({ _id: "b", version: "2.0.0" }),
+    ];
+    const items = await service.listHistory("demo-skill", "2.0.0");
+    expect(items).toHaveLength(1);
+    expect(items[0]!._id).toBe("b");
+  });
+});
+
+// ---- summaryByVersion ------------------------------------------------
+
+describe("summaryByVersion", () => {
+  test("maps records into a version-keyed object", async () => {
+    const { service, repo } = buildService();
+    repo.perVersion = [
+      completedRecord({ _id: "a", version: "1.0.0" }),
+      completedRecord({ _id: "b", version: "2.0.0" }),
+    ];
+    const out = await service.summaryByVersion("demo-skill");
+    expect(Object.keys(out).sort()).toEqual(["1.0.0", "2.0.0"]);
+    expect(out["1.0.0"]!._id).toBe("a");
+    expect(out["2.0.0"]!._id).toBe("b");
+  });
+});
+
+// ---- runAudit (cache) ------------------------------------------------
+
+describe("runAudit", () => {
+  test("cache hit (force=false) returns the cached row and skips createRunning", async () => {
+    const { service, repo } = buildService();
+    repo.cached = completedRecord({ _id: "cached-1" });
+    const rec = await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    expect(rec._id).toBe("cached-1");
+    expect(repo.createRunningCalls).toHaveLength(0);
+  });
+
+  test("cache miss creates a running row and returns it", async () => {
+    fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
+    const { service, repo } = buildService();
+    repo.cached = null;
+    const rec = await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    expect(rec._id).toBe("audit-running-1");
+    expect(repo.createRunningCalls).toHaveLength(1);
+    await flushFinalize();
+  });
+
+  test("force=true bypasses the cache lookup entirely", async () => {
+    fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
+    const { service, repo } = buildService();
+    repo.cached = completedRecord({ _id: "cached-should-be-ignored" });
+    const rec = await service.runAudit("demo-skill", { triggeredBy: "owner-1", force: true });
+    expect(rec._id).toBe("audit-running-1");
+    expect(repo.createRunningCalls).toHaveLength(1);
+    await flushFinalize();
+  });
+});
+
+// ---- finalizeAudit (via runAudit + flush) ----------------------------
+
+describe("finalizeAudit", () => {
+  test("happy path: valid scoring JSON marks completed + fans out", async () => {
+    fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
+    const { service, repo, notification } = buildService();
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    expect(repo.markCompletedCalls).toHaveLength(1);
+    expect(repo.markCompletedCalls[0]!.result.verdict).toBe("green");
+    expect(repo.markFailedCalls).toHaveLength(0);
+    // Owner always notified on completion.
+    expect(notification.completed).toHaveLength(1);
+    expect(notification.completed[0]!.ownerUserId).toBe("owner-1");
+  });
+
+  test("parse failure marks failed with the scoring-JSON message", async () => {
+    fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
+    const { service, repo } = buildService({ llmText: "this is not json at all" });
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    expect(repo.markCompletedCalls).toHaveLength(0);
+    expect(repo.markFailedCalls).toHaveLength(1);
+    expect(repo.markFailedCalls[0]!.errorMessage).toContain("valid scoring JSON");
+  });
+
+  test("throw path (non-ok package fetch) marks failed with a message", async () => {
+    fetchPlan = { ok: false, status: 500, bytes: new Uint8Array() };
+    const { service, repo } = buildService();
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    expect(repo.markCompletedCalls).toHaveLength(0);
+    expect(repo.markFailedCalls).toHaveLength(1);
+    // finalizeAudit records err.message (not the AppError code).
+    expect(repo.markFailedCalls[0]!.errorMessage).toContain("Failed to download package");
+  });
+});
+
+// ---- buildAuditContext (via finalize) --------------------------------
+
+describe("buildAuditContext", () => {
+  test("walks the zip and skips binary extensions", async () => {
+    fetchPlan = {
+      ok: true,
+      status: 200,
+      bytes: await buildZip({
+        "SKILL.md": "# readable",
+        "logo.png": "BINARYBYTES",
+        "scripts/main.js": "console.log('hi')",
+      }),
+    };
+    const { service, repo } = buildService();
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    // Completed → context build succeeded; binary skip didn't crash it.
+    expect(repo.markCompletedCalls).toHaveLength(1);
+    expect(repo.markFailedCalls).toHaveLength(0);
+  });
+
+  test("truncates the bundle past the 120KB limit", async () => {
+    const big = "a".repeat(130 * 1024);
+    fetchPlan = {
+      ok: true,
+      status: 200,
+      bytes: await buildZip({ "SKILL.md": "# small", "big.txt": big }),
+    };
+    const { service, repo } = buildService();
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    // Truncation marker means the loop broke cleanly → still completes.
+    expect(repo.markCompletedCalls).toHaveLength(1);
+  });
+
+  test("missing presignedPackageUrl marks failed with audit_package_unavailable", async () => {
+    fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
+    const { service, repo } = buildService({
+      skill: baseSkill({ presignedPackageUrl: "" }),
+    });
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    expect(repo.markFailedCalls).toHaveLength(1);
+    expect(repo.markFailedCalls[0]!.errorMessage).toContain("No storage URL");
+  });
+
+  test("non-ok package fetch marks failed with the download-failed message", async () => {
+    fetchPlan = { ok: false, status: 404, bytes: new Uint8Array() };
+    const { service, repo } = buildService();
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    expect(repo.markFailedCalls).toHaveLength(1);
+    expect(repo.markFailedCalls[0]!.errorMessage).toContain("Failed to download package");
+  });
+});
+
+// ---- fanOutNotifications (via finalize, risky verdict) ----------------
+
+describe("fanOutNotifications", () => {
+  test("green verdict notifies the owner only — consumers skipped", async () => {
+    fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
+    const { service, notification } = buildService({
+      skill: baseSkill({ sharedWithUsers: ["consumer-a"] }),
+      llmText: VALID_SCORING_JSON,
+    });
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    expect(notification.completed).toHaveLength(1);
+    expect(notification.risky).toHaveLength(0);
+  });
+
+  test("risky verdict notifies consumers, expands orgs, and de-dupes the owner", async () => {
+    fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
+    const orgs = new FakeOrgsClient();
+    // Org expands to two members, one of which is the owner (must be de-duped).
+    orgs.membersByOrg.set("org-1", [{ userId: "consumer-b" }, { userId: "owner-1" }]);
+    const { service, notification } = buildService({
+      skill: baseSkill({
+        sharedWithUsers: ["consumer-a", "owner-1"],
+        sharedWithOrgs: ["org-1"],
+      }),
+      llmText: RISKY_SCORING_JSON,
+      orgs,
+    });
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+
+    // Owner notified on completion.
+    expect(notification.completed).toHaveLength(1);
+    expect(notification.completed[0]!.ownerUserId).toBe("owner-1");
+    // org expansion happened.
+    expect(orgs.listOrgMembersCalls).toContain("org-1");
+    // Consumers: consumer-a (direct) + consumer-b (org) — owner-1 de-duped.
+    const consumerIds = notification.risky.map((r) => r.consumerUserId).sort();
+    expect(consumerIds).toEqual(["consumer-a", "consumer-b"]);
+    expect(consumerIds).not.toContain("owner-1");
+  });
+
+  test("no notificationService wired → finalize still completes, no fan-out", async () => {
+    fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
+    const { service, repo } = buildService({ withNotification: false });
+    await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
+    await flushFinalize();
+    expect(repo.markCompletedCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #873

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-52411-13976`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
