### PR TITLE
chore: [Misc] test(api): skills/crud unit tests — raise src/domains/skills/cr

### DIFF
--- a/.changeset/test-874-crud-coverage.md
+++ b/.changeset/test-874-crud-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add unit + integration test coverage for the skills CRUD module (repositories, routes, service) (#874)

--- a/ornn-api/src/domains/skills/crud/repository.test.ts
+++ b/ornn-api/src/domains/skills/crud/repository.test.ts
@@ -1,0 +1,700 @@
+/**
+ * SkillRepository unit tests (#874).
+ *
+ * Backed by mongodb-memory-server (mirrors the notifications / audit
+ * repository harness). The `skills` collection keys each skill by its
+ * UUID-string `_id` (the public GUID). Pins the query surface that the
+ * service + search + admin layers all lean on:
+ *   - applyScope visibility matrix (public / private-author / shared-user /
+ *     shared-org / mine / shared-with-me / anonymous)
+ *   - keywordSearch (_id exact, name/desc regex, escapeRegex on `.*`)
+ *   - applyExtraFilters (tagsAll $all, systemFilter only/exclude,
+ *     nyxidServiceId, sharedWith*Any)
+ *   - pagination skip/limit + countByScope
+ *   - basic CRUD (create / findByGuid / findByName / update / hardDelete /
+ *     clearSource) + invalid_skill_id guard
+ *   - dist-tags set/delete (dotted path)
+ *   - nyxid-service tie + findByNyxidService
+ *   - mirror eligibility / sync-state / counts
+ *   - all five aggregates
+ *
+ * @module domains/skills/crud/repository.test
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { MongoClient, type Db } from "mongodb";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { SkillRepository } from "./repository";
+import { AppError } from "../../../shared/types/index";
+import type { SkillMetadata } from "../../../shared/types/index";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: SkillRepository;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("skills_crud_test");
+  repo = new SkillRepository(db);
+  await repo.ensureIndexes();
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("skills").deleteMany({});
+});
+
+// ---- Fixtures --------------------------------------------------------
+
+const META: SkillMetadata = { category: "plain", tags: ["alpha", "beta"] };
+
+/**
+ * Raw-seed a skill doc. The repo expects `_id` to carry the public GUID
+ * string, mirroring production. Sensible defaults keep call sites terse;
+ * any field can be overridden.
+ */
+function makeSkillDoc(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const now = new Date();
+  return {
+    _id: "guid-1",
+    name: "demo-skill",
+    description: "A demo skill for tests.",
+    license: null,
+    compatibility: null,
+    metadata: META,
+    skillHash: "hash-1",
+    storageKey: "skills/guid-1/1.0.zip",
+    createdBy: "owner-1",
+    createdByEmail: "owner@test.local",
+    createdByDisplayName: "Owner One",
+    createdOn: now,
+    updatedBy: "owner-1",
+    updatedOn: now,
+    isPrivate: true,
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    latestVersion: "1.0",
+    ...overrides,
+  };
+}
+
+async function seed(...docs: Array<Record<string, unknown>>): Promise<void> {
+  await db.collection("skills").insertMany(docs.map((d) => makeSkillDoc(d)) as never);
+}
+
+// ---- Basic CRUD ------------------------------------------------------
+
+describe("create / findByGuid / findByName", () => {
+  test("create persists and round-trips through mapDoc", async () => {
+    const created = await repo.create({
+      guid: "g-new",
+      name: "new-skill",
+      description: "fresh",
+      metadata: META,
+      skillHash: "h",
+      storageKey: "skills/g-new/1.0.zip",
+      createdBy: "owner-1",
+      latestVersion: "1.0",
+    });
+    expect(created.guid).toBe("g-new");
+    expect(created.isPrivate).toBe(true); // default
+    expect(created.sharedWithUsers).toEqual([]);
+    const found = await repo.findByGuid("g-new");
+    expect(found!.name).toBe("new-skill");
+  });
+
+  test("create with source stamps the origin pointer", async () => {
+    const created = await repo.create({
+      guid: "g-src",
+      name: "src-skill",
+      description: "fresh",
+      metadata: META,
+      skillHash: "h",
+      storageKey: "skills/g-src/1.0.zip",
+      createdBy: "owner-1",
+      latestVersion: "1.0",
+      source: { type: "github", repo: "o/r", ref: "main", path: "" },
+    });
+    expect(created.source?.repo).toBe("o/r");
+  });
+
+  test("duplicate name → skill_name_exists conflict", async () => {
+    await seed({ _id: "guid-1", name: "dup-name" });
+    let thrown: unknown;
+    try {
+      await repo.create({
+        guid: "g-2",
+        name: "dup-name",
+        description: "x",
+        metadata: META,
+        skillHash: "h",
+        storageKey: "k",
+        createdBy: "u",
+        latestVersion: "1.0",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("skill_name_exists");
+  });
+
+  test("findByName returns the matching skill", async () => {
+    await seed({ _id: "guid-1", name: "by-name" });
+    expect((await repo.findByName("by-name"))!.guid).toBe("guid-1");
+    expect(await repo.findByName("missing")).toBeNull();
+  });
+
+  test("findByGuid throws invalid_skill_id on an empty guid", async () => {
+    let thrown: unknown;
+    try {
+      await repo.findByGuid("");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("invalid_skill_id");
+  });
+});
+
+describe("update / hardDelete / clearSource", () => {
+  test("update mutates only the supplied fields", async () => {
+    await seed({ _id: "guid-1", name: "before", description: "old", isPrivate: true });
+    const updated = await repo.update("guid-1", {
+      name: "after",
+      isPrivate: false,
+      sharedWithUsers: ["u-2"],
+      updatedBy: "owner-1",
+    });
+    expect(updated.name).toBe("after");
+    expect(updated.isPrivate).toBe(false);
+    expect(updated.sharedWithUsers).toEqual(["u-2"]);
+    // Untouched field preserved.
+    expect(updated.description).toBe("old");
+  });
+
+  test("hardDelete removes the doc", async () => {
+    await seed({ _id: "guid-1" });
+    await repo.hardDelete("guid-1");
+    expect(await repo.findByGuid("guid-1")).toBeNull();
+  });
+
+  test("clearSource unsets the source field", async () => {
+    await seed({
+      _id: "guid-1",
+      source: { type: "github", repo: "o/r", ref: "main", path: "" },
+    });
+    const after = await repo.clearSource("guid-1", "owner-1");
+    expect(after!.source).toBeUndefined();
+  });
+});
+
+// ---- Dist-tags -------------------------------------------------------
+
+describe("dist-tags", () => {
+  test("setDistTag writes a dotted path and deleteDistTag removes it", async () => {
+    await seed({ _id: "guid-1" });
+    await repo.setDistTag("guid-1", "beta", "1.1");
+    let doc = await repo.findByGuid("guid-1");
+    expect(doc!.distTags).toEqual({ beta: "1.1" });
+    await repo.deleteDistTag("guid-1", "beta");
+    doc = await repo.findByGuid("guid-1");
+    // mapDistTags collapses the now-empty object to undefined.
+    expect(doc!.distTags).toBeUndefined();
+  });
+});
+
+// ---- Scope visibility matrix ----------------------------------------
+
+describe("findByScope / findAllByScope — visibility matrix", () => {
+  // A small fixture covering each visibility branch.
+  async function seedMatrix(): Promise<void> {
+    await seed(
+      { _id: "pub", name: "public-skill", isPrivate: false, createdBy: "author-x" },
+      { _id: "mine", name: "my-private", isPrivate: true, createdBy: "me" },
+      {
+        _id: "shared-user",
+        name: "shared-with-me-user",
+        isPrivate: true,
+        createdBy: "author-y",
+        sharedWithUsers: ["me"],
+      },
+      {
+        _id: "shared-org",
+        name: "shared-with-org",
+        isPrivate: true,
+        createdBy: "author-z",
+        sharedWithOrgs: ["org-A"],
+      },
+      {
+        _id: "other-private",
+        name: "not-visible",
+        isPrivate: true,
+        createdBy: "stranger",
+      },
+    );
+  }
+
+  test("public scope returns only public skills (anonymous ok)", async () => {
+    await seedMatrix();
+    const { skills, total } = await repo.findByScope("public", "", [], 1, 20);
+    expect(total).toBe(1);
+    expect(skills.map((s) => s.guid)).toEqual(["pub"]);
+  });
+
+  test("private scope returns author + shared-user + shared-org", async () => {
+    await seedMatrix();
+    const { skills } = await repo.findByScope("private", "me", ["org-A"], 1, 20);
+    expect(new Set(skills.map((s) => s.guid))).toEqual(
+      new Set(["mine", "shared-user", "shared-org"]),
+    );
+  });
+
+  test("private scope for an anonymous caller matches nothing", async () => {
+    await seedMatrix();
+    const { total } = await repo.findByScope("private", "", [], 1, 20);
+    expect(total).toBe(0);
+  });
+
+  test("mine scope returns only skills I authored", async () => {
+    await seedMatrix();
+    const { skills } = await repo.findByScope("mine", "me", ["org-A"], 1, 20);
+    expect(skills.map((s) => s.guid)).toEqual(["mine"]);
+  });
+
+  test("mine scope for an anonymous caller matches nothing", async () => {
+    await seedMatrix();
+    const { total } = await repo.findByScope("mine", "", [], 1, 20);
+    expect(total).toBe(0);
+  });
+
+  test("shared-with-me excludes my own authored skills", async () => {
+    await seedMatrix();
+    const { skills } = await repo.findByScope("shared-with-me", "me", ["org-A"], 1, 20);
+    expect(new Set(skills.map((s) => s.guid))).toEqual(
+      new Set(["shared-user", "shared-org"]),
+    );
+  });
+
+  test("shared-with-me with no grants matches nothing", async () => {
+    await seedMatrix();
+    const { total } = await repo.findByScope("shared-with-me", "", [], 1, 20);
+    expect(total).toBe(0);
+  });
+
+  test("mixed scope unions public + visible private", async () => {
+    await seedMatrix();
+    const { skills } = await repo.findByScope("mixed", "me", ["org-A"], 1, 20);
+    expect(new Set(skills.map((s) => s.guid))).toEqual(
+      new Set(["pub", "mine", "shared-user", "shared-org"]),
+    );
+  });
+
+  test("findAllByScope (public) returns the projected docs unpaginated", async () => {
+    await seedMatrix();
+    const all = await repo.findAllByScope("public", "", []);
+    expect(all.map((s) => s.guid)).toEqual(["pub"]);
+  });
+
+  test("restrictToGuids=[] short-circuits to empty without a query", async () => {
+    await seedMatrix();
+    const { skills, total } = await repo.findByScope("public", "", [], 1, 20, []);
+    expect(skills).toEqual([]);
+    expect(total).toBe(0);
+  });
+
+  test("restrictToGuids narrows the matched set", async () => {
+    await seedMatrix();
+    const { skills } = await repo.findByScope("mixed", "me", ["org-A"], 1, 20, ["pub"]);
+    expect(skills.map((s) => s.guid)).toEqual(["pub"]);
+  });
+});
+
+// ---- Pagination + countByScope --------------------------------------
+
+describe("pagination + countByScope", () => {
+  async function seedTen(): Promise<void> {
+    const docs: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < 10; i++) {
+      docs.push({
+        _id: `pub-${i}`,
+        name: `pub-${i}`,
+        isPrivate: false,
+        createdBy: "author-x",
+        createdOn: new Date(2026, 0, i + 1),
+      });
+    }
+    await seed(...docs);
+  }
+
+  test("skip/limit slice the result and report the unpaged total", async () => {
+    await seedTen();
+    const page1 = await repo.findByScope("public", "", [], 1, 3);
+    expect(page1.skills).toHaveLength(3);
+    expect(page1.total).toBe(10);
+    const page2 = await repo.findByScope("public", "", [], 2, 3);
+    expect(page2.skills).toHaveLength(3);
+    // Pages are disjoint (sorted createdOn desc).
+    const overlap = page1.skills
+      .map((s) => s.guid)
+      .filter((g) => page2.skills.some((s) => s.guid === g));
+    expect(overlap).toEqual([]);
+  });
+
+  test("countByScope matches the unpaged total", async () => {
+    await seedTen();
+    expect(await repo.countByScope("public", "", [])).toBe(10);
+  });
+
+  test("countByScope short-circuits to 0 for an empty-match scope", async () => {
+    await seedTen();
+    expect(await repo.countByScope("mine", "", [])).toBe(0);
+  });
+});
+
+// ---- keywordSearch ---------------------------------------------------
+
+describe("keywordSearch", () => {
+  async function seedSearch(): Promise<void> {
+    await seed(
+      { _id: "alpha-guid", name: "alpha-tool", description: "first thing", isPrivate: false, createdBy: "x" },
+      { _id: "beta-guid", name: "beta-tool", description: "second thing", isPrivate: false, createdBy: "x" },
+      { _id: "weird-guid", name: "weird.*name", description: "edge", isPrivate: false, createdBy: "x" },
+    );
+  }
+
+  test("matches an exact _id", async () => {
+    await seedSearch();
+    const { skills } = await repo.keywordSearch("alpha-guid", "public", "", [], 1, 20);
+    expect(skills.map((s) => s.guid)).toContain("alpha-guid");
+  });
+
+  test("matches a case-insensitive name regex", async () => {
+    await seedSearch();
+    const { skills } = await repo.keywordSearch("ALPHA", "public", "", [], 1, 20);
+    expect(skills.map((s) => s.name)).toContain("alpha-tool");
+  });
+
+  test("matches a description regex", async () => {
+    await seedSearch();
+    const { skills } = await repo.keywordSearch("second", "public", "", [], 1, 20);
+    expect(skills.map((s) => s.guid)).toEqual(["beta-guid"]);
+  });
+
+  test("treats a query with regex metacharacters literally (escapeRegex)", async () => {
+    await seedSearch();
+    // Un-escaped, `.*` is a catch-all that would match all three rows.
+    // Escaped, it only matches the one name carrying the literal `.*`.
+    const { skills } = await repo.keywordSearch(".*", "public", "", [], 1, 20);
+    expect(skills.map((s) => s.guid)).toEqual(["weird-guid"]);
+  });
+
+  test("restrictToGuids=[] short-circuits to empty", async () => {
+    await seedSearch();
+    const { skills, total } = await repo.keywordSearch("alpha", "public", "", [], 1, 20, []);
+    expect(skills).toEqual([]);
+    expect(total).toBe(0);
+  });
+});
+
+// ---- applyExtraFilters ----------------------------------------------
+
+describe("applyExtraFilters", () => {
+  async function seedFilters(): Promise<void> {
+    await seed(
+      {
+        _id: "tagged",
+        name: "tagged-skill",
+        isPrivate: false,
+        createdBy: "x",
+        metadata: { category: "plain", tags: ["red", "blue"] },
+      },
+      {
+        _id: "system",
+        name: "system-skill",
+        isPrivate: false,
+        createdBy: "x",
+        isSystemSkill: true,
+        nyxidServiceId: "svc-1",
+      },
+      {
+        _id: "plain-pub",
+        name: "plain-pub",
+        isPrivate: false,
+        createdBy: "x",
+      },
+    );
+  }
+
+  test("tagsAll requires every requested tag ($all)", async () => {
+    await seedFilters();
+    const both = await repo.findByScope("public", "", [], 1, 20, undefined, {
+      tagsAll: ["red", "blue"],
+    });
+    expect(both.skills.map((s) => s.guid)).toEqual(["tagged"]);
+    const missing = await repo.findByScope("public", "", [], 1, 20, undefined, {
+      tagsAll: ["red", "green"],
+    });
+    expect(missing.skills).toEqual([]);
+  });
+
+  test("systemFilter=only keeps just system skills", async () => {
+    await seedFilters();
+    const { skills } = await repo.findByScope("public", "", [], 1, 20, undefined, {
+      systemFilter: "only",
+    });
+    expect(skills.map((s) => s.guid)).toEqual(["system"]);
+  });
+
+  test("systemFilter=exclude drops system skills", async () => {
+    await seedFilters();
+    const { skills } = await repo.findByScope("public", "", [], 1, 20, undefined, {
+      systemFilter: "exclude",
+    });
+    expect(skills.map((s) => s.guid).sort()).toEqual(["plain-pub", "tagged"]);
+  });
+
+  test("nyxidServiceId narrows to a single service", async () => {
+    await seedFilters();
+    const { skills } = await repo.findByScope("public", "", [], 1, 20, undefined, {
+      nyxidServiceId: "svc-1",
+    });
+    expect(skills.map((s) => s.guid)).toEqual(["system"]);
+  });
+
+  test("sharedWithOrgsAny / sharedWithUsersAny / createdByAny intersect", async () => {
+    await seed(
+      {
+        _id: "org-shared",
+        name: "org-shared",
+        isPrivate: true,
+        createdBy: "author-a",
+        sharedWithOrgs: ["org-Q"],
+        sharedWithUsers: ["u-q"],
+      },
+    );
+    const byOrg = await repo.findByScope("private", "author-a", ["org-Q"], 1, 20, undefined, {
+      sharedWithOrgsAny: ["org-Q"],
+    });
+    expect(byOrg.skills.map((s) => s.guid)).toEqual(["org-shared"]);
+    const byUser = await repo.findByScope("private", "author-a", ["org-Q"], 1, 20, undefined, {
+      sharedWithUsersAny: ["u-q"],
+    });
+    expect(byUser.skills.map((s) => s.guid)).toEqual(["org-shared"]);
+    const byAuthor = await repo.findByScope("private", "author-a", ["org-Q"], 1, 20, undefined, {
+      createdByAny: ["author-a"],
+    });
+    expect(byAuthor.skills.map((s) => s.guid)).toEqual(["org-shared"]);
+  });
+});
+
+// ---- nyxid-service tie ----------------------------------------------
+
+describe("setNyxidService / findByNyxidService", () => {
+  test("tie sets the cached fields + optional privacy flip", async () => {
+    await seed({ _id: "guid-1", isPrivate: true });
+    const tied = await repo.setNyxidService("guid-1", {
+      nyxidServiceId: "svc-9",
+      nyxidServiceSlug: "svc-9-slug",
+      nyxidServiceLabel: "Service 9",
+      isSystemSkill: true,
+      isPrivate: false,
+      updatedBy: "admin-1",
+    });
+    expect(tied.nyxidServiceId).toBe("svc-9");
+    expect(tied.isSystemSkill).toBe(true);
+    expect(tied.isPrivate).toBe(false);
+  });
+
+  test("untie wipes the cached fields", async () => {
+    await seed({
+      _id: "guid-1",
+      isPrivate: false,
+      nyxidServiceId: "svc-9",
+      isSystemSkill: true,
+    });
+    const untied = await repo.setNyxidService("guid-1", {
+      nyxidServiceId: null,
+      nyxidServiceSlug: null,
+      nyxidServiceLabel: null,
+      isSystemSkill: false,
+      updatedBy: "admin-1",
+    });
+    expect(untied.nyxidServiceId).toBeNull();
+    expect(untied.isSystemSkill).toBe(false);
+  });
+
+  test("findByNyxidService (public scope) returns public skills tied to it", async () => {
+    await seed(
+      { _id: "s1", name: "s1", isPrivate: false, createdBy: "x", nyxidServiceId: "svc-1", isSystemSkill: true },
+      { _id: "s2", name: "s2", isPrivate: false, createdBy: "x", nyxidServiceId: "other" },
+    );
+    const { skills, total } = await repo.findByNyxidService("svc-1", "public", "", [], 1, 20);
+    expect(total).toBe(1);
+    expect(skills.map((s) => s.guid)).toEqual(["s1"]);
+  });
+});
+
+// ---- Mirror group ----------------------------------------------------
+
+describe("mirror eligibility + sync state + counts", () => {
+  async function seedMirror(): Promise<void> {
+    await seed(
+      { _id: "pub-synced", name: "pub-synced", isPrivate: false, latestVersion: "1.0", createdOn: new Date(2026, 0, 1) },
+      { _id: "pub-lagging", name: "pub-lagging", isPrivate: false, latestVersion: "2.0", createdOn: new Date(2026, 0, 2) },
+      { _id: "pub-never", name: "pub-never", isPrivate: false, latestVersion: "1.0", createdOn: new Date(2026, 0, 3) },
+      { _id: "priv-1", name: "priv-1", isPrivate: true, latestVersion: "1.0" },
+    );
+    await repo.setMirrorSyncState("pub-synced", {
+      version: "1.0",
+      syncedAt: new Date(),
+      commitSha: "sha-synced",
+    });
+    await repo.setMirrorSyncState("pub-lagging", {
+      version: "1.0", // lags behind latestVersion 2.0
+      syncedAt: new Date(),
+      commitSha: "sha-lag",
+    });
+  }
+
+  test("findAllEligibleForMirror returns only public skills", async () => {
+    await seedMirror();
+    const eligible = await repo.findAllEligibleForMirror();
+    expect(eligible.map((s) => s.guid).sort()).toEqual([
+      "pub-lagging",
+      "pub-never",
+      "pub-synced",
+    ]);
+  });
+
+  test("getMirrorCounts classifies synced / lagging / neverSynced", async () => {
+    await seedMirror();
+    const counts = await repo.getMirrorCounts();
+    expect(counts.eligible).toBe(3);
+    expect(counts.synced).toBe(1);
+    expect(counts.lagging).toBe(1);
+    expect(counts.neverSynced).toBe(1);
+    expect(counts.oldestUnsyncedAt).toEqual(new Date(2026, 0, 3));
+  });
+
+  test("setMirrorSyncState(null) clears the stamp", async () => {
+    await seedMirror();
+    await repo.setMirrorSyncState("pub-synced", null);
+    const doc = await repo.findByGuid("pub-synced");
+    expect(doc!.mirrorSync).toBeUndefined();
+  });
+
+  test("setMirrorSyncStateBulk stamps + clears in one roundtrip", async () => {
+    await seedMirror();
+    await repo.setMirrorSyncStateBulk([
+      { guid: "pub-never", state: { version: "1.0", syncedAt: new Date(), commitSha: "sha-new" } },
+      { guid: "pub-lagging", state: null },
+    ]);
+    expect((await repo.findByGuid("pub-never"))!.mirrorSync?.commitSha).toBe("sha-new");
+    expect((await repo.findByGuid("pub-lagging"))!.mirrorSync).toBeUndefined();
+  });
+
+  test("setMirrorSyncStateBulk is a no-op on an empty list", async () => {
+    await expect(repo.setMirrorSyncStateBulk([])).resolves.toBeUndefined();
+  });
+
+  test("clearAllMirrorSyncStamps drops every stamp", async () => {
+    await seedMirror();
+    await repo.clearAllMirrorSyncStamps();
+    expect((await repo.findByGuid("pub-synced"))!.mirrorSync).toBeUndefined();
+    expect((await repo.findByGuid("pub-lagging"))!.mirrorSync).toBeUndefined();
+  });
+
+  test("clearMirrorSyncForIneligibleSkills only heals private skills", async () => {
+    await seedMirror();
+    // Force a stamp onto the private skill, then heal.
+    await repo.setMirrorSyncState("priv-1", {
+      version: "1.0",
+      syncedAt: new Date(),
+      commitSha: "sha-priv",
+    });
+    await repo.clearMirrorSyncForIneligibleSkills();
+    expect((await repo.findByGuid("priv-1"))!.mirrorSync).toBeUndefined();
+    // The public synced skill keeps its stamp.
+    expect((await repo.findByGuid("pub-synced"))!.mirrorSync?.commitSha).toBe("sha-synced");
+  });
+});
+
+// ---- Aggregates ------------------------------------------------------
+
+describe("aggregates", () => {
+  test("aggregateGrantsByOwner counts grantees on my skills", async () => {
+    await seed(
+      { _id: "a", name: "a", createdBy: "me", sharedWithOrgs: ["org-A"], sharedWithUsers: ["u-1"] },
+      { _id: "b", name: "b", createdBy: "me", sharedWithOrgs: ["org-A"], sharedWithUsers: [] },
+      { _id: "c", name: "c", createdBy: "other", sharedWithOrgs: ["org-Z"], sharedWithUsers: [] },
+    );
+    const res = await repo.aggregateGrantsByOwner("me");
+    expect(res.orgs).toEqual([{ id: "org-A", skillCount: 2 }]);
+    expect(res.users).toEqual([{ userId: "u-1", skillCount: 1 }]);
+  });
+
+  test("aggregateGrantsByOwner returns empty for a blank user", async () => {
+    expect(await repo.aggregateGrantsByOwner("")).toEqual({ orgs: [], users: [] });
+  });
+
+  test("aggregateSourcesForReader counts visibility bridges", async () => {
+    await seed(
+      { _id: "x", name: "x", isPrivate: true, createdBy: "author-1", sharedWithOrgs: ["org-A"], sharedWithUsers: [] },
+      { _id: "y", name: "y", isPrivate: true, createdBy: "author-2", sharedWithOrgs: [], sharedWithUsers: ["me"] },
+    );
+    const res = await repo.aggregateSourcesForReader("me", ["org-A"]);
+    expect(res.orgs).toEqual([{ id: "org-A", skillCount: 1 }]);
+    expect(res.users).toEqual([{ userId: "author-2", skillCount: 1 }]);
+  });
+
+  test("aggregateTagsByScope counts distinct tags within scope", async () => {
+    await seed(
+      { _id: "t1", name: "t1", isPrivate: false, createdBy: "x", metadata: { category: "plain", tags: ["red", "blue"] } },
+      { _id: "t2", name: "t2", isPrivate: false, createdBy: "x", metadata: { category: "plain", tags: ["red"] } },
+    );
+    const tags = await repo.aggregateTagsByScope("public", "", []);
+    const byName = Object.fromEntries(tags.map((t) => [t.name, t.count]));
+    expect(byName.red).toBe(2);
+    expect(byName.blue).toBe(1);
+  });
+
+  test("aggregateAuthorsByScope counts per author with cached label", async () => {
+    await seed(
+      { _id: "p1", name: "p1", isPrivate: false, createdBy: "author-1", createdByEmail: "a1@test.local", createdByDisplayName: "A1" },
+      { _id: "p2", name: "p2", isPrivate: false, createdBy: "author-1", createdByEmail: "a1@test.local", createdByDisplayName: "A1" },
+    );
+    const authors = await repo.aggregateAuthorsByScope("public", "", []);
+    expect(authors).toHaveLength(1);
+    expect(authors[0]!.userId).toBe("author-1");
+    expect(authors[0]!.count).toBe(2);
+    expect(authors[0]!.email).toBe("a1@test.local");
+  });
+
+  test("aggregateSystemServices groups by tied service", async () => {
+    await seed(
+      { _id: "s1", name: "s1", isPrivate: false, createdBy: "x", isSystemSkill: true, nyxidServiceId: "svc-1", nyxidServiceSlug: "svc-1", nyxidServiceLabel: "Service 1" },
+      { _id: "s2", name: "s2", isPrivate: false, createdBy: "x", isSystemSkill: true, nyxidServiceId: "svc-1", nyxidServiceSlug: "svc-1", nyxidServiceLabel: "Service 1" },
+      { _id: "s3", name: "s3", isPrivate: false, createdBy: "x", isSystemSkill: false },
+    );
+    const services = await repo.aggregateSystemServices();
+    expect(services).toHaveLength(1);
+    expect(services[0]!.id).toBe("svc-1");
+    expect(services[0]!.count).toBe(2);
+    expect(services[0]!.label).toBe("Service 1");
+  });
+});

--- a/ornn-api/src/domains/skills/crud/routes.test.ts
+++ b/ornn-api/src/domains/skills/crud/routes.test.ts
@@ -1,0 +1,1064 @@
+/**
+ * Route-level tests for the skill CRUD routes (#874).
+ *
+ * Mounts the real `createSkillRoutes` on a bare Hono app and supplies
+ * DI fakes for the two primary collaborators:
+ *   - `skillService` — a Proxy whose un-asserted methods THROW, so any
+ *     handler that accidentally reaches an un-stubbed method fails loud
+ *     instead of silently returning undefined.
+ *   - `skillRepo` — a hand-rolled fake exposing only `findByGuid` /
+ *     `findByName` / `findByNyxidService` (the canRead/canManage gates).
+ *
+ * Auth is wired the same way production does it: a top-level middleware
+ * stamps `c.set("auth", ...)` (mirrors `proxyAuthSetup`), then the route's
+ * own `nyxidAuthMiddleware` / `requirePermission` / `buildActorContext`
+ * read from it. The org-lookup getter is left unmounted, so
+ * `buildActorContext` resolves to `{ memberships: [], membershipsResolved:
+ * true }` — every test caller is "member of no org", which is all these
+ * gate-and-delegate tests need.
+ *
+ * The onError handler mirrors the global RFC 7807 mapping so thrown
+ * AppErrors surface with the right status + `code`.
+ *
+ * @module domains/skills/crud/routes.test
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import JSZip from "jszip";
+import { createSkillRoutes, type SkillRoutesConfig } from "./routes";
+import {
+  AppError,
+  buildProblemJsonBody,
+  type SkillDetailResponse,
+  type SkillDocument,
+} from "../../../shared/types/index";
+import { __resetRateLimitForTests } from "../../../middleware/rateLimit";
+
+const CREATE = "ornn:skill:create";
+const READ = "ornn:skill:read";
+const UPDATE = "ornn:skill:update";
+const DELETE = "ornn:skill:delete";
+const ADMIN = "ornn:admin:skill";
+const OWNER = "owner-1";
+
+// ---- Fixtures --------------------------------------------------------
+
+function detail(overrides: Partial<SkillDetailResponse> = {}): SkillDetailResponse {
+  return {
+    guid: "guid-1",
+    name: "demo-skill",
+    description: "a demo",
+    license: null,
+    compatibility: null,
+    metadata: {},
+    tags: [],
+    skillHash: "hash-1",
+    presignedPackageUrl: "https://storage.test/skill.zip",
+    isPrivate: false,
+    createdBy: OWNER,
+    createdOn: "2026-01-01T00:00:00Z",
+    updatedOn: "2026-01-01T00:00:00Z",
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    version: "1.0",
+    ...overrides,
+  };
+}
+
+function skillDoc(overrides: Partial<SkillDocument> = {}): SkillDocument {
+  return {
+    guid: "guid-1",
+    name: "demo-skill",
+    description: "a demo",
+    license: null,
+    compatibility: null,
+    metadata: { category: "plain" },
+    skillHash: "hash-1",
+    storageKey: "skills/guid-1/1.0.zip",
+    createdBy: OWNER,
+    createdOn: new Date("2026-01-01T00:00:00Z"),
+    updatedBy: OWNER,
+    updatedOn: new Date("2026-01-01T00:00:00Z"),
+    isPrivate: false,
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    latestVersion: "1.0",
+    ...overrides,
+  } as SkillDocument;
+}
+
+// ---- Fakes -----------------------------------------------------------
+
+/**
+ * A skillService stand-in: only the methods listed in `impl` are callable.
+ * Every other property resolves to a function that throws — so an
+ * accidental handler reach is loud rather than silent.
+ */
+function fakeSkillService(impl: Record<string, (...args: unknown[]) => unknown>) {
+  return new Proxy(impl, {
+    get(target, prop: string) {
+      if (prop in target) return target[prop];
+      return (..._args: unknown[]) => {
+        throw new Error(`skillService.${prop} should not be called in this test`);
+      };
+    },
+  }) as unknown as SkillRoutesConfig["skillService"];
+}
+
+interface BuildOpts {
+  authenticated?: boolean;
+  userId?: string;
+  permissions?: string[];
+  /** Forwarded user access token — required by GET /nyxid-services/:id/skills. */
+  userAccessToken?: string;
+  service?: Record<string, (...args: unknown[]) => unknown>;
+  repo?: Partial<{
+    findByGuid: (guid: string) => Promise<SkillDocument | null>;
+    findByName: (name: string) => Promise<SkillDocument | null>;
+    findByNyxidService: (...args: unknown[]) => Promise<unknown>;
+  }>;
+  nyxidServiceClient?: { findVisibleToCaller: (...args: unknown[]) => Promise<unknown> };
+  extraNyxidServices?: readonly string[];
+}
+
+function buildApp(opts: BuildOpts = {}) {
+  const {
+    authenticated = true,
+    userId = OWNER,
+    permissions = [],
+    userAccessToken,
+    service = {},
+    repo = {},
+    nyxidServiceClient,
+    extraNyxidServices = [],
+  } = opts;
+
+  const skillRepo = {
+    findByGuid: repo.findByGuid ?? (async () => null),
+    findByName: repo.findByName ?? (async () => null),
+    findByNyxidService: repo.findByNyxidService ?? (async () => ({ skills: [], total: 0 })),
+  } as unknown as SkillRoutesConfig["skillRepo"];
+
+  const config: SkillRoutesConfig = {
+    skillService: fakeSkillService(service),
+    skillRepo,
+    maxFileSize: 10 * 1024 * 1024,
+    nyxidServiceClient: (nyxidServiceClient ??
+      { findVisibleToCaller: async () => null }) as unknown as SkillRoutesConfig["nyxidServiceClient"],
+    extraNyxidServicesResolver: async () => extraNyxidServices,
+  };
+
+  const app = new Hono();
+  if (authenticated) {
+    app.use("*", async (c, next) => {
+      c.set("auth" as never, {
+        userId,
+        email: `${userId}@test.local`,
+        displayName: userId,
+        roles: [],
+        permissions,
+        ...(userAccessToken !== undefined ? { userAccessToken } : {}),
+      } as never);
+      await next();
+    });
+  }
+  app.route("/api/v1", createSkillRoutes(config));
+  app.onError((err, c) => {
+    const code = (err as { code?: string }).code ?? "internal_error";
+    const status = (err as { statusCode?: number }).statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode: status,
+      code,
+      message: err.message,
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, status as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  return app;
+}
+
+beforeEach(() => __resetRateLimitForTests());
+afterEach(() => __resetRateLimitForTests());
+
+/** A minimal valid skill ZIP as an ArrayBuffer (a valid `BodyInit`). */
+async function skillZipBytes(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  const folder = zip.folder("demo-skill")!;
+  folder.file(
+    "SKILL.md",
+    [
+      "---",
+      "name: demo-skill",
+      "description: A demo skill.",
+      "metadata:",
+      "  category: plain",
+      'version: "1.0"',
+      "---",
+      "# demo-skill",
+    ].join("\n"),
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+// ======================================================================
+// POST /skills
+// ======================================================================
+
+describe("POST /skills", () => {
+  test("401 when unauthenticated", async () => {
+    const app = buildApp({ authenticated: false });
+    const res = await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "content-type": "application/zip" },
+      body: new Uint8Array([1, 2, 3]),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("403 without ornn:skill:create", async () => {
+    const app = buildApp({ permissions: [READ] });
+    const res = await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "content-type": "application/zip" },
+      body: new Uint8Array([1, 2, 3]),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("400 invalid_content_type for a non-zip body", async () => {
+    const app = buildApp({ permissions: [CREATE] });
+    const res = await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { code: string }).code).toBe("invalid_content_type");
+  });
+
+  test("201 + Location, delegating to createSkill then getSkill", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      permissions: [CREATE],
+      service: {
+        createSkill: async () => {
+          calls.push("createSkill");
+          return { guid: "guid-1" };
+        },
+        getSkill: async () => {
+          calls.push("getSkill");
+          return detail();
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "content-type": "application/zip" },
+      body: await skillZipBytes(),
+    });
+    expect(res.status).toBe(201);
+    expect(res.headers.get("Location")).toBe("/api/v1/skills/guid-1");
+    expect(calls).toEqual(["createSkill", "getSkill"]);
+    const body = (await res.json()) as { data: { guid: string }; error: null };
+    expect(body.data.guid).toBe("guid-1");
+    expect(body.error).toBeNull();
+  });
+
+  test("400 empty_body for an empty zip body", async () => {
+    const app = buildApp({ permissions: [CREATE] });
+    const res = await app.request("/api/v1/skills", {
+      method: "POST",
+      headers: { "content-type": "application/zip" },
+      body: new Uint8Array([]),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { code: string }).code).toBe("empty_body");
+  });
+});
+
+// ======================================================================
+// POST /skills/pull
+// ======================================================================
+
+describe("POST /skills/pull", () => {
+  test("403 without create permission", async () => {
+    const app = buildApp({ permissions: [READ] });
+    const res = await app.request("/api/v1/skills/pull", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repo: "o/r" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("400 when neither githubUrl nor repo is provided", async () => {
+    const app = buildApp({ permissions: [CREATE] });
+    const res = await app.request("/api/v1/skills/pull", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("201 delegating to createSkillFromGitHub", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      permissions: [CREATE],
+      service: {
+        createSkillFromGitHub: async () => {
+          calls.push("createSkillFromGitHub");
+          return { guid: "guid-1", source: { type: "github", repo: "o/r", ref: "HEAD", path: "" } };
+        },
+        getSkill: async () => detail(),
+      },
+    });
+    const res = await app.request("/api/v1/skills/pull", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repo: "o/r" }),
+    });
+    expect(res.status).toBe(201);
+    expect(calls).toContain("createSkillFromGitHub");
+  });
+});
+
+// ======================================================================
+// POST /skills/:id/refresh
+// ======================================================================
+
+describe("POST /skills/:id/refresh", () => {
+  test("403 not_skill_owner for a non-owner non-admin", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [UPDATE],
+      service: { getSkill: async () => detail({ createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/refresh", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { code: string }).code).toBe("not_skill_owner");
+  });
+
+  test("owner triggers a real refresh (200)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      service: {
+        getSkill: async () => detail({ createdBy: OWNER }),
+        refreshSkillFromSource: async () => {
+          calls.push("refreshSkillFromSource");
+          return detail({ createdBy: OWNER });
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/refresh", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toContain("refreshSkillFromSource");
+  });
+
+  test("dryRun delegates to previewRefreshFromSource", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      service: {
+        getSkill: async () => detail({ createdBy: OWNER }),
+        previewRefreshFromSource: async () => {
+          calls.push("previewRefreshFromSource");
+          return { skill: { guid: "guid-1", name: "demo-skill" }, hasChanges: false };
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/refresh", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ dryRun: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["previewRefreshFromSource"]);
+  });
+});
+
+// ======================================================================
+// PUT /skills/:id/source
+// ======================================================================
+
+describe("PUT /skills/:id/source", () => {
+  test("403 for a non-owner", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [UPDATE],
+      service: { getSkill: async () => detail({ createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/source", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ githubUrl: "https://github.com/o/r" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("owner sets the source (200)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      service: {
+        getSkill: async () => detail({ createdBy: OWNER }),
+        setSkillSource: async () => {
+          calls.push("setSkillSource");
+          return detail({ createdBy: OWNER });
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/source", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ githubUrl: "https://github.com/o/r" }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toContain("setSkillSource");
+  });
+});
+
+// ======================================================================
+// GET /skills/:idOrName/json
+// ======================================================================
+
+describe("GET /skills/:idOrName/json", () => {
+  test("401 without auth", async () => {
+    const app = buildApp({ authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/json");
+    expect(res.status).toBe(401);
+  });
+
+  test("404 when a private skill is not readable by the caller", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [READ],
+      service: { getSkill: async () => detail({ isPrivate: true, createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/json");
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { code: string }).code).toBe("skill_not_found");
+  });
+
+  test("200 delegating to getSkillJson for a public skill", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      permissions: [READ],
+      service: {
+        getSkill: async () => detail({ isPrivate: false }),
+        getSkillJson: async () => {
+          calls.push("getSkillJson");
+          return { name: "demo-skill", description: "d", version: "1.0", metadata: {}, files: {} };
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/json");
+    expect(res.status).toBe(200);
+    expect(calls).toContain("getSkillJson");
+  });
+});
+
+// ======================================================================
+// GET /skills/:idOrName/versions
+// ======================================================================
+
+describe("GET /skills/:idOrName/versions", () => {
+  test("404 for an anonymous caller on a private skill", async () => {
+    const app = buildApp({
+      authenticated: false,
+      service: { getSkill: async () => detail({ isPrivate: true }) },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/versions");
+    expect(res.status).toBe(404);
+  });
+
+  test("200 with items for a public skill", async () => {
+    const app = buildApp({
+      authenticated: false,
+      service: {
+        getSkill: async () => detail({ isPrivate: false }),
+        listSkillVersions: async () => [{ version: "1.0" }],
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/versions");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { items: unknown[] } };
+    expect(body.data.items).toHaveLength(1);
+  });
+});
+
+// ======================================================================
+// GET /skills/:idOrName/versions/:from/diff/:to
+// ======================================================================
+
+describe("GET .../diff", () => {
+  test("200 delegating to diffVersions", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      authenticated: false,
+      service: {
+        getSkill: async () => detail({ isPrivate: false }),
+        diffVersions: async () => {
+          calls.push("diffVersions");
+          return { diff: {} };
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/versions/1.0/diff/1.1");
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["diffVersions"]);
+  });
+
+  test("404 for an anonymous caller on a private skill", async () => {
+    const app = buildApp({
+      authenticated: false,
+      service: { getSkill: async () => detail({ isPrivate: true }) },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/versions/1.0/diff/1.1");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ======================================================================
+// GET /skills/:idOrName
+// ======================================================================
+
+describe("GET /skills/:idOrName", () => {
+  test("200 for a public skill (anonymous)", async () => {
+    const app = buildApp({
+      authenticated: false,
+      service: { getSkill: async () => detail({ isPrivate: false }) },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { guid: string } };
+    expect(body.data.guid).toBe("guid-1");
+  });
+
+  test("404 for an anonymous caller on a private skill", async () => {
+    const app = buildApp({
+      authenticated: false,
+      service: { getSkill: async () => detail({ isPrivate: true }) },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill");
+    expect(res.status).toBe(404);
+  });
+
+  test("sets RFC 8594 Deprecation header on a deprecated skill", async () => {
+    const app = buildApp({
+      authenticated: false,
+      service: { getSkill: async () => detail({ isPrivate: false, isDeprecated: true }) },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Deprecation")).toBe("true");
+    expect(res.headers.get("Link")).toContain('rel="deprecation"');
+  });
+});
+
+// ======================================================================
+// PATCH /skills/:id/versions/:version (deprecation toggle)
+// ======================================================================
+
+describe("PATCH /skills/:id/versions/:version", () => {
+  test("404 when the skill is unknown", async () => {
+    const app = buildApp({ permissions: [UPDATE], repo: { findByGuid: async () => null } });
+    const res = await app.request("/api/v1/skills/guid-1/versions/1.0", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isDeprecated: true }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("403 when the caller cannot manage the skill", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/versions/1.0", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isDeprecated: true }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("200 delegating to setVersionDeprecation for the owner", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        setVersionDeprecation: async () => {
+          calls.push("setVersionDeprecation");
+          return { skillGuid: "guid-1", skillName: "demo-skill", version: "1.0", isDeprecated: true };
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/versions/1.0", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isDeprecated: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["setVersionDeprecation"]);
+  });
+});
+
+// ======================================================================
+// Dist-tags
+// ======================================================================
+
+describe("dist-tags routes", () => {
+  test("GET dist-tags 200 for a public skill", async () => {
+    const app = buildApp({
+      authenticated: false,
+      repo: { findByGuid: async () => skillDoc({ isPrivate: false }) },
+      service: { getDistTags: async () => ({ latest: "1.0" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/dist-tags");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { tags: Record<string, string> } };
+    expect(body.data.tags.latest).toBe("1.0");
+  });
+
+  test("GET dist-tags 404 for an unknown skill", async () => {
+    const app = buildApp({ authenticated: false, repo: { findByGuid: async () => null, findByName: async () => null } });
+    const res = await app.request("/api/v1/skills/guid-1/dist-tags");
+    expect(res.status).toBe(404);
+  });
+
+  test("PUT dist-tag 403 for a non-owner", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/dist-tags/beta", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ version: "1.0" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("PUT dist-tag 200 delegating to setDistTag (owner)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        setDistTag: async () => {
+          calls.push("setDistTag");
+          return { latest: "1.0", beta: "1.0" };
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/dist-tags/beta", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ version: "1.0" }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["setDistTag"]);
+  });
+
+  test("DELETE dist-tag 200 delegating to deleteDistTag (owner)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        deleteDistTag: async () => {
+          calls.push("deleteDistTag");
+          return { latest: "1.0" };
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/dist-tags/beta", { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["deleteDistTag"]);
+  });
+});
+
+// ======================================================================
+// PUT /skills/:id
+// ======================================================================
+
+describe("PUT /skills/:id", () => {
+  test("404 when the skill is unknown", async () => {
+    const app = buildApp({ permissions: [UPDATE], repo: { findByGuid: async () => null } });
+    const res = await app.request("/api/v1/skills/guid-1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isPrivate: true }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("403 when the caller cannot manage", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isPrivate: true }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("400 no_update when neither zip nor isPrivate is supplied", async () => {
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { code: string }).code).toBe("no_update");
+  });
+
+  test("200 JSON visibility update delegating to updateSkill (owner)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        updateSkill: async () => {
+          calls.push("updateSkill");
+          return detail({ createdBy: OWNER });
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isPrivate: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["updateSkill"]);
+  });
+
+  test("200 ZIP republish delegating to updateSkill (owner)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        updateSkill: async () => {
+          calls.push("updateSkill");
+          return detail({ createdBy: OWNER });
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1", {
+      method: "PUT",
+      headers: { "content-type": "application/zip" },
+      body: await skillZipBytes(),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["updateSkill"]);
+  });
+});
+
+// ======================================================================
+// PUT /skills/:id/permissions
+// ======================================================================
+
+describe("PUT /skills/:id/permissions", () => {
+  test("403 for a non-owner", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/permissions", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isPrivate: false }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("200 delegating to setSkillPermissions (owner)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        setSkillPermissions: async () => {
+          calls.push("setSkillPermissions");
+          return detail({ createdBy: OWNER });
+        },
+        getSkill: async () => detail({ createdBy: OWNER }),
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/permissions", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isPrivate: false, sharedWithUsers: [], sharedWithOrgs: [] }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toContain("setSkillPermissions");
+  });
+});
+
+// ======================================================================
+// PUT /skills/:id/nyxid-service
+// ======================================================================
+
+describe("PUT /skills/:id/nyxid-service", () => {
+  test("403 for a non-owner", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/nyxid-service", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ nyxidServiceId: "svc-1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("200 delegating to tieToNyxidService (owner)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        tieToNyxidService: async () => {
+          calls.push("tieToNyxidService");
+          return detail({ createdBy: OWNER });
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/nyxid-service", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ nyxidServiceId: null }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["tieToNyxidService"]);
+  });
+});
+
+// ======================================================================
+// GET /nyxid-services/:serviceId/skills
+// ======================================================================
+
+describe("GET /nyxid-services/:serviceId/skills", () => {
+  test("404 when the caller has no forwarded token", async () => {
+    const app = buildApp({ permissions: [READ] });
+    const res = await app.request("/api/v1/nyxid-services/svc-1/skills");
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { code: string }).code).toBe("NYXID_SERVICE_NOT_FOUND");
+  });
+
+  test("404 when the service is not visible to the caller", async () => {
+    const app = buildApp({
+      permissions: [READ],
+      userAccessToken: "tok-1",
+      nyxidServiceClient: { findVisibleToCaller: async () => null },
+    });
+    const res = await app.request("/api/v1/nyxid-services/svc-1/skills");
+    expect(res.status).toBe(404);
+  });
+
+  test("200 listing skills for an admin (public) service", async () => {
+    const app = buildApp({
+      permissions: [READ],
+      userAccessToken: "tok-1",
+      nyxidServiceClient: {
+        findVisibleToCaller: async () => ({
+          id: "svc-1",
+          slug: "svc-1",
+          label: "Service 1",
+          visibility: "public",
+          createdBy: "admin-x",
+        }),
+      },
+      repo: {
+        findByNyxidService: async () => ({
+          skills: [
+            {
+              guid: "guid-1",
+              name: "demo-skill",
+              description: "a demo",
+              createdBy: OWNER,
+              createdOn: new Date("2026-01-01T00:00:00Z"),
+              updatedOn: new Date("2026-01-01T00:00:00Z"),
+              isPrivate: false,
+              metadata: { category: "plain", tags: ["x"] },
+              isSystemSkill: true,
+            },
+          ],
+          total: 1,
+        }),
+      },
+    });
+    const res = await app.request("/api/v1/nyxid-services/svc-1/skills");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { items: Array<{ guid: string }>; total: number; service: { tier: string } };
+    };
+    expect(body.data.total).toBe(1);
+    expect(body.data.items[0]!.guid).toBe("guid-1");
+    expect(body.data.service.tier).toBe("admin");
+  });
+
+  test("404 on a personal service the caller does not own", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [READ],
+      userAccessToken: "tok-1",
+      nyxidServiceClient: {
+        findVisibleToCaller: async () => ({
+          id: "svc-1",
+          slug: "svc-1",
+          label: "Service 1",
+          visibility: "private",
+          createdBy: "someone-else",
+        }),
+      },
+    });
+    const res = await app.request("/api/v1/nyxid-services/svc-1/skills");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PUT /skills/:id/nyxid-service — synthetic service", () => {
+  test("ties to a synthetic:<slug> service from EXTRA_NYXID_SERVICES", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      userAccessToken: "tok-1",
+      extraNyxidServices: ["My Synthetic Service"],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        tieToNyxidService: async (...args: unknown[]) => {
+          calls.push("tieToNyxidService");
+          // Drive the route's synthetic resolver to assert it short-circuits
+          // the NyxID round-trip for a `synthetic:` id.
+          const lookup = args[3] as (id: string) => Promise<unknown>;
+          const resolved = (await lookup("synthetic:my-synthetic-service")) as {
+            visibility: string;
+          } | null;
+          expect(resolved?.visibility).toBe("public");
+          return detail({ createdBy: OWNER, isSystemSkill: true, isPrivate: false });
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/nyxid-service", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ nyxidServiceId: "synthetic:my-synthetic-service" }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["tieToNyxidService"]);
+  });
+});
+
+// ======================================================================
+// DELETE /skills/:id
+// ======================================================================
+
+describe("DELETE /skills/:id", () => {
+  test("403 without delete permission", async () => {
+    const app = buildApp({ permissions: [UPDATE] });
+    const res = await app.request("/api/v1/skills/guid-1", { method: "DELETE" });
+    expect(res.status).toBe(403);
+  });
+
+  test("404 when the skill is unknown", async () => {
+    const app = buildApp({ permissions: [DELETE], repo: { findByGuid: async () => null } });
+    const res = await app.request("/api/v1/skills/guid-1", { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+
+  test("200 delegating to deleteSkill (owner)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [DELETE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        deleteSkill: async () => {
+          calls.push("deleteSkill");
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1", { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["deleteSkill"]);
+    const body = (await res.json()) as { data: { success: boolean } };
+    expect(body.data.success).toBe(true);
+  });
+});
+
+// ======================================================================
+// DELETE /skills/:id/versions/:version
+// ======================================================================
+
+describe("DELETE /skills/:id/versions/:version", () => {
+  test("403 when the caller cannot manage", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [DELETE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: "someone-else" }) },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/versions/1.0", { method: "DELETE" });
+    expect(res.status).toBe(403);
+  });
+
+  test("200 delegating to deleteVersion (owner)", async () => {
+    const calls: string[] = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [DELETE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: {
+        deleteVersion: async () => {
+          calls.push("deleteVersion");
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/guid-1/versions/1.0", { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(["deleteVersion"]);
+  });
+});

--- a/ornn-api/src/domains/skills/crud/routes.test.ts
+++ b/ornn-api/src/domains/skills/crud/routes.test.ts
@@ -28,7 +28,6 @@ import { Hono } from "hono";
 import JSZip from "jszip";
 import { createSkillRoutes, type SkillRoutesConfig } from "./routes";
 import {
-  AppError,
   buildProblemJsonBody,
   type SkillDetailResponse,
   type SkillDocument,
@@ -39,7 +38,6 @@ const CREATE = "ornn:skill:create";
 const READ = "ornn:skill:read";
 const UPDATE = "ornn:skill:update";
 const DELETE = "ornn:skill:delete";
-const ADMIN = "ornn:admin:skill";
 const OWNER = "owner-1";
 
 // ---- Fixtures --------------------------------------------------------

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -17,14 +17,14 @@
  * download + extraction runs hermetically (no MinIO, no network).
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import JSZip from "jszip";
-import { SkillService } from "./service";
+import { SkillService, resolveDistTag, isValidTagName, type SkillServiceDeps } from "./service";
 import { SYSTEM_ACTOR, canReadSkill, type ActorContext } from "./authorize";
 import type { SkillRepository } from "./repository";
 import type { SkillVersionRepository } from "./skillVersionRepository";
 import type { IStorageClient } from "../../../clients/storageClient";
-import type { SkillDocument } from "../../../shared/types/index";
+import type { SkillDocument, SkillVersionDocument } from "../../../shared/types/index";
 import { AppError } from "../../../shared/types/index";
 
 const SECRET_BODY = "SECRET_FROM_PACKAGE_b91c";
@@ -457,5 +457,697 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
     expect(msg).not.toContain("org-A");
     // Atomic — no partial persistence of the member org.
     expect(state.updateCalled).toBe(false);
+  });
+});
+
+// ======================================================================
+// #874 — broad SkillService coverage via DI fakes (no memory-server).
+//
+// A `makeService(overrides)` builder hands back a service whose repo /
+// version-repo / storage are fully stubbable; un-stubbed methods are
+// either irrelevant to the path under test or supplied per-test. All
+// fakes are in-memory and hermetic.
+// ======================================================================
+
+interface FakeState {
+  skills: Map<string, SkillDocument>;
+  byName: Map<string, SkillDocument>;
+  versions: SkillVersionDocument[];
+  distTags: Map<string, Record<string, string>>;
+  uploads: Array<{ key: string; bytes: number }>;
+  deletes: string[];
+}
+
+function versionDoc(overrides: Partial<SkillVersionDocument> = {}): SkillVersionDocument {
+  return {
+    _id: "guid-1@1.0",
+    skillGuid: "guid-1",
+    version: "1.0",
+    majorVersion: 1,
+    minorVersion: 0,
+    storageKey: "skills/guid-1/1.0.zip",
+    skillHash: "hash-1",
+    metadata: { category: "plain" },
+    license: null,
+    compatibility: null,
+    createdBy: "owner-1",
+    createdOn: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as SkillVersionDocument;
+}
+
+/** Build a valid SKILL.md ZIP as raw bytes (for createSkill / updateSkill). */
+async function validSkillZip(opts: { name?: string; version?: string } = {}): Promise<Uint8Array> {
+  const { name = "demo-skill", version = "1.0" } = opts;
+  const zip = new JSZip();
+  const folder = zip.folder(name)!;
+  folder.file(
+    "SKILL.md",
+    [
+      "---",
+      `name: ${name}`,
+      "description: A demo skill used by service tests.",
+      "metadata:",
+      "  category: plain",
+      `version: "${version}"`,
+      "---",
+      `# ${name}`,
+    ].join("\n"),
+  );
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+function makeFakeDeps(seed?: Partial<FakeState>): { deps: SkillServiceDeps; state: FakeState } {
+  const state: FakeState = {
+    skills: seed?.skills ?? new Map(),
+    byName: seed?.byName ?? new Map(),
+    versions: seed?.versions ?? [],
+    distTags: seed?.distTags ?? new Map(),
+    uploads: [],
+    deletes: [],
+  };
+
+  const skillRepo = {
+    findByGuid: async (guid: string) => state.skills.get(guid) ?? null,
+    findByName: async (name: string) => state.byName.get(name) ?? null,
+    create: async (data: { guid: string; name: string; latestVersion: string }) => {
+      const doc = makeSkillDoc({
+        guid: data.guid,
+        name: data.name,
+        latestVersion: data.latestVersion,
+        isPrivate: true,
+      });
+      state.skills.set(data.guid, doc);
+      state.byName.set(data.name, doc);
+      return doc;
+    },
+    update: async (guid: string, patch: Record<string, unknown>) => {
+      const cur = state.skills.get(guid)!;
+      const next = { ...cur, ...patch } as SkillDocument;
+      state.skills.set(guid, next);
+      state.byName.set(next.name, next);
+      return next;
+    },
+    setDistTag: async (guid: string, tag: string, version: string) => {
+      const tags = state.distTags.get(guid) ?? {};
+      tags[tag] = version;
+      state.distTags.set(guid, tags);
+      // Reflect on the stored doc so getDistTags (which re-reads the skill)
+      // sees the change — mirrors the real dotted-path $set.
+      const cur = state.skills.get(guid);
+      if (cur) state.skills.set(guid, { ...cur, distTags: { ...tags } } as SkillDocument);
+    },
+    deleteDistTag: async (guid: string, tag: string) => {
+      const tags = state.distTags.get(guid) ?? {};
+      delete tags[tag];
+      state.distTags.set(guid, tags);
+      const cur = state.skills.get(guid);
+      if (cur) state.skills.set(guid, { ...cur, distTags: { ...tags } } as SkillDocument);
+    },
+    clearSource: async (guid: string) => {
+      const cur = state.skills.get(guid);
+      if (!cur) return null;
+      const next = { ...cur, source: undefined } as SkillDocument;
+      state.skills.set(guid, next);
+      state.byName.set(next.name, next);
+      return next;
+    },
+    setNyxidService: async (guid: string, data: Record<string, unknown>) => {
+      const cur = state.skills.get(guid)!;
+      const next = { ...cur, ...data } as SkillDocument;
+      state.skills.set(guid, next);
+      return next;
+    },
+    hardDelete: async (guid: string) => {
+      const doc = state.skills.get(guid);
+      if (doc) state.byName.delete(doc.name);
+      state.skills.delete(guid);
+    },
+  } as unknown as SkillRepository;
+
+  const skillVersionRepo = {
+    create: async (data: { version: string; majorVersion: number; minorVersion: number }) => {
+      const v = versionDoc({
+        _id: `guid-1@${data.version}`,
+        version: data.version,
+        majorVersion: data.majorVersion,
+        minorVersion: data.minorVersion,
+      });
+      state.versions.push(v);
+      return v;
+    },
+    findBySkillAndVersion: async (guid: string, version: string) =>
+      state.versions.find((v) => v.skillGuid === guid && v.version === version) ?? null,
+    findLatestBySkill: async (guid: string) => {
+      const list = state.versions
+        .filter((v) => v.skillGuid === guid)
+        .sort((a, b) => b.majorVersion - a.majorVersion || b.minorVersion - a.minorVersion);
+      return list[0] ?? null;
+    },
+    listBySkill: async (guid: string) =>
+      state.versions
+        .filter((v) => v.skillGuid === guid)
+        .sort((a, b) => b.majorVersion - a.majorVersion || b.minorVersion - a.minorVersion),
+    deleteOne: async () => true,
+    deleteAllBySkill: async (guid: string) => {
+      const before = state.versions.length;
+      state.versions = state.versions.filter((v) => v.skillGuid !== guid);
+      return before - state.versions.length;
+    },
+    setDeprecation: async (
+      guid: string,
+      version: string,
+      isDeprecated: boolean,
+      note?: string | null,
+    ) => {
+      const v = state.versions.find((x) => x.skillGuid === guid && x.version === version);
+      if (!v) throw AppError.notFound("skill_version_not_found", "missing");
+      v.isDeprecated = isDeprecated;
+      v.deprecationNote = isDeprecated ? note ?? null : null;
+      return v;
+    },
+  } as unknown as SkillVersionRepository;
+
+  const storageClient = {
+    upload: async (_bucket: string, key: string, data: Uint8Array) => {
+      state.uploads.push({ key, bytes: data.byteLength });
+      return { url: `https://storage.test/${key}` };
+    },
+    delete: async (_bucket: string, key: string) => {
+      state.deletes.push(key);
+    },
+    getPresignedUrl: async () => ({ presignedUrl: "http://unused", expiresAt: "" }),
+  } as unknown as IStorageClient;
+
+  return {
+    deps: { skillRepo, skillVersionRepo, storageClient, storageBucketResolver: async () => "test-bucket" },
+    state,
+  };
+}
+
+describe("resolveDistTag / isValidTagName (#463)", () => {
+  it("isValidTagName accepts npm-style tags and rejects bad shapes", () => {
+    expect(isValidTagName("beta")).toBe(true);
+    expect(isValidTagName("rc-1")).toBe(true);
+    expect(isValidTagName("1beta")).toBe(false); // must start with a letter
+    expect(isValidTagName("Beta")).toBe(false); // uppercase
+    expect(isValidTagName("")).toBe(false);
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(resolveDistTag(makeSkillDoc(), "")).toBeUndefined();
+  });
+
+  it("returns a literal version verbatim", () => {
+    expect(resolveDistTag(makeSkillDoc(), "1.2")).toBe("1.2");
+  });
+
+  it("resolves a known dist-tag", () => {
+    const skill = makeSkillDoc({ distTags: { beta: "1.1" } });
+    expect(resolveDistTag(skill, "@beta")).toBe("1.1");
+  });
+
+  it("falls back to latestVersion for @latest on a legacy skill", () => {
+    const skill = makeSkillDoc({ latestVersion: "2.0", distTags: undefined });
+    expect(resolveDistTag(skill, "@latest")).toBe("2.0");
+  });
+
+  it("throws 400 for an empty @-tag", () => {
+    let thrown: unknown;
+    try {
+      resolveDistTag(makeSkillDoc(), "@");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("invalid_dist_tag");
+  });
+
+  it("throws 404 for an unknown tag", () => {
+    let thrown: unknown;
+    try {
+      resolveDistTag(makeSkillDoc(), "@nope");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("skill_version_not_found");
+  });
+});
+
+describe("SkillService.createSkill", () => {
+  it("validates, uploads, persists, version-creates and seeds latest dist-tag", async () => {
+    const { deps, state } = makeFakeDeps();
+    const service = new SkillService(deps);
+    const { guid } = await service.createSkill(await validSkillZip(), "owner-1");
+    expect(guid).toBeTruthy();
+    // Uploaded a versioned blob + created a version row + latest tag.
+    expect(state.uploads).toHaveLength(1);
+    expect(state.versions).toHaveLength(1);
+    const created = [...state.skills.values()][0]!;
+    expect(state.distTags.get(created.guid)?.latest).toBe("1.0");
+  });
+
+  it("rejects a reserved-verb name", async () => {
+    const { deps } = makeFakeDeps();
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.createSkill(await validSkillZip({ name: "search" }), "owner-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("reserved_name");
+  });
+
+  it("rejects a name conflict", async () => {
+    const existing = makeSkillDoc({ guid: "other", name: "demo-skill" });
+    const { deps } = makeFakeDeps({ byName: new Map([["demo-skill", existing]]) });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.createSkill(await validSkillZip(), "owner-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("skill_name_exists");
+  });
+});
+
+describe("SkillService.updateSkill", () => {
+  it("JSON visibility-only update touches the doc, not storage", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", isPrivate: true });
+    const { deps, state } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+    });
+    const service = new SkillService(deps);
+    const updated = await service.updateSkill("guid-1", "owner-1", { isPrivate: false });
+    expect(updated.isPrivate).toBe(false);
+    expect(state.uploads).toHaveLength(0);
+  });
+
+  it("ZIP republish uploads a new version + bumps latest", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", isPrivate: false, latestVersion: "1.0" });
+    const { deps, state } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 })],
+    });
+    const service = new SkillService(deps);
+    await service.updateSkill("guid-1", "owner-1", { zipBuffer: await validSkillZip({ version: "1.1" }) });
+    expect(state.uploads).toHaveLength(1);
+    expect(state.versions.map((v) => v.version)).toContain("1.1");
+    expect(state.distTags.get("guid-1")?.latest).toBe("1.1");
+  });
+
+  it("rejects a non-incrementing version", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", latestVersion: "2.0" });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc({ version: "2.0", majorVersion: 2, minorVersion: 0 })],
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.updateSkill("guid-1", "owner-1", { zipBuffer: await validSkillZip({ version: "1.1" }) });
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("VERSION_NOT_INCREMENTED");
+  });
+
+  it("404 when the skill is unknown", async () => {
+    const { deps } = makeFakeDeps();
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.updateSkill("nope", "owner-1", { isPrivate: false });
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("skill_not_found");
+  });
+});
+
+describe("SkillService.getSkill / dist-tags / versions", () => {
+  function seededService() {
+    const skill = makeSkillDoc({ guid: "guid-1", latestVersion: "1.0", distTags: { beta: "1.0" } });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 })],
+    });
+    return new SkillService(deps);
+  }
+
+  it("getSkill (latest) returns a detail response", async () => {
+    const res = await seededService().getSkill("guid-1");
+    expect(res.guid).toBe("guid-1");
+    expect(res.version).toBe("1.0");
+  });
+
+  it("getSkill (specific version) overlays that version", async () => {
+    const res = await seededService().getSkill("guid-1", "1.0");
+    expect(res.version).toBe("1.0");
+  });
+
+  it("getSkill 404 for an unknown version", async () => {
+    let thrown: unknown;
+    try {
+      await seededService().getSkill("guid-1", "9.9");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("skill_version_not_found");
+  });
+
+  it("getDistTags always synthesizes latest", async () => {
+    const tags = await seededService().getDistTags("guid-1");
+    expect(tags.latest).toBe("1.0");
+    expect(tags.beta).toBe("1.0");
+  });
+
+  it("setDistTag rejects the immutable `latest`", async () => {
+    let thrown: unknown;
+    try {
+      await seededService().setDistTag("guid-1", "latest", "1.0");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("dist_tag_immutable");
+  });
+
+  it("setDistTag rejects an invalid tag name", async () => {
+    let thrown: unknown;
+    try {
+      await seededService().setDistTag("guid-1", "Bad Tag", "1.0");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("invalid_dist_tag");
+  });
+
+  it("setDistTag 404 when the target version is unknown", async () => {
+    let thrown: unknown;
+    try {
+      await seededService().setDistTag("guid-1", "beta", "9.9");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("skill_version_not_found");
+  });
+
+  it("setDistTag persists a valid tag", async () => {
+    const svc = seededService();
+    const tags = await svc.setDistTag("guid-1", "stable", "1.0");
+    expect(tags.stable).toBe("1.0");
+  });
+
+  it("deleteDistTag rejects the immutable `latest`", async () => {
+    let thrown: unknown;
+    try {
+      await seededService().deleteDistTag("guid-1", "latest");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("dist_tag_immutable");
+  });
+
+  it("listSkillVersions returns the integrity-augmented list", async () => {
+    const list = await seededService().listSkillVersions("guid-1");
+    expect(list).toHaveLength(1);
+    expect(list[0]!.version).toBe("1.0");
+    expect(list[0]!.integrity.startsWith("sha256-")).toBe(true);
+  });
+
+  it("setVersionDeprecation toggles the flag", async () => {
+    const res = await seededService().setVersionDeprecation("guid-1", "1.0", true, "deprecated");
+    expect(res.isDeprecated).toBe(true);
+    expect(res.deprecationNote).toBe("deprecated");
+  });
+});
+
+describe("SkillService.deleteVersion / deleteSkill", () => {
+  it("deleteSkill cascades version rows + storage cleanup", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1" });
+    const { deps, state } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 })],
+    });
+    const service = new SkillService(deps);
+    await service.deleteSkill("guid-1");
+    expect(state.skills.has("guid-1")).toBe(false);
+    expect(state.versions).toHaveLength(0);
+    expect(state.deletes.length).toBeGreaterThan(0);
+  });
+
+  it("deleteVersion refuses the only remaining version", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", latestVersion: "1.0" });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 })],
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.deleteVersion("guid-1", "1.0");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("SKILL_VERSION_LAST");
+  });
+
+  it("deleteVersion refuses the current latest", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", latestVersion: "1.1" });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [
+        versionDoc({ version: "1.1", majorVersion: 1, minorVersion: 1 }),
+        versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 }),
+      ],
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.deleteVersion("guid-1", "1.1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("SKILL_VERSION_LATEST");
+  });
+
+  it("deleteVersion removes a non-latest version", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", latestVersion: "1.1" });
+    const { deps, state } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [
+        versionDoc({ version: "1.1", majorVersion: 1, minorVersion: 1 }),
+        versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 }),
+      ],
+    });
+    const service = new SkillService(deps);
+    await service.deleteVersion("guid-1", "1.0");
+    expect(state.deletes.length).toBeGreaterThan(0);
+  });
+});
+
+describe("SkillService.tieToNyxidService", () => {
+  function tieService() {
+    const skill = makeSkillDoc({ guid: "guid-1", isPrivate: true });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc()],
+    });
+    return new SkillService(deps);
+  }
+
+  it("untie (serviceId=null) clears the tie", async () => {
+    const res = await tieService().tieToNyxidService("guid-1", null, { userId: "owner-1", isPlatformAdmin: false }, async () => null);
+    expect(res.nyxidServiceId).toBeNull();
+  });
+
+  it("404 when the service lookup returns null", async () => {
+    let thrown: unknown;
+    try {
+      await tieService().tieToNyxidService("guid-1", "svc-1", { userId: "owner-1", isPlatformAdmin: false }, async () => null);
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("NYXID_SERVICE_NOT_FOUND");
+  });
+
+  it("ties to an admin service and forces public", async () => {
+    const res = await tieService().tieToNyxidService(
+      "guid-1",
+      "svc-1",
+      { userId: "owner-1", isPlatformAdmin: false },
+      async () => ({ id: "svc-1", slug: "svc-1", label: "Service 1", visibility: "public", createdBy: "x" }),
+    );
+    expect(res.isSystemSkill).toBe(true);
+    expect(res.isPrivate).toBe(false);
+  });
+
+  it("rejects tying to another user's personal service", async () => {
+    let thrown: unknown;
+    try {
+      await tieService().tieToNyxidService(
+        "guid-1",
+        "svc-1",
+        { userId: "owner-1", isPlatformAdmin: false },
+        async () => ({ id: "svc-1", slug: "svc-1", label: "Service 1", visibility: "private", createdBy: "other-user" }),
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("NYXID_SERVICE_NOT_ELIGIBLE");
+  });
+});
+
+describe("SkillService.diffVersions", () => {
+  it("rejects identical from/to versions", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1" });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.diffVersions("guid-1", "1.0", "1.0");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("same_version");
+  });
+
+  it("404 when a version is unknown", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1" });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 })],
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.diffVersions("guid-1", "1.0", "9.9");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("skill_version_not_found");
+  });
+});
+
+describe("SkillService.setSkillSource / refresh / preview (globalThis.fetch swap)", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("setSkillSource(null) clears the source", async () => {
+    const skill = makeSkillDoc({
+      guid: "guid-1",
+      source: { type: "github", repo: "o/r", ref: "main", path: "" },
+    });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc()],
+    });
+    const service = new SkillService(deps);
+    const res = await service.setSkillSource("guid-1", null, "owner-1");
+    expect(res.source).toBeUndefined();
+  });
+
+  it("setSkillSource parses a GitHub URL and stores the pointer", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1" });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc()],
+    });
+    const service = new SkillService(deps);
+    const res = await service.setSkillSource("guid-1", "https://github.com/owner/repo", "owner-1");
+    expect(res.source?.repo).toBe("owner/repo");
+  });
+
+  it("setSkillSource rejects a malformed GitHub URL", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1" });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.setSkillSource("guid-1", "not-a-github-url", "owner-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("invalid_github_url");
+  });
+
+  it("refreshSkillFromSource rejects a skill with no source", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", source: undefined });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.refreshSkillFromSource("guid-1", "owner-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("NO_SOURCE");
+  });
+
+  it("previewRefreshFromSource rejects a skill with no source", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", source: undefined });
+    const { deps } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.previewRefreshFromSource("guid-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("NO_SOURCE");
+  });
+});
+
+describe("SkillService.validateZipFormat", () => {
+  it("flags a non-ZIP buffer", async () => {
+    const { deps } = makeFakeDeps();
+    const service = new SkillService(deps);
+    const violations = await service.validateZipFormat(new Uint8Array([1, 2, 3, 4]));
+    expect(violations.some((v) => v.rule === "valid-zip")).toBe(true);
+  });
+
+  it("passes a well-formed package with zero violations", async () => {
+    const { deps } = makeFakeDeps();
+    const service = new SkillService(deps);
+    const violations = await service.validateZipFormat(await validSkillZip());
+    expect(violations).toEqual([]);
+  });
+
+  it("flags a missing SKILL.md", async () => {
+    const zip = new JSZip();
+    zip.folder("demo-skill")!.file("notes.txt", "hi");
+    const buf = await zip.generateAsync({ type: "uint8array" });
+    const { deps } = makeFakeDeps();
+    const service = new SkillService(deps);
+    const violations = await service.validateZipFormat(buf);
+    expect(violations.some((v) => v.rule === "skill-md-exists" || v.rule === "allowed-root-items")).toBe(true);
   });
 });

--- a/ornn-api/src/domains/skills/crud/skillVersionRepository.test.ts
+++ b/ornn-api/src/domains/skills/crud/skillVersionRepository.test.ts
@@ -1,0 +1,297 @@
+/**
+ * SkillVersionRepository unit tests (#874).
+ *
+ * Backed by mongodb-memory-server (mirrors the notifications / audit
+ * repository test harness). The `skill_versions` collection keys each
+ * immutable snapshot by `_id = ${skillGuid}@${version}`, giving free
+ * uniqueness on (skillGuid, version). Pins:
+ *   - ensureIndexes resolves
+ *   - create assigns defaults + round-trips through mapDoc, duplicate
+ *     `_id` → SKILL_VERSION_EXISTS conflict
+ *   - findBySkillAndVersion hit / miss
+ *   - findLatestBySkill + listBySkill order major/minor desc (seeded
+ *     out of order)
+ *   - deleteAllBySkill returns the cascade count
+ *   - deleteOne true / false
+ *   - setAgentsealScan persists, mapScan nulls a malformed record
+ *   - setDeprecation on (note + null-note) / off (clears) / missing → 404
+ *
+ * @module domains/skills/crud/skillVersionRepository.test
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { MongoClient, type Db } from "mongodb";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  SkillVersionRepository,
+  type CreateSkillVersionData,
+  type AgentsealScanRecord,
+} from "./skillVersionRepository";
+import { AppError } from "../../../shared/types/index";
+import type { SkillMetadata } from "../../../shared/types/index";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: SkillVersionRepository;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("skill_versions_test");
+  repo = new SkillVersionRepository(db);
+  await repo.ensureIndexes();
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("skill_versions").deleteMany({});
+});
+
+// ---- Fixtures --------------------------------------------------------
+
+const META: SkillMetadata = { category: "plain", tags: ["alpha"] };
+
+function createInput(
+  overrides: Partial<CreateSkillVersionData> = {},
+): CreateSkillVersionData {
+  return {
+    skillGuid: "skill-1",
+    version: "1.0",
+    majorVersion: 1,
+    minorVersion: 0,
+    storageKey: "skills/skill-1/1.0.zip",
+    skillHash: "hash-10",
+    metadata: META,
+    createdBy: "user-1",
+    ...overrides,
+  };
+}
+
+/** Seed a version row straight into Mongo, bypassing the repo. */
+async function seedRaw(doc: Record<string, unknown>): Promise<void> {
+  await db.collection("skill_versions").insertOne(doc as never);
+}
+
+const scanRecord: AgentsealScanRecord = {
+  score: 88,
+  findings: [{ rule: "demo", severity: "low" }],
+  scannedAt: "2026-01-01T00:00:00.000Z",
+  agentsealVersion: "0.3.1",
+  scannedFiles: 4,
+};
+
+describe("ensureIndexes", () => {
+  test("resolves without throwing (idempotent across calls)", async () => {
+    await expect(repo.ensureIndexes()).resolves.toBeUndefined();
+    await expect(repo.ensureIndexes()).resolves.toBeUndefined();
+  });
+});
+
+describe("create", () => {
+  test("persists with _id = guid@version and applies null defaults", async () => {
+    const created = await repo.create(createInput());
+    expect(created._id).toBe("skill-1@1.0");
+    expect(created.skillGuid).toBe("skill-1");
+    expect(created.version).toBe("1.0");
+    // Unset optionals coerce to null on the doc, undefined on the mapped view.
+    expect(created.license).toBeNull();
+    expect(created.compatibility).toBeNull();
+    expect(created.createdByEmail).toBeUndefined();
+    expect(created.createdByDisplayName).toBeUndefined();
+    expect(created.releaseNotes).toBeNull();
+    expect(created.isDeprecated).toBe(false);
+    expect(created.deprecationNote).toBeNull();
+    expect(created.agentsealScan).toBeNull();
+    expect(created.createdOn).toBeInstanceOf(Date);
+  });
+
+  test("preserves the supplied optional fields", async () => {
+    const created = await repo.create(
+      createInput({
+        license: "MIT",
+        compatibility: "claude>=3",
+        createdByEmail: "a@test.local",
+        createdByDisplayName: "Author",
+        releaseNotes: "first cut",
+        createdOn: new Date("2026-02-02T00:00:00Z"),
+      }),
+    );
+    expect(created.license).toBe("MIT");
+    expect(created.compatibility).toBe("claude>=3");
+    expect(created.createdByEmail).toBe("a@test.local");
+    expect(created.createdByDisplayName).toBe("Author");
+    expect(created.releaseNotes).toBe("first cut");
+    expect(created.createdOn.toISOString()).toBe("2026-02-02T00:00:00.000Z");
+  });
+
+  test("a duplicate (skillGuid, version) throws SKILL_VERSION_EXISTS", async () => {
+    await repo.create(createInput());
+    let thrown: unknown;
+    try {
+      await repo.create(createInput());
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("SKILL_VERSION_EXISTS");
+    expect((thrown as AppError).statusCode).toBe(409);
+  });
+});
+
+describe("findBySkillAndVersion", () => {
+  test("returns the matching version", async () => {
+    await repo.create(createInput());
+    const found = await repo.findBySkillAndVersion("skill-1", "1.0");
+    expect(found).not.toBeNull();
+    expect(found!._id).toBe("skill-1@1.0");
+  });
+
+  test("returns null when no row matches", async () => {
+    expect(await repo.findBySkillAndVersion("skill-1", "9.9")).toBeNull();
+  });
+});
+
+describe("findLatestBySkill / listBySkill ordering", () => {
+  // Seed deliberately out of insertion order so the major/minor desc sort
+  // is exercised rather than insertion order.
+  async function seedThree(): Promise<void> {
+    await repo.create(createInput({ version: "1.1", majorVersion: 1, minorVersion: 1 }));
+    await repo.create(createInput({ version: "2.0", majorVersion: 2, minorVersion: 0 }));
+    await repo.create(createInput({ version: "1.0", majorVersion: 1, minorVersion: 0 }));
+  }
+
+  test("findLatestBySkill returns the highest major/minor", async () => {
+    await seedThree();
+    const latest = await repo.findLatestBySkill("skill-1");
+    expect(latest!.version).toBe("2.0");
+  });
+
+  test("findLatestBySkill returns null for an unknown skill", async () => {
+    expect(await repo.findLatestBySkill("nope")).toBeNull();
+  });
+
+  test("listBySkill returns every version newest-first", async () => {
+    await seedThree();
+    const rows = await repo.listBySkill("skill-1");
+    expect(rows.map((r) => r.version)).toEqual(["2.0", "1.1", "1.0"]);
+  });
+
+  test("listBySkill returns [] for an unknown skill", async () => {
+    expect(await repo.listBySkill("nope")).toEqual([]);
+  });
+});
+
+describe("deleteAllBySkill", () => {
+  test("removes every version of the skill and returns the count", async () => {
+    await repo.create(createInput({ version: "1.0", majorVersion: 1, minorVersion: 0 }));
+    await repo.create(createInput({ version: "1.1", majorVersion: 1, minorVersion: 1 }));
+    // A sibling skill must be untouched.
+    await repo.create(
+      createInput({ skillGuid: "skill-2", version: "1.0", majorVersion: 1, minorVersion: 0 }),
+    );
+    const deleted = await repo.deleteAllBySkill("skill-1");
+    expect(deleted).toBe(2);
+    expect(await repo.listBySkill("skill-1")).toEqual([]);
+    expect(await repo.listBySkill("skill-2")).toHaveLength(1);
+  });
+
+  test("returns 0 when nothing matches", async () => {
+    expect(await repo.deleteAllBySkill("nope")).toBe(0);
+  });
+});
+
+describe("deleteOne", () => {
+  test("returns true when the row existed", async () => {
+    await repo.create(createInput());
+    expect(await repo.deleteOne("skill-1", "1.0")).toBe(true);
+    expect(await repo.findBySkillAndVersion("skill-1", "1.0")).toBeNull();
+  });
+
+  test("returns false when nothing was deleted", async () => {
+    expect(await repo.deleteOne("skill-1", "1.0")).toBe(false);
+  });
+});
+
+describe("setAgentsealScan", () => {
+  test("persists the scan record on the version doc", async () => {
+    await repo.create(createInput());
+    const updated = await repo.setAgentsealScan("skill-1", "1.0", scanRecord);
+    expect(updated).not.toBeNull();
+    expect(updated!.agentsealScan).not.toBeNull();
+    expect(updated!.agentsealScan!.score).toBe(88);
+    expect(updated!.agentsealScan!.scannedFiles).toBe(4);
+    expect(updated!.agentsealScan!.agentsealVersion).toBe("0.3.1");
+  });
+
+  test("returns null (no throw) when the version row is missing", async () => {
+    expect(await repo.setAgentsealScan("skill-1", "9.9", scanRecord)).toBeNull();
+  });
+
+  test("mapScan coerces a malformed agentsealScan to null on read-back", async () => {
+    // Seed a row whose agentsealScan is structurally broken (missing score).
+    await seedRaw({
+      _id: "skill-1@1.0",
+      skillGuid: "skill-1",
+      version: "1.0",
+      majorVersion: 1,
+      minorVersion: 0,
+      storageKey: "skills/skill-1/1.0.zip",
+      skillHash: "hash-10",
+      metadata: META,
+      createdBy: "user-1",
+      createdOn: new Date(),
+      agentsealScan: { findings: [], scannedAt: "x", agentsealVersion: "0.1" },
+    });
+    const found = await repo.findBySkillAndVersion("skill-1", "1.0");
+    expect(found!.agentsealScan).toBeNull();
+  });
+});
+
+describe("setDeprecation", () => {
+  test("marks deprecated with a note", async () => {
+    await repo.create(createInput());
+    const updated = await repo.setDeprecation("skill-1", "1.0", true, "use 2.0 instead");
+    expect(updated.isDeprecated).toBe(true);
+    expect(updated.deprecationNote).toBe("use 2.0 instead");
+  });
+
+  test("marks deprecated with an explicit null note", async () => {
+    await repo.create(createInput());
+    const updated = await repo.setDeprecation("skill-1", "1.0", true, null);
+    expect(updated.isDeprecated).toBe(true);
+    expect(updated.deprecationNote).toBeNull();
+  });
+
+  test("un-deprecating clears any prior note", async () => {
+    await repo.create(createInput());
+    await repo.setDeprecation("skill-1", "1.0", true, "stale");
+    const updated = await repo.setDeprecation("skill-1", "1.0", false, "ignored");
+    expect(updated.isDeprecated).toBe(false);
+    expect(updated.deprecationNote).toBeNull();
+  });
+
+  test("throws 404 skill_version_not_found for a missing row", async () => {
+    let thrown: unknown;
+    try {
+      await repo.setDeprecation("skill-1", "9.9", true);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("skill_version_not_found");
+    expect((thrown as AppError).statusCode).toBe(404);
+  });
+});

--- a/ornn-api/tests/integration/skillsCrud.test.ts
+++ b/ornn-api/tests/integration/skillsCrud.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Integration: skills CRUD lifecycle spine (#874).
+ *
+ * Boots the real `bootstrap()` wiring against in-memory Mongo (shared
+ * harness) and walks one happy lifecycle through the actual route →
+ * service → repository stack: read → read-by-version → list versions →
+ * dist-tags set/get/delete → delete a non-latest version → delete the
+ * skill. This is a WIRING guard, not a branch matrix — the per-branch
+ * behaviour is covered by the colocated unit suites.
+ *
+ * Zero network / zero external services: the harness points chrono-storage
+ * at an empty/unreachable URL, so this test seeds the skill + version rows
+ * directly via the `db` handle rather than POST-ing a real ZIP (which would
+ * trigger a storage upload). The read paths mint presigned URLs
+ * best-effort (failures are swallowed by the service) and the delete path's
+ * storage cleanup is likewise best-effort — so the whole spine runs without
+ * contacting chrono-storage. This is the documented deviation from the
+ * "create via real ZIP" plan step, forced by the no-network harness rule.
+ *
+ * @module tests/integration/skillsCrud
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { startHarness, authHeaders, type Harness } from "./harness";
+
+const OWNER = "user_crud_owner";
+const GUID = "11111111-1111-1111-1111-111111111111";
+
+let harness: Harness;
+
+beforeAll(async () => {
+  harness = await startHarness();
+}, 30_000);
+
+afterAll(async () => {
+  await harness.cleanup();
+});
+
+beforeEach(async () => {
+  await harness.db.collection("skills").deleteMany({});
+  await harness.db.collection("skill_versions").deleteMany({});
+});
+
+/** Seed a public skill + two version rows straight into Mongo. */
+async function seedSkill(): Promise<void> {
+  const now = new Date();
+  await harness.db.collection("skills").insertOne({
+    _id: GUID as never,
+    name: "crud-spine-skill",
+    description: "Integration lifecycle spine.",
+    license: null,
+    compatibility: null,
+    metadata: { category: "plain", tags: ["spine"] },
+    skillHash: "hash-11",
+    storageKey: `skills/${GUID}/1.1.zip`,
+    createdBy: OWNER,
+    createdByEmail: `${OWNER}@test.local`,
+    createdByDisplayName: "Owner",
+    createdOn: now,
+    updatedBy: OWNER,
+    updatedOn: now,
+    isPrivate: false,
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    latestVersion: "1.1",
+    distTags: { latest: "1.1" },
+  } as never);
+
+  for (const [version, major, minor] of [
+    ["1.0", 1, 0],
+    ["1.1", 1, 1],
+  ] as const) {
+    await harness.db.collection("skill_versions").insertOne({
+      _id: `${GUID}@${version}` as never,
+      skillGuid: GUID,
+      version,
+      majorVersion: major,
+      minorVersion: minor,
+      storageKey: `skills/${GUID}/${version}.zip`,
+      skillHash: `hash-${version}`,
+      metadata: { category: "plain" },
+      license: null,
+      compatibility: null,
+      createdBy: OWNER,
+      createdOn: now,
+    } as never);
+  }
+}
+
+describe("integration: skills CRUD lifecycle spine", () => {
+  test("read → versions → dist-tags → delete-version → delete", async () => {
+    await seedSkill();
+    const headers = authHeaders({
+      userId: OWNER,
+      email: `${OWNER}@test.local`,
+      permissions: ["ornn:skill:read", "ornn:skill:update", "ornn:skill:delete"],
+    });
+
+    // 1. GET the skill (latest).
+    const getRes = await harness.app.request(`/api/v1/skills/${GUID}`, { headers });
+    expect(getRes.status).toBe(200);
+    const getBody = (await getRes.json()) as { data: { guid: string; version: string } };
+    expect(getBody.data.guid).toBe(GUID);
+    expect(getBody.data.version).toBe("1.1");
+
+    // 2. GET a specific version.
+    const verRes = await harness.app.request(`/api/v1/skills/${GUID}?version=1.0`, { headers });
+    expect(verRes.status).toBe(200);
+    expect(((await verRes.json()) as { data: { version: string } }).data.version).toBe("1.0");
+
+    // 3. List versions (newest first).
+    const listRes = await harness.app.request(`/api/v1/skills/${GUID}/versions`, { headers });
+    expect(listRes.status).toBe(200);
+    const listBody = (await listRes.json()) as { data: { items: Array<{ version: string }> } };
+    expect(listBody.data.items.map((i) => i.version)).toEqual(["1.1", "1.0"]);
+
+    // 4. Set a dist-tag.
+    const setTagRes = await harness.app.request(`/api/v1/skills/${GUID}/dist-tags/stable`, {
+      method: "PUT",
+      headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify({ version: "1.0" }),
+    });
+    expect(setTagRes.status).toBe(200);
+    expect(((await setTagRes.json()) as { data: { tags: Record<string, string> } }).data.tags.stable).toBe("1.0");
+
+    // 5. Read dist-tags.
+    const getTagsRes = await harness.app.request(`/api/v1/skills/${GUID}/dist-tags`, { headers });
+    expect(getTagsRes.status).toBe(200);
+    const tagsBody = (await getTagsRes.json()) as { data: { tags: Record<string, string> } };
+    expect(tagsBody.data.tags.latest).toBe("1.1");
+    expect(tagsBody.data.tags.stable).toBe("1.0");
+
+    // 6. Delete the dist-tag.
+    const delTagRes = await harness.app.request(`/api/v1/skills/${GUID}/dist-tags/stable`, {
+      method: "DELETE",
+      headers,
+    });
+    expect(delTagRes.status).toBe(200);
+
+    // 7. Delete the non-latest version (1.0).
+    const delVerRes = await harness.app.request(`/api/v1/skills/${GUID}/versions/1.0`, {
+      method: "DELETE",
+      headers,
+    });
+    expect(delVerRes.status).toBe(200);
+    const remaining = await harness.db.collection("skill_versions").countDocuments({ skillGuid: GUID });
+    expect(remaining).toBe(1);
+
+    // 8. Delete the whole skill.
+    const delRes = await harness.app.request(`/api/v1/skills/${GUID}`, { method: "DELETE", headers });
+    expect(delRes.status).toBe(200);
+    const after = await harness.db.collection("skills").countDocuments({ _id: GUID as never });
+    expect(after).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #874

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-68068-20268`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
