### PR TITLE
chore: [Misc] test(api): skills/generation unit tests — raise src/domains/ski

### DIFF
--- a/.changeset/test-875-generation-coverage.md
+++ b/.changeset/test-875-generation-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add unit test coverage for the skill-generation module (prompts, service, routes) (#875)

--- a/ornn-api/src/domains/skills/generation/prompts.test.ts
+++ b/ornn-api/src/domains/skills/generation/prompts.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the skill-generation prompt builders (#875).
+ *
+ * Three builders + three system-prompt constants are pinned here. The
+ * assertions are STRUCTURAL — they check that each conditional fragment
+ * is present when (and only when) its option is supplied, plus the
+ * fixed scaffolding the downstream parser / LLM relies on. We do NOT
+ * snapshot the whole literal so prose edits don't break the test.
+ *
+ * @module domains/skills/generation/prompts.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  GENERATION_SYSTEM_PROMPT,
+  OPENAPI_GENERATION_SYSTEM_PROMPT,
+  SOURCE_CODE_GENERATION_SYSTEM_PROMPT,
+  buildDirectGenerationPrompt,
+  buildOpenApiGenerationPrompt,
+  buildSourceCodeGenerationPrompt,
+} from "./prompts";
+
+describe("buildDirectGenerationPrompt", () => {
+  test("uses GENERATION_SYSTEM_PROMPT as instructions and embeds the query", () => {
+    const out = buildDirectGenerationPrompt("a web screenshot tool");
+
+    expect(out.instructions).toBe(GENERATION_SYSTEM_PROMPT);
+    expect(out.userPrompt).toContain("a web screenshot tool");
+    // The query is wrapped in the fixed "Generate a skill for:" scaffold.
+    expect(out.userPrompt).toContain('Generate a skill for: "a web screenshot tool"');
+  });
+
+  test("preserves an empty query without leaking placeholder tokens", () => {
+    const out = buildDirectGenerationPrompt("");
+    expect(out.userPrompt).toBe('Generate a skill for: ""');
+    expect(out.userPrompt).not.toContain("${");
+  });
+});
+
+describe("buildOpenApiGenerationPrompt", () => {
+  const SPEC = '{"openapi":"3.0.0","info":{"title":"Demo"}}';
+  const ENDPOINTS_FRAGMENT = "Focus ONLY on these endpoints:";
+  const DESCRIPTION_FRAGMENT = "Additional context:";
+
+  test("no options — neither endpoints nor description fragment", () => {
+    const out = buildOpenApiGenerationPrompt(SPEC);
+    expect(out).toContain(SPEC);
+    expect(out).toContain("Generate a PLAIN API reference skill");
+    expect(out).not.toContain(ENDPOINTS_FRAGMENT);
+    expect(out).not.toContain(DESCRIPTION_FRAGMENT);
+  });
+
+  test("endpoints only — endpoints fragment present, description absent", () => {
+    const out = buildOpenApiGenerationPrompt(SPEC, {
+      endpoints: ["GET /users", "POST /users"],
+    });
+    expect(out).toContain(`${ENDPOINTS_FRAGMENT} GET /users, POST /users`);
+    expect(out).not.toContain(DESCRIPTION_FRAGMENT);
+  });
+
+  test("description only — description fragment present, endpoints absent", () => {
+    const out = buildOpenApiGenerationPrompt(SPEC, {
+      description: "internal billing API",
+    });
+    expect(out).toContain(`${DESCRIPTION_FRAGMENT} internal billing API`);
+    expect(out).not.toContain(ENDPOINTS_FRAGMENT);
+  });
+
+  test("both — both fragments present", () => {
+    const out = buildOpenApiGenerationPrompt(SPEC, {
+      endpoints: ["GET /ping"],
+      description: "health checks only",
+    });
+    expect(out).toContain(`${ENDPOINTS_FRAGMENT} GET /ping`);
+    expect(out).toContain(`${DESCRIPTION_FRAGMENT} health checks only`);
+  });
+
+  test("empty endpoints array does NOT emit the endpoints fragment", () => {
+    const out = buildOpenApiGenerationPrompt(SPEC, { endpoints: [] });
+    expect(out).not.toContain(ENDPOINTS_FRAGMENT);
+  });
+});
+
+describe("buildSourceCodeGenerationPrompt", () => {
+  const CODE = "// FILE: src/routes.ts\napp.get('/x', h);";
+  const FRAMEWORK_FRAGMENT = "Detected framework hint:";
+  const SOURCE_URL_FRAGMENT = "Source URL (for context only";
+  const DESCRIPTION_FRAGMENT = "Additional context:";
+
+  test("no options — only the SOURCE CODE fence wraps the code", () => {
+    const out = buildSourceCodeGenerationPrompt(CODE);
+    expect(out).toContain("--- SOURCE CODE ---");
+    expect(out).toContain("--- END SOURCE CODE ---");
+    expect(out).toContain(CODE);
+    expect(out).not.toContain(FRAMEWORK_FRAGMENT);
+    expect(out).not.toContain(SOURCE_URL_FRAGMENT);
+    expect(out).not.toContain(DESCRIPTION_FRAGMENT);
+  });
+
+  test("framework only", () => {
+    const out = buildSourceCodeGenerationPrompt(CODE, { framework: "hono" });
+    expect(out).toContain(`${FRAMEWORK_FRAGMENT} hono.`);
+    expect(out).not.toContain(SOURCE_URL_FRAGMENT);
+    expect(out).not.toContain(DESCRIPTION_FRAGMENT);
+  });
+
+  test("sourceUrl only", () => {
+    const out = buildSourceCodeGenerationPrompt(CODE, {
+      sourceUrl: "https://github.com/acme/api",
+    });
+    expect(out).toContain("https://github.com/acme/api");
+    expect(out).toContain(SOURCE_URL_FRAGMENT);
+    expect(out).not.toContain(FRAMEWORK_FRAGMENT);
+    expect(out).not.toContain(DESCRIPTION_FRAGMENT);
+  });
+
+  test("description only", () => {
+    const out = buildSourceCodeGenerationPrompt(CODE, {
+      description: "public REST surface",
+    });
+    expect(out).toContain(`${DESCRIPTION_FRAGMENT} public REST surface`);
+    expect(out).not.toContain(FRAMEWORK_FRAGMENT);
+    expect(out).not.toContain(SOURCE_URL_FRAGMENT);
+  });
+
+  test("all three options — every fragment present and code still fenced", () => {
+    const out = buildSourceCodeGenerationPrompt(CODE, {
+      framework: "express",
+      sourceUrl: "https://github.com/acme/api/tree/main/src",
+      description: "v2 endpoints",
+    });
+    expect(out).toContain(`${FRAMEWORK_FRAGMENT} express.`);
+    expect(out).toContain("https://github.com/acme/api/tree/main/src");
+    expect(out).toContain(`${DESCRIPTION_FRAGMENT} v2 endpoints`);
+    expect(out).toContain("--- SOURCE CODE ---");
+    expect(out).toContain(CODE);
+    expect(out).toContain("--- END SOURCE CODE ---");
+  });
+});
+
+describe("system prompt constants", () => {
+  test("all three are non-empty", () => {
+    expect(GENERATION_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+    expect(OPENAPI_GENERATION_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+    expect(SOURCE_CODE_GENERATION_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+  });
+});

--- a/ornn-api/src/domains/skills/generation/routes.test.ts
+++ b/ornn-api/src/domains/skills/generation/routes.test.ts
@@ -72,6 +72,7 @@ function happyFrames(): SkillStreamEvent[] {
 
 interface ChargeCall {
   userId: string;
+  permissions: readonly string[] | undefined;
   surface: string;
   outcome: ChargeOutcome;
   modelId: string;
@@ -131,13 +132,20 @@ class FakeGenerationService {
 class FakeQuotaService {
   allowed = true;
   checkAllowedCalls = 0;
+  checkAllowedArgs: Array<{ permissions: readonly string[] | undefined }> = [];
   charges: ChargeCall[] = [];
 
-  async checkAllowed(): Promise<
+  async checkAllowed(input: {
+    userId: string;
+    permissions: readonly string[] | undefined;
+    surface: string;
+    now: Date;
+  }): Promise<
     | { allowed: true; isAdminBypass: boolean }
     | { allowed: false; isAdminBypass: false; surface: "skillGen"; message: string }
   > {
     this.checkAllowedCalls += 1;
+    this.checkAllowedArgs.push({ permissions: input.permissions });
     if (this.allowed) return { allowed: true, isAdminBypass: false };
     return {
       allowed: false,
@@ -149,6 +157,7 @@ class FakeQuotaService {
 
   async chargeOnCompletion(input: {
     userId: string;
+    permissions: readonly string[] | undefined;
     surface: string;
     outcome: ChargeOutcome;
     modelId: string;
@@ -156,6 +165,7 @@ class FakeQuotaService {
   }): Promise<void> {
     this.charges.push({
       userId: input.userId,
+      permissions: input.permissions,
       surface: input.surface,
       outcome: input.outcome,
       modelId: input.modelId,
@@ -343,6 +353,10 @@ describe("POST /skills/generate — charge-outcome matrix", () => {
     expect(quota.charges[0]!.modelId).toBe(MODEL_ID);
     expect(quota.charges[0]!.userId).toBe(USER_ID);
     expect(quota.charges[0]!.now).toBeInstanceOf(Date);
+    // The auth context's permissions flow into BOTH quota gates — a
+    // regression dropping the field on either call would pass silently.
+    expect(quota.charges[0]!.permissions).toEqual([BUILD_PERM]);
+    expect(quota.checkAllowedArgs[0]!.permissions).toEqual([BUILD_PERM]);
   });
 
   it("validation_error without complete charges outcome=skill_error", async () => {
@@ -507,7 +521,7 @@ describe("POST /skills/generate — validation", () => {
 describe("POST /skills/generate — multipart", () => {
   async function makeZip(): Promise<Blob> {
     const zip = new JSZip();
-    zip.file("SKILL.md", "# Demo\nA demo skill package.");
+    zip.file("SKILL.md", "# Demo\nA demo skill package. DISTINCTIVE_SKILL_MARKER_42");
     zip.file("scripts/main.js", "console.log('hi');");
     const bytes = await zip.generateAsync({ type: "uint8array" });
     return new Blob([bytes as unknown as BlobPart], { type: "application/zip" });
@@ -534,7 +548,12 @@ describe("POST /skills/generate — multipart", () => {
     // The resolved model id is what the generator is told to use.
     expect(gen.generateStreamCalls[0]!.modelOverride).toBe(MODEL_ID);
     // The package content is folded into the query.
-    expect(gen.generateStreamCalls[0]!.query).toContain("improve this skill");
+    const query = gen.generateStreamCalls[0]!.query;
+    expect(query).toContain("improve this skill");
+    // analyzePackageContent → "Existing skill package content:" prefix
+    // branch: the SKILL.md from the ZIP must be threaded into the query.
+    expect(query).toContain("Existing skill package content:");
+    expect(query).toContain("DISTINCTIVE_SKILL_MARKER_42");
   });
 
   it("rejects multipart with a missing prompt", async () => {

--- a/ornn-api/src/domains/skills/generation/routes.test.ts
+++ b/ornn-api/src/domains/skills/generation/routes.test.ts
@@ -1,0 +1,695 @@
+/**
+ * Route-level tests for the skill-generation routes (#875).
+ *
+ * Mounts `createGenerationRoutes` on a bare Hono app, stubs the upstream
+ * auth context (production wires this via proxyAuthSetup), and supplies
+ * hand-rolled fakes for the four collaborators (generationService,
+ * quotaService, llmProvidersService, keepAliveIntervalMsResolver). The
+ * project onError → RFC 7807 mapping is replicated so thrown AppErrors
+ * surface with the right status.
+ *
+ * SSE responses are drained from `res.text()` and split on "\n\n"; each
+ * `data:` line is parsed as JSON. We assert the transport headers
+ * (Cache-Control no-cache, X-Accel-Buffering no), the event-type
+ * sequence, and the terminal event. Keep-alive cadence is NOT asserted.
+ *
+ * Charge-outcome matrix (#808/#827): the route derives the quota charge
+ * outcome from the emitted event stream —
+ *   generation_complete            → "success"
+ *   validation_error (no complete) → "skill_error"
+ *   only error events              → "system_error"
+ * Each case asserts the captured `chargeOnCompletion` args.
+ *
+ * Preflight order (#808): model resolution runs FIRST. A resolution
+ * failure → 503 and `checkAllowed` is NEVER called; resolution ok +
+ * quota denied → 429.
+ *
+ * The rate-limit middleware mounted on POST /skills/generate is reset
+ * between tests via its `__resetRateLimitForTests` seam so the
+ * per-process bucket can't bleed 429s across cases.
+ *
+ * @module domains/skills/generation/routes.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import JSZip from "jszip";
+import { createGenerationRoutes, type GenerationRoutesConfig } from "./routes";
+import { __resetRateLimitForTests } from "../../../middleware/rateLimit";
+import { buildProblemJsonBody } from "../../../shared/types/index";
+import type { SkillStreamEvent } from "../../../shared/types/index";
+import type { ChargeOutcome } from "../../quota/types";
+import type { ModelResolution } from "../../settings/llmProviders/service";
+
+const BUILD_PERM = "ornn:skill:build";
+const USER_ID = "user-1";
+const MODEL_ID = "resolved-model";
+
+// ---- SSE stream frame helpers ----------------------------------------
+
+function startEvent(): SkillStreamEvent {
+  return { type: "generation_start" };
+}
+function tokenEvent(content: string): SkillStreamEvent {
+  return { type: "token", content };
+}
+function completeEvent(raw: string): SkillStreamEvent {
+  return { type: "generation_complete", raw };
+}
+function validationErrorEvent(): SkillStreamEvent {
+  return { type: "validation_error", message: "Invalid JSON from LLM", retrying: false };
+}
+function errorEvent(message: string): SkillStreamEvent {
+  return { type: "error", message };
+}
+
+/** Default happy stream: start → token → complete. */
+function happyFrames(): SkillStreamEvent[] {
+  return [startEvent(), tokenEvent("{}"), completeEvent('{"name":"x"}')];
+}
+
+// ---- Fakes -----------------------------------------------------------
+
+interface ChargeCall {
+  userId: string;
+  surface: string;
+  outcome: ChargeOutcome;
+  modelId: string;
+  now: Date;
+}
+
+class FakeGenerationService {
+  /** Frames every generate* method yields, in order. */
+  frames: SkillStreamEvent[] = happyFrames();
+  generateStreamCalls: Array<{ query: string; modelOverride: string | undefined }> = [];
+  fromOpenApiCalls: Array<{ spec: string }> = [];
+  fromSourceCalls: Array<{
+    code: string;
+    framework: string | undefined;
+    sourceUrl: string | undefined;
+  }> = [];
+  withHistoryCalls: Array<{ messages: unknown[] }> = [];
+
+  private async *emit(): AsyncIterable<SkillStreamEvent> {
+    for (const f of this.frames) yield f;
+  }
+
+  generateStream(
+    query: string,
+    _signal?: AbortSignal,
+    modelOverride?: string,
+  ): AsyncIterable<SkillStreamEvent> {
+    this.generateStreamCalls.push({ query, modelOverride });
+    return this.emit();
+  }
+
+  generateStreamWithHistory(
+    messages: unknown[],
+  ): AsyncIterable<SkillStreamEvent> {
+    this.withHistoryCalls.push({ messages });
+    return this.emit();
+  }
+
+  generateFromOpenApi(spec: string): AsyncIterable<SkillStreamEvent> {
+    this.fromOpenApiCalls.push({ spec });
+    return this.emit();
+  }
+
+  generateFromSource(
+    code: string,
+    options?: { framework?: string; sourceUrl?: string },
+  ): AsyncIterable<SkillStreamEvent> {
+    this.fromSourceCalls.push({
+      code,
+      framework: options?.framework,
+      sourceUrl: options?.sourceUrl,
+    });
+    return this.emit();
+  }
+}
+
+class FakeQuotaService {
+  allowed = true;
+  checkAllowedCalls = 0;
+  charges: ChargeCall[] = [];
+
+  async checkAllowed(): Promise<
+    | { allowed: true; isAdminBypass: boolean }
+    | { allowed: false; isAdminBypass: false; surface: "skillGen"; message: string }
+  > {
+    this.checkAllowedCalls += 1;
+    if (this.allowed) return { allowed: true, isAdminBypass: false };
+    return {
+      allowed: false,
+      isAdminBypass: false,
+      surface: "skillGen",
+      message: "Monthly skill-generation quota exhausted",
+    };
+  }
+
+  async chargeOnCompletion(input: {
+    userId: string;
+    surface: string;
+    outcome: ChargeOutcome;
+    modelId: string;
+    now: Date;
+  }): Promise<void> {
+    this.charges.push({
+      userId: input.userId,
+      surface: input.surface,
+      outcome: input.outcome,
+      modelId: input.modelId,
+      now: input.now,
+    });
+  }
+}
+
+class FakeLlmProvidersService {
+  resolution: ModelResolution = {
+    kind: "ok",
+    modelId: MODEL_ID,
+    displayName: "Resolved Model",
+    providerId: "prov-1",
+  };
+  resolveModelCalls = 0;
+  resolveModelArgs: Array<{ surface: string; requested: string | undefined }> = [];
+
+  async resolveModel(params: {
+    surface: string;
+    requested?: string;
+  }): Promise<ModelResolution> {
+    this.resolveModelCalls += 1;
+    this.resolveModelArgs.push({ surface: params.surface, requested: params.requested });
+    return this.resolution;
+  }
+}
+
+// ---- App builder -----------------------------------------------------
+
+interface BuildOpts {
+  permissions?: string[];
+  keepAliveResolver?: () => Promise<number>;
+}
+
+function buildApp(
+  fakes: {
+    generationService?: FakeGenerationService;
+    quotaService?: FakeQuotaService;
+    llmProvidersService?: FakeLlmProvidersService;
+  } = {},
+  opts: BuildOpts = {},
+): {
+  app: Hono;
+  generationService: FakeGenerationService;
+  quotaService: FakeQuotaService;
+  llmProvidersService: FakeLlmProvidersService;
+} {
+  const { permissions = [BUILD_PERM], keepAliveResolver } = opts;
+  const generationService = fakes.generationService ?? new FakeGenerationService();
+  const quotaService = fakes.quotaService ?? new FakeQuotaService();
+  const llmProvidersService =
+    fakes.llmProvidersService ?? new FakeLlmProvidersService();
+
+  const config: GenerationRoutesConfig = {
+    generationService: generationService as unknown as GenerationRoutesConfig["generationService"],
+    quotaService: quotaService as unknown as GenerationRoutesConfig["quotaService"],
+    llmProvidersService:
+      llmProvidersService as unknown as GenerationRoutesConfig["llmProvidersService"],
+    keepAliveIntervalMsResolver: keepAliveResolver ?? (async () => 15_000),
+  };
+
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("auth" as never, {
+      userId: USER_ID,
+      email: `${USER_ID}@test.local`,
+      displayName: USER_ID,
+      roles: [],
+      permissions,
+    } as never);
+    await next();
+  });
+  app.route("/api/v1", createGenerationRoutes(config));
+  app.onError((err, c) => {
+    const code = (err as { code?: string }).code ?? "internal_error";
+    const status = (err as { statusCode?: number }).statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode: status,
+      code,
+      message: err.message,
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, status as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+
+  return { app, generationService, quotaService, llmProvidersService };
+}
+
+// ---- SSE parsing helper ----------------------------------------------
+
+interface ParsedSse {
+  events: Array<Record<string, unknown>>;
+  types: string[];
+}
+
+async function parseSse(res: Response): Promise<ParsedSse> {
+  const text = await res.text();
+  const events: Array<Record<string, unknown>> = [];
+  for (const block of text.split("\n\n")) {
+    for (const line of block.split("\n")) {
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(5).trim();
+      if (!payload) continue; // keep-alive frames carry empty data
+      try {
+        events.push(JSON.parse(payload) as Record<string, unknown>);
+      } catch {
+        // ignore non-JSON data lines
+      }
+    }
+  }
+  return { events, types: events.map((e) => String(e.type)) };
+}
+
+// ---- Test lifecycle --------------------------------------------------
+
+beforeEach(() => __resetRateLimitForTests());
+afterEach(() => __resetRateLimitForTests());
+
+// ---- Transport + happy path ------------------------------------------
+
+describe("POST /skills/generate — transport + happy path", () => {
+  it("streams SSE with no-cache + no-buffering headers", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "make a thing" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-cache");
+    expect(res.headers.get("X-Accel-Buffering")).toBe("no");
+  });
+
+  it("emits start → token → complete and threads the resolved model", async () => {
+    const { app, generationService } = buildApp();
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "make a thing" }),
+    });
+    const { types } = await parseSse(res);
+    expect(types).toEqual(["generation_start", "token", "generation_complete"]);
+    expect(generationService.generateStreamCalls[0]!.modelOverride).toBe(MODEL_ID);
+  });
+
+  it("handles a multi-turn messages[] body", async () => {
+    const gen = new FakeGenerationService();
+    const { app } = buildApp({ generationService: gen });
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          { role: "user", content: "a" },
+          { role: "assistant", content: "b" },
+        ],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const { types } = await parseSse(res);
+    expect(types).toContain("generation_complete");
+    expect(gen.withHistoryCalls).toHaveLength(1);
+  });
+});
+
+// ---- Charge-outcome matrix (#808/#827) -------------------------------
+
+describe("POST /skills/generate — charge-outcome matrix", () => {
+  it("generation_complete charges outcome=success", async () => {
+    const quota = new FakeQuotaService();
+    const { app } = buildApp({ quotaService: quota });
+    await parseSse(
+      await app.request("/api/v1/skills/generate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "p" }),
+      }),
+    );
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("success");
+    expect(quota.charges[0]!.modelId).toBe(MODEL_ID);
+    expect(quota.charges[0]!.userId).toBe(USER_ID);
+    expect(quota.charges[0]!.now).toBeInstanceOf(Date);
+  });
+
+  it("validation_error without complete charges outcome=skill_error", async () => {
+    const gen = new FakeGenerationService();
+    gen.frames = [startEvent(), validationErrorEvent()];
+    const quota = new FakeQuotaService();
+    const { app } = buildApp({ generationService: gen, quotaService: quota });
+    await parseSse(
+      await app.request("/api/v1/skills/generate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "p" }),
+      }),
+    );
+    expect(quota.charges[0]!.outcome).toBe("skill_error");
+  });
+
+  it("only error events charge outcome=system_error", async () => {
+    const gen = new FakeGenerationService();
+    gen.frames = [startEvent(), errorEvent("LLM error: gateway 502")];
+    const quota = new FakeQuotaService();
+    const { app } = buildApp({ generationService: gen, quotaService: quota });
+    await parseSse(
+      await app.request("/api/v1/skills/generate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "p" }),
+      }),
+    );
+    expect(quota.charges[0]!.outcome).toBe("system_error");
+  });
+});
+
+// ---- Preflight order (#808) ------------------------------------------
+
+describe("POST /skills/generate — preflight order", () => {
+  it("model resolution failure → 503 and checkAllowed is NEVER called", async () => {
+    const providers = new FakeLlmProvidersService();
+    providers.resolution = { kind: "no-models-enabled", surface: "skillGen" };
+    const quota = new FakeQuotaService();
+    const { app } = buildApp({
+      llmProvidersService: providers,
+      quotaService: quota,
+    });
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "p" }),
+    });
+    expect(res.status).toBe(503);
+    expect(quota.checkAllowedCalls).toBe(0);
+    expect(quota.charges).toHaveLength(0);
+  });
+
+  it("resolution ok + quota denied → 429", async () => {
+    const quota = new FakeQuotaService();
+    quota.allowed = false;
+    const { app } = buildApp({ quotaService: quota });
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "p" }),
+    });
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("quota_exceeded");
+    // No charge when the slot was never reserved.
+    expect(quota.charges).toHaveLength(0);
+  });
+});
+
+// ---- Validation cases ------------------------------------------------
+
+describe("POST /skills/generate — validation", () => {
+  it("rejects a message that exceeds the content cap", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "x".repeat(32_001) }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("content_too_long");
+  });
+
+  it("rejects a prompt that exceeds the content cap", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "x".repeat(32_001) }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("prompt_too_long");
+  });
+
+  it("rejects a missing prompt", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("missing_prompt");
+  });
+
+  it("rejects malformed JSON with invalid_body", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{ not json",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_body");
+  });
+
+  it("rejects a top-level array body with 400", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([1, 2, 3]),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_body");
+  });
+
+  it("rejects an unsupported content-type with 400", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: "prompt=hi",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_content_type");
+  });
+
+  it("rejects when the caller lacks ornn:skill:build", async () => {
+    const { app } = buildApp({}, { permissions: [] });
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "p" }),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---- Multipart ------------------------------------------------------
+
+describe("POST /skills/generate — multipart", () => {
+  async function makeZip(): Promise<Blob> {
+    const zip = new JSZip();
+    zip.file("SKILL.md", "# Demo\nA demo skill package.");
+    zip.file("scripts/main.js", "console.log('hi');");
+    const bytes = await zip.generateAsync({ type: "uint8array" });
+    return new Blob([bytes as unknown as BlobPart], { type: "application/zip" });
+  }
+
+  it("accepts a multipart prompt + ZIP package + modelId field", async () => {
+    const gen = new FakeGenerationService();
+    const providers = new FakeLlmProvidersService();
+    const { app } = buildApp({ generationService: gen, llmProvidersService: providers });
+    const form = new FormData();
+    form.set("prompt", "improve this skill");
+    form.set("modelId", "picked-model");
+    form.set("package", await makeZip(), "skill.zip");
+
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const { types } = await parseSse(res);
+    expect(types).toContain("generation_complete");
+    // The modelId form field is read and threaded into model resolution.
+    expect(providers.resolveModelArgs[0]!.requested).toBe("picked-model");
+    // The resolved model id is what the generator is told to use.
+    expect(gen.generateStreamCalls[0]!.modelOverride).toBe(MODEL_ID);
+    // The package content is folded into the query.
+    expect(gen.generateStreamCalls[0]!.query).toContain("improve this skill");
+  });
+
+  it("rejects multipart with a missing prompt", async () => {
+    const { app } = buildApp();
+    const form = new FormData();
+    form.set("modelId", "x");
+
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("missing_prompt");
+  });
+});
+
+// ---- from-source -----------------------------------------------------
+
+describe("POST /skills/generate/from-source", () => {
+  it("rejects when neither code nor repoUrl is supplied", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate/from-source", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("missing_source");
+  });
+
+  it("rejects ambiguous code + repoUrl", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate/from-source", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        code: "app.get('/x', h)",
+        repoUrl: "https://github.com/acme/api",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("AMBIGUOUS_SOURCE");
+  });
+
+  it("rejects empty inline source", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate/from-source", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: "   \n  " }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("empty_source");
+  });
+
+  it("streams generation for inline code", async () => {
+    const gen = new FakeGenerationService();
+    const { app } = buildApp({ generationService: gen });
+    const res = await app.request("/api/v1/skills/generate/from-source", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: "app.get('/x', h)", framework: "hono" }),
+    });
+    expect(res.status).toBe(200);
+    const { types } = await parseSse(res);
+    expect(types).toContain("generation_complete");
+    expect(gen.fromSourceCalls[0]!.code).toContain("app.get('/x', h)");
+    expect(gen.fromSourceCalls[0]!.framework).toBe("hono");
+  });
+
+  it("maps a repo fetch failure to repo_fetch_failed", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("network unreachable");
+    }) as unknown as typeof fetch;
+    try {
+      const { app } = buildApp();
+      const res = await app.request("/api/v1/skills/generate/from-source", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repoUrl: "https://github.com/acme/api" }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe("repo_fetch_failed");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
+// ---- from-openapi ----------------------------------------------------
+
+describe("POST /skills/generate/from-openapi", () => {
+  it("streams generation for a valid spec", async () => {
+    const gen = new FakeGenerationService();
+    const { app } = buildApp({ generationService: gen });
+    const res = await app.request("/api/v1/skills/generate/from-openapi", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ spec: '{"openapi":"3.0.0"}' }),
+    });
+    expect(res.status).toBe(200);
+    const { types } = await parseSse(res);
+    expect(types).toContain("generation_complete");
+    expect(gen.fromOpenApiCalls[0]!.spec).toContain("openapi");
+  });
+
+  it("rejects a missing spec with 400", async () => {
+    const { app } = buildApp();
+    const res = await app.request("/api/v1/skills/generate/from-openapi", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---- Keep-alive fallback --------------------------------------------
+
+describe("keep-alive resolution fallback", () => {
+  it("falls back to the 15s default when the resolver throws", async () => {
+    const { app } = buildApp(
+      {},
+      {
+        keepAliveResolver: async () => {
+          throw new Error("settings read failed");
+        },
+      },
+    );
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "p" }),
+    });
+    // The stream still completes — a thrown resolver does not break the request.
+    expect(res.status).toBe(200);
+    const { types } = await parseSse(res);
+    expect(types).toContain("generation_complete");
+  });
+
+  it("falls back to the 15s default when the resolver returns 0 / NaN", async () => {
+    const { app } = buildApp({}, { keepAliveResolver: async () => 0 });
+    const res = await app.request("/api/v1/skills/generate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "p" }),
+    });
+    expect(res.status).toBe(200);
+    const { types } = await parseSse(res);
+    expect(types).toContain("generation_complete");
+  });
+});

--- a/ornn-api/src/domains/skills/generation/service.test.ts
+++ b/ornn-api/src/domains/skills/generation/service.test.ts
@@ -1,0 +1,680 @@
+/**
+ * Unit tests for the SkillGenerationService (#875).
+ *
+ * The service is DI-driven: a `NyxLlmClient` (faked at the typed
+ * AsyncIterable seam) + a `defaultsResolver`. No real network / DB /
+ * LLM is touched. The fake client exposes the same two methods the
+ * service calls — `stream()` (async generator of
+ * `ResponsesApiStreamEvent`) and `complete()` (returns
+ * `ResponsesApiOutput[]`) — and is cast through `unknown` to the real
+ * `NyxLlmClient` type so the call sites stay honest.
+ *
+ * Coverage:
+ *   - extractTextFromEvent: both delta shapes + unknown type → null
+ *     (exercised end-to-end via generateStream token accumulation).
+ *   - resolveDefaults: happy / empty / whitespace-only model throws
+ *     SKILLGEN_LLM_NOT_CONFIGURED / modelOverride wins.
+ *   - generateStream: happy / pre-abort / mid-abort / stream-throw /
+ *     invalid-then-retry-success / retry-throw / retry-still-invalid /
+ *     resolver-throw.
+ *   - generateStreamWithHistory: first-msg rewrite + assistant
+ *     passthrough / non-retry validation_error / pass / abort + throw.
+ *   - generateFromOpenApi / generateFromSource: happy + invalid +
+ *     option pass-through.
+ *   - parseAndValidate: fence strip / brace slice / readmeMd migration
+ *     (with + without frontmatter) / schema-fail / non-JSON.
+ *
+ * @module domains/skills/generation/service.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { SkillGenerationService } from "./service";
+import type {
+  SkillGenLlmDefaults,
+  SkillGenLlmDefaultsResolver,
+} from "./service";
+import type {
+  NyxLlmClient,
+  NyxLlmStreamParams,
+  NyxLlmCompleteParams,
+  ResponsesApiStreamEvent,
+  ResponsesApiOutput,
+} from "../../../clients/nyxid/llm";
+import type { SkillStreamEvent } from "../../../shared/types/index";
+
+// ---- Fixtures --------------------------------------------------------
+
+const DEFAULTS: SkillGenLlmDefaults = {
+  model: "default-model",
+  maxOutputTokens: 4096,
+  temperature: 0.5,
+};
+
+/** A schema-valid generated-skill JSON document. */
+const VALID_SKILL = JSON.stringify({
+  name: "demo-skill",
+  description: "A perfectly valid demo skill for testing purposes.",
+  category: "plain",
+  tags: ["demo", "test"],
+  readmeBody:
+    "# Demo Skill\n\nThis readme body is comfortably over the fifty character minimum length.",
+  runtimes: [],
+  dependencies: [],
+  envVars: [],
+  scripts: [],
+});
+
+// ---- Responses-API stream frame helpers ------------------------------
+
+/** `response.output_text.delta` frame ({ delta: string }). */
+function outputTextDelta(text: string): ResponsesApiStreamEvent {
+  return { type: "response.output_text.delta", delta: text };
+}
+
+/** `response.content_part.delta` frame ({ delta: { type, text } }). */
+function contentPartDelta(text: string): ResponsesApiStreamEvent {
+  return {
+    type: "response.content_part.delta",
+    delta: { type: "output_text", text },
+  };
+}
+
+/** An event the extractor must ignore (returns null → no token). */
+function unknownFrame(): ResponsesApiStreamEvent {
+  return { type: "response.something.else", foo: "bar" };
+}
+
+/** A `complete()` output carrying text in the Responses-API shape. */
+function completeOutput(text: string): ResponsesApiOutput[] {
+  return [{ type: "message", content: [{ type: "output_text", text }] }];
+}
+
+// ---- Fake NyxLlmClient -----------------------------------------------
+
+interface FakeClientOpts {
+  /** Frames the stream() generator yields, in order. */
+  streamFrames?: ResponsesApiStreamEvent[];
+  /** When set, stream() throws this after yielding `throwAfter` frames. */
+  streamThrow?: Error;
+  /** Yield this many frames before throwing (default 0 = throw first). */
+  throwAfter?: number;
+  /** complete() result — output array. */
+  completeResult?: ResponsesApiOutput[];
+  /** When set, complete() throws this. */
+  completeThrow?: Error;
+  /** Optional callback invoked once between each stream frame yield. */
+  onFrame?: (index: number) => void;
+}
+
+function makeClient(opts: FakeClientOpts): {
+  client: NyxLlmClient;
+  streamParams: NyxLlmStreamParams[];
+  completeParams: NyxLlmCompleteParams[];
+} {
+  const streamParams: NyxLlmStreamParams[] = [];
+  const completeParams: NyxLlmCompleteParams[] = [];
+  const {
+    streamFrames = [],
+    streamThrow,
+    throwAfter = 0,
+    completeResult = [],
+    completeThrow,
+    onFrame,
+  } = opts;
+
+  const fake = {
+    async *stream(params: NyxLlmStreamParams): AsyncIterable<ResponsesApiStreamEvent> {
+      streamParams.push(params);
+      let i = 0;
+      for (const frame of streamFrames) {
+        if (streamThrow && i >= throwAfter) throw streamThrow;
+        yield frame;
+        onFrame?.(i);
+        i += 1;
+      }
+      if (streamThrow && i >= throwAfter) throw streamThrow;
+    },
+    async complete(params: NyxLlmCompleteParams): Promise<ResponsesApiOutput[]> {
+      completeParams.push(params);
+      if (completeThrow) throw completeThrow;
+      return completeResult;
+    },
+  };
+
+  return { client: fake as unknown as NyxLlmClient, streamParams, completeParams };
+}
+
+function makeResolver(
+  value: SkillGenLlmDefaults | (() => Promise<SkillGenLlmDefaults>),
+): SkillGenLlmDefaultsResolver {
+  if (typeof value === "function") return value;
+  return async () => value;
+}
+
+async function drain(
+  it: AsyncIterable<SkillStreamEvent>,
+): Promise<SkillStreamEvent[]> {
+  const out: SkillStreamEvent[] = [];
+  for await (const e of it) out.push(e);
+  return out;
+}
+
+function types(events: SkillStreamEvent[]): string[] {
+  return events.map((e) => e.type);
+}
+
+// ---- resolveDefaults (via generateStream) ----------------------------
+
+describe("resolveDefaults", () => {
+  test("happy path resolves and threads model into the stream call", async () => {
+    const { client, streamParams } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toContain("generation_complete");
+    expect(streamParams[0]!.model).toBe("default-model");
+    expect(streamParams[0]!.max_output_tokens).toBe(4096);
+    expect(streamParams[0]!.temperature).toBe(0.5);
+  });
+
+  test("empty model string yields SKILLGEN_LLM_NOT_CONFIGURED error", async () => {
+    const { client } = makeClient({});
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver({ ...DEFAULTS, model: "" }),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toEqual(["error"]);
+    expect((events[0] as { message: string }).message).toContain(
+      "SKILLGEN_LLM_NOT_CONFIGURED",
+    );
+  });
+
+  test("whitespace-only model string also throws not-configured", async () => {
+    const { client } = makeClient({});
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver({ ...DEFAULTS, model: "   " }),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toEqual(["error"]);
+    expect((events[0] as { message: string }).message).toContain(
+      "SKILLGEN_LLM_NOT_CONFIGURED",
+    );
+  });
+
+  test("modelOverride wins over the resolved default", async () => {
+    const { client, streamParams } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    await drain(svc.generateStream("q", undefined, "override-model"));
+    expect(streamParams[0]!.model).toBe("override-model");
+  });
+
+  test("resolver throwing surfaces a single error event then returns", async () => {
+    const { client } = makeClient({});
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(async () => {
+        throw new Error("settings collection unreachable");
+      }),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toEqual(["error"]);
+    expect((events[0] as { message: string }).message).toContain(
+      "settings collection unreachable",
+    );
+  });
+});
+
+// ---- extractTextFromEvent (via token accumulation) -------------------
+
+describe("extractTextFromEvent", () => {
+  test("accumulates from response.output_text.delta frames", async () => {
+    const half = VALID_SKILL.slice(0, 20);
+    const rest = VALID_SKILL.slice(20);
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta(half), outputTextDelta(rest)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    const complete = events.find((e) => e.type === "generation_complete");
+    expect((complete as { raw: string }).raw).toBe(VALID_SKILL);
+  });
+
+  test("accumulates from response.content_part.delta frames", async () => {
+    const { client } = makeClient({
+      streamFrames: [contentPartDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toContain("generation_complete");
+  });
+
+  test("unknown frame types are skipped (no token emitted)", async () => {
+    const { client } = makeClient({
+      streamFrames: [unknownFrame(), outputTextDelta(VALID_SKILL), unknownFrame()],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    const tokens = events.filter((e) => e.type === "token");
+    expect(tokens).toHaveLength(1);
+  });
+
+  test("content_part.delta with wrong inner type emits no token", async () => {
+    const badFrame: ResponsesApiStreamEvent = {
+      type: "response.content_part.delta",
+      delta: { type: "not_output_text", text: "ignored" },
+    };
+    const { client } = makeClient({
+      streamFrames: [badFrame, outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(events.filter((e) => e.type === "token")).toHaveLength(1);
+  });
+});
+
+// ---- generateStream --------------------------------------------------
+
+describe("generateStream", () => {
+  test("happy sequence: start → token(s) → complete", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toEqual([
+      "generation_start",
+      "token",
+      "generation_complete",
+    ]);
+  });
+
+  test("pre-aborted signal yields error before any LLM call", async () => {
+    const { client, streamParams } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const events = await drain(svc.generateStream("q", ctrl.signal));
+    expect(types(events)).toEqual(["error"]);
+    expect(streamParams).toHaveLength(0);
+  });
+
+  test("mid-stream abort (flipped between frames) stops with error", async () => {
+    const ctrl = new AbortController();
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta("part-one"), outputTextDelta("part-two")],
+      onFrame: (i) => {
+        if (i === 0) ctrl.abort();
+      },
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q", ctrl.signal));
+    expect(types(events)).toContain("error");
+    expect(types(events)).not.toContain("generation_complete");
+  });
+
+  test("stream throwing surfaces an LLM error event", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta("partial")],
+      streamThrow: new Error("gateway 502"),
+      throwAfter: 1,
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    const err = events.find((e) => e.type === "error");
+    expect((err as { message: string }).message).toContain("gateway 502");
+    expect(types(events)).not.toContain("generation_complete");
+  });
+
+  test("invalid accumulated output retries via complete() and succeeds", async () => {
+    const { client, completeParams } = makeClient({
+      streamFrames: [outputTextDelta("not json at all")],
+      completeResult: completeOutput(VALID_SKILL),
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toContain("validation_error");
+    expect(
+      (events.find((e) => e.type === "validation_error") as { retrying: boolean })
+        .retrying,
+    ).toBe(true);
+    const complete = events.find((e) => e.type === "generation_complete");
+    expect((complete as { raw: string }).raw).toBe(VALID_SKILL);
+    expect(completeParams).toHaveLength(1);
+  });
+
+  test("retry complete() throwing surfaces an LLM retry error", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta("garbage")],
+      completeThrow: new Error("retry gateway timeout"),
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toContain("validation_error");
+    const err = events.find((e) => e.type === "error");
+    expect((err as { message: string }).message).toContain("retry gateway timeout");
+    expect(types(events)).not.toContain("generation_complete");
+  });
+
+  test("retry still invalid yields a terminal error", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta("garbage")],
+      completeResult: completeOutput("still not json"),
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateStream("q"));
+    expect(types(events)).toContain("validation_error");
+    const err = events.find((e) => e.type === "error");
+    expect((err as { message: string }).message).toContain("after retry");
+    expect(types(events)).not.toContain("generation_complete");
+  });
+});
+
+// ---- generateStreamWithHistory ---------------------------------------
+
+describe("generateStreamWithHistory", () => {
+  test("rewrites the first user message and passes assistant turns through", async () => {
+    const { client, streamParams } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    await drain(
+      svc.generateStreamWithHistory([
+        { role: "user", content: "a calculator" },
+        { role: "assistant", content: "ok here is a draft" },
+        { role: "user", content: "make it support hex" },
+      ]),
+    );
+    const input = streamParams[0]!.input;
+    // [0] developer system prompt, [1] rewritten first user msg.
+    expect(input[0]!.role).toBe("developer");
+    expect(input[1]!.role).toBe("user");
+    expect(input[1]!.content).toBe('Generate a skill for: "a calculator"');
+    // Assistant turn preserved verbatim.
+    expect(input[2]!.role).toBe("assistant");
+    expect(input[2]!.content).toBe("ok here is a draft");
+    // Subsequent user turn NOT rewritten.
+    expect(input[3]!.content).toBe("make it support hex");
+  });
+
+  test("invalid output emits a non-retry validation_error then complete", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta("not valid json")],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(
+      svc.generateStreamWithHistory([{ role: "user", content: "x" }]),
+    );
+    const ve = events.find((e) => e.type === "validation_error");
+    expect((ve as { retrying: boolean }).retrying).toBe(false);
+    // History path never retries — it still emits generation_complete.
+    expect(types(events)).toContain("generation_complete");
+  });
+
+  test("valid output passes through to generation_complete", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(
+      svc.generateStreamWithHistory([{ role: "user", content: "x" }]),
+    );
+    expect(types(events)).not.toContain("validation_error");
+    expect(types(events)).toContain("generation_complete");
+  });
+
+  test("pre-aborted signal yields error before any LLM call", async () => {
+    const { client, streamParams } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const events = await drain(
+      svc.generateStreamWithHistory([{ role: "user", content: "x" }], ctrl.signal),
+    );
+    expect(types(events)).toEqual(["error"]);
+    expect(streamParams).toHaveLength(0);
+  });
+
+  test("stream throwing surfaces an LLM error event", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta("partial")],
+      streamThrow: new Error("multi-turn 503"),
+      throwAfter: 1,
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(
+      svc.generateStreamWithHistory([{ role: "user", content: "x" }]),
+    );
+    const err = events.find((e) => e.type === "error");
+    expect((err as { message: string }).message).toContain("multi-turn 503");
+  });
+});
+
+// ---- generateFromOpenApi ---------------------------------------------
+
+describe("generateFromOpenApi", () => {
+  test("happy path streams tokens to generation_complete", async () => {
+    const { client, streamParams } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(
+      svc.generateFromOpenApi('{"openapi":"3.0.0"}', {
+        endpoints: ["GET /x"],
+        description: "ctx",
+      }),
+    );
+    expect(types(events)).toContain("generation_complete");
+    // Defence-in-depth: option fragments flow through the builder.
+    const userMsg = streamParams[0]!.input[1]!.content as string;
+    expect(userMsg).toContain("Focus ONLY on these endpoints: GET /x");
+    expect(userMsg).toContain("Additional context: ctx");
+  });
+
+  test("invalid output emits a non-retry validation_error then complete", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta("not json")],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateFromOpenApi('{"openapi":"3.0.0"}'));
+    const ve = events.find((e) => e.type === "validation_error");
+    expect((ve as { retrying: boolean }).retrying).toBe(false);
+    expect(types(events)).toContain("generation_complete");
+  });
+});
+
+// ---- generateFromSource ----------------------------------------------
+
+describe("generateFromSource", () => {
+  test("happy path streams tokens to generation_complete + passes options", async () => {
+    const { client, streamParams } = makeClient({
+      streamFrames: [outputTextDelta(VALID_SKILL)],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(
+      svc.generateFromSource("// FILE: r.ts\napp.get('/x', h);", {
+        framework: "hono",
+        description: "ctx",
+        sourceUrl: "https://github.com/acme/api",
+      }),
+    );
+    expect(types(events)).toContain("generation_complete");
+    const userMsg = streamParams[0]!.input[1]!.content as string;
+    expect(userMsg).toContain("Detected framework hint: hono.");
+    expect(userMsg).toContain("https://github.com/acme/api");
+    expect(userMsg).toContain("Additional context: ctx");
+    expect(userMsg).toContain("--- SOURCE CODE ---");
+  });
+
+  test("invalid output emits a non-retry validation_error then complete", async () => {
+    const { client } = makeClient({
+      streamFrames: [outputTextDelta("garbage")],
+    });
+    const svc = new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+    const events = await drain(svc.generateFromSource("code"));
+    const ve = events.find((e) => e.type === "validation_error");
+    expect((ve as { retrying: boolean }).retrying).toBe(false);
+    expect(types(events)).toContain("generation_complete");
+  });
+});
+
+// ---- parseAndValidate (direct) ---------------------------------------
+
+describe("parseAndValidate", () => {
+  function svc(): SkillGenerationService {
+    const { client } = makeClient({});
+    return new SkillGenerationService({
+      llmClient: client,
+      defaultsResolver: makeResolver(DEFAULTS),
+    });
+  }
+
+  test("strips a ```json fence", () => {
+    const out = svc().parseAndValidate("```json\n" + VALID_SKILL + "\n```");
+    expect(out).not.toBeNull();
+    expect(out!.name).toBe("demo-skill");
+  });
+
+  test("strips a bare ``` fence", () => {
+    const out = svc().parseAndValidate("```\n" + VALID_SKILL + "\n```");
+    expect(out).not.toBeNull();
+  });
+
+  test("slices the brace span out of prose-wrapped output", () => {
+    const out = svc().parseAndValidate(
+      "Sure! Here is your skill:\n" + VALID_SKILL + "\nHope that helps.",
+    );
+    expect(out).not.toBeNull();
+    expect(out!.name).toBe("demo-skill");
+  });
+
+  test("migrates readmeMd → readmeBody, stripping YAML frontmatter", () => {
+    const withFrontmatter = JSON.stringify({
+      name: "legacy-skill",
+      description: "A legacy skill carrying readmeMd with frontmatter.",
+      category: "plain",
+      tags: ["legacy"],
+      readmeMd:
+        "---\ntitle: Legacy\nfoo: bar\n---\n# Legacy Skill\n\nBody content that is well over the fifty character minimum requirement.",
+      runtimes: [],
+      dependencies: [],
+      envVars: [],
+      scripts: [],
+    });
+    const out = svc().parseAndValidate(withFrontmatter);
+    expect(out).not.toBeNull();
+    expect(out!.readmeBody).toContain("# Legacy Skill");
+    expect(out!.readmeBody).not.toContain("title: Legacy");
+  });
+
+  test("migrates readmeMd → readmeBody when there is no frontmatter", () => {
+    const noFrontmatter = JSON.stringify({
+      name: "legacy-plain",
+      description: "A legacy skill carrying readmeMd without frontmatter.",
+      category: "plain",
+      tags: ["legacy"],
+      readmeMd:
+        "# Plain Legacy\n\nThis body has no YAML frontmatter and is over the fifty char minimum.",
+      runtimes: [],
+      dependencies: [],
+      envVars: [],
+      scripts: [],
+    });
+    const out = svc().parseAndValidate(noFrontmatter);
+    expect(out).not.toBeNull();
+    expect(out!.readmeBody).toContain("# Plain Legacy");
+  });
+
+  test("schema violation returns null", () => {
+    const badSchema = JSON.stringify({
+      name: "Bad Name With Spaces",
+      description: "short",
+      category: "plain",
+      tags: [],
+      readmeBody: "too short",
+      runtimes: [],
+      dependencies: [],
+      envVars: [],
+      scripts: [],
+    });
+    expect(svc().parseAndValidate(badSchema)).toBeNull();
+  });
+
+  test("non-JSON input returns null", () => {
+    expect(svc().parseAndValidate("this is not json at all")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #875

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-81335-28989`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
