### PR TITLE
chore: [Misc] test(api): admin + platform + admin-users route tests — raise s

### DIFF
--- a/.changeset/test-877-admin-routes-coverage.md
+++ b/.changeset/test-877-admin-routes-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add route test coverage for admin skills, platform settings, and admin users (#877)

--- a/ornn-api/src/domains/admin-users/routes.test.ts
+++ b/ornn-api/src/domains/admin-users/routes.test.ts
@@ -153,11 +153,17 @@ describe("GET /admin/users", () => {
     expect(listCalls[0]!.dir).toBe("asc");
   });
 
-  test("invalid sort key → zod throws → 500 (route does not silently pass)", async () => {
+  test("invalid sort currently escapes as 500 internal_error (KNOWN DEFECT — should be 400; tracked in #908)", async () => {
+    // Documents current buggy behavior: the route calls raw `sortKeySchema.parse`
+    // (and `dirSchema.parse`) on the `sort`/`dir` query params. A bad value makes
+    // zod throw a ZodError, which carries no `statusCode`/`code`, so it escapes to
+    // the bootstrap's non-AppError→500 mapper instead of being a client error.
+    // Target fix: mirror the `role` param's `safeParse` guard and raise a 400
+    // `invalid_sort` / `invalid_dir` AppError. Until that lands we pin the
+    // current 500 so the regression is visible and the fix flips this assertion.
     const res = await app.request("/admin/users?sort=bogusColumn", {
       headers: authHeaders(),
     });
-    // sortKeySchema.parse throws a ZodError (no statusCode) → onError 500.
     expect(res.status).toBe(500);
     expect(listCalls.length).toBe(0);
   });

--- a/ornn-api/src/domains/admin-users/routes.test.ts
+++ b/ornn-api/src/domains/admin-users/routes.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Admin-users routes — mount + dispatch tests (#877).
+ *
+ * Dependency-injected fake `AdminUsersService` — NO MongoDB. The route is
+ * the unit under test: role defaulting + validation, page/pageSize
+ * clamping, the `q` trim→undefined elision, and the
+ * `exactOptionalPropertyTypes` conditional spread that must NOT pass
+ * `q`/`sort`/`dir` keys to the service when they're absent.
+ *
+ * Harness mirrors `domains/admin/quota/routes.test.ts`: synthetic auth
+ * middleware reading `x-test-perms`, an `onError` rendering RFC 7807
+ * problem+json via `buildProblemJsonBody`, and `app.request()` dispatch.
+ *
+ * The admin permission is imported from the real export
+ * (`QUOTA_ADMIN_PERMISSION`) rather than hardcoded so this test tracks
+ * the route's gate if the constant ever changes.
+ *
+ * @module domains/admin-users/routes.test
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { QUOTA_ADMIN_PERMISSION } from "../quota/types";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { buildProblemJsonBody } from "../../shared/types/index";
+import { createAdminUsersRoutes } from "./routes";
+import type { AdminUsersService, ListUsersParams } from "./service";
+
+/** Captured params the route handed the service. */
+let listCalls: ListUsersParams[];
+let app: Hono<{ Variables: AuthVariables }>;
+
+/**
+ * Throwing-proxy DI fake — `listUsers` is the only legitimate access.
+ * Returns a fixed empty page so the route's response envelope is exercised.
+ */
+function makeService(): AdminUsersService {
+  const impl: Partial<AdminUsersService> = {
+    async listUsers(params: ListUsersParams) {
+      listCalls.push(params);
+      return { items: [], page: params.page, pageSize: params.pageSize, total: 0, totalPages: 1 };
+    },
+  };
+  return new Proxy(impl as AdminUsersService, {
+    get(target, prop, receiver) {
+      if (prop in target) return Reflect.get(target, prop, receiver);
+      throw new Error(`adminUsersService.${String(prop)} accessed but not faked`);
+    },
+  });
+}
+
+function authHeaders(perms: string[] = [QUOTA_ADMIN_PERMISSION]) {
+  return { "x-test-perms": perms.join(",") };
+}
+
+beforeEach(() => {
+  listCalls = [];
+  const router = createAdminUsersRoutes({ adminUsersService: makeService() });
+  app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    const permsHeader = c.req.header("x-test-perms") ?? "";
+    const permissions = permsHeader.length > 0 ? permsHeader.split(",") : [];
+    c.set("auth", {
+      userId: "admin1",
+      email: "admin@x.test",
+      displayName: "Admin",
+      roles: [],
+      permissions,
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    const e = err as { statusCode?: number; code?: string; message: string };
+    const statusCode = e.statusCode ?? 500;
+    const code = e.code ?? "internal_error";
+    const body = buildProblemJsonBody({
+      statusCode,
+      code,
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  app.route("/", router);
+});
+
+describe("GET /admin/users", () => {
+  test("default role=normal + no optional keys passed through", async () => {
+    const res = await app.request("/admin/users", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { total: number }; error: null };
+    expect(json.error).toBeNull();
+    expect(json.data.total).toBe(0);
+    expect(listCalls).toHaveLength(1);
+    const call = listCalls[0]!;
+    expect(call.role).toBe("normal"); // default
+    expect(call.page).toBe(1);
+    expect(call.pageSize).toBe(20);
+    // exactOptionalPropertyTypes: absent optionals are NOT spread in.
+    expect("q" in call).toBe(false);
+    expect("sort" in call).toBe(false);
+    expect("dir" in call).toBe(false);
+  });
+
+  test("role=admin is forwarded", async () => {
+    const res = await app.request("/admin/users?role=admin", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    expect(listCalls[0]!.role).toBe("admin");
+  });
+
+  test("invalid role → 400 invalid_role; service not called", async () => {
+    const res = await app.request("/admin/users?role=superuser", { headers: authHeaders() });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_role");
+    expect(listCalls.length).toBe(0);
+  });
+
+  test("pageSize clamps to ≤ 200; page floors at ≥ 1", async () => {
+    const res = await app.request("/admin/users?page=0&pageSize=5000", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    expect(listCalls[0]!.page).toBe(1);
+    expect(listCalls[0]!.pageSize).toBe(200);
+  });
+
+  test("q whitespace-only trims to undefined and is elided", async () => {
+    const res = await app.request(`/admin/users?q=${encodeURIComponent("   ")}`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    expect("q" in listCalls[0]!).toBe(false);
+  });
+
+  test("q with content is trimmed and forwarded", async () => {
+    const res = await app.request(`/admin/users?q=${encodeURIComponent("  alice  ")}`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    expect(listCalls[0]!.q).toBe("alice");
+  });
+
+  test("sort + dir parse via zod and are forwarded", async () => {
+    const res = await app.request("/admin/users?sort=skillCount&dir=asc", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    expect(listCalls[0]!.sort).toBe("skillCount");
+    expect(listCalls[0]!.dir).toBe("asc");
+  });
+
+  test("invalid sort key → zod throws → 500 (route does not silently pass)", async () => {
+    const res = await app.request("/admin/users?sort=bogusColumn", {
+      headers: authHeaders(),
+    });
+    // sortKeySchema.parse throws a ZodError (no statusCode) → onError 500.
+    expect(res.status).toBe(500);
+    expect(listCalls.length).toBe(0);
+  });
+
+  test("403 when admin perm missing — listUsers never called", async () => {
+    const res = await app.request("/admin/users", { headers: authHeaders([]) });
+    expect(res.status).toBe(403);
+    expect(listCalls.length).toBe(0);
+  });
+});

--- a/ornn-api/src/domains/admin/routes.test.ts
+++ b/ornn-api/src/domains/admin/routes.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Admin skill-management routes — mount + dispatch tests (#877).
+ *
+ * Mirrors the harness in `domains/admin/quota/routes.test.ts`: a Hono
+ * app with a synthetic auth middleware that reads `x-test-perms`, an
+ * `onError` that renders RFC 7807 problem+json via `buildProblemJsonBody`,
+ * and `app.request()` for dispatch.
+ *
+ * `createAdminRoutes` reads `skillRepo["collection"]` directly and drives
+ * a live MongoDB cursor chain (countDocuments + find/sort/skip/limit), so
+ * the skill repository is a REAL `SkillRepository` over an in-memory
+ * MongoDB — never a faked cursor. `skillService`, `analyticsEmitter`, and
+ * `agentsealScanner` are dependency-injected fakes so the 403 gate can be
+ * proven to fire BEFORE any service/DB work (call-count-0 + DB-untouched).
+ *
+ * @module domains/admin/routes.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Collection, type Db } from "mongodb";
+import { SkillRepository } from "../skills/crud/repository";
+import { AnalyticsEmitter, type AnalyticsTracker } from "../../infra/analytics";
+import type { IAgentSealScanner, ScanInput, ScanResult } from "../../infra/agentseal";
+import type { SkillService } from "../skills/crud/service";
+import type { UserDirectoryRepository } from "../users/repository";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { buildProblemJsonBody } from "../../shared/types/index";
+import { createAdminRoutes, type AdminRoutesConfig } from "./routes";
+
+const ADMIN_PERM = "ornn:admin:skill";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let skillRepo: SkillRepository;
+let skillCollection: Collection;
+/** Default app — scanner omitted, fresh DI fakes per test. */
+let app: Hono<{ Variables: AuthVariables }>;
+
+/** Recorded analytics emissions, asserted by the happy-path cases. */
+interface TrackCall {
+  userId: string | null;
+  event: string;
+  properties: Record<string, unknown>;
+}
+let trackCalls: TrackCall[];
+
+class RecordingTracker implements AnalyticsTracker {
+  track(
+    userId: string | null,
+    event: string,
+    properties?: Readonly<Record<string, unknown>>,
+  ): void {
+    trackCalls.push({ userId, event, properties: { ...(properties ?? {}) } });
+  }
+  async shutdown(): Promise<void> {
+    /* no-op */
+  }
+}
+
+/** Call counters on the DI-faked skill service. */
+let deleteSkillCalls: string[];
+let rescanCalls: Array<{ idOrName: string; version: string }>;
+/** Configurable rescan result for the happy-path AgentSeal case. */
+let rescanResult: Awaited<ReturnType<SkillService["rescanVersion"]>>;
+
+/**
+ * Throwing proxy — any property access that the route layer does NOT
+ * legitimately use (everything but `deleteSkill` / `rescanVersion`)
+ * surfaces as a hard failure rather than a silent `undefined`.
+ */
+function throwingSkillService(
+  overrides: Partial<SkillService>,
+): SkillService {
+  return new Proxy(overrides as SkillService, {
+    get(target, prop, receiver) {
+      if (prop in target) return Reflect.get(target, prop, receiver);
+      throw new Error(`skillService.${String(prop)} accessed but not faked`);
+    },
+  });
+}
+
+function makeSkillService(): SkillService {
+  return throwingSkillService({
+    async deleteSkill(guid: string): Promise<void> {
+      deleteSkillCalls.push(guid);
+    },
+    async rescanVersion(idOrName: string, version: string) {
+      rescanCalls.push({ idOrName, version });
+      return rescanResult;
+    },
+  } as Partial<SkillService>);
+}
+
+/** AgentSeal scanner DI fake — wired only in the happy-path rescan case. */
+let scannerScanCalls: ScanInput[];
+function makeScanner(): IAgentSealScanner {
+  return {
+    async scan(input: ScanInput): Promise<ScanResult | null> {
+      scannerScanCalls.push(input);
+      return null;
+    },
+  };
+}
+
+/**
+ * `userDirectoryRepo` is held on the config for future drill-downs and is
+ * only `void`-referenced by the module today — a throwing proxy proves it
+ * is never actually consumed.
+ */
+const userDirectoryRepo = new Proxy(
+  {},
+  {
+    get(_t, prop) {
+      throw new Error(`userDirectoryRepo.${String(prop)} unexpectedly used`);
+    },
+  },
+) as UserDirectoryRepository;
+
+function buildApp(config: AdminRoutesConfig): Hono<{ Variables: AuthVariables }> {
+  const router = createAdminRoutes(config);
+  const app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    const permsHeader = c.req.header("x-test-perms") ?? "";
+    const permissions = permsHeader.length > 0 ? permsHeader.split(",") : [];
+    c.set("auth", {
+      userId: "admin1",
+      email: "admin@x.test",
+      displayName: "Admin",
+      roles: [],
+      permissions,
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    const e = err as { statusCode?: number; code?: string; message: string };
+    const statusCode = e.statusCode ?? 500;
+    const code = e.code ?? "internal_error";
+    const body = buildProblemJsonBody({
+      statusCode,
+      code,
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  app.route("/", router);
+  return app;
+}
+
+function baseConfig(
+  overrides: Partial<AdminRoutesConfig> = {},
+): AdminRoutesConfig {
+  return {
+    analyticsEmitter: new AnalyticsEmitter({
+      tracker: new RecordingTracker(),
+      errorSampleRate: 0,
+    }),
+    userDirectoryRepo,
+    skillRepo,
+    skillService: makeSkillService(),
+    ...overrides,
+  };
+}
+
+function authHeaders(perms: string[] = [ADMIN_PERM]) {
+  return { "x-test-perms": perms.join(",") };
+}
+
+async function seedSkill(
+  doc: Record<string, unknown>,
+): Promise<void> {
+  await skillCollection.insertOne(doc as never);
+}
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("admin_routes_test");
+  skillRepo = new SkillRepository(db);
+  await skillRepo.ensureIndexes();
+  skillCollection = db.collection("skills");
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await skillCollection.deleteMany({});
+  trackCalls = [];
+  deleteSkillCalls = [];
+  rescanCalls = [];
+  scannerScanCalls = [];
+  rescanResult = {
+    skillGuid: "g-1",
+    skillName: "alpha",
+    version: "1.0",
+    scan: { score: 92, findings: [{ rule: "x" }], scannedAt: "2026-06-05T00:00:00Z", agentsealVersion: "1.2.3" },
+  };
+  app = buildApp(baseConfig());
+});
+
+describe("GET /admin/skills", () => {
+  test("default page/pageSize clamp + item mapping (Date→ISO, tags fallback)", async () => {
+    const createdOn = new Date("2026-01-02T03:04:05Z");
+    const updatedOn = new Date("2026-02-03T04:05:06Z");
+    await seedSkill({
+      _id: "g-1",
+      name: "alpha",
+      description: "first skill",
+      createdBy: "u1",
+      createdByEmail: "u1@x.test",
+      createdByDisplayName: "User One",
+      createdOn,
+      updatedOn,
+      metadata: { tags: ["t1", "t2"] },
+      isPrivate: false,
+    });
+    // A doc missing isPrivate + tags exercises the defaults.
+    await seedSkill({
+      _id: "g-2",
+      name: "beta",
+      description: "second skill",
+      createdBy: "u2",
+      createdOn,
+      updatedOn,
+    });
+
+    const res = await app.request("/admin/skills", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: {
+        items: Array<{
+          guid: string;
+          createdOn: string;
+          updatedOn: string;
+          isPrivate: boolean;
+          tags: string[];
+          createdByEmail: string;
+          createdByDisplayName: string;
+        }>;
+        total: number;
+        page: number;
+        pageSize: number;
+        totalPages: number;
+      };
+      error: null;
+    };
+    expect(json.error).toBeNull();
+    expect(json.data.total).toBe(2);
+    expect(json.data.page).toBe(1); // clamped to ≥ 1
+    expect(json.data.pageSize).toBe(20); // default
+    expect(json.data.totalPages).toBe(1);
+    const byGuid = new Map(json.data.items.map((i) => [i.guid, i]));
+    const alpha = byGuid.get("g-1")!;
+    expect(alpha.createdOn).toBe(createdOn.toISOString());
+    expect(alpha.updatedOn).toBe(updatedOn.toISOString());
+    expect(alpha.isPrivate).toBe(false);
+    expect(alpha.tags).toEqual(["t1", "t2"]);
+    const beta = byGuid.get("g-2")!;
+    expect(beta.isPrivate).toBe(true); // default fallback
+    expect(beta.tags).toEqual([]); // tags fallback
+    expect(beta.createdByEmail).toBe(""); // missing → ""
+    expect(beta.createdByDisplayName).toBe("");
+  });
+
+  test("page < 1 and pageSize > 100 clamp to page≥1 / pageSize≤100", async () => {
+    const res = await app.request("/admin/skills?page=0&pageSize=9999", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { page: number; pageSize: number } };
+    expect(json.data.page).toBe(1);
+    expect(json.data.pageSize).toBe(100);
+  });
+
+  test("q regex-escapes special chars + matches name OR description", async () => {
+    await seedSkill({
+      _id: "g-dot",
+      name: "a.b.c",
+      description: "literal dotted name",
+      createdBy: "u1",
+      createdOn: new Date(),
+      updatedOn: new Date(),
+    });
+    // A decoy that an UNescaped `.` regex would also match.
+    await seedSkill({
+      _id: "g-decoy",
+      name: "axbxc",
+      description: "should not match an escaped query",
+      createdBy: "u1",
+      createdOn: new Date(),
+      updatedOn: new Date(),
+    });
+    // Matches via description only.
+    await seedSkill({
+      _id: "g-desc",
+      name: "unrelated",
+      description: "contains a.b.c inside the body",
+      createdBy: "u1",
+      createdOn: new Date(),
+      updatedOn: new Date(),
+    });
+
+    const res = await app.request(`/admin/skills?q=${encodeURIComponent("a.b.c")}`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { items: Array<{ guid: string }>; total: number } };
+    const guids = json.data.items.map((i) => i.guid).sort();
+    expect(guids).toEqual(["g-desc", "g-dot"]); // decoy excluded by escape
+    expect(json.data.total).toBe(2);
+  });
+
+  test("userId query maps to createdBy filter", async () => {
+    await seedSkill({
+      _id: "g-mine",
+      name: "mine",
+      description: "owned by u1",
+      createdBy: "u1",
+      createdOn: new Date(),
+      updatedOn: new Date(),
+    });
+    await seedSkill({
+      _id: "g-theirs",
+      name: "theirs",
+      description: "owned by u2",
+      createdBy: "u2",
+      createdOn: new Date(),
+      updatedOn: new Date(),
+    });
+
+    const res = await app.request("/admin/skills?userId=u1", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { items: Array<{ guid: string }>; total: number } };
+    expect(json.data.total).toBe(1);
+    expect(json.data.items[0]!.guid).toBe("g-mine");
+  });
+
+  test("pagination math — second page offset + totalPages", async () => {
+    for (let i = 0; i < 5; i++) {
+      await seedSkill({
+        _id: `g-${i}`,
+        name: `skill-${i}`,
+        description: `desc ${i}`,
+        createdBy: "u1",
+        createdOn: new Date(Date.now() + i * 1000),
+        updatedOn: new Date(),
+      });
+    }
+    const res = await app.request("/admin/skills?page=2&pageSize=2", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { items: unknown[]; total: number; page: number; pageSize: number; totalPages: number };
+    };
+    expect(json.data.total).toBe(5);
+    expect(json.data.page).toBe(2);
+    expect(json.data.pageSize).toBe(2);
+    expect(json.data.items.length).toBe(2);
+    expect(json.data.totalPages).toBe(3); // ceil(5 / 2)
+  });
+
+  test("403 when admin perm missing — DB never queried", async () => {
+    await seedSkill({
+      _id: "g-1",
+      name: "alpha",
+      description: "seeded",
+      createdBy: "u1",
+      createdOn: new Date(),
+      updatedOn: new Date(),
+    });
+    let countQueries = 0;
+    const realCount = skillCollection.countDocuments.bind(skillCollection);
+    skillCollection.countDocuments = ((...args: Parameters<typeof realCount>) => {
+      countQueries += 1;
+      return realCount(...args);
+    }) as typeof skillCollection.countDocuments;
+    try {
+      const res = await app.request("/admin/skills", { headers: authHeaders([]) });
+      expect(res.status).toBe(403);
+      expect(countQueries).toBe(0); // gate fired before the cursor chain
+    } finally {
+      skillCollection.countDocuments = realCount;
+    }
+  });
+});
+
+describe("DELETE /admin/skills/:id", () => {
+  test("happy path — deleteSkill called + adminAction analytics emitted", async () => {
+    const res = await app.request("/admin/skills/g-1", {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { success: boolean }; error: null };
+    expect(json.data.success).toBe(true);
+    expect(json.error).toBeNull();
+    expect(deleteSkillCalls).toEqual(["g-1"]);
+    const emitted = trackCalls.find((t) => t.event === "skill.deleted");
+    expect(emitted).toBeDefined();
+    expect(emitted!.properties.skillId).toBe("g-1");
+    expect(emitted!.properties.adminAction).toBe(true);
+  });
+
+  test("403 when admin perm missing — deleteSkill never called", async () => {
+    const res = await app.request("/admin/skills/g-1", {
+      method: "DELETE",
+      headers: authHeaders([]),
+    });
+    expect(res.status).toBe(403);
+    expect(deleteSkillCalls.length).toBe(0);
+  });
+});
+
+describe("POST /admin/skills/:idOrName/versions/:version/agentseal-rescan", () => {
+  test("503 when scanner is not wired — rescanVersion never called", async () => {
+    const res = await app.request(
+      "/admin/skills/alpha/versions/1.0/agentseal-rescan",
+      { method: "POST", headers: authHeaders() },
+    );
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { data: null; error: { code: string } };
+    expect(json.data).toBeNull();
+    expect(json.error.code).toBe("agentseal_disabled");
+    expect(rescanCalls.length).toBe(0);
+  });
+
+  test("happy path with scanner wired — envelope + analytics with score/findings", async () => {
+    const appWithScanner = buildApp(baseConfig({ agentsealScanner: makeScanner() }));
+    const res = await appWithScanner.request(
+      "/admin/skills/alpha/versions/1.0/agentseal-rescan",
+      { method: "POST", headers: authHeaders() },
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { skillGuid: string; version: string; scan: { score: number } };
+      error: null;
+    };
+    expect(json.error).toBeNull();
+    expect(json.data.skillGuid).toBe("g-1");
+    expect(json.data.scan.score).toBe(92);
+    expect(rescanCalls).toEqual([{ idOrName: "alpha", version: "1.0" }]);
+    const emitted = trackCalls.find((t) => t.event === "skill.agentseal_rescanned");
+    expect(emitted).toBeDefined();
+    expect(emitted!.properties.score).toBe(92);
+    expect(emitted!.properties.findings).toBe(1);
+    expect(emitted!.properties.adminAction).toBe(true);
+  });
+
+  test("403 when admin perm missing — rescanVersion never called", async () => {
+    const appWithScanner = buildApp(baseConfig({ agentsealScanner: makeScanner() }));
+    const res = await appWithScanner.request(
+      "/admin/skills/alpha/versions/1.0/agentseal-rescan",
+      { method: "POST", headers: authHeaders([]) },
+    );
+    expect(res.status).toBe(403);
+    expect(rescanCalls.length).toBe(0);
+    expect(scannerScanCalls.length).toBe(0);
+  });
+});

--- a/ornn-api/src/domains/platform/routes.test.ts
+++ b/ornn-api/src/domains/platform/routes.test.ts
@@ -168,6 +168,33 @@ describe("PATCH /admin/settings — validation", () => {
     expect(patchCalls.length).toBe(0);
   });
 
+  // Lower-bound boundary: the guard rejects `n < 0` before rounding/persisting.
+  test("auditWaiverThreshold negative (-1) → 400 invalid_setting", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ auditWaiverThreshold: -1 }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_setting");
+    expect(patchCalls.length).toBe(0);
+  });
+
+  // Non-numeric input: Number("x") is NaN, so the `!Number.isFinite(n)` arm of
+  // the same guard fires → 400 invalid_setting (route never coerces it to 0).
+  test("auditWaiverThreshold non-number ('x') → 400 invalid_setting", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ auditWaiverThreshold: "x" }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_setting");
+    expect(patchCalls.length).toBe(0);
+  });
+
   test("auditWaiverThreshold rounds to 1 decimal place", async () => {
     const res = await app.request("/admin/settings", {
       method: "PATCH",

--- a/ornn-api/src/domains/platform/routes.test.ts
+++ b/ornn-api/src/domains/platform/routes.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Admin platform-settings routes — mount + dispatch tests (#877).
+ *
+ * Pure dependency-injected fake `PlatformSettingsService` — NO MongoDB.
+ * The route layer is the unit under test: response masking, the
+ * field-by-field PATCH validation gauntlet, and the "preserve existing"
+ * semantics around the mid-mask sentinel.
+ *
+ * Harness mirrors `domains/admin/quota/routes.test.ts`: synthetic auth
+ * middleware reading `x-test-perms`, an `onError` rendering RFC 7807
+ * problem+json via `buildProblemJsonBody`, and `app.request()` dispatch.
+ *
+ * Secret-leak guard: every assertion on a settings body verifies the
+ * plaintext apiKey is ABSENT and only the bullet-masked form is present.
+ *
+ * @module domains/platform/routes.test
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { midMaskSecret } from "../../infra/crypto";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { buildProblemJsonBody } from "../../shared/types/index";
+import { createPlatformSettingsRoutes } from "./routes";
+import type { PlatformSettingsService } from "./service";
+import type { LlmProviderConfig, PlatformSettings } from "./types";
+
+const ADMIN_PERM = "ornn:admin:skill";
+/** A real, never-masked plaintext key — its raw form must never appear in a body. */
+const PLAINTEXT_KEY = "sk-live-deadbeefcafef00d-secret";
+const STORED_GATEWAY = "https://gw.stored.test";
+
+/** Recorded patches the route handed to the service. */
+let patchCalls: Array<Partial<PlatformSettings>>;
+/** Number of times the preserve path consulted the existing config. */
+let getLlmConfigCalls: number;
+/** What the fake `getLlmProviderConfig` returns (the stored shape). */
+let storedLlmConfig: LlmProviderConfig;
+/** What the fake `patch` returns (echoes the patch merged over a base). */
+let app: Hono<{ Variables: AuthVariables }>;
+
+/**
+ * Throwing proxy DI fake — only `get`, `patch`, `getLlmProviderConfig`
+ * are legitimately used by the route. Any other access is a bug.
+ */
+function makeService(): PlatformSettingsService {
+  const impl: Partial<PlatformSettingsService> = {
+    async get(): Promise<PlatformSettings> {
+      return {
+        auditWaiverThreshold: 6,
+        llmProvider: { gatewayUrl: STORED_GATEWAY, apiKey: PLAINTEXT_KEY },
+      };
+    },
+    async getLlmProviderConfig(): Promise<LlmProviderConfig> {
+      getLlmConfigCalls += 1;
+      return storedLlmConfig;
+    },
+    async patch(partial: Partial<PlatformSettings>): Promise<PlatformSettings> {
+      patchCalls.push(partial);
+      return {
+        auditWaiverThreshold: partial.auditWaiverThreshold ?? 6,
+        llmProvider: partial.llmProvider ?? {
+          gatewayUrl: STORED_GATEWAY,
+          apiKey: PLAINTEXT_KEY,
+        },
+      };
+    },
+  };
+  return new Proxy(impl as PlatformSettingsService, {
+    get(target, prop, receiver) {
+      if (prop in target) return Reflect.get(target, prop, receiver);
+      throw new Error(`platformSettingsService.${String(prop)} accessed but not faked`);
+    },
+  });
+}
+
+function authHeaders(perms: string[] = [ADMIN_PERM]) {
+  return { "x-test-perms": perms.join(",") };
+}
+
+function jsonHeaders(perms: string[] = [ADMIN_PERM]) {
+  return { "content-type": "application/json", ...authHeaders(perms) };
+}
+
+beforeEach(() => {
+  patchCalls = [];
+  getLlmConfigCalls = 0;
+  storedLlmConfig = { gatewayUrl: STORED_GATEWAY, apiKey: PLAINTEXT_KEY };
+
+  const router = createPlatformSettingsRoutes({ platformSettingsService: makeService() });
+  app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    const permsHeader = c.req.header("x-test-perms") ?? "";
+    const permissions = permsHeader.length > 0 ? permsHeader.split(",") : [];
+    c.set("auth", {
+      userId: "admin1",
+      email: "admin@x.test",
+      displayName: "Admin",
+      roles: [],
+      permissions,
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    const e = err as { statusCode?: number; code?: string; message: string };
+    const statusCode = e.statusCode ?? 500;
+    const code = e.code ?? "internal_error";
+    const body = buildProblemJsonBody({
+      statusCode,
+      code,
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  app.route("/", router);
+});
+
+describe("GET /admin/settings", () => {
+  test("200 masks apiKey — plaintext absent, mid-mask present", async () => {
+    const res = await app.request("/admin/settings", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const raw = await res.text();
+    // Hard secret-leak guard: the plaintext key must never appear anywhere.
+    expect(raw).not.toContain(PLAINTEXT_KEY);
+    const json = JSON.parse(raw) as {
+      data: { llmProvider: { gatewayUrl: string; apiKey: string } };
+      error: null;
+    };
+    expect(json.error).toBeNull();
+    expect(json.data.llmProvider.gatewayUrl).toBe(STORED_GATEWAY);
+    expect(json.data.llmProvider.apiKey).toBe(midMaskSecret(PLAINTEXT_KEY));
+    expect(json.data.llmProvider.apiKey).toContain("•");
+    expect(json.data.llmProvider.apiKey).not.toBe(PLAINTEXT_KEY);
+  });
+
+  test("403 when admin perm missing", async () => {
+    const res = await app.request("/admin/settings", { headers: authHeaders([]) });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("PATCH /admin/settings — validation", () => {
+  test("non-object body → 400 invalid_body", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify(["not", "an", "object"]),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_body");
+    expect(patchCalls.length).toBe(0);
+  });
+
+  test("auditWaiverThreshold out of [0,10] → 400 invalid_setting", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ auditWaiverThreshold: 11 }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_setting");
+    expect(patchCalls.length).toBe(0);
+  });
+
+  test("auditWaiverThreshold rounds to 1 decimal place", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ auditWaiverThreshold: 6.789 }),
+    });
+    expect(res.status).toBe(200);
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]!.auditWaiverThreshold).toBe(6.8); // Math.round(6.789*10)/10
+  });
+
+  test("llmProvider non-object → 400 invalid_setting", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ llmProvider: "not-an-object" }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_setting");
+    expect(patchCalls.length).toBe(0);
+  });
+
+  test("llmProvider.gatewayUrl non-string → 400 invalid_setting", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ llmProvider: { gatewayUrl: 123 } }),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { code: string }).code).toBe("invalid_setting");
+    expect(patchCalls.length).toBe(0);
+  });
+
+  test("llmProvider.gatewayUrl invalid URL → 400 invalid_setting", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ llmProvider: { gatewayUrl: "not a url" } }),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { code: string }).code).toBe("invalid_setting");
+    expect(patchCalls.length).toBe(0);
+  });
+
+  test("empty patch (no known keys) → 400 invalid_setting", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ unknownKey: "ignored" }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_setting");
+    expect(patchCalls.length).toBe(0);
+  });
+});
+
+describe("PATCH /admin/settings — preserve semantics", () => {
+  test("gatewayUrl omitted → existing consulted + preserved in patch", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ llmProvider: { apiKey: "" } }),
+    });
+    expect(res.status).toBe(200);
+    expect(getLlmConfigCalls).toBeGreaterThanOrEqual(1);
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]!.llmProvider!.gatewayUrl).toBe(STORED_GATEWAY);
+  });
+
+  test("apiKey mid-mask sentinel → stored key preserved (not bullets)", async () => {
+    const masked = midMaskSecret(PLAINTEXT_KEY); // contains the bullet sentinel
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ llmProvider: { gatewayUrl: "https://gw.new.test", apiKey: masked } }),
+    });
+    expect(res.status).toBe(200);
+    expect(patchCalls).toHaveLength(1);
+    // The sentinel must resolve to the stored key, NOT the bullet string.
+    expect(patchCalls[0]!.llmProvider!.apiKey).toBe(PLAINTEXT_KEY);
+    expect(patchCalls[0]!.llmProvider!.apiKey).not.toContain("•");
+    expect(patchCalls[0]!.llmProvider!.gatewayUrl).toBe("https://gw.new.test");
+    // Response is re-masked — plaintext never leaks back out.
+    const raw = await res.text();
+    expect(raw).not.toContain(PLAINTEXT_KEY);
+  });
+
+  test("apiKey omitted → stored key preserved via getLlmProviderConfig", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ llmProvider: { gatewayUrl: "https://gw.new.test" } }),
+    });
+    expect(res.status).toBe(200);
+    expect(getLlmConfigCalls).toBeGreaterThanOrEqual(1);
+    expect(patchCalls[0]!.llmProvider!.apiKey).toBe(PLAINTEXT_KEY);
+  });
+
+  test("real apiKey → trimmed + stored verbatim", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        llmProvider: { gatewayUrl: "https://gw.new.test", apiKey: `  ${PLAINTEXT_KEY}  ` },
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(patchCalls[0]!.llmProvider!.apiKey).toBe(PLAINTEXT_KEY); // trimmed
+    // The response body re-masks the just-set key.
+    const raw = await res.text();
+    expect(raw).not.toContain(PLAINTEXT_KEY);
+    const json = JSON.parse(raw) as { data: { llmProvider: { apiKey: string } } };
+    expect(json.data.llmProvider.apiKey).toContain("•");
+  });
+});


### PR DESCRIPTION
Closes #877

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-93836-15340`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
