### PR TITLE
chore: [Misc] test(api): analytics domain tests — raise src/domains/analytics

### DIFF
--- a/.changeset/test-880-analytics-coverage.md
+++ b/.changeset/test-880-analytics-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add analytics test coverage (service pass-through, route validation, PostHog tracker fail-open) (#880)

--- a/ornn-api/src/domains/analytics/routes.test.ts
+++ b/ornn-api/src/domains/analytics/routes.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Route-level tests for the analytics read routes (#880).
+ *
+ * Mounts `createAnalyticsRoutes` on a bare Hono app, stubs the upstream
+ * auth context (production wires this via proxyAuthSetup), and supplies
+ * hand-rolled fakes for the two collaborators (analyticsService,
+ * skillService). The project onError → RFC 7807 mapping is replicated so
+ * thrown AppErrors surface with the right status. Harness cloned from
+ * `skills/audit/routes.test.ts`.
+ *
+ * Coverage:
+ *   - GET /skills/:id/analytics        → 200 / INVALID_WINDOW 400 /
+ *     window+version passthrough
+ *   - GET .../analytics/pulls          → 200 / INVALID_BUCKET 400 /
+ *     invalid_range (bad from / bad to / from>=to) / from-to-version
+ *     passthrough
+ *   - authorizeRead visibility         → public anon 200 / private anon
+ *     404 / private authed canRead 200 / private authed !canRead 404
+ *
+ * @module domains/analytics/routes.test
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { createAnalyticsRoutes, type AnalyticsRoutesConfig } from "./routes";
+import { buildProblemJsonBody } from "../../shared/types/index";
+import type { SkillAnalyticsSummary, PullBucketCount } from "./types";
+import type { SkillDetailResponse } from "../../shared/types/index";
+
+const OWNER_ID = "owner-1";
+
+// ---- Fixtures --------------------------------------------------------
+
+function summary(overrides: Partial<SkillAnalyticsSummary> = {}): SkillAnalyticsSummary {
+  return {
+    skillGuid: "skill-guid-1",
+    window: "30d",
+    executionCount: 0,
+    successCount: 0,
+    failureCount: 0,
+    timeoutCount: 0,
+    successRate: null,
+    latencyMs: { p50: null, p95: null, p99: null },
+    uniqueUsers: 0,
+    topErrorCodes: [],
+    ...overrides,
+  };
+}
+
+function skill(overrides: Partial<SkillDetailResponse> = {}): SkillDetailResponse {
+  return {
+    guid: "skill-guid-1",
+    name: "demo-skill",
+    description: "a demo",
+    license: null,
+    compatibility: null,
+    metadata: {},
+    tags: [],
+    skillHash: "hash-1",
+    presignedPackageUrl: "https://storage.test/skill.zip",
+    isPrivate: false,
+    createdBy: OWNER_ID,
+    createdOn: "2026-01-01T00:00:00Z",
+    updatedOn: "2026-01-01T00:00:00Z",
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+// ---- Fakes -----------------------------------------------------------
+
+class FakeAnalyticsService {
+  summaryResult: SkillAnalyticsSummary = summary();
+  pullsResult: ReadonlyArray<PullBucketCount> = [];
+  getSummaryCalls: Array<{
+    skillGuid: string;
+    window: "7d" | "30d" | "all";
+    version?: string | undefined;
+  }> = [];
+  getPullsCalls: Array<{
+    skillGuid: string;
+    bucket: string;
+    from?: Date | undefined;
+    to?: Date | undefined;
+    version?: string | undefined;
+  }> = [];
+
+  async getSummary(
+    skillGuid: string,
+    window: "7d" | "30d" | "all",
+    version?: string,
+  ): Promise<SkillAnalyticsSummary> {
+    this.getSummaryCalls.push({ skillGuid, window, version });
+    return this.summaryResult;
+  }
+  async getPullsTimeSeries(params: {
+    skillGuid: string;
+    bucket: string;
+    from?: Date;
+    to?: Date;
+    version?: string;
+  }): Promise<ReadonlyArray<PullBucketCount>> {
+    this.getPullsCalls.push(params);
+    return this.pullsResult;
+  }
+}
+
+class FakeSkillService {
+  constructor(private s: SkillDetailResponse) {}
+  async getSkill(): Promise<SkillDetailResponse> {
+    return this.s;
+  }
+}
+
+// ---- App builder -----------------------------------------------------
+
+function buildApp(
+  cfg: { analyticsService?: FakeAnalyticsService; skillService?: FakeSkillService },
+  opts: { authenticated?: boolean; userId?: string; permissions?: string[] } = {},
+): { app: Hono; analyticsService: FakeAnalyticsService } {
+  const { authenticated = true, userId = OWNER_ID, permissions = [] } = opts;
+  const analyticsService = cfg.analyticsService ?? new FakeAnalyticsService();
+  const skillService = cfg.skillService ?? new FakeSkillService(skill());
+
+  const full: AnalyticsRoutesConfig = {
+    analyticsService: analyticsService as unknown as AnalyticsRoutesConfig["analyticsService"],
+    skillService: skillService as unknown as AnalyticsRoutesConfig["skillService"],
+  };
+
+  const app = new Hono();
+  if (authenticated) {
+    app.use("*", async (c, next) => {
+      c.set("auth" as never, {
+        userId,
+        email: `${userId}@test.local`,
+        displayName: userId,
+        roles: [],
+        permissions,
+      } as never);
+      await next();
+    });
+  }
+  app.route("/api/v1", createAnalyticsRoutes(full));
+  app.onError((err, c) => {
+    const code = (err as { code?: string }).code ?? "internal_error";
+    const status = (err as { statusCode?: number }).statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode: status,
+      code,
+      message: err.message,
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, status as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  return { app, analyticsService };
+}
+
+// ---- GET /skills/:id/analytics ---------------------------------------
+
+describe("GET /skills/:idOrName/analytics", () => {
+  it("returns 200 with the summary for a public skill (anonymous)", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics");
+    expect(res.status).toBe(200);
+    const parsed = (await res.json()) as { data: { skillGuid: string }; error: null };
+    expect(parsed.data.skillGuid).toBe("skill-guid-1");
+    expect(parsed.error).toBeNull();
+  });
+
+  it("returns 400 INVALID_WINDOW for an unrecognized window", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics?window=year");
+    expect(res.status).toBe(400);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("INVALID_WINDOW");
+  });
+
+  it("passes window + version through to the service", async () => {
+    const { app, analyticsService } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics?window=7d&version=2.1.0");
+    expect(res.status).toBe(200);
+    expect(analyticsService.getSummaryCalls[0]!.window).toBe("7d");
+    expect(analyticsService.getSummaryCalls[0]!.version).toBe("2.1.0");
+    expect(analyticsService.getSummaryCalls[0]!.skillGuid).toBe("skill-guid-1");
+  });
+});
+
+// ---- GET /skills/:id/analytics/pulls ---------------------------------
+
+describe("GET /skills/:idOrName/analytics/pulls", () => {
+  it("returns 200 with the items array for a public skill (anonymous)", async () => {
+    const svc = new FakeAnalyticsService();
+    svc.pullsResult = [
+      { bucket: "2026-01-01T00:00:00.000Z", total: 2, bySource: { api: 2, web: 0, playground: 0 } },
+    ];
+    const { app } = buildApp({ analyticsService: svc }, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics/pulls");
+    expect(res.status).toBe(200);
+    const parsed = (await res.json()) as { data: { items: unknown[] }; error: null };
+    expect(parsed.data.items).toHaveLength(1);
+  });
+
+  it("returns 400 INVALID_BUCKET for an unrecognized bucket", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics/pulls?bucket=week");
+    expect(res.status).toBe(400);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("INVALID_BUCKET");
+  });
+
+  it("returns 400 invalid_range for a non-ISO 'from'", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics/pulls?from=not-a-date");
+    expect(res.status).toBe(400);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("invalid_range");
+  });
+
+  it("returns 400 invalid_range for a non-ISO 'to'", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics/pulls?to=nope");
+    expect(res.status).toBe(400);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("invalid_range");
+  });
+
+  it("returns 400 invalid_range when from >= to", async () => {
+    const { app } = buildApp({}, { authenticated: false });
+    const res = await app.request(
+      "/api/v1/skills/demo-skill/analytics/pulls?from=2026-02-01T00:00:00Z&to=2026-01-01T00:00:00Z",
+    );
+    expect(res.status).toBe(400);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("invalid_range");
+  });
+
+  it("passes bucket + from + to + version through to the service", async () => {
+    const { app, analyticsService } = buildApp({}, { authenticated: false });
+    const res = await app.request(
+      "/api/v1/skills/demo-skill/analytics/pulls?bucket=month&from=2026-01-01T00:00:00Z&to=2026-02-01T00:00:00Z&version=1.0.0",
+    );
+    expect(res.status).toBe(200);
+    const call = analyticsService.getPullsCalls[0]!;
+    expect(call.skillGuid).toBe("skill-guid-1");
+    expect(call.bucket).toBe("month");
+    expect(call.from?.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    expect(call.to?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+    expect(call.version).toBe("1.0.0");
+  });
+});
+
+// ---- authorizeRead visibility ----------------------------------------
+
+describe("analytics visibility (authorizeRead)", () => {
+  it("allows an anonymous caller to read a PUBLIC skill's analytics", async () => {
+    const skillSvc = new FakeSkillService(skill({ isPrivate: false }));
+    const { app } = buildApp({ skillService: skillSvc }, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 skill_not_found for an anonymous caller on a PRIVATE skill", async () => {
+    const skillSvc = new FakeSkillService(skill({ isPrivate: true }));
+    const { app } = buildApp({ skillService: skillSvc }, { authenticated: false });
+    const res = await app.request("/api/v1/skills/demo-skill/analytics");
+    expect(res.status).toBe(404);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("skill_not_found");
+  });
+
+  it("allows an authed caller who can read the PRIVATE skill (author)", async () => {
+    const skillSvc = new FakeSkillService(skill({ isPrivate: true, createdBy: OWNER_ID }));
+    const { app } = buildApp(
+      { skillService: skillSvc },
+      { authenticated: true, userId: OWNER_ID, permissions: [] },
+    );
+    const res = await app.request("/api/v1/skills/demo-skill/analytics");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 when an authed caller cannot read the PRIVATE skill", async () => {
+    const skillSvc = new FakeSkillService(
+      skill({ isPrivate: true, createdBy: "someone-else" }),
+    );
+    const { app } = buildApp(
+      { skillService: skillSvc },
+      { authenticated: true, userId: "stranger", permissions: [] },
+    );
+    const res = await app.request("/api/v1/skills/demo-skill/analytics");
+    expect(res.status).toBe(404);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("skill_not_found");
+  });
+});

--- a/ornn-api/src/domains/analytics/service.test.ts
+++ b/ornn-api/src/domains/analytics/service.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for `AnalyticsService` (#880).
+ *
+ * The service is a thin facade over `AnalyticsRepository`: every method
+ * forwards to the repo. These tests pin the forwarding contract with a
+ * hand-rolled `FakeAnalyticsRepository` (no Mongo) and assert the EXACT
+ * arguments handed to each repo method — in particular the
+ * `exactOptionalPropertyTypes` arm in `getSummary` (service.ts:50), where
+ * a present `version` forwards `{ version }` and an absent one forwards
+ * `{}` rather than `{ version: undefined }`.
+ *
+ * @module domains/analytics/service.test
+ */
+
+import { describe, expect, it } from "bun:test";
+import { AnalyticsService } from "./service";
+import type {
+  AggregatePullsParams,
+  RecordEventInput,
+  RecordPullInput,
+} from "./repository";
+import type { PullBucketCount, SkillAnalyticsSummary } from "./types";
+
+// ---- Fixtures --------------------------------------------------------
+
+function summary(overrides: Partial<SkillAnalyticsSummary> = {}): SkillAnalyticsSummary {
+  return {
+    skillGuid: "skill-guid-1",
+    window: "30d",
+    executionCount: 0,
+    successCount: 0,
+    failureCount: 0,
+    timeoutCount: 0,
+    successRate: null,
+    latencyMs: { p50: null, p95: null, p99: null },
+    uniqueUsers: 0,
+    topErrorCodes: [],
+    ...overrides,
+  };
+}
+
+function eventInput(overrides: Partial<RecordEventInput> = {}): RecordEventInput {
+  return {
+    skillGuid: "skill-guid-1",
+    skillName: "demo-skill",
+    outcome: "success",
+    latencyMs: 42,
+    userId: "user-1",
+    source: "playground",
+    ...overrides,
+  };
+}
+
+function pullInput(overrides: Partial<RecordPullInput> = {}): RecordPullInput {
+  return {
+    skillGuid: "skill-guid-1",
+    skillName: "demo-skill",
+    skillVersion: "1.0.0",
+    userId: "user-1",
+    source: "api",
+    ...overrides,
+  };
+}
+
+// ---- Fake repo -------------------------------------------------------
+
+/** Records every call's args so the test can assert exact forwarding. */
+class FakeAnalyticsRepository {
+  recordEventCalls: RecordEventInput[] = [];
+  recordPullCalls: RecordPullInput[] = [];
+  summarizeCalls: Array<{
+    skillGuid: string;
+    window: "7d" | "30d" | "all";
+    options: { version?: string; topErrorsLimit?: number };
+  }> = [];
+  aggregateCalls: AggregatePullsParams[] = [];
+
+  summarizeResult: SkillAnalyticsSummary = summary();
+  aggregateResult: ReadonlyArray<PullBucketCount> = [];
+
+  async recordEvent(input: RecordEventInput): Promise<void> {
+    this.recordEventCalls.push(input);
+  }
+  async recordPull(input: RecordPullInput): Promise<void> {
+    this.recordPullCalls.push(input);
+  }
+  async summarize(
+    skillGuid: string,
+    window: "7d" | "30d" | "all",
+    options: { version?: string; topErrorsLimit?: number } = {},
+  ): Promise<SkillAnalyticsSummary> {
+    this.summarizeCalls.push({ skillGuid, window, options });
+    return this.summarizeResult;
+  }
+  async aggregatePullsByBucket(
+    params: AggregatePullsParams,
+  ): Promise<ReadonlyArray<PullBucketCount>> {
+    this.aggregateCalls.push(params);
+    return this.aggregateResult;
+  }
+}
+
+function build(): { service: AnalyticsService; repo: FakeAnalyticsRepository } {
+  const repo = new FakeAnalyticsRepository();
+  const service = new AnalyticsService({
+    analyticsRepo: repo as unknown as ConstructorParameters<
+      typeof AnalyticsService
+    >[0]["analyticsRepo"],
+  });
+  return { service, repo };
+}
+
+// ---- recordExecution -------------------------------------------------
+
+describe("AnalyticsService.recordExecution", () => {
+  it("forwards the event input verbatim to repo.recordEvent", async () => {
+    const { service, repo } = build();
+    const input = eventInput({ outcome: "failure", errorCode: "boom" });
+
+    await service.recordExecution(input);
+
+    expect(repo.recordEventCalls).toHaveLength(1);
+    expect(repo.recordEventCalls[0]).toEqual(input);
+    expect(repo.recordPullCalls).toHaveLength(0);
+  });
+});
+
+// ---- recordPull ------------------------------------------------------
+
+describe("AnalyticsService.recordPull", () => {
+  it("forwards the pull input verbatim to repo.recordPull", async () => {
+    const { service, repo } = build();
+    const input = pullInput({ source: "web" });
+
+    await service.recordPull(input);
+
+    expect(repo.recordPullCalls).toHaveLength(1);
+    expect(repo.recordPullCalls[0]).toEqual(input);
+    expect(repo.recordEventCalls).toHaveLength(0);
+  });
+});
+
+// ---- getSummary ------------------------------------------------------
+
+describe("AnalyticsService.getSummary", () => {
+  it("defaults the window to 30d and forwards an empty options object", async () => {
+    const { service, repo } = build();
+
+    await service.getSummary("skill-guid-1");
+
+    expect(repo.summarizeCalls).toHaveLength(1);
+    expect(repo.summarizeCalls[0]!.window).toBe("30d");
+    // exactOptionalPropertyTypes (service.ts:50): absent version → `{}`,
+    // NOT `{ version: undefined }`.
+    expect(repo.summarizeCalls[0]!.options).toEqual({});
+    expect("version" in repo.summarizeCalls[0]!.options).toBe(false);
+  });
+
+  it("forwards an explicit window through to the repo", async () => {
+    const { service, repo } = build();
+
+    await service.getSummary("skill-guid-1", "7d");
+
+    expect(repo.summarizeCalls[0]!.window).toBe("7d");
+  });
+
+  it("forwards { version } when a version is provided", async () => {
+    const { service, repo } = build();
+
+    await service.getSummary("skill-guid-1", "all", "2.1.0");
+
+    expect(repo.summarizeCalls[0]!.skillGuid).toBe("skill-guid-1");
+    expect(repo.summarizeCalls[0]!.window).toBe("all");
+    expect(repo.summarizeCalls[0]!.options).toEqual({ version: "2.1.0" });
+  });
+
+  it("returns the repo's summary unchanged", async () => {
+    const { service, repo } = build();
+    repo.summarizeResult = summary({ executionCount: 7, window: "7d" });
+
+    const result = await service.getSummary("skill-guid-1", "7d");
+
+    expect(result).toBe(repo.summarizeResult);
+    expect(result.executionCount).toBe(7);
+  });
+});
+
+// ---- getPullsTimeSeries ----------------------------------------------
+
+describe("AnalyticsService.getPullsTimeSeries", () => {
+  it("forwards the params verbatim to repo.aggregatePullsByBucket", async () => {
+    const { service, repo } = build();
+    const params: AggregatePullsParams = {
+      skillGuid: "skill-guid-1",
+      bucket: "day",
+      from: new Date("2026-01-01T00:00:00Z"),
+      to: new Date("2026-02-01T00:00:00Z"),
+      version: "1.0.0",
+    };
+
+    await service.getPullsTimeSeries(params);
+
+    expect(repo.aggregateCalls).toHaveLength(1);
+    expect(repo.aggregateCalls[0]).toEqual(params);
+  });
+
+  it("returns the repo's bucket rows unchanged", async () => {
+    const { service, repo } = build();
+    repo.aggregateResult = [
+      { bucket: "2026-01-01T00:00:00.000Z", total: 3, bySource: { api: 3, web: 0, playground: 0 } },
+    ];
+
+    const result = await service.getPullsTimeSeries({ skillGuid: "skill-guid-1", bucket: "day" });
+
+    expect(result).toBe(repo.aggregateResult);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/ornn-api/src/infra/analytics/posthog.test.ts
+++ b/ornn-api/src/infra/analytics/posthog.test.ts
@@ -16,13 +16,41 @@
  * VALUES never are.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { PostHog } from "posthog-node";
 import { NoopTracker, PosthogTracker, createTracker } from "./posthog";
 import type { Logger } from "../../shared/logger";
 
 const FAKE_KEY = "phc_fake_key_for_test";
 const FAKE_HOST = "https://eu.i.posthog.com";
+
+// ---- Open-handle hygiene ---------------------------------------------
+//
+// Every `new PosthogTracker(...)` (directly or via `createTracker`) runs
+// the constructor's `new PostHog(...)`, which spins up a live posthog-node
+// v5 client. v5 arms its background flush timer lazily (first `capture`),
+// so in this suite — where we swap `.client` for a stub before any capture
+// reaches the real client — the timer is usually NOT armed and the process
+// exits clean. But that is an implementation detail of the SDK, not a
+// guarantee we want to depend on. So we register every REAL client the
+// moment it is created and `await client.shutdown()` each in afterEach,
+// making the no-open-handles property explicit rather than incidental.
+const leakedClients: PostHog[] = [];
+
+/** Register a real posthog-node client for deterministic draining. */
+function registerForDrain(client: PostHog): void {
+  leakedClients.push(client);
+}
+
+afterEach(async () => {
+  // Drain every real client created during the test, swallowing failures
+  // (these clients never connect to a live backend). Clear after so each
+  // test only drains its own.
+  await Promise.all(
+    leakedClients.map((c) => c.shutdown().catch(() => undefined)),
+  );
+  leakedClients.length = 0;
+});
 
 // ---- Test doubles ----------------------------------------------------
 
@@ -54,11 +82,6 @@ class FakeLogger {
 
   asLogger(): Logger {
     return this as unknown as Logger;
-  }
-
-  /** Every object arg passed to any level, flattened for value scans. */
-  allLoggedObjects(): Record<string, unknown>[] {
-    return [...this.infoCalls, ...this.debugCalls, ...this.errorCalls].map((c) => c.obj);
   }
 }
 
@@ -95,7 +118,12 @@ function trackerWith(stub: object, logger: FakeLogger, projectId?: string | null
     },
     logger.asLogger(),
   );
-  (tracker as unknown as { client: object }).client = stub;
+  // The constructor already built a live `PostHog` client. Capture it for
+  // draining BEFORE we overwrite the field with the stub, otherwise the
+  // real client (and any timer it may have armed) is orphaned.
+  const fieldSeam = tracker as unknown as { client: object };
+  registerForDrain(fieldSeam.client as PostHog);
+  fieldSeam.client = stub;
   return tracker;
 }
 
@@ -172,21 +200,31 @@ describe("PosthogTracker.track / shutdown", () => {
     expect(captured.event).toBe("skill.executed");
     expect(captured.properties).toEqual({ a: 1, b: 2 });
 
-    // info logged once with the property KEY list.
+    // Redaction oracle — exact-object assertion, not a substring scan. The
+    // info line MUST be EXACTLY the redacted shape: event name + redacted
+    // distinctId + property KEY list, and NOTHING else (no values, no
+    // stray properties body). `toEqual` fails on any extra key, so a future
+    // change that leaks `properties` (or any value-bearing field) onto the
+    // info line is caught structurally rather than by a fragile `:1` scan.
     expect(logger.infoCalls).toHaveLength(1);
-    expect(logger.infoCalls[0]!.obj.propKeys).toEqual(["a", "b"]);
+    expect(logger.infoCalls[0]!.obj).toEqual({
+      event: "skill.executed",
+      distinctId: "user-id",
+      propKeys: ["a", "b"],
+    });
 
-    // Redaction contract: no property VALUE (1 or 2) appears in ANY log
-    // object arg. JSON-serialize each and scan for the values.
-    for (const obj of logger.allLoggedObjects()) {
-      // `properties` is intentionally only present on the debug body line;
-      // strip it before scanning so we test the info/error redaction, not
-      // the deliberate debug-level body.
-      const { properties: _props, ...rest } = obj;
-      const serialized = JSON.stringify(rest);
-      expect(serialized).not.toContain(":1");
-      expect(serialized).not.toContain(":2");
-    }
+    // No error line on the happy path.
+    expect(logger.errorCalls).toHaveLength(0);
+
+    // The debug body line is the ONLY place values are allowed; it carries
+    // the full properties object verbatim. Asserting its exact shape pins
+    // the value/key boundary: values live here and only here.
+    expect(logger.debugCalls).toHaveLength(1);
+    expect(logger.debugCalls[0]!.obj).toEqual({
+      event: "skill.executed",
+      distinctId: "user-id",
+      properties: { a: 1, b: 2 },
+    });
   });
 
   test("anonymous caller gets an anon: distinctId and it stays redacted", () => {
@@ -202,10 +240,15 @@ describe("PosthogTracker.track / shutdown", () => {
 
     // The logged distinctId is the redacted form (anon: + 8 chars head is
     // longer than 8 so it gets truncated with the ellipsis).
-    const loggedId = logger.infoCalls[0]!.obj.distinctId as string;
+    const { distinctId: loggedId, ...rest } = logger.infoCalls[0]!.obj;
     expect(loggedId).toMatch(/^anon:.*…$/);
     // The full anonymous id is never logged at info level verbatim.
     expect(loggedId).not.toBe(captured.distinctId);
+
+    // Exact-object oracle on the rest of the info line: the volatile
+    // distinctId is stripped above; everything else MUST match the redacted
+    // shape with no extra value-bearing fields.
+    expect(rest).toEqual({ event: "skill.viewed", propKeys: [] });
   });
 
   test("redactDistinctId truncates ids longer than 8 chars", () => {
@@ -215,7 +258,11 @@ describe("PosthogTracker.track / shutdown", () => {
 
     tracker.track("0123456789abcdef", "evt");
 
-    expect(logger.infoCalls[0]!.obj.distinctId).toBe("01234567…");
+    expect(logger.infoCalls[0]!.obj).toEqual({
+      event: "evt",
+      distinctId: "01234567…",
+      propKeys: [],
+    });
   });
 
   test("redactDistinctId leaves ids of 8 chars or fewer verbatim", () => {
@@ -225,7 +272,11 @@ describe("PosthogTracker.track / shutdown", () => {
 
     tracker.track("short", "evt");
 
-    expect(logger.infoCalls[0]!.obj.distinctId).toBe("short");
+    expect(logger.infoCalls[0]!.obj).toEqual({
+      event: "evt",
+      distinctId: "short",
+      propKeys: [],
+    });
   });
 
   test("omits the properties key on capture when no properties are passed", () => {
@@ -239,7 +290,11 @@ describe("PosthogTracker.track / shutdown", () => {
     // exactOptionalPropertyTypes (#657): the spread omits `properties`
     // entirely rather than passing `undefined`.
     expect("properties" in captured).toBe(false);
-    expect(logger.infoCalls[0]!.obj.propKeys).toEqual([]);
+    expect(logger.infoCalls[0]!.obj).toEqual({
+      event: "evt",
+      distinctId: "user-id",
+      propKeys: [],
+    });
   });
 
   test("fail-open: a throwing capture is caught and logged, never rethrown", () => {
@@ -256,8 +311,16 @@ describe("PosthogTracker.track / shutdown", () => {
 
     expect(() => tracker.track("user-id", "evt", { a: 1 })).not.toThrow();
     expect(logger.errorCalls).toHaveLength(1);
-    expect(logger.errorCalls[0]!.obj.event).toBe("evt");
     expect(logger.errorCalls[0]!.msg).toBe("PostHog capture failed");
+
+    // Redaction oracle on the ERROR line: the property value (`1`) MUST NOT
+    // leak even on the failure path. Strip the volatile `err` (an Error
+    // instance) and assert the rest is EXACTLY the event name — no
+    // distinctId, no propKeys, no properties body. `err` is asserted
+    // separately so a future change carrying `properties` here fails.
+    const { err, ...rest } = logger.errorCalls[0]!.obj;
+    expect(err).toBeInstanceOf(Error);
+    expect(rest).toEqual({ event: "evt" });
   });
 
   test("shutdown success logs an info line", async () => {

--- a/ornn-api/src/infra/analytics/posthog.test.ts
+++ b/ornn-api/src/infra/analytics/posthog.test.ts
@@ -3,10 +3,101 @@
  * real `posthog-node` client here — that's an external dependency. We
  * verify the factory picks Noop vs Posthog correctly and the
  * Noop implementation is a true no-op.
+ *
+ * The `PosthogTracker.track / shutdown` block (#880) exercises the
+ * fire-and-forget emission path, the distinctId redaction contract, and
+ * the fail-open error handling WITHOUT touching the network. We construct
+ * a real `PosthogTracker` (so the constructor's `new PostHog(...)` runs)
+ * and then overwrite its private `client` field with a hand-rolled stub
+ * via the established `as unknown as` field-cast seam — no `mock.module`,
+ * which is process-global and unsafe across the suite (see
+ * safeFetch.test.ts:26-28). A hand-rolled logger captures every arg so we
+ * can assert the redaction contract: property KEYS are logged, property
+ * VALUES never are.
  */
 
 import { describe, expect, test } from "bun:test";
+import { PostHog } from "posthog-node";
 import { NoopTracker, PosthogTracker, createTracker } from "./posthog";
+import type { Logger } from "../../shared/logger";
+
+const FAKE_KEY = "phc_fake_key_for_test";
+const FAKE_HOST = "https://eu.i.posthog.com";
+
+// ---- Test doubles ----------------------------------------------------
+
+interface LogCall {
+  readonly obj: Record<string, unknown>;
+  readonly msg: string;
+}
+
+/** Hand-rolled pino-shaped logger that records every call's args. */
+class FakeLogger {
+  readonly infoCalls: LogCall[] = [];
+  readonly debugCalls: LogCall[] = [];
+  readonly errorCalls: LogCall[] = [];
+
+  info(obj: Record<string, unknown>, msg: string): void {
+    this.infoCalls.push({ obj, msg });
+  }
+  debug(obj: Record<string, unknown>, msg: string): void {
+    this.debugCalls.push({ obj, msg });
+  }
+  error(obj: Record<string, unknown>, msg: string): void {
+    this.errorCalls.push({ obj, msg });
+  }
+  // The tracker calls `logger.child(...)` once in the constructor; return
+  // self so the child shares the same capture arrays.
+  child(): FakeLogger {
+    return this;
+  }
+
+  asLogger(): Logger {
+    return this as unknown as Logger;
+  }
+
+  /** Every object arg passed to any level, flattened for value scans. */
+  allLoggedObjects(): Record<string, unknown>[] {
+    return [...this.infoCalls, ...this.debugCalls, ...this.errorCalls].map((c) => c.obj);
+  }
+}
+
+/** Minimal `posthog-node` client surface the tracker drives. */
+interface CaptureArg {
+  readonly distinctId: string;
+  readonly event: string;
+  readonly properties?: Record<string, unknown>;
+}
+
+class FakeClient {
+  readonly captureCalls: CaptureArg[] = [];
+
+  capture(arg: CaptureArg): void {
+    this.captureCalls.push(arg);
+  }
+  async shutdown(): Promise<void> {
+    /* resolves */
+  }
+}
+
+/**
+ * Construct a real tracker, then swap its private `client` for `stub`.
+ * The constructor still ran `new PostHog(...)`; we replace the field so
+ * `track`/`shutdown` drive the stub instead of the live client. This is
+ * the constructor/field-cast seam — no `mock.module`.
+ */
+function trackerWith(stub: object, logger: FakeLogger, projectId?: string | null): PosthogTracker {
+  const tracker = new PosthogTracker(
+    {
+      apiKey: FAKE_KEY,
+      host: FAKE_HOST,
+      ...(projectId !== undefined ? { projectId } : {}),
+    },
+    logger.asLogger(),
+  );
+  (tracker as unknown as { client: object }).client = stub;
+  return tracker;
+}
 
 describe("NoopTracker", () => {
   test("track is a no-op (no throw, no return value)", () => {
@@ -62,6 +153,174 @@ describe("createTracker", () => {
     expect(tracker).toBeInstanceOf(PosthogTracker);
     // Drain so the test process exits cleanly. Failures from the
     // network shutdown are swallowed by the impl.
+    await tracker.shutdown();
+  });
+});
+
+describe("PosthogTracker.track / shutdown", () => {
+  test("happy path: captures the event and logs key list without values", () => {
+    const logger = new FakeLogger();
+    const client = new FakeClient();
+    const tracker = trackerWith(client, logger);
+
+    tracker.track("user-id", "skill.executed", { a: 1, b: 2 });
+
+    // The SDK was driven exactly once with the caller's distinctId + props.
+    expect(client.captureCalls).toHaveLength(1);
+    const captured = client.captureCalls[0]!;
+    expect(captured.distinctId).toBe("user-id");
+    expect(captured.event).toBe("skill.executed");
+    expect(captured.properties).toEqual({ a: 1, b: 2 });
+
+    // info logged once with the property KEY list.
+    expect(logger.infoCalls).toHaveLength(1);
+    expect(logger.infoCalls[0]!.obj.propKeys).toEqual(["a", "b"]);
+
+    // Redaction contract: no property VALUE (1 or 2) appears in ANY log
+    // object arg. JSON-serialize each and scan for the values.
+    for (const obj of logger.allLoggedObjects()) {
+      // `properties` is intentionally only present on the debug body line;
+      // strip it before scanning so we test the info/error redaction, not
+      // the deliberate debug-level body.
+      const { properties: _props, ...rest } = obj;
+      const serialized = JSON.stringify(rest);
+      expect(serialized).not.toContain(":1");
+      expect(serialized).not.toContain(":2");
+    }
+  });
+
+  test("anonymous caller gets an anon: distinctId and it stays redacted", () => {
+    const logger = new FakeLogger();
+    const client = new FakeClient();
+    const tracker = trackerWith(client, logger);
+
+    tracker.track(null, "skill.viewed");
+
+    expect(client.captureCalls).toHaveLength(1);
+    const captured = client.captureCalls[0]!;
+    expect(captured.distinctId).toMatch(/^anon:/);
+
+    // The logged distinctId is the redacted form (anon: + 8 chars head is
+    // longer than 8 so it gets truncated with the ellipsis).
+    const loggedId = logger.infoCalls[0]!.obj.distinctId as string;
+    expect(loggedId).toMatch(/^anon:.*…$/);
+    // The full anonymous id is never logged at info level verbatim.
+    expect(loggedId).not.toBe(captured.distinctId);
+  });
+
+  test("redactDistinctId truncates ids longer than 8 chars", () => {
+    const logger = new FakeLogger();
+    const client = new FakeClient();
+    const tracker = trackerWith(client, logger);
+
+    tracker.track("0123456789abcdef", "evt");
+
+    expect(logger.infoCalls[0]!.obj.distinctId).toBe("01234567…");
+  });
+
+  test("redactDistinctId leaves ids of 8 chars or fewer verbatim", () => {
+    const logger = new FakeLogger();
+    const client = new FakeClient();
+    const tracker = trackerWith(client, logger);
+
+    tracker.track("short", "evt");
+
+    expect(logger.infoCalls[0]!.obj.distinctId).toBe("short");
+  });
+
+  test("omits the properties key on capture when no properties are passed", () => {
+    const logger = new FakeLogger();
+    const client = new FakeClient();
+    const tracker = trackerWith(client, logger);
+
+    tracker.track("user-id", "evt");
+
+    const captured = client.captureCalls[0]!;
+    // exactOptionalPropertyTypes (#657): the spread omits `properties`
+    // entirely rather than passing `undefined`.
+    expect("properties" in captured).toBe(false);
+    expect(logger.infoCalls[0]!.obj.propKeys).toEqual([]);
+  });
+
+  test("fail-open: a throwing capture is caught and logged, never rethrown", () => {
+    const logger = new FakeLogger();
+    const throwing = {
+      capture(): void {
+        throw new Error("transport down");
+      },
+      async shutdown(): Promise<void> {
+        /* resolves */
+      },
+    };
+    const tracker = trackerWith(throwing, logger);
+
+    expect(() => tracker.track("user-id", "evt", { a: 1 })).not.toThrow();
+    expect(logger.errorCalls).toHaveLength(1);
+    expect(logger.errorCalls[0]!.obj.event).toBe("evt");
+    expect(logger.errorCalls[0]!.msg).toBe("PostHog capture failed");
+  });
+
+  test("shutdown success logs an info line", async () => {
+    const logger = new FakeLogger();
+    const client = new FakeClient();
+    const tracker = trackerWith(client, logger, "proj-1");
+
+    await expect(tracker.shutdown()).resolves.toBeUndefined();
+    const infoMsgs = logger.infoCalls.map((c) => c.msg);
+    expect(infoMsgs).toContain("PostHog client shut down");
+  });
+
+  test("shutdown swallows a rejecting client.shutdown() and logs the error", async () => {
+    const logger = new FakeLogger();
+    const rejecting = {
+      capture(): void {
+        /* unused */
+      },
+      async shutdown(): Promise<void> {
+        throw new Error("drain failed");
+      },
+    };
+    const tracker = trackerWith(rejecting, logger);
+
+    // Fail-open: never rejects, even though the underlying drain threw.
+    await expect(tracker.shutdown()).resolves.toBeUndefined();
+    expect(logger.errorCalls).toHaveLength(1);
+    expect(logger.errorCalls[0]!.msg).toBe("PostHog shutdown failed");
+  });
+
+  test("constructor registers an on('error') handler that logs transport errors", async () => {
+    const logger = new FakeLogger();
+
+    // Capture the handler the *constructor* installs on its live client by
+    // intercepting `PostHog.prototype.on` for the duration of construction.
+    // This is a prototype patch on the already-imported class (restored in
+    // `finally`) — NOT `mock.module`, so it is process-local and torn down
+    // deterministically. It lets us invoke the real source closure (which
+    // closes over `this.logger`) rather than a re-implementation.
+    let registered: ((err: unknown) => void) | undefined;
+    const proto = PostHog.prototype as unknown as {
+      on?: (event: string, fn: (err: unknown) => void) => void;
+    };
+    const original = proto.on;
+    proto.on = function patchedOn(event: string, fn: (err: unknown) => void): void {
+      if (event === "error") registered = fn;
+    };
+
+    let tracker: PosthogTracker;
+    try {
+      tracker = new PosthogTracker({ apiKey: FAKE_KEY, host: FAKE_HOST }, logger.asLogger());
+    } finally {
+      if (original) proto.on = original;
+      else delete proto.on;
+    }
+
+    expect(registered).toBeDefined();
+    registered!(new Error("buffered flush failed"));
+
+    const errMsgs = logger.errorCalls.map((c) => c.msg);
+    expect(errMsgs).toContain("PostHog transport error");
+
+    // Drain the live client so the test process exits cleanly.
     await tracker.shutdown();
   });
 });


### PR DESCRIPTION
Closes #880

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-14094-2697`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
