### PR TITLE
chore: [Misc] test(api): settings + llmProviders tests — raise src/domains/se

### DIFF
--- a/.changeset/test-881-settings-coverage.md
+++ b/.changeset/test-881-settings-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add settings + LLM-provider test coverage (migration, repositories, routes) (#881)

--- a/ornn-api/src/domains/settings/llmProviders/migration.test.ts
+++ b/ornn-api/src/domains/settings/llmProviders/migration.test.ts
@@ -225,6 +225,9 @@ describe("migrateModelCatalogIntoProviders", () => {
     expect(result.legacyCollectionDropped).toBe(false);
     // Collection deliberately left intact for manual review.
     expect(await legacyCollectionExists()).toBe(true);
+    // ...and not just present but unemptied — the row survives so the
+    // operator has the original data to reconcile by hand.
+    expect(await db.collection("models").countDocuments()).toBe(1);
   });
 
   test("empty legacy collection → dropped (clean handoff)", async () => {

--- a/ornn-api/src/domains/settings/llmProviders/migration.test.ts
+++ b/ornn-api/src/domains/settings/llmProviders/migration.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for the #270 boot migration that folds the standalone `models`
+ * collection into per-provider `llm_providers.models[]` arrays.
+ *
+ * Uses `mongodb-memory-server` (already a test dep) so the migration's
+ * actual update semantics — `arrayFilters` per-model `$set`, the
+ * backfill `replace`, the conditional `drop` — run against a real Mongo
+ * rather than a hand-rolled fake. The logic under test IS the query, so
+ * an in-memory stub would test nothing meaningful.
+ *
+ * Covers:
+ *   1. No legacy collection → short-circuit, nothing copied/dropped.
+ *   2. `true` legacy flags fold via arrayFilters onto matching per-
+ *      provider model rows.
+ *   3. NO-LOSS guard — `false`/absent legacy flags never overwrite an
+ *      already-set per-provider value.
+ *   4. Backfill — legacy `enabled: true` maps to `enabledForX`; the
+ *      legacy `enabled` field is deleted afterwards.
+ *   5. Idempotent rerun — second pass is a no-op (legacy gone, docs
+ *      byte-stable).
+ *   6. Safe-drop guard — rows present but zero flags copied leaves the
+ *      collection intact and takes the warn branch.
+ *   7. Empty legacy collection → dropped (clean handoff).
+ *
+ * @module domains/settings/llmProviders/migration.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db, type Document } from "mongodb";
+import { migrateModelCatalogIntoProviders } from "./migration";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("llm_providers_migration_test");
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("llm_providers").deleteMany({});
+  // `drop()` errors if the collection is absent — swallow it so each
+  // test starts from a clean "no legacy collection" state.
+  await db.collection("models").drop().catch(() => {});
+});
+
+interface ProviderModelRow extends Document {
+  id: string;
+  enabledForPlayground?: boolean;
+  enabledForSkillGen?: boolean;
+  defaultForPlayground?: boolean;
+  defaultForSkillGen?: boolean;
+  enabled?: boolean;
+}
+
+function provider(id: string, models: ProviderModelRow[]): Document {
+  return { _id: id as unknown as Document["_id"], name: id, models };
+}
+
+async function readProvider(id: string): Promise<Document | null> {
+  return db
+    .collection("llm_providers")
+    .findOne({ _id: id as unknown as Document["_id"] });
+}
+
+async function legacyCollectionExists(): Promise<boolean> {
+  return db.listCollections({ name: "models" }).hasNext();
+}
+
+describe("migrateModelCatalogIntoProviders", () => {
+  test("no legacy `models` collection → short-circuits, copies nothing", async () => {
+    await db
+      .collection("llm_providers")
+      .insertOne(provider("p1", [{ id: "gpt-4o", enabledForPlayground: true }]));
+
+    const result = await migrateModelCatalogIntoProviders(db);
+
+    expect(result.legacyRowsConsidered).toBe(0);
+    expect(result.flagsCopied).toBe(0);
+    expect(result.legacyCollectionDropped).toBe(false);
+    // Backfill still runs on the boolean-typed gaps of the existing doc.
+    expect(result.modelsBackfilled).toBe(1);
+  });
+
+  test("true legacy flags fold onto matching per-provider model rows", async () => {
+    await db.collection("llm_providers").insertMany([
+      provider("p1", [{ id: "gpt-4o" }]),
+      provider("p2", [{ id: "gpt-4o" }, { id: "gpt-3.5" }]),
+    ]);
+    await db.collection("models").insertOne({
+      modelId: "gpt-4o",
+      enabledForPlayground: true,
+      defaultForSkillGen: true,
+    });
+
+    const result = await migrateModelCatalogIntoProviders(db);
+
+    expect(result.legacyRowsConsidered).toBe(1);
+    // Two providers carry gpt-4o; each gets the two `true` flags set.
+    expect(result.flagsCopied).toBe(4);
+
+    const p1Models = (await readProvider("p1"))?.models as ProviderModelRow[];
+    const p1Gpt4o = p1Models.find((m) => m.id === "gpt-4o")!;
+    expect(p1Gpt4o.enabledForPlayground).toBe(true);
+    expect(p1Gpt4o.defaultForSkillGen).toBe(true);
+
+    const p2Models = (await readProvider("p2"))?.models as ProviderModelRow[];
+    const p2Gpt4o = p2Models.find((m) => m.id === "gpt-4o")!;
+    expect(p2Gpt4o.enabledForPlayground).toBe(true);
+    // The sibling row on p2 that doesn't match the legacy modelId is
+    // untouched by the fold (it gets backfilled to false separately).
+    const p2Gpt35 = p2Models.find((m) => m.id === "gpt-3.5")!;
+    expect(p2Gpt35.enabledForPlayground).toBe(false);
+  });
+
+  test("NO-LOSS guard — false/absent legacy flags don't overwrite set values", async () => {
+    // Per-provider row already has enabledForPlayground:true. The legacy
+    // row carries enabledForPlayground:false (and an absent skillGen),
+    // which must NOT clobber the already-set per-provider value.
+    await db
+      .collection("llm_providers")
+      .insertOne(
+        provider("p1", [
+          { id: "gpt-4o", enabledForPlayground: true, enabledForSkillGen: true },
+        ]),
+      );
+    await db.collection("models").insertOne({
+      modelId: "gpt-4o",
+      enabledForPlayground: false,
+      // enabledForSkillGen absent entirely
+    });
+
+    const result = await migrateModelCatalogIntoProviders(db);
+
+    // The legacy row has zero `true` flags → nothing copied for it.
+    expect(result.flagsCopied).toBe(0);
+    const models = (await readProvider("p1"))?.models as ProviderModelRow[];
+    const gpt4o = models.find((m) => m.id === "gpt-4o")!;
+    expect(gpt4o.enabledForPlayground).toBe(true);
+    expect(gpt4o.enabledForSkillGen).toBe(true);
+  });
+
+  test("backfill — legacy `enabled:true` maps to enabledForX, drops `enabled`", async () => {
+    await db.collection("llm_providers").insertOne(
+      provider("p1", [
+        // Pre-#270 shape: single `enabled` boolean, no surface flags.
+        { id: "gpt-4o", enabled: true },
+        { id: "gpt-3.5", enabled: false },
+      ]),
+    );
+    // Empty legacy collection so the fold loop is skipped but the
+    // collection-exists branch + drop still runs.
+    await db.collection("models").insertOne({ modelId: "irrelevant" });
+    await db.collection("models").deleteMany({});
+    await db.createCollection("models");
+
+    const result = await migrateModelCatalogIntoProviders(db);
+
+    expect(result.modelsBackfilled).toBe(2);
+    const models = (await readProvider("p1"))?.models as ProviderModelRow[];
+    const gpt4o = models.find((m) => m.id === "gpt-4o")!;
+    // `enabled:true` → both enabledForX true; defaults backfilled false.
+    expect(gpt4o.enabledForPlayground).toBe(true);
+    expect(gpt4o.enabledForSkillGen).toBe(true);
+    expect(gpt4o.defaultForPlayground).toBe(false);
+    expect(gpt4o.defaultForSkillGen).toBe(false);
+    expect("enabled" in gpt4o).toBe(false);
+
+    const gpt35 = models.find((m) => m.id === "gpt-3.5")!;
+    expect(gpt35.enabledForPlayground).toBe(false);
+    expect(gpt35.enabledForSkillGen).toBe(false);
+    expect("enabled" in gpt35).toBe(false);
+  });
+
+  test("idempotent rerun — second pass is a no-op, docs byte-stable", async () => {
+    await db.collection("llm_providers").insertOne(
+      provider("p1", [{ id: "gpt-4o" }]),
+    );
+    await db.collection("models").insertOne({
+      modelId: "gpt-4o",
+      enabledForPlayground: true,
+    });
+
+    await migrateModelCatalogIntoProviders(db);
+    const afterFirst = await readProvider("p1");
+    expect(await legacyCollectionExists()).toBe(false);
+
+    const second = await migrateModelCatalogIntoProviders(db);
+    const afterSecond = await readProvider("p1");
+
+    // Legacy gone → short-circuit; backfill already filled every flag so
+    // nothing is dirty on the rerun.
+    expect(second.legacyRowsConsidered).toBe(0);
+    expect(second.flagsCopied).toBe(0);
+    expect(second.modelsBackfilled).toBe(0);
+    expect(JSON.stringify(afterSecond)).toBe(JSON.stringify(afterFirst));
+  });
+
+  test("safe-drop guard — rows present, zero copied → collection intact + warn", async () => {
+    // A provider whose model id matches NOTHING in the legacy catalog,
+    // plus legacy rows that carry `true` flags for an unrelated model.
+    // legacyRowsConsidered > 0 AND flagsCopied === 0 → the "leave it for
+    // an operator" branch.
+    await db
+      .collection("llm_providers")
+      .insertOne(provider("p1", [{ id: "claude-x" }]));
+    await db.collection("models").insertOne({
+      modelId: "gpt-4o", // no provider carries this id
+      enabledForPlayground: true,
+    });
+
+    const result = await migrateModelCatalogIntoProviders(db);
+
+    expect(result.legacyRowsConsidered).toBe(1);
+    expect(result.flagsCopied).toBe(0);
+    expect(result.legacyCollectionDropped).toBe(false);
+    // Collection deliberately left intact for manual review.
+    expect(await legacyCollectionExists()).toBe(true);
+  });
+
+  test("empty legacy collection → dropped (clean handoff)", async () => {
+    await db
+      .collection("llm_providers")
+      .insertOne(provider("p1", [{ id: "gpt-4o" }]));
+    // Create the collection with zero rows.
+    await db.createCollection("models");
+
+    const result = await migrateModelCatalogIntoProviders(db);
+
+    expect(result.legacyRowsConsidered).toBe(0);
+    expect(result.legacyCollectionDropped).toBe(true);
+    expect(await legacyCollectionExists()).toBe(false);
+  });
+});

--- a/ornn-api/src/domains/settings/llmProviders/repository.test.ts
+++ b/ornn-api/src/domains/settings/llmProviders/repository.test.ts
@@ -1,0 +1,303 @@
+/**
+ * LlmProvidersRepository unit tests (#270 storage layer).
+ *
+ * Uses `mongodb-memory-server` so the array-filter writes
+ * (`clearDefaultsForSurfaceExcept`), the unique-on-name index, and the
+ * `normalizeModel` read shim all run against a real Mongo. The logic
+ * under test is mostly the Mongo query itself, so a fake collection
+ * would test nothing meaningful.
+ *
+ * Covers:
+ *   - CRUD round-trips: insert / findById / findByName (hit + miss) /
+ *     list (sorted by name) / replace / deleteById (true + false).
+ *   - ensureIndexes — unique-on-name rejects a duplicate insert.
+ *   - clearDefaultsForSurfaceExcept — keep=null clears every provider;
+ *     keep-set clears siblings (incl. the cross-provider $ne arrayFilter)
+ *     while leaving the keeper's chosen model untouched, across ≥2
+ *     providers.
+ *   - normalizeModel — a pre-#270 `enabled`-only row reads back as the
+ *     four surface flags; string `firstSeenAt`/`lastSyncedAt` coerce to
+ *     `Date`.
+ *
+ * @module domains/settings/llmProviders/repository.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db, type Document } from "mongodb";
+import { LlmProvidersRepository, type StoredProvider } from "./repository";
+import type { LlmProviderModel } from "./types";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: LlmProvidersRepository;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("llm_providers_repo_test");
+  repo = new LlmProvidersRepository(db);
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("llm_providers").deleteMany({});
+});
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+function model(
+  id: string,
+  overrides: Partial<LlmProviderModel> = {},
+): LlmProviderModel {
+  return {
+    id,
+    displayName: id,
+    enabledForPlayground: false,
+    enabledForSkillGen: false,
+    defaultForPlayground: false,
+    defaultForSkillGen: false,
+    removed: false,
+    firstSeenAt: NOW,
+    lastSyncedAt: NOW,
+    ...overrides,
+  };
+}
+
+function stored(
+  id: string,
+  name: string,
+  models: LlmProviderModel[] = [],
+): StoredProvider {
+  return {
+    _id: id,
+    name,
+    gatewayUrl: "https://api.example.com",
+    modelListUrl: "https://api.example.com/v1/models",
+    apiFormat: "chat-completion",
+    auth: { kind: "apiKey", apiKeyEnc: "v1:fake" },
+    models,
+    maxOutputTokens: 8192,
+    defaultTemperature: 0.7,
+    createdAt: NOW,
+    updatedAt: NOW,
+    updatedBy: "u-admin",
+  };
+}
+
+describe("LlmProvidersRepository CRUD", () => {
+  test("insert + findById round-trips the stored doc", async () => {
+    await repo.insert(stored("p1", "alpha", [model("gpt-4o")]));
+    const found = await repo.findById("p1");
+    expect(found?._id).toBe("p1");
+    expect(found?.name).toBe("alpha");
+    expect(found?.models[0]?.id).toBe("gpt-4o");
+  });
+
+  test("findById miss returns null", async () => {
+    expect(await repo.findById("nope")).toBeNull();
+  });
+
+  test("findByName hit + miss", async () => {
+    await repo.insert(stored("p1", "alpha"));
+    expect((await repo.findByName("alpha"))?._id).toBe("p1");
+    expect(await repo.findByName("ghost")).toBeNull();
+  });
+
+  test("list returns every provider sorted by name", async () => {
+    await repo.insert(stored("p2", "zeta"));
+    await repo.insert(stored("p1", "alpha"));
+    await repo.insert(stored("p3", "mu"));
+    const all = await repo.list();
+    expect(all.map((p) => p.name)).toEqual(["alpha", "mu", "zeta"]);
+  });
+
+  test("replace swaps the full document", async () => {
+    await repo.insert(stored("p1", "alpha", [model("gpt-4o")]));
+    await repo.replace("p1", stored("p1", "alpha-renamed", [model("gpt-5")]));
+    const found = await repo.findById("p1");
+    expect(found?.name).toBe("alpha-renamed");
+    expect(found?.models.map((m) => m.id)).toEqual(["gpt-5"]);
+  });
+
+  test("deleteById returns true on hit, false on miss", async () => {
+    await repo.insert(stored("p1", "alpha"));
+    expect(await repo.deleteById("p1")).toBe(true);
+    expect(await repo.deleteById("p1")).toBe(false);
+  });
+});
+
+describe("LlmProvidersRepository.ensureIndexes", () => {
+  test("unique-on-name rejects a duplicate insert", async () => {
+    await repo.ensureIndexes();
+    await repo.insert(stored("p1", "dupe"));
+    let err: unknown = null;
+    try {
+      await repo.insert(stored("p2", "dupe"));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    expect((err as { code?: number }).code).toBe(11000);
+    // Drop the index again so unrelated tests in this file aren't bound
+    // by the unique constraint.
+    await db.collection("llm_providers").dropIndex("name_1");
+  });
+});
+
+describe("LlmProvidersRepository.clearDefaultsForSurfaceExcept", () => {
+  test("keep=null clears the surface default on every provider", async () => {
+    await repo.insert(
+      stored("p1", "alpha", [model("gpt-4o", { defaultForPlayground: true })]),
+    );
+    await repo.insert(
+      stored("p2", "beta", [model("claude", { defaultForPlayground: true })]),
+    );
+
+    await repo.clearDefaultsForSurfaceExcept("Playground", null);
+
+    const p1 = await repo.findById("p1");
+    const p2 = await repo.findById("p2");
+    expect(p1?.models[0]?.defaultForPlayground).toBe(false);
+    expect(p2?.models[0]?.defaultForPlayground).toBe(false);
+  });
+
+  test("keep-set clears siblings but leaves the keeper untouched ($ne filter)", async () => {
+    // Keeper provider has two defaulted rows on the same surface — the
+    // chosen model must survive, its sibling must clear. Another provider
+    // also holds a default that must clear (the cross-provider $ne path).
+    await repo.insert(
+      stored("p1", "alpha", [
+        model("keep-me", { defaultForPlayground: true }),
+        model("sibling", { defaultForPlayground: true }),
+      ]),
+    );
+    await repo.insert(
+      stored("p2", "beta", [model("other", { defaultForPlayground: true })]),
+    );
+
+    await repo.clearDefaultsForSurfaceExcept("Playground", {
+      providerId: "p1",
+      modelId: "keep-me",
+    });
+
+    const p1 = await repo.findById("p1");
+    const keepMe = p1?.models.find((m) => m.id === "keep-me");
+    const sibling = p1?.models.find((m) => m.id === "sibling");
+    expect(keepMe?.defaultForPlayground).toBe(true);
+    expect(sibling?.defaultForPlayground).toBe(false);
+
+    const p2 = await repo.findById("p2");
+    expect(p2?.models[0]?.defaultForPlayground).toBe(false);
+  });
+
+  test("SkillGen surface is targeted independently of Playground", async () => {
+    await repo.insert(
+      stored("p1", "alpha", [
+        model("gpt-4o", {
+          defaultForPlayground: true,
+          defaultForSkillGen: true,
+        }),
+      ]),
+    );
+
+    await repo.clearDefaultsForSurfaceExcept("SkillGen", null);
+
+    const p1 = await repo.findById("p1");
+    const m = p1?.models[0];
+    // Only the SkillGen flag is cleared; Playground default survives.
+    expect(m?.defaultForSkillGen).toBe(false);
+    expect(m?.defaultForPlayground).toBe(true);
+  });
+});
+
+describe("LlmProvidersRepository.normalizeModel (read shim)", () => {
+  test("pre-#270 enabled-only doc reads back as four surface flags", async () => {
+    // Insert a raw legacy-shaped model row directly, bypassing the typed
+    // `insert` so we can exercise the read normalizer.
+    await db.collection("llm_providers").insertOne({
+      _id: "p1" as unknown as Document["_id"],
+      name: "legacy",
+      gatewayUrl: "https://api.example.com",
+      modelListUrl: "https://api.example.com/v1/models",
+      apiFormat: "chat-completion",
+      auth: { kind: "apiKey", apiKeyEnc: "v1:fake" },
+      models: [
+        // Only the legacy `enabled` boolean — none of the surface flags.
+        { id: "gpt-4o", displayName: "GPT-4o", enabled: true, firstSeenAt: NOW, lastSyncedAt: NOW },
+      ],
+      maxOutputTokens: 8192,
+      defaultTemperature: 0.7,
+      createdAt: NOW,
+      updatedAt: NOW,
+      updatedBy: "system",
+    });
+
+    const found = await repo.findById("p1");
+    const m = found!.models[0]!;
+    expect(m.enabledForPlayground).toBe(true);
+    expect(m.enabledForSkillGen).toBe(true);
+    expect(m.defaultForPlayground).toBe(false);
+    expect(m.defaultForSkillGen).toBe(false);
+    expect(m.removed).toBe(false);
+  });
+
+  test("string firstSeenAt/lastSyncedAt coerce to Date on read", async () => {
+    await db.collection("llm_providers").insertOne({
+      _id: "p2" as unknown as Document["_id"],
+      name: "stringdates",
+      gatewayUrl: "https://api.example.com",
+      modelListUrl: "https://api.example.com/v1/models",
+      apiFormat: "chat-completion",
+      auth: { kind: "apiKey", apiKeyEnc: "v1:fake" },
+      models: [
+        {
+          id: "gpt-4o",
+          displayName: "GPT-4o",
+          enabledForPlayground: true,
+          enabledForSkillGen: false,
+          defaultForPlayground: false,
+          defaultForSkillGen: false,
+          removed: false,
+          firstSeenAt: "2026-01-01T00:00:00.000Z",
+          lastSyncedAt: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+      maxOutputTokens: 8192,
+      defaultTemperature: 0.7,
+      createdAt: NOW,
+      updatedAt: NOW,
+      updatedBy: "system",
+    });
+
+    const found = await repo.findById("p2");
+    const m = found!.models[0]!;
+    expect(m.firstSeenAt).toBeInstanceOf(Date);
+    expect(m.lastSyncedAt).toBeInstanceOf(Date);
+    expect(m.firstSeenAt.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("missing updatedBy defaults to system on read", async () => {
+    await db.collection("llm_providers").insertOne({
+      _id: "p3" as unknown as Document["_id"],
+      name: "noupdater",
+      gatewayUrl: "https://api.example.com",
+      modelListUrl: "https://api.example.com/v1/models",
+      apiFormat: "chat-completion",
+      auth: { kind: "apiKey", apiKeyEnc: "v1:fake" },
+      models: [],
+      maxOutputTokens: 8192,
+      defaultTemperature: 0.7,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    const found = await repo.findById("p3");
+    expect(found?.updatedBy).toBe("system");
+  });
+});

--- a/ornn-api/src/domains/settings/llmProviders/routes.test.ts
+++ b/ornn-api/src/domains/settings/llmProviders/routes.test.ts
@@ -303,6 +303,70 @@ describe("LlmProviders admin routes", () => {
     const m = parsed.data.models.find((x) => x.id === "gpt-4o")!;
     expect(m.enabledForSkillGen).toBe(true);
   });
+
+  // The masking guard must hold for every auth kind, not just apiKey —
+  // service.maskAuth runs midMaskSecret over `clientSecret` (tokenUrl)
+  // and `password` (basic) too. POST a provider with each non-apiKey
+  // kind and assert the same strongest masking on the round-trip body:
+  // plaintext secret ABSENT, mid-mask sentinel form PRESENT.
+  it("POST tokenUrl auth: 201 mid-masks clientSecret, plaintext absent", async () => {
+    const { app } = makeApp();
+    const clientSecret = "cs-real-plaintext-secret-67890";
+    const res = await app.request("/api/v1/admin/settings/llm-providers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(
+        providerBody({
+          name: "tokenurl-test",
+          auth: {
+            kind: "tokenUrl",
+            tokenUrl: "https://auth.example.com/oauth/token",
+            clientId: "client-abc",
+            clientSecret,
+          },
+        }),
+      ),
+    });
+    expect(res.status).toBe(201);
+    const text = await res.text();
+    expect(text.includes(clientSecret)).toBe(false);
+    const parsed = JSON.parse(text) as {
+      data: {
+        auth: { kind: string; clientId: string; clientSecret: string };
+      };
+    };
+    expect(parsed.data.auth.kind).toBe("tokenUrl");
+    // Non-secret fields pass through untouched.
+    expect(parsed.data.auth.clientId).toBe("client-abc");
+    expect(isMidMaskSentinel(parsed.data.auth.clientSecret)).toBe(true);
+    expect(parsed.data.auth.clientSecret).not.toBe(clientSecret);
+  });
+
+  it("POST basic auth: 201 mid-masks password, plaintext absent", async () => {
+    const { app } = makeApp();
+    const password = "pw-real-plaintext-secret-13579";
+    const res = await app.request("/api/v1/admin/settings/llm-providers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(
+        providerBody({
+          name: "basic-test",
+          auth: { kind: "basic", username: "svc-user", password },
+        }),
+      ),
+    });
+    expect(res.status).toBe(201);
+    const text = await res.text();
+    expect(text.includes(password)).toBe(false);
+    const parsed = JSON.parse(text) as {
+      data: { auth: { kind: string; username: string; password: string } };
+    };
+    expect(parsed.data.auth.kind).toBe("basic");
+    // Non-secret field passes through untouched.
+    expect(parsed.data.auth.username).toBe("svc-user");
+    expect(isMidMaskSentinel(parsed.data.auth.password)).toBe(true);
+    expect(parsed.data.auth.password).not.toBe(password);
+  });
 });
 
 describe("LlmProviders picker route /me/models", () => {

--- a/ornn-api/src/domains/settings/llmProviders/routes.test.ts
+++ b/ornn-api/src/domains/settings/llmProviders/routes.test.ts
@@ -1,6 +1,16 @@
 /**
- * Route-level test: S3 — `POST /admin/settings/llm-providers` 201
- * response carries mid-masked secrets, never plaintext.
+ * Route-level tests for the admin LLM-providers bundle + the `/me/models`
+ * picker (Story 7.1 + #270).
+ *
+ * Harness: a real `LlmProvidersService` wired to an in-memory `FakeRepo`
+ * and a `StubFetcher`, mounted under a Hono app whose auth context is
+ * pre-set (production wires this via proxyAuthSetup) and whose onError
+ * emits the RFC 7807 envelope. Every masked response asserts the
+ * mid-mask sentinel form is present AND the raw plaintext secret is
+ * absent.
+ *
+ * Also unit-tests `throwModelResolutionError` as a pure function across
+ * all four `ModelResolution` kinds.
  *
  * @module domains/settings/llmProviders/routes.test
  */
@@ -11,10 +21,12 @@ import { isMidMaskSentinel } from "../../../infra/crypto";
 import {
   LlmProvidersService,
   type ModelListFetcher,
+  type ModelResolution,
+  type Surface,
 } from "./service";
 import type { StoredProvider } from "./repository";
-import { createLlmProvidersRoutes } from "./routes";
-import { buildProblemJsonBody } from "../../../shared/types/index";
+import { createLlmProvidersRoutes, createLlmPickerRoutes, throwModelResolutionError } from "./routes";
+import { AppError, buildProblemJsonBody } from "../../../shared/types/index";
 
 const KEY = "ornn-test-passphrase-32-chars-min-okOK";
 
@@ -40,80 +52,407 @@ class FakeRepo {
   async deleteById(id: string) {
     return this.rows.delete(id);
   }
-}
-
-class StubFetcher implements ModelListFetcher {
-  async fetch() {
-    return [];
+  // patchModel needs this when a default flag is flipped on (matches the
+  // in-memory implementation used by service.test.ts).
+  async clearDefaultsForSurfaceExcept(
+    surface: "Playground" | "SkillGen",
+    keep: { providerId: string; modelId: string } | null,
+  ): Promise<void> {
+    const defKey =
+      surface === "Playground" ? "defaultForPlayground" : "defaultForSkillGen";
+    for (const [id, doc] of this.rows) {
+      const isKeeper = keep && id === keep.providerId;
+      const nextModels = doc.models.map((m) => {
+        if (isKeeper && m.id === keep!.modelId) return m;
+        if ((m as unknown as Record<string, unknown>)[defKey] !== true) return m;
+        return { ...m, [defKey]: false };
+      });
+      this.rows.set(id, { ...doc, models: nextModels });
+    }
   }
 }
 
-describe("LlmProviders POST", () => {
-  it("S3: 201 response body carries mid-masked apiKey, not plaintext", async () => {
-    const repo = new FakeRepo();
-    const svc = new LlmProvidersService({
-      repo: repo as unknown as import("./repository").LlmProvidersRepository,
-      encryptionKey: KEY,
-      modelListFetcher: new StubFetcher(),
-    });
-    const routes = createLlmProvidersRoutes({ llmProvidersService: svc });
-    const app = new Hono();
-    // Stub upstream auth context (production wires this via proxyAuthSetup).
-    app.use("*", async (c, next) => {
-      c.set("auth" as never, {
-        userId: "u-admin",
-        email: "admin@test.local",
-        displayName: "Admin",
-        permissions: ["ornn:admin:skill"],
-      } as never);
-      await next();
-    });
-    app.route("/api/v1", routes);
-    app.onError((err, c) => {
-      const code = (err as { code?: string }).code ?? "internal_error";
-      const status = (err as { statusCode?: number }).statusCode ?? 500;
-      const body = buildProblemJsonBody({
-        statusCode: status,
-        code,
-        message: err.message,
-        instance: c.req.path,
-        requestId: null,
-      });
-      return c.json(body, status as never, {
-        "Content-Type": "application/problem+json",
-      });
-    });
+class StubFetcher implements ModelListFetcher {
+  next: ReadonlyArray<{ id: string; displayName: string }> = [];
+  async fetch() {
+    return this.next;
+  }
+}
 
-    const plaintext = "sk-real-plaintext-secret-12345";
-    const body = {
-      name: "openai-test",
-      gatewayUrl: "https://api.openai.com",
-      modelListUrl: "https://api.openai.com/v1/models",
-      apiFormat: "chat-completion",
-      auth: { kind: "apiKey", apiKey: plaintext },
-      models: [{ id: "gpt-4o", displayName: "GPT-4o", enabled: true }],
-      defaultModelId: "gpt-4o",
-      maxOutputTokens: 8192,
-      defaultTemperature: 0.7,
-    };
+const ADMIN_AUTH = {
+  userId: "u-admin",
+  email: "admin@test.local",
+  displayName: "Admin",
+  permissions: ["ornn:admin:skill"],
+};
 
+/**
+ * Build a service + a Hono app with the routes mounted under `/api/v1`,
+ * a pre-set admin auth context, and the standard RFC 7807 onError. The
+ * `sectionDefaultResolver` is optional so the picker tests can exercise
+ * both the wired and the absent path.
+ */
+function makeApp(
+  routeKind: "admin" | "picker" = "admin",
+  opts: { sectionDefaultResolver?: (s: Surface) => Promise<string | null> } = {},
+) {
+  const repo = new FakeRepo();
+  const fetcher = new StubFetcher();
+  const svc = new LlmProvidersService({
+    repo: repo as unknown as import("./repository").LlmProvidersRepository,
+    encryptionKey: KEY,
+    modelListFetcher: fetcher,
+  });
+  const routes =
+    routeKind === "admin"
+      ? createLlmProvidersRoutes({ llmProvidersService: svc })
+      : createLlmPickerRoutes({
+          llmProvidersService: svc,
+          ...(opts.sectionDefaultResolver
+            ? { sectionDefaultResolver: opts.sectionDefaultResolver }
+            : {}),
+        });
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("auth" as never, ADMIN_AUTH as never);
+    await next();
+  });
+  app.route("/api/v1", routes);
+  app.onError((err, c) => {
+    const code = (err as { code?: string }).code ?? "internal_error";
+    const status = (err as { statusCode?: number }).statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode: status,
+      code,
+      message: err.message,
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, status as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  return { app, svc, repo, fetcher };
+}
+
+const PLAINTEXT = "sk-real-plaintext-secret-12345";
+
+function providerBody(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "openai-test",
+    gatewayUrl: "https://api.openai.com",
+    modelListUrl: "https://api.openai.com/v1/models",
+    apiFormat: "chat-completion",
+    auth: { kind: "apiKey", apiKey: PLAINTEXT },
+    models: [
+      {
+        id: "gpt-4o",
+        displayName: "GPT-4o",
+        enabledForPlayground: true,
+        defaultForPlayground: true,
+      },
+    ],
+    maxOutputTokens: 8192,
+    defaultTemperature: 0.7,
+    ...overrides,
+  };
+}
+
+/** POST a provider through the route and return its id. */
+async function seedProvider(app: Hono, body = providerBody()) {
+  const res = await app.request("/api/v1/admin/settings/llm-providers", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(201);
+  return ((await res.json()) as { data: { _id: string } }).data._id;
+}
+
+/** Assert a JSON text body masks the apiKey: sentinel present, plaintext gone. */
+function assertMaskedApiKey(text: string) {
+  expect(text.includes(PLAINTEXT)).toBe(false);
+  const parsed = JSON.parse(text) as {
+    data: { auth: { kind: string; apiKey: string } };
+  };
+  expect(parsed.data.auth.kind).toBe("apiKey");
+  expect(isMidMaskSentinel(parsed.data.auth.apiKey)).toBe(true);
+  expect(parsed.data.auth.apiKey).not.toBe(PLAINTEXT);
+}
+
+describe("LlmProviders admin routes", () => {
+  it("POST: 201 body carries mid-masked apiKey, not plaintext", async () => {
+    const { app } = makeApp();
     const res = await app.request("/api/v1/admin/settings/llm-providers", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
+      body: JSON.stringify(providerBody()),
     });
     expect(res.status).toBe(201);
-    const text = await res.text();
-    expect(text.includes(plaintext)).toBe(false);
+    assertMaskedApiKey(await res.text());
+  });
 
+  it("GET list: returns every provider, masked", async () => {
+    const { app } = makeApp();
+    await seedProvider(app);
+    const res = await app.request("/api/v1/admin/settings/llm-providers");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text.includes(PLAINTEXT)).toBe(false);
     const parsed = JSON.parse(text) as {
-      data: { auth: { kind: string; apiKey: string } };
+      data: { items: Array<{ auth: { apiKey: string } }> };
     };
-    expect(parsed.data.auth.kind).toBe("apiKey");
-    expect(isMidMaskSentinel(parsed.data.auth.apiKey)).toBe(true);
-    // Mid-mask format keeps first 4 + last 4 — confirm the body we sent
-    // shows up in masked form (head + tail) but never as the full
-    // plaintext string.
-    expect(parsed.data.auth.apiKey).not.toBe(plaintext);
+    expect(parsed.data.items).toHaveLength(1);
+    expect(isMidMaskSentinel(parsed.data.items[0]!.auth.apiKey)).toBe(true);
+  });
+
+  it("GET /:id: 200 masked for a known provider", async () => {
+    const { app } = makeApp();
+    const id = await seedProvider(app);
+    const res = await app.request(`/api/v1/admin/settings/llm-providers/${id}`);
+    expect(res.status).toBe(200);
+    assertMaskedApiKey(await res.text());
+  });
+
+  it("GET /:id: 404 provider_not_found for an unknown id", async () => {
+    const { app } = makeApp();
+    const res = await app.request(
+      "/api/v1/admin/settings/llm-providers/does-not-exist",
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("provider_not_found");
+  });
+
+  it("PUT /:id: 200 masked echo, plaintext absent", async () => {
+    const { app } = makeApp();
+    const id = await seedProvider(app);
+    const res = await app.request(`/api/v1/admin/settings/llm-providers/${id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ maxOutputTokens: 4096 }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    assertMaskedApiKey(text);
+    const parsed = JSON.parse(text) as { data: { maxOutputTokens: number } };
+    expect(parsed.data.maxOutputTokens).toBe(4096);
+  });
+
+  it("DELETE /:id: 204 on hit", async () => {
+    const { app } = makeApp();
+    const id = await seedProvider(app);
+    const res = await app.request(`/api/v1/admin/settings/llm-providers/${id}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+  });
+
+  it("DELETE /:id: 404 provider_not_found on miss", async () => {
+    const { app } = makeApp();
+    const res = await app.request(
+      "/api/v1/admin/settings/llm-providers/ghost",
+      { method: "DELETE" },
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("provider_not_found");
+  });
+
+  it("POST /:id/sync: 200, masked provider + sync result", async () => {
+    const { app, fetcher } = makeApp();
+    const id = await seedProvider(app);
+    fetcher.next = [
+      { id: "gpt-4o", displayName: "GPT-4o" },
+      { id: "gpt-5", displayName: "GPT-5" },
+    ];
+    const res = await app.request(
+      `/api/v1/admin/settings/llm-providers/${id}/sync`,
+      { method: "POST" },
+    );
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text.includes(PLAINTEXT)).toBe(false);
+    const parsed = JSON.parse(text) as {
+      data: {
+        provider: { auth: { apiKey: string } };
+        result: { added: number };
+      };
+    };
+    expect(isMidMaskSentinel(parsed.data.provider.auth.apiKey)).toBe(true);
+    expect(parsed.data.result.added).toBe(1);
+  });
+
+  it("PATCH /:id/models/:modelId: 200 masked echo, flag applied", async () => {
+    const { app } = makeApp();
+    const id = await seedProvider(app);
+    const res = await app.request(
+      `/api/v1/admin/settings/llm-providers/${id}/models/gpt-4o`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabledForSkillGen: true }),
+      },
+    );
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    assertMaskedApiKey(text);
+    const parsed = JSON.parse(text) as {
+      data: { models: Array<{ id: string; enabledForSkillGen: boolean }> };
+    };
+    const m = parsed.data.models.find((x) => x.id === "gpt-4o")!;
+    expect(m.enabledForSkillGen).toBe(true);
+  });
+});
+
+describe("LlmProviders picker route /me/models", () => {
+  it("valid surface: 200 with items + defaultModelId", async () => {
+    const { app, svc } = makeApp("picker");
+    await svc.create(
+      {
+        ...providerBody({ name: "p1" }),
+        models: [
+          {
+            id: "gpt-4o",
+            displayName: "GPT-4o",
+            enabledForPlayground: true,
+            defaultForPlayground: true,
+          },
+        ],
+      },
+      { userId: "u", email: "e@x", displayName: "x" },
+    );
+    const res = await app.request("/api/v1/me/models?surface=playground");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        items: Array<{ modelId: string; isDefault: boolean }>;
+        defaultModelId: string | null;
+      };
+    };
+    expect(body.data.items[0]?.modelId).toBe("gpt-4o");
+    expect(body.data.defaultModelId).toBe("gpt-4o");
+  });
+
+  it("invalid surface: 400 invalid_surface", async () => {
+    const { app } = makeApp("picker");
+    const res = await app.request("/api/v1/me/models?surface=bogus");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_surface");
+  });
+
+  it("sectionDefaultResolver wired: pin overrides per-model default", async () => {
+    const { app, svc } = makeApp("picker", {
+      sectionDefaultResolver: async () => "gpt-3.5",
+    });
+    await svc.create(
+      {
+        ...providerBody({ name: "p1" }),
+        models: [
+          {
+            id: "gpt-4o",
+            displayName: "GPT-4o",
+            enabledForPlayground: true,
+            defaultForPlayground: true,
+          },
+          {
+            id: "gpt-3.5",
+            displayName: "GPT-3.5",
+            enabledForPlayground: true,
+          },
+        ],
+      },
+      { userId: "u", email: "e@x", displayName: "x" },
+    );
+    const res = await app.request("/api/v1/me/models?surface=playground");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { defaultModelId: string } };
+    expect(body.data.defaultModelId).toBe("gpt-3.5");
+  });
+
+  it("sectionDefaultResolver absent: falls back to per-model default", async () => {
+    const { app, svc } = makeApp("picker");
+    await svc.create(
+      {
+        ...providerBody({ name: "p1" }),
+        models: [
+          {
+            id: "gpt-4o",
+            displayName: "GPT-4o",
+            enabledForPlayground: true,
+            defaultForPlayground: true,
+          },
+          {
+            id: "gpt-3.5",
+            displayName: "GPT-3.5",
+            enabledForPlayground: true,
+          },
+        ],
+      },
+      { userId: "u", email: "e@x", displayName: "x" },
+    );
+    const res = await app.request("/api/v1/me/models?surface=playground");
+    const body = (await res.json()) as { data: { defaultModelId: string } };
+    expect(body.data.defaultModelId).toBe("gpt-4o");
+  });
+});
+
+describe("throwModelResolutionError (pure fn)", () => {
+  it("ok resolution → throws a programmer-error guard", () => {
+    const ok: ModelResolution = {
+      kind: "ok",
+      modelId: "m",
+      displayName: "M",
+      providerId: "p",
+    };
+    expect(() => throwModelResolutionError(ok)).toThrow(
+      "throwModelResolutionError called on ok resolution",
+    );
+  });
+
+  it("no-models-enabled → 503 MODEL_UNAVAILABLE (surface label)", () => {
+    let err: AppError | null = null;
+    try {
+      throwModelResolutionError({ kind: "no-models-enabled", surface: "skillGen" });
+    } catch (e) {
+      err = e as AppError;
+    }
+    expect(err?.statusCode).toBe(503);
+    expect(err?.code).toBe("MODEL_UNAVAILABLE");
+    expect(err?.message).toContain("skill-generation");
+  });
+
+  it("not-enabled → 400 MODEL_NOT_ENABLED", () => {
+    let err: AppError | null = null;
+    try {
+      throwModelResolutionError({
+        kind: "not-enabled",
+        surface: "playground",
+        modelId: "gpt-4o",
+      });
+    } catch (e) {
+      err = e as AppError;
+    }
+    expect(err?.statusCode).toBe(400);
+    expect(err?.code).toBe("MODEL_NOT_ENABLED");
+    expect(err?.message).toContain("gpt-4o");
+    expect(err?.message).toContain("playground");
+  });
+
+  it("not-found → 400 MODEL_NOT_FOUND", () => {
+    let err: AppError | null = null;
+    try {
+      throwModelResolutionError({
+        kind: "not-found",
+        surface: "playground",
+        modelId: "ghost",
+      });
+    } catch (e) {
+      err = e as AppError;
+    }
+    expect(err?.statusCode).toBe(400);
+    expect(err?.code).toBe("MODEL_NOT_FOUND");
+    expect(err?.message).toContain("ghost");
   });
 });

--- a/ornn-api/src/domains/settings/repository.test.ts
+++ b/ornn-api/src/domains/settings/repository.test.ts
@@ -1,0 +1,142 @@
+/**
+ * SettingsRepository unit tests — per-section persistence in the
+ * `platform_settings` collection.
+ *
+ * Uses `mongodb-memory-server` so the `upsert` with `$set` +
+ * `$setOnInsert`, and the null-coalescing read defaults, run against a
+ * real Mongo. The logic under test is the Mongo query and its document
+ * shape, so a fake collection would test nothing meaningful.
+ *
+ * Covers:
+ *   - getSection hit + miss + the null-coalescing defaults (value→null,
+ *     updatedAt→epoch, updatedBy→"system" when fields are absent).
+ *   - listSections returns every section row with the same defaults.
+ *   - putSection: the `$setOnInsert` insert path (createdAt stamped,
+ *     actor recorded) THEN the update path (value replaced, createdAt
+ *     preserved, updatedBy/updatedAt advanced).
+ *
+ * @module domains/settings/repository.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db, type Document } from "mongodb";
+import { SettingsRepository } from "./repository";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+let repo: SettingsRepository;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("settings_repo_test");
+  repo = new SettingsRepository(db);
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("platform_settings").deleteMany({});
+});
+
+describe("SettingsRepository.getSection", () => {
+  test("miss returns null", async () => {
+    expect(await repo.getSection("playground")).toBeNull();
+  });
+
+  test("hit returns the stored payload + metadata", async () => {
+    const at = new Date("2026-03-01T00:00:00.000Z");
+    await db.collection("platform_settings").insertOne({
+      _id: "playground" as unknown as Document["_id"],
+      value: { defaultMonthlyQuota: 500 },
+      updatedAt: at,
+      updatedBy: "admin@test.local",
+    });
+    const got = await repo.getSection("playground");
+    expect(got?._id).toBe("playground");
+    expect(got?.value).toEqual({ defaultMonthlyQuota: 500 });
+    expect(got?.updatedAt.getTime()).toBe(at.getTime());
+    expect(got?.updatedBy).toBe("admin@test.local");
+  });
+
+  test("null-coalescing defaults when fields are absent", async () => {
+    // A row with neither value, updatedAt, nor updatedBy.
+    await db
+      .collection("platform_settings")
+      .insertOne({ _id: "mirror" as unknown as Document["_id"] });
+    const got = await repo.getSection("mirror");
+    expect(got?.value).toBeNull();
+    expect(got?.updatedAt.getTime()).toBe(new Date(0).getTime());
+    expect(got?.updatedBy).toBe("system");
+  });
+});
+
+describe("SettingsRepository.listSections", () => {
+  test("returns every section row with applied defaults", async () => {
+    await db.collection("platform_settings").insertMany([
+      {
+        _id: "playground" as unknown as Document["_id"],
+        value: { a: 1 },
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedBy: "u1",
+      },
+      // Bare row → defaults applied on read.
+      { _id: "telemetry" as unknown as Document["_id"] },
+    ]);
+    const all = await repo.listSections();
+    expect(all.map((s) => s._id).sort()).toEqual(["playground", "telemetry"]);
+    const telemetry = all.find((s) => s._id === "telemetry")!;
+    expect(telemetry.value).toBeNull();
+    expect(telemetry.updatedBy).toBe("system");
+    expect(telemetry.updatedAt.getTime()).toBe(new Date(0).getTime());
+  });
+});
+
+describe("SettingsRepository.putSection", () => {
+  test("$setOnInsert insert path then update path", async () => {
+    type StoredRow = {
+      value: Record<string, unknown>;
+      updatedBy: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    const t1 = new Date("2026-01-01T00:00:00.000Z");
+    // ── Insert path ──
+    await repo.putSection("playground", { quota: 200 }, "admin@a", t1);
+    const inserted = (await db
+      .collection("platform_settings")
+      .findOne({
+        _id: "playground" as unknown as Document["_id"],
+      })) as unknown as StoredRow;
+    expect(inserted.value).toEqual({ quota: 200 });
+    expect(inserted.updatedBy).toBe("admin@a");
+    expect(inserted.createdAt.getTime()).toBe(t1.getTime());
+    expect(inserted.updatedAt.getTime()).toBe(t1.getTime());
+
+    // ── Update path ── ($setOnInsert is a no-op; createdAt preserved)
+    const t2 = new Date("2026-02-01T00:00:00.000Z");
+    await repo.putSection("playground", { quota: 999 }, "admin@b", t2);
+    const updated = (await db
+      .collection("platform_settings")
+      .findOne({
+        _id: "playground" as unknown as Document["_id"],
+      })) as unknown as StoredRow;
+    expect(updated.value).toEqual({ quota: 999 });
+    expect(updated.updatedBy).toBe("admin@b");
+    expect(updated.updatedAt.getTime()).toBe(t2.getTime());
+    // createdAt is stamped once on insert and never bumped on update.
+    expect(updated.createdAt.getTime()).toBe(t1.getTime());
+    // Still exactly one row for this section.
+    expect(
+      await db
+        .collection("platform_settings")
+        .countDocuments({ _id: "playground" as unknown as Document["_id"] }),
+    ).toBe(1);
+  });
+});

--- a/ornn-api/src/domains/settings/routes.test.ts
+++ b/ornn-api/src/domains/settings/routes.test.ts
@@ -136,7 +136,10 @@ describe("Settings admin routes", () => {
       body: JSON.stringify({ enabled: false, appPrivateKey: "new-secret" }),
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
+    const text = await res.text();
+    // The just-submitted plaintext must never round-trip in the response.
+    expect(text.includes("new-secret")).toBe(false);
+    const body = JSON.parse(text) as {
       meta: { changedFields: string[] };
       data: { appPrivateKey: string };
     };

--- a/ornn-api/src/domains/settings/routes.test.ts
+++ b/ornn-api/src/domains/settings/routes.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Route-level tests for the per-section admin settings bundle
+ * (`GET`/`PUT` per section).
+ *
+ * Harness: a fake `SettingsService` (only `getSection`/`putSection` are
+ * exercised by the routes) mounted under a Hono app whose auth context
+ * is pre-set and whose onError emits the RFC 7807 envelope.
+ *
+ * Covers:
+ *   - GET on a section with secret fields (mirror) mid-masks the secret
+ *     — plaintext absent from the body.
+ *   - GET on a no-secret section (playground) returns the value
+ *     verbatim (the `secretFields.length === 0` early return).
+ *   - PUT echoes `meta.changedFields` from the service result.
+ *   - PUT's `currentActor` falls back to `unknown`/`unknown@local` when
+ *     the auth context lacks userId/email.
+ *   - PUT with a non-object body → 400 invalid_body.
+ *
+ * @module domains/settings/routes.test
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { isMidMaskSentinel } from "../../infra/crypto";
+import { buildProblemJsonBody } from "../../shared/types/index";
+import { createSettingsRoutes } from "./routes";
+import type { SettingsActor, SettingsService } from "./types";
+
+const SECRET_PLAINTEXT = "-----BEGIN PRIVATE KEY-----\nABCDEFGHIJKLMNOP\n-----END-----";
+
+/**
+ * Minimal SettingsService fake. Records the last `putSection` call so a
+ * test can assert the actor the route resolved. Only the two methods the
+ * routes call are implemented; the rest throw if ever reached.
+ */
+class FakeSettingsService implements Partial<SettingsService> {
+  lastPutActor: SettingsActor | null = null;
+  sectionValues = new Map<string, Record<string, unknown>>();
+
+  async getSection<T>(id: string): Promise<T> {
+    return (this.sectionValues.get(id) ?? {}) as T;
+  }
+
+  async putSection<T>(
+    id: string,
+    value: T,
+    actor: SettingsActor,
+  ): Promise<{ value: T; changedFields: ReadonlyArray<string> }> {
+    this.lastPutActor = actor;
+    this.sectionValues.set(id, value as Record<string, unknown>);
+    return { value, changedFields: ["enabled", "appPrivateKey"] };
+  }
+}
+
+/**
+ * Mount the settings routes with a pre-set auth context. `auth` defaults
+ * to a full admin identity; pass a partial to exercise the
+ * `currentActor` fallback. Always includes the admin permission so the
+ * `adminGuard` lets the request through.
+ */
+function makeApp(auth: Record<string, unknown> = {
+  userId: "u-admin",
+  email: "admin@test.local",
+  displayName: "Admin",
+}) {
+  const svc = new FakeSettingsService();
+  const routes = createSettingsRoutes({
+    settingsService: svc as unknown as SettingsService,
+  });
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("auth" as never, {
+      ...auth,
+      permissions: ["ornn:admin:skill"],
+    } as never);
+    await next();
+  });
+  app.route("/api/v1", routes);
+  app.onError((err, c) => {
+    const code = (err as { code?: string }).code ?? "internal_error";
+    const status = (err as { statusCode?: number }).statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode: status,
+      code,
+      message: err.message,
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, status as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  return { app, svc };
+}
+
+describe("Settings admin routes", () => {
+  it("GET mirror: mid-masks the secret field, plaintext absent", async () => {
+    const { app, svc } = makeApp();
+    svc.sectionValues.set("mirror", {
+      enabled: true,
+      owner: "ChronoAIProject",
+      appPrivateKey: SECRET_PLAINTEXT,
+    });
+    const res = await app.request("/api/v1/admin/settings/mirror");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text.includes(SECRET_PLAINTEXT)).toBe(false);
+    const body = JSON.parse(text) as {
+      data: { appPrivateKey: string; owner: string };
+    };
+    expect(isMidMaskSentinel(body.data.appPrivateKey)).toBe(true);
+    // Non-secret field passes through untouched.
+    expect(body.data.owner).toBe("ChronoAIProject");
+  });
+
+  it("GET playground: no-secret section returns value verbatim", async () => {
+    const { app, svc } = makeApp();
+    svc.sectionValues.set("playground", {
+      defaultMonthlyQuota: 200,
+      defaultModelId: "gpt-4o",
+    });
+    const res = await app.request("/api/v1/admin/settings/playground");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { defaultMonthlyQuota: number; defaultModelId: string };
+    };
+    expect(body.data.defaultMonthlyQuota).toBe(200);
+    expect(body.data.defaultModelId).toBe("gpt-4o");
+  });
+
+  it("PUT: echoes meta.changedFields from the service", async () => {
+    const { app } = makeApp();
+    const res = await app.request("/api/v1/admin/settings/mirror", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false, appPrivateKey: "new-secret" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      meta: { changedFields: string[] };
+      data: { appPrivateKey: string };
+    };
+    expect(body.meta.changedFields).toEqual(["enabled", "appPrivateKey"]);
+    // Response masks the secret on the way back out.
+    expect(isMidMaskSentinel(body.data.appPrivateKey)).toBe(true);
+  });
+
+  it("PUT: currentActor falls back to unknown when auth lacks fields", async () => {
+    // Auth context carries the admin permission (so adminGuard passes)
+    // but no userId/email/displayName — currentActor must fill defaults.
+    const { app, svc } = makeApp({});
+    const res = await app.request("/api/v1/admin/settings/playground", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ defaultMonthlyQuota: 300 }),
+    });
+    expect(res.status).toBe(200);
+    expect(svc.lastPutActor?.userId).toBe("unknown");
+    expect(svc.lastPutActor?.email).toBe("unknown@local");
+    expect(svc.lastPutActor?.displayName).toBeUndefined();
+  });
+
+  it("PUT: non-object body → 400 invalid_body", async () => {
+    const { app } = makeApp();
+    const res = await app.request("/api/v1/admin/settings/playground", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify("just a string"),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_body");
+  });
+});


### PR DESCRIPTION
Closes #881

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-18835-8408`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
