### PR TITLE
chore: [Misc] test(api): broadcasts + announcements + quota route tests — rai

### DIFF
--- a/.changeset/test-882-content-quota-coverage.md
+++ b/.changeset/test-882-content-quota-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add broadcasts, announcements, and quota route/bootstrap/migration test coverage (#882)

--- a/ornn-api/src/domains/announcements/bootstrap.test.ts
+++ b/ornn-api/src/domains/announcements/bootstrap.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Announcements bootstrap wiring tests (#882).
+ *
+ * `wireAnnouncements` builds repo → ensureIndexes (fire-and-forget) →
+ * one-shot bilingual backfill → service → routes, returning the service +
+ * routes. Failures in the migration / index creation are non-fatal.
+ *
+ *   1. Happy path — `mongodb-memory-server`: resolves with a service +
+ *      routes, and the bilingual backfill runs against the real Mongo.
+ *   2. Fail-soft — an injected `Db` whose `createIndex` rejects (repo's
+ *      inner guard) and whose `updateMany` resolves to a malformed result
+ *      so the migration's post-`try` `matchedCount` read throws, exercising
+ *      the bootstrap's migration `.catch`. The wiring still resolves.
+ *
+ * @module domains/announcements/bootstrap.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db, type Document } from "mongodb";
+import pino from "pino";
+import { wireAnnouncements } from "./bootstrap";
+
+const logger = pino({ level: "silent" });
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("announcements_bootstrap_test");
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("announcements").deleteMany({});
+});
+
+describe("wireAnnouncements — happy path", () => {
+  test("returns service + routes and runs the bilingual backfill", async () => {
+    // Legacy single-locale doc — the backfill copies `title` into
+    // `titleEn` / `titleZh`.
+    await db.collection("announcements").insertOne({
+      _id: "a-legacy" as unknown as Document["_id"],
+      title: "Legacy title",
+      bodyMarkdown: "Legacy body",
+      ctaLabel: "Legacy CTA",
+      enabled: true,
+      startsAt: null,
+      endsAt: null,
+      createdBy: "admin1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const { service, routes } = await wireAnnouncements({ db, logger });
+    expect(service).toBeDefined();
+    expect(typeof routes.request).toBe("function");
+
+    const doc = await db
+      .collection("announcements")
+      .findOne({ _id: "a-legacy" as unknown as Document["_id"] });
+    expect(doc?.titleEn).toBe("Legacy title");
+    expect(doc?.titleZh).toBe("Legacy title");
+    expect(doc?.bodyMarkdownEn).toBe("Legacy body");
+    expect(doc?.ctaLabelEn).toBe("Legacy CTA");
+  });
+});
+
+describe("wireAnnouncements — fail-soft", () => {
+  test("injected failing db still resolves with service + routes", async () => {
+    const failingDb = {
+      collection: () => ({
+        // Rejects → caught by the repo's own ensureIndexes try/catch.
+        createIndex: () => Promise.reject(new Error("index boom")),
+        // Resolves a malformed result so the migration's post-`try`
+        // `result.matchedCount` read throws, hitting the bootstrap's
+        // migration `.catch` (non-fatal).
+        updateMany: () => Promise.resolve(undefined),
+      }),
+    } as unknown as Db;
+
+    const { service, routes } = await wireAnnouncements({ db: failingDb, logger });
+    expect(service).toBeDefined();
+    expect(typeof routes.request).toBe("function");
+
+    // Drain the fire-and-forget ensureIndexes().catch.
+    await Promise.resolve();
+  });
+});

--- a/ornn-api/src/domains/announcements/migration.test.ts
+++ b/ornn-api/src/domains/announcements/migration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the announcements bilingual boot backfill.
+ *
+ * Uses `mongodb-memory-server` so the migration's actual `$ifNull`
+ * aggregate-pipeline `updateMany` runs against a real Mongo. Covers:
+ *
+ *   1. Legacy single-locale docs (`title` / `bodyMarkdown` / `ctaLabel`)
+ *      are backfilled into the `*En` / `*Zh` slots — including the
+ *      `ctaLabel` null branch of the `$ifNull` pipeline.
+ *   2. Already-migrated docs (`titleEn` present) are left untouched.
+ *   3. Re-running on a fully-migrated DB is a no-op.
+ *   4. Empty collection → no-op.
+ *   5. Injected-failure arm: a rejecting `updateMany` is caught + logged
+ *      and the migration returns rather than throwing.
+ *
+ * @module domains/announcements/migration.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db, type Document } from "mongodb";
+import pino from "pino";
+import { migrateAnnouncementsToBilingual } from "./migration";
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+const logger = pino({ level: "silent" });
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("announcements_migration_test");
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("announcements").deleteMany({});
+});
+
+describe("migrateAnnouncementsToBilingual", () => {
+  test("backfills *En/*Zh from legacy single-locale fields (ctaLabel set)", async () => {
+    await db.collection("announcements").insertOne({
+      _id: "a-cta" as unknown as Document["_id"],
+      title: "Legacy title",
+      bodyMarkdown: "Legacy body",
+      ctaLabel: "Legacy CTA",
+      enabled: true,
+      startsAt: null,
+      endsAt: null,
+      createdBy: "admin1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await migrateAnnouncementsToBilingual(db, logger);
+
+    const doc = await db
+      .collection("announcements")
+      .findOne({ _id: "a-cta" as unknown as Document["_id"] });
+    expect(doc?.titleEn).toBe("Legacy title");
+    expect(doc?.titleZh).toBe("Legacy title");
+    expect(doc?.bodyMarkdownEn).toBe("Legacy body");
+    expect(doc?.bodyMarkdownZh).toBe("Legacy body");
+    expect(doc?.ctaLabelEn).toBe("Legacy CTA");
+    expect(doc?.ctaLabelZh).toBe("Legacy CTA");
+  });
+
+  test("ctaLabel null branch of the $ifNull pipeline → ctaLabel*: null", async () => {
+    await db.collection("announcements").insertOne({
+      _id: "a-nocta" as unknown as Document["_id"],
+      title: "No CTA title",
+      bodyMarkdown: "Body",
+      // No ctaLabel key → $ifNull falls back to the null literal.
+      enabled: false,
+      startsAt: null,
+      endsAt: null,
+      createdBy: "admin1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await migrateAnnouncementsToBilingual(db, logger);
+
+    const doc = await db
+      .collection("announcements")
+      .findOne({ _id: "a-nocta" as unknown as Document["_id"] });
+    expect(doc?.titleEn).toBe("No CTA title");
+    expect(doc?.ctaLabelEn).toBeNull();
+    expect(doc?.ctaLabelZh).toBeNull();
+  });
+
+  test("leaves already-migrated docs (titleEn present) untouched", async () => {
+    await db.collection("announcements").insertOne({
+      _id: "a-done" as unknown as Document["_id"],
+      title: "old",
+      bodyMarkdown: "old body",
+      ctaLabel: "old cta",
+      titleEn: "EN title",
+      titleZh: "ZH title",
+      bodyMarkdownEn: "EN body",
+      bodyMarkdownZh: "ZH body",
+      ctaLabelEn: "EN cta",
+      ctaLabelZh: "ZH cta",
+      enabled: true,
+      startsAt: null,
+      endsAt: null,
+      createdBy: "admin1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await migrateAnnouncementsToBilingual(db, logger);
+
+    const doc = await db
+      .collection("announcements")
+      .findOne({ _id: "a-done" as unknown as Document["_id"] });
+    // Not overwritten with the legacy `title`.
+    expect(doc?.titleEn).toBe("EN title");
+    expect(doc?.titleZh).toBe("ZH title");
+    expect(doc?.ctaLabelEn).toBe("EN cta");
+  });
+
+  test("is idempotent — second run on a migrated DB is a no-op", async () => {
+    await db.collection("announcements").insertOne({
+      _id: "a-idem" as unknown as Document["_id"],
+      title: "T",
+      bodyMarkdown: "B",
+      ctaLabel: null,
+      enabled: true,
+      startsAt: null,
+      endsAt: null,
+      createdBy: "admin1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await migrateAnnouncementsToBilingual(db, logger);
+    const first = await db
+      .collection("announcements")
+      .findOne({ _id: "a-idem" as unknown as Document["_id"] });
+    expect(first?.titleEn).toBe("T");
+
+    await migrateAnnouncementsToBilingual(db, logger);
+    const second = await db
+      .collection("announcements")
+      .findOne({ _id: "a-idem" as unknown as Document["_id"] });
+    expect(second?.titleEn).toBe("T");
+  });
+
+  test("no-op on an empty announcements collection", async () => {
+    await migrateAnnouncementsToBilingual(db, logger);
+    expect(await db.collection("announcements").countDocuments()).toBe(0);
+  });
+
+  test("injected-failure arm: rejecting updateMany is caught, returns without throwing", async () => {
+    const failingDb = {
+      collection: () => ({
+        updateMany: () => Promise.reject(new Error("mongo unavailable")),
+      }),
+    } as unknown as Db;
+
+    // Must resolve (not reject) — the internal try/catch logs + returns.
+    await expect(
+      migrateAnnouncementsToBilingual(failingDb, logger),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/ornn-api/src/domains/announcements/routes.test.ts
+++ b/ornn-api/src/domains/announcements/routes.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Announcement routes tests (#882).
+ *
+ * Mounts `createAnnouncementRoutes` on a bare Hono app. The public
+ * endpoints take no auth; the admin endpoints run through the real
+ * `requirePermission("ornn:admin:skill")` gate, toggled per-test via an
+ * `x-test-perms` header (harness cloned from `admin/quota/routes.test.ts`).
+ * `AnnouncementService` is a throwing Proxy stubbed per-case.
+ *
+ * Covers:
+ *   - public GET `/announcements` + `/announcements/active` (no auth, no
+ *     `createdBy` leak in the public shape);
+ *   - admin no-permission → 403 on every admin handler;
+ *   - POST 201 + Location + `toAdminDto` date serialization on BOTH the
+ *     non-null (`.toISOString()`) and null arms;
+ *   - `assertCtaPairing`: url-without-label → 400 (path `ctaLabelEn`),
+ *     label-without-url → 400 (path `ctaUrl`), both-set pass, both-null
+ *     pass;
+ *   - PATCH `{}` → 400 `invalid_announcement_input` (the explicit
+ *     "no fields to update" guard);
+ *   - `ctaLabel*` / `ctaUrl` `?? null` create-call mapping;
+ *   - `titleEn` / `titleZh` i18n round-trip through the DTO.
+ *
+ * @module domains/announcements/routes.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { buildProblemJsonBody } from "../../shared/types/index";
+import { createAnnouncementRoutes } from "./routes";
+import type { AnnouncementService } from "./service";
+import type {
+  AnnouncementDocument,
+  PublicAnnouncement,
+  PublicAnnouncementListItem,
+} from "./types";
+
+const ADMIN_PERM = "ornn:admin:skill";
+
+function fakeService(overrides: Partial<AnnouncementService>): AnnouncementService {
+  const target = { ...overrides } as Record<string, unknown>;
+  return new Proxy(target, {
+    get(t, prop: string) {
+      if (prop in t) return t[prop];
+      throw new Error(`unexpected AnnouncementService.${String(prop)} call`);
+    },
+  }) as unknown as AnnouncementService;
+}
+
+function buildApp(service: AnnouncementService) {
+  const router = createAnnouncementRoutes({ announcementService: service });
+  const app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    const permsHeader = c.req.header("x-test-perms") ?? "";
+    const permissions = permsHeader.length > 0 ? permsHeader.split(",") : [];
+    c.set("auth", {
+      userId: "admin1",
+      email: "admin@x.test",
+      displayName: "Admin",
+      roles: [],
+      permissions,
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    const e = err as { statusCode?: number; code?: string; message: string };
+    const statusCode = e.statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode,
+      code: e.code ?? "internal_error",
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  app.route("/", router);
+  return app;
+}
+
+function authHeaders(perms: string[] = [ADMIN_PERM]) {
+  return { "content-type": "application/json", "x-test-perms": perms.join(",") };
+}
+
+function sampleDoc(over: Partial<AnnouncementDocument> = {}): AnnouncementDocument {
+  return {
+    _id: "a-1",
+    titleEn: "Title EN",
+    titleZh: "标题中文",
+    bodyMarkdownEn: "Body EN",
+    bodyMarkdownZh: "正文中文",
+    ctaLabelEn: "Learn more",
+    ctaLabelZh: "了解更多",
+    ctaUrl: "https://example.com",
+    enabled: true,
+    startsAt: new Date("2026-06-01T00:00:00.000Z"),
+    endsAt: new Date("2026-07-01T00:00:00.000Z"),
+    createdBy: "admin1",
+    createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-02T00:00:00.000Z"),
+    ...over,
+  };
+}
+
+function samplePublic(): PublicAnnouncement {
+  return {
+    id: "a-1",
+    titleEn: "Title EN",
+    titleZh: "标题中文",
+    bodyMarkdownEn: "Body EN",
+    bodyMarkdownZh: "正文中文",
+    ctaLabelEn: "Learn more",
+    ctaLabelZh: "了解更多",
+    ctaUrl: "https://example.com",
+  };
+}
+
+/** Minimal valid create body (no CTA → both-null passes the pairing rule). */
+const validCreateBody = {
+  titleEn: "Title EN",
+  titleZh: "标题中文",
+  bodyMarkdownEn: "Body EN",
+  bodyMarkdownZh: "正文中文",
+  enabled: true,
+};
+
+describe("public GET /announcements", () => {
+  test("returns the list, no auth required, no createdBy leak", async () => {
+    const item: PublicAnnouncementListItem = {
+      ...samplePublic(),
+      publishedAt: "2026-05-01T00:00:00.000Z",
+    };
+    const app = buildApp(fakeService({ listPublished: async () => [item] }));
+    // No x-test-perms header at all — anonymous caller.
+    const res = await app.request("/announcements");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { items: PublicAnnouncementListItem[] };
+    };
+    expect(json.data.items).toHaveLength(1);
+    expect(json.data.items[0]!.publishedAt).toBe("2026-05-01T00:00:00.000Z");
+    expect("createdBy" in json.data.items[0]!).toBe(false);
+  });
+});
+
+describe("public GET /announcements/active", () => {
+  test("returns the active announcement under data.active", async () => {
+    const app = buildApp(fakeService({ getActive: async () => samplePublic() }));
+    const res = await app.request("/announcements/active");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { active: PublicAnnouncement | null } };
+    expect(json.data.active?.id).toBe("a-1");
+    expect(
+      "createdBy" in (json.data.active as unknown as Record<string, unknown>),
+    ).toBe(false);
+  });
+
+  test("returns null when nothing is active", async () => {
+    const app = buildApp(fakeService({ getActive: async () => null }));
+    const res = await app.request("/announcements/active");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { active: PublicAnnouncement | null } };
+    expect(json.data.active).toBeNull();
+  });
+});
+
+describe("admin endpoints — permission gate (real requirePermission)", () => {
+  test("GET /admin/announcements without perm → 403", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/announcements", { headers: authHeaders([]) });
+    expect(res.status).toBe(403);
+  });
+
+  test("POST /admin/announcements without perm → 403, service untouched", async () => {
+    let calls = 0;
+    const app = buildApp(
+      fakeService({
+        create: async () => {
+          calls++;
+          return sampleDoc();
+        },
+      }),
+    );
+    const res = await app.request("/admin/announcements", {
+      method: "POST",
+      headers: authHeaders([]),
+      body: JSON.stringify(validCreateBody),
+    });
+    expect(res.status).toBe(403);
+    expect(calls).toBe(0);
+  });
+
+  test("PATCH without perm → 403", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/announcements/a-1", {
+      method: "PATCH",
+      headers: authHeaders([]),
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("DELETE without perm → 403", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/announcements/a-1", {
+      method: "DELETE",
+      headers: authHeaders([]),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /admin/announcements", () => {
+  test("maps docs through toAdminDto (createdBy + ISO dates present)", async () => {
+    const app = buildApp(fakeService({ listAll: async () => [sampleDoc()] }));
+    const res = await app.request("/admin/announcements", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      data: { items: Array<Record<string, unknown>> };
+    };
+    const row = json.data.items[0]!;
+    expect(row.id).toBe("a-1");
+    expect(row.createdBy).toBe("admin1");
+    expect(row.createdAt).toBe("2026-05-01T00:00:00.000Z");
+    expect(row.titleEn).toBe("Title EN");
+    expect(row.titleZh).toBe("标题中文");
+  });
+});
+
+describe("POST /admin/announcements", () => {
+  test("201 + Location + toAdminDto with non-null dates (.toISOString arm)", async () => {
+    let captured: Record<string, unknown> = {};
+    const app = buildApp(
+      fakeService({
+        create: async (input) => {
+          captured = input as unknown as Record<string, unknown>;
+          return sampleDoc({ _id: "a-new" });
+        },
+      }),
+    );
+    const res = await app.request("/admin/announcements", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        ...validCreateBody,
+        ctaLabelEn: "Go",
+        ctaLabelZh: "走",
+        ctaUrl: "https://example.com",
+        startsAt: "2026-06-01T00:00:00.000Z",
+        endsAt: "2026-07-01T00:00:00.000Z",
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(res.headers.get("Location")).toBe("/api/v1/admin/announcements/a-new");
+    const json = (await res.json()) as { data: Record<string, unknown> };
+    // Non-null window → toISOString arm.
+    expect(json.data.startsAt).toBe("2026-06-01T00:00:00.000Z");
+    expect(json.data.endsAt).toBe("2026-07-01T00:00:00.000Z");
+    // CTA `?? null` mapping forwarded the provided values to the service.
+    expect(captured.ctaLabelEn).toBe("Go");
+    expect(captured.ctaLabelZh).toBe("走");
+    expect(captured.ctaUrl).toBe("https://example.com");
+    expect(captured.createdBy).toBe("admin1");
+  });
+
+  test("201 + toAdminDto with null dates (null arm) + ctaLabel/ctaUrl ?? null", async () => {
+    let captured: Record<string, unknown> = {};
+    const app = buildApp(
+      fakeService({
+        create: async (input) => {
+          captured = input as unknown as Record<string, unknown>;
+          return sampleDoc({
+            _id: "a-null",
+            ctaLabelEn: null,
+            ctaLabelZh: null,
+            ctaUrl: null,
+            startsAt: null,
+            endsAt: null,
+          });
+        },
+      }),
+    );
+    const res = await app.request("/admin/announcements", {
+      method: "POST",
+      headers: authHeaders(),
+      // No CTA, no window → service receives explicit nulls via `?? null`.
+      body: JSON.stringify(validCreateBody),
+    });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { data: Record<string, unknown> };
+    // Null window → null arm of the ternary.
+    expect(json.data.startsAt).toBeNull();
+    expect(json.data.endsAt).toBeNull();
+    expect(json.data.ctaLabelEn).toBeNull();
+    expect(json.data.ctaUrl).toBeNull();
+    // Route's `?? null` mapping turned absent body fields into nulls.
+    expect(captured.ctaLabelEn).toBeNull();
+    expect(captured.ctaLabelZh).toBeNull();
+    expect(captured.ctaUrl).toBeNull();
+    expect(captured.startsAt).toBeNull();
+    expect(captured.endsAt).toBeNull();
+  });
+
+  test("titleEn/titleZh round-trip through the DTO", async () => {
+    const app = buildApp(
+      fakeService({
+        create: async () =>
+          sampleDoc({ _id: "a-i18n", titleEn: "Hello", titleZh: "你好" }),
+      }),
+    );
+    const res = await app.request("/admin/announcements", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ ...validCreateBody, titleEn: "Hello", titleZh: "你好" }),
+    });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { data: { titleEn: string; titleZh: string } };
+    expect(json.data.titleEn).toBe("Hello");
+    expect(json.data.titleZh).toBe("你好");
+  });
+});
+
+describe("POST /admin/announcements — assertCtaPairing", () => {
+  test("url without label → 400 with path ctaLabelEn", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/announcements", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ ...validCreateBody, ctaUrl: "https://example.com" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string; detail: string };
+    expect(body.code).toBe("invalid_announcement_input");
+    // The refinement attaches the issue to `ctaLabelEn` when only the url is set.
+    expect(body.detail).toContain("ctaLabelEn");
+  });
+
+  test("label without url → 400 with path ctaUrl", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/announcements", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ ...validCreateBody, ctaLabelEn: "Click" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string; detail: string };
+    expect(body.code).toBe("invalid_announcement_input");
+    expect(body.detail).toContain("ctaUrl");
+  });
+
+  test("both set → passes the pairing rule", async () => {
+    const app = buildApp(
+      fakeService({ create: async () => sampleDoc({ _id: "a-pair" }) }),
+    );
+    const res = await app.request("/admin/announcements", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        ...validCreateBody,
+        ctaLabelEn: "Click",
+        ctaUrl: "https://example.com",
+      }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  test("both null → passes the pairing rule", async () => {
+    const app = buildApp(
+      fakeService({ create: async () => sampleDoc({ _id: "a-none" }) }),
+    );
+    const res = await app.request("/admin/announcements", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ ...validCreateBody, ctaLabelEn: null, ctaUrl: null }),
+    });
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("PATCH /admin/announcements/:id", () => {
+  test("empty body → 400 invalid_announcement_input", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/announcements/a-1", {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_announcement_input");
+  });
+
+  test("valid patch → 200 + toAdminDto", async () => {
+    let captured: { id?: string; patch?: Record<string, unknown> } = {};
+    const app = buildApp(
+      fakeService({
+        update: async (id, patch) => {
+          captured = { id, patch: patch as unknown as Record<string, unknown> };
+          return sampleDoc({ enabled: false });
+        },
+      }),
+    );
+    const res = await app.request("/admin/announcements/a-1", {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(200);
+    expect(captured.id).toBe("a-1");
+    expect(captured.patch!.enabled).toBe(false);
+    const json = (await res.json()) as { data: { enabled: boolean } };
+    expect(json.data.enabled).toBe(false);
+  });
+});
+
+describe("DELETE /admin/announcements/:id", () => {
+  test("returns { data: { id } }", async () => {
+    let deletedId: string | undefined;
+    const app = buildApp(
+      fakeService({
+        delete: async (id) => {
+          deletedId = id;
+        },
+      }),
+    );
+    const res = await app.request("/admin/announcements/a-9", {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { id: string } };
+    expect(json.data.id).toBe("a-9");
+    expect(deletedId).toBe("a-9");
+  });
+});

--- a/ornn-api/src/domains/broadcasts/bootstrap.test.ts
+++ b/ornn-api/src/domains/broadcasts/bootstrap.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Broadcasts bootstrap wiring tests (#882).
+ *
+ * `wireBroadcastsRepo` runs `ensureIndexes` (fire-and-forget) + the
+ * one-shot `recipientUserIds` backfill against a real Mongo, then returns
+ * the shared repo. `wireBroadcasts` builds the service + routes on top.
+ *
+ *   1. Happy path — `mongodb-memory-server`: both functions resolve, the
+ *      backfill runs, and pre-#502 docs are migrated to `null`.
+ *   2. Fail-soft — an injected `Db` whose `updateMany` / `createIndex`
+ *      reject: wiring still resolves (the migration + ensureIndexes
+ *      swallow + log their own failures), nothing is thrown.
+ *
+ * @module domains/broadcasts/bootstrap.test
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, type Db, type Document } from "mongodb";
+import pino from "pino";
+import { wireBroadcasts, wireBroadcastsRepo } from "./bootstrap";
+
+const logger = pino({ level: "silent" });
+
+let mongo: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  client = new MongoClient(mongo.getUri());
+  await client.connect();
+  db = client.db("broadcasts_bootstrap_test");
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  await db.collection("broadcasts").deleteMany({});
+  await db.collection("broadcast_read_receipts").deleteMany({});
+});
+
+describe("wireBroadcastsRepo / wireBroadcasts — happy path", () => {
+  test("returns a repo, runs the backfill, and builds service + routes", async () => {
+    // Pre-#502 doc with no recipientUserIds field — the backfill should
+    // set it to null on boot.
+    await db.collection("broadcasts").insertOne({
+      _id: "b-legacy" as unknown as Document["_id"],
+      titleI18n: { en: "a", zh: "甲" },
+      bodyMarkdownI18n: { en: "x", zh: "x" },
+      createdBy: "u-admin",
+      updatedBy: "u-admin",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const { repo } = await wireBroadcastsRepo({ db, logger });
+    expect(repo).toBeDefined();
+
+    const doc = await db
+      .collection("broadcasts")
+      .findOne({ _id: "b-legacy" as unknown as Document["_id"] });
+    expect("recipientUserIds" in (doc as Document)).toBe(true);
+    expect(doc?.recipientUserIds).toBeNull();
+
+    const { service, routes } = wireBroadcasts({ repo });
+    expect(service).toBeDefined();
+    // The routes object is a Hono app — it exposes a request dispatcher.
+    expect(typeof routes.request).toBe("function");
+  });
+});
+
+describe("wireBroadcastsRepo — fail-soft", () => {
+  test("injected db whose updateMany rejects (inner backfill guard) still resolves", async () => {
+    const boom = () => Promise.reject(new Error("mongo unavailable"));
+    // Minimal Db stub: every collection rejects on the calls the repo
+    // ensureIndexes + the backfill make. The backfill's own try/catch
+    // logs + swallows the rejection, so the wiring promise must resolve.
+    const failingDb = {
+      collection: () => ({
+        createIndex: boom,
+        updateMany: boom,
+      }),
+    } as unknown as Db;
+
+    const wiring = await wireBroadcastsRepo({ db: failingDb, logger });
+    expect(wiring.repo).toBeDefined();
+
+    // Drain the fire-and-forget ensureIndexes().catch so the rejected
+    // promise is observed within the test (no unhandled rejection).
+    await Promise.resolve();
+  });
+
+  test("backfill rejection that escapes its inner guard hits the bootstrap .catch", async () => {
+    // `updateMany` resolves a malformed result so the backfill's post-`try`
+    // `result.matchedCount` read throws OUTSIDE its internal try/catch — the
+    // rejection then propagates to `backfill(...).catch(...)` in bootstrap.ts
+    // (the non-fatal error-log arm). Wiring must still resolve.
+    const failingDb = {
+      collection: () => ({
+        createIndex: () => Promise.resolve("idx"),
+        updateMany: () => Promise.resolve(undefined),
+      }),
+    } as unknown as Db;
+
+    const wiring = await wireBroadcastsRepo({ db: failingDb, logger });
+    expect(wiring.repo).toBeDefined();
+    await Promise.resolve();
+  });
+});

--- a/ornn-api/src/domains/broadcasts/routes.test.ts
+++ b/ornn-api/src/domains/broadcasts/routes.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Broadcast admin routes tests (#882).
+ *
+ * Mounts `createBroadcastRoutes` on a bare Hono app — the real
+ * `requirePermission("ornn:admin:skill")` gate is exercised by toggling
+ * an `x-test-perms` header in a setup middleware (harness cloned from
+ * `admin/quota/routes.test.ts`). The `BroadcastService` is a throwing
+ * Proxy so any unexpected method call is a loud failure; the handful of
+ * methods each test needs are stubbed per-case.
+ *
+ * Covers, for each of the four handlers:
+ *   - the no-permission → 403 path through the real gate;
+ *   - POST 201 + Location header + `recipientUserIds` conditional spread
+ *     (present / absent arms);
+ *   - POST / PATCH invalid-body → 400 `invalid_broadcast_input`;
+ *   - PATCH `titleI18n` / `bodyMarkdownI18n` conditional-spread arms;
+ *   - DELETE → `{ data: { id } }`.
+ *
+ * @module domains/broadcasts/routes.test
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { buildProblemJsonBody } from "../../shared/types/index";
+import { createBroadcastRoutes } from "./routes";
+import type { BroadcastService } from "./service";
+import type { AdminBroadcastResponse } from "./types";
+
+const ADMIN_PERM = "ornn:admin:skill";
+
+/**
+ * Throwing Proxy: every property access blows up unless the test
+ * overrides it via `Object.assign`. Keeps the fake honest — a route
+ * touching an unexpected service method surfaces immediately instead of
+ * silently returning `undefined`.
+ */
+function fakeService(overrides: Partial<BroadcastService>): BroadcastService {
+  const target = { ...overrides } as Record<string, unknown>;
+  return new Proxy(target, {
+    get(t, prop: string) {
+      if (prop in t) return t[prop];
+      throw new Error(`unexpected BroadcastService.${String(prop)} call`);
+    },
+  }) as unknown as BroadcastService;
+}
+
+function buildApp(service: BroadcastService) {
+  const router = createBroadcastRoutes({ broadcastService: service });
+  const app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    const permsHeader = c.req.header("x-test-perms") ?? "";
+    const permissions = permsHeader.length > 0 ? permsHeader.split(",") : [];
+    c.set("auth", {
+      userId: "admin1",
+      email: "admin@x.test",
+      displayName: "Admin",
+      roles: [],
+      permissions,
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    const e = err as { statusCode?: number; code?: string; message: string };
+    const statusCode = e.statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode,
+      code: e.code ?? "internal_error",
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  app.route("/", router);
+  return app;
+}
+
+function authHeaders(perms: string[] = [ADMIN_PERM]) {
+  return { "content-type": "application/json", "x-test-perms": perms.join(",") };
+}
+
+function sampleResponse(over: Partial<AdminBroadcastResponse> = {}): AdminBroadcastResponse {
+  return {
+    id: "b-1",
+    titleI18n: { en: "Hello", zh: "你好" },
+    bodyMarkdownI18n: { en: "Body", zh: "正文" },
+    createdBy: "admin1",
+    updatedBy: "admin1",
+    recipientUserIds: null,
+    createdAt: "2026-06-05T00:00:00.000Z",
+    updatedAt: "2026-06-05T00:00:00.000Z",
+    readCount: 0,
+    ...over,
+  };
+}
+
+const validCreateBody = {
+  titleI18n: { en: "Hello", zh: "你好" },
+  bodyMarkdownI18n: { en: "Body", zh: "正文" },
+};
+
+describe("broadcast routes — permission gate (real requirePermission)", () => {
+  test("GET without admin perm → 403", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/broadcasts", { headers: authHeaders([]) });
+    expect(res.status).toBe(403);
+  });
+
+  test("POST without admin perm → 403, service untouched", async () => {
+    let createCalls = 0;
+    const app = buildApp(
+      fakeService({
+        create: async () => {
+          createCalls++;
+          return sampleResponse();
+        },
+      }),
+    );
+    const res = await app.request("/admin/broadcasts", {
+      method: "POST",
+      headers: authHeaders([]),
+      body: JSON.stringify(validCreateBody),
+    });
+    expect(res.status).toBe(403);
+    expect(createCalls).toBe(0);
+  });
+
+  test("PATCH without admin perm → 403", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/broadcasts/b-1", {
+      method: "PATCH",
+      headers: authHeaders([]),
+      body: JSON.stringify({ titleI18n: { en: "x", zh: "x" } }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("DELETE without admin perm → 403", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/broadcasts/b-1", {
+      method: "DELETE",
+      headers: authHeaders([]),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /admin/broadcasts", () => {
+  test("returns the service list under data.items", async () => {
+    const app = buildApp(
+      fakeService({ listAdmin: async () => [sampleResponse()] }),
+    );
+    const res = await app.request("/admin/broadcasts", { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { items: AdminBroadcastResponse[] } };
+    expect(json.data.items).toHaveLength(1);
+    expect(json.data.items[0]!.id).toBe("b-1");
+  });
+});
+
+describe("POST /admin/broadcasts", () => {
+  test("201 + Location + everyone broadcast (recipientUserIds spread absent)", async () => {
+    let captured: unknown;
+    const app = buildApp(
+      fakeService({
+        create: async (params) => {
+          captured = params;
+          return sampleResponse({ id: "b-new" });
+        },
+      }),
+    );
+    const res = await app.request("/admin/broadcasts", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify(validCreateBody),
+    });
+    expect(res.status).toBe(201);
+    expect(res.headers.get("Location")).toBe("/api/v1/admin/broadcasts/b-new");
+    const json = (await res.json()) as { data: AdminBroadcastResponse };
+    expect(json.data.id).toBe("b-new");
+    // No recipientUserIds key in the body → service params omit it (the
+    // `...(data.recipientUserIds !== undefined ? ... : {})` falsy arm).
+    expect("recipientUserIds" in (captured as Record<string, unknown>)).toBe(false);
+  });
+
+  test("201 with targeted recipients (recipientUserIds spread present)", async () => {
+    let captured: { recipientUserIds?: readonly string[] } = {};
+    const app = buildApp(
+      fakeService({
+        create: async (params) => {
+          captured = params;
+          return sampleResponse({ recipientUserIds: ["u-1", "u-2"] });
+        },
+      }),
+    );
+    const res = await app.request("/admin/broadcasts", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ ...validCreateBody, recipientUserIds: ["u-1", "u-2"] }),
+    });
+    expect(res.status).toBe(201);
+    expect(captured.recipientUserIds).toEqual(["u-1", "u-2"]);
+  });
+
+  test("invalid body → 400 invalid_broadcast_input", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/broadcasts", {
+      method: "POST",
+      headers: authHeaders(),
+      // Missing bodyMarkdownI18n → schema fails.
+      body: JSON.stringify({ titleI18n: { en: "x", zh: "x" } }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_broadcast_input");
+  });
+});
+
+describe("PATCH /admin/broadcasts/:id", () => {
+  test("titleI18n-only patch passes only the title arm to the service", async () => {
+    let captured: Record<string, unknown> = {};
+    const app = buildApp(
+      fakeService({
+        update: async (_id, params) => {
+          captured = params as unknown as Record<string, unknown>;
+          return sampleResponse();
+        },
+      }),
+    );
+    const res = await app.request("/admin/broadcasts/b-1", {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ titleI18n: { en: "New", zh: "新" } }),
+    });
+    expect(res.status).toBe(200);
+    expect(captured.titleI18n).toEqual({ en: "New", zh: "新" });
+    expect("bodyMarkdownI18n" in captured).toBe(false);
+    expect(captured.updatedBy).toBe("admin1");
+  });
+
+  test("bodyMarkdownI18n-only patch passes only the body arm to the service", async () => {
+    let captured: Record<string, unknown> = {};
+    const app = buildApp(
+      fakeService({
+        update: async (_id, params) => {
+          captured = params as unknown as Record<string, unknown>;
+          return sampleResponse();
+        },
+      }),
+    );
+    const res = await app.request("/admin/broadcasts/b-1", {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ bodyMarkdownI18n: { en: "New body", zh: "新正文" } }),
+    });
+    expect(res.status).toBe(200);
+    expect(captured.bodyMarkdownI18n).toEqual({ en: "New body", zh: "新正文" });
+    expect("titleI18n" in captured).toBe(false);
+  });
+
+  test("invalid body → 400 invalid_broadcast_input", async () => {
+    const app = buildApp(fakeService({}));
+    const res = await app.request("/admin/broadcasts/b-1", {
+      method: "PATCH",
+      headers: authHeaders(),
+      // Empty patch fails the schema's "at least one field" refinement.
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("invalid_broadcast_input");
+  });
+});
+
+describe("DELETE /admin/broadcasts/:id", () => {
+  test("returns { data: { id } }", async () => {
+    let deletedId: string | undefined;
+    const app = buildApp(
+      fakeService({
+        delete: async (id) => {
+          deletedId = id;
+        },
+      }),
+    );
+    const res = await app.request("/admin/broadcasts/b-9", {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { id: string } };
+    expect(json.data.id).toBe("b-9");
+    expect(deletedId).toBe("b-9");
+  });
+});

--- a/ornn-api/src/domains/quota/service.test.ts
+++ b/ornn-api/src/domains/quota/service.test.ts
@@ -9,10 +9,15 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
 import { QuotaService, type QuotaDefaults } from "./service";
+import { createQuotaRoutes, throwQuotaError } from "./routes";
+import type { AuthVariables } from "../../middleware/nyxidAuth";
+import { AppError, buildProblemJsonBody } from "../../shared/types/index";
 import {
   type QuotaBucketDoc,
   type QuotaGrantAuditDoc,
+  type QuotaSnapshot,
   type Surface,
   bucketId,
   monthBounds,
@@ -671,5 +676,92 @@ describe("bulk grant aggregates results", () => {
     });
     expect(r.length).toBe(3);
     expect(r.every((x) => x.ok)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route surface (#882) — GET /me/quota + throwQuotaError helper.
+//
+// Reuses the FakeRepo + FakeDefaults via `build()` — no second fake. The
+// route is mounted on a bare Hono app with an `x-test-perms` setup
+// middleware (#877 harness, cloned from admin/quota/routes.test.ts) so the
+// auth context the handler reads via `getAuth(c)` is populated.
+// ---------------------------------------------------------------------------
+
+function buildQuotaApp(opts: { defaultPg?: number; defaultSg?: number } = {}) {
+  const { service, repo } = build(opts);
+  const router = createQuotaRoutes({ quotaService: service });
+  const app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    const permsHeader = c.req.header("x-test-perms") ?? "";
+    const permissions = permsHeader.length > 0 ? permsHeader.split(",") : [];
+    c.set("auth", {
+      userId: "u1",
+      email: "u1@x.test",
+      displayName: "U1",
+      roles: [],
+      permissions,
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    const e = err as { statusCode?: number; code?: string; message: string };
+    const statusCode = e.statusCode ?? 500;
+    const body = buildProblemJsonBody({
+      statusCode,
+      code: e.code ?? "internal_error",
+      message: e.message ?? "",
+      instance: c.req.path,
+      requestId: null,
+    });
+    return c.json(body, statusCode as never, {
+      "Content-Type": "application/problem+json",
+    });
+  });
+  app.route("/", router);
+  return { app, repo };
+}
+
+describe("GET /me/quota", () => {
+  test("returns the caller snapshot under { data }", async () => {
+    const { app } = buildQuotaApp();
+    const res = await app.request("/me/quota");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: QuotaSnapshot };
+    expect(json.data.playground.used).toBe(0);
+    expect(json.data.playground.defaultAllotment).toBe(100);
+    expect(json.data.playground.remaining).toBe(100);
+    expect(json.data.monthMarker).toMatch(/^\d{4}-\d{2}$/);
+    expect(json.data.isAdmin).toBe(false);
+  });
+
+  test("threads permissions through to getSnapshot (admin flag)", async () => {
+    const { app } = buildQuotaApp();
+    const res = await app.request("/me/quota", {
+      headers: { "x-test-perms": ADMIN_PERM },
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: QuotaSnapshot };
+    expect(json.data.isAdmin).toBe(true);
+  });
+});
+
+describe("throwQuotaError", () => {
+  test("throws an AppError 429 quota_exceeded with the decision message", () => {
+    let caught: unknown;
+    try {
+      throwQuotaError({
+        allowed: false,
+        surface: "playground",
+        message: "playground quota exhausted",
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    const e = caught as AppError;
+    expect(e.statusCode).toBe(429);
+    expect(e.code).toBe("quota_exceeded");
+    expect(e.message).toBe("playground quota exhausted");
   });
 });


### PR DESCRIPTION
Closes #882

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-24308-31465`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
