### PR TITLE
chore: [Misc] test(api): clients + infra tests — raise src/clients/llmModelLi

### DIFF
--- a/.changeset/test-883-clients-infra-coverage.md
+++ b/.changeset/test-883-clients-infra-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Add client and infra test coverage (LLM model-list client, sandbox client, Mongo connect) (#883)

--- a/ornn-api/src/clients/llmModelListClient.test.ts
+++ b/ornn-api/src/clients/llmModelListClient.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Behavioural tests for `LlmModelListClient` (#883 coverage).
+ *
+ * The SSRF-rebind path lives in the sibling `llmModelListClient.ssrf.test.ts`;
+ * this file exercises the happy paths and the non-SSRF failure branches:
+ *   - `buildAuthHeaders` for all four auth shapes (apiKey / basic /
+ *     tokenUrl / empty) with on-the-wire assertions (Bearer header,
+ *     Basic base64, OAuth2 client_credentials POST body, then the Bearer
+ *     access_token), plus the token-endpoint failure modes.
+ *   - payload parsing across `[]`, `{ data }`, `{ models }`, `{ items }`.
+ *   - `displayName` fallback (`display_name` > `name` > `id`) and the
+ *     id-trim / blank-id skip.
+ *   - empty-URL guard, non-2xx with credential redaction, non-JSON body,
+ *     timeout (`TimeoutError`), and generic transport error.
+ *
+ * Like the ssrf sibling, dns is stubbed BEFORE the client import so the
+ * shared `safeFetch` preflight (bound in `url.ts` at load) sees a public
+ * IP for every host and lets the in-file `fetch` spy answer. `mock.module`
+ * on `node:dns/promises` is process-global and cannot be torn down per
+ * file; the established exception is to make it host-aware and resolve to
+ * a benign public IP, which is harmless to sibling tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type {
+  ApiFormat,
+  LlmProviderAuth,
+} from "../domains/settings/llmProviders/types";
+
+// All hosts resolve to a benign public IP so `safeFetch`'s preflight
+// passes and the request reaches the in-file fetch spy.
+mock.module("node:dns/promises", () => ({
+  lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+}));
+
+const { LlmModelListClient } = await import("./llmModelListClient");
+
+const ALLOWLIST_ENV = "ORNN_URL_ALLOWLIST_CIDR";
+const originalFetch = globalThis.fetch;
+const originalAllowlist = process.env[ALLOWLIST_ENV];
+
+const apiFormat: ApiFormat = "responses";
+const MODEL_LIST_URL = "https://gateway.example.com/v1/models";
+const TOKEN_URL = "https://gateway.example.com/oauth/token";
+
+interface RecordedCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+/** Each queued responder answers the next fetch in call order. */
+type Responder = (call: RecordedCall) => Response | Promise<Response>;
+
+let calls: RecordedCall[];
+let responders: Responder[];
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  calls = [];
+  responders = [];
+  delete process.env[ALLOWLIST_ENV];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const call: RecordedCall = { url, init };
+    calls.push(call);
+    const responder = responders.shift();
+    if (!responder) {
+      throw new Error(`No responder queued for fetch to ${url}`);
+    }
+    return responder(call);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalAllowlist === undefined) delete process.env[ALLOWLIST_ENV];
+  else process.env[ALLOWLIST_ENV] = originalAllowlist;
+});
+
+/** Read a header off a recorded `RequestInit` regardless of its shape. */
+function headerOf(init: RequestInit | undefined, name: string): string | undefined {
+  const source = init?.headers;
+  if (!source) return undefined;
+  const lower = name.toLowerCase();
+  if (source instanceof Headers) return source.get(name) ?? undefined;
+  if (Array.isArray(source)) {
+    return source.find(([k]) => k.toLowerCase() === lower)?.[1];
+  }
+  for (const [k, v] of Object.entries(source as Record<string, string>)) {
+    if (k.toLowerCase() === lower) return v;
+  }
+  return undefined;
+}
+
+describe("LlmModelListClient.buildAuthHeaders (via fetch wire shape)", () => {
+  it("apiKey → Bearer authorization header", async () => {
+    responders.push(() => jsonResponse({ data: [] }));
+    const auth: LlmProviderAuth = { kind: "apiKey", apiKey: "sk-test-123" };
+    await new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth });
+    expect(calls).toHaveLength(1);
+    expect(headerOf(calls[0]?.init, "authorization")).toBe("Bearer sk-test-123");
+  });
+
+  it("apiKey with empty value → no authorization header", async () => {
+    responders.push(() => jsonResponse({ data: [] }));
+    const auth: LlmProviderAuth = { kind: "apiKey", apiKey: "" };
+    await new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth });
+    expect(headerOf(calls[0]?.init, "authorization")).toBeUndefined();
+  });
+
+  it("basic → Basic base64(user:pass) authorization header", async () => {
+    responders.push(() => jsonResponse({ data: [] }));
+    const auth: LlmProviderAuth = { kind: "basic", username: "alice", password: "s3cr3t" };
+    await new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth });
+    const expected = `Basic ${Buffer.from("alice:s3cr3t").toString("base64")}`;
+    expect(headerOf(calls[0]?.init, "authorization")).toBe(expected);
+  });
+
+  it("basic with empty username → no authorization header", async () => {
+    responders.push(() => jsonResponse({ data: [] }));
+    const auth: LlmProviderAuth = { kind: "basic", username: "", password: "x" };
+    await new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth });
+    expect(headerOf(calls[0]?.init, "authorization")).toBeUndefined();
+  });
+
+  it("tokenUrl → POSTs client_credentials then uses the returned access_token", async () => {
+    // First fetch: the OAuth2 token exchange. Second: the model list.
+    responders.push((call) => {
+      expect(call.url).toBe(TOKEN_URL);
+      expect(call.init?.method).toBe("POST");
+      expect(headerOf(call.init, "Content-Type")).toBe("application/x-www-form-urlencoded");
+      const body = new URLSearchParams(String(call.init?.body));
+      expect(body.get("grant_type")).toBe("client_credentials");
+      expect(body.get("client_id")).toBe("client-abc");
+      expect(body.get("client_secret")).toBe("client-secret-xyz");
+      return jsonResponse({ access_token: "issued-token-777" });
+    });
+    responders.push((call) => {
+      expect(call.url).toBe(MODEL_LIST_URL);
+      expect(headerOf(call.init, "authorization")).toBe("Bearer issued-token-777");
+      return jsonResponse({ data: [{ id: "m1" }] });
+    });
+    const auth: LlmProviderAuth = {
+      kind: "tokenUrl",
+      tokenUrl: TOKEN_URL,
+      clientId: "client-abc",
+      clientSecret: "client-secret-xyz",
+    };
+    const out = await new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth });
+    expect(calls).toHaveLength(2);
+    expect(out).toEqual([{ id: "m1", displayName: "m1" }]);
+  });
+
+  it("tokenUrl with empty tokenUrl → no authorization header, no token POST", async () => {
+    responders.push(() => jsonResponse({ data: [] }));
+    const auth: LlmProviderAuth = {
+      kind: "tokenUrl",
+      tokenUrl: "",
+      clientId: "c",
+      clientSecret: "s",
+    };
+    await new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(MODEL_LIST_URL);
+    expect(headerOf(calls[0]?.init, "authorization")).toBeUndefined();
+  });
+});
+
+describe("LlmModelListClient token-endpoint failures", () => {
+  const tokenAuth: LlmProviderAuth = {
+    kind: "tokenUrl",
+    tokenUrl: TOKEN_URL,
+    clientId: "cid",
+    clientSecret: "super-secret-value",
+  };
+
+  it("non-2xx token response → throws, body credential-redacted, no model fetch", async () => {
+    responders.push(() =>
+      new Response('{"error":"invalid_client","api_key":"leaked-key-abc"}', {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(
+      new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth: tokenAuth }),
+    ).rejects.toThrow(/OAuth2 token exchange failed \(401\)/);
+    // The model-list endpoint must never be reached when auth fails.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("non-2xx token body has secrets stripped before surfacing", async () => {
+    responders.push(() =>
+      new Response("bearer eyJsigned.jwt.value apiKey=raw-secret-123", { status: 403 }),
+    );
+    let message = "";
+    try {
+      await new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth: tokenAuth });
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("OAuth2 token exchange failed (403)");
+    expect(message).not.toContain("eyJsigned.jwt.value");
+    expect(message).not.toContain("raw-secret-123");
+    expect(message).toContain("[REDACTED]");
+  });
+
+  it("token response missing access_token → throws", async () => {
+    responders.push(() => jsonResponse({ token_type: "bearer" }));
+    await expect(
+      new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth: tokenAuth }),
+    ).rejects.toThrow("OAuth2 token response missing access_token");
+  });
+
+  it("token exchange timeout → wrapped friendly timeout message", async () => {
+    responders.push(() => {
+      const err = new Error("aborted");
+      err.name = "TimeoutError";
+      throw err;
+    });
+    await expect(
+      new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth: tokenAuth }),
+    ).rejects.toThrow(/OAuth2 token exchange timed out after \d+ms/);
+  });
+
+  it("token exchange generic transport error → wrapped failure message", async () => {
+    responders.push(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    await expect(
+      new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth: tokenAuth }),
+    ).rejects.toThrow(/OAuth2 token exchange failed: ECONNREFUSED/);
+  });
+});
+
+describe("LlmModelListClient payload parsing", () => {
+  const auth: LlmProviderAuth = { kind: "apiKey", apiKey: "sk" };
+
+  async function fetchWith(payload: unknown): Promise<ReadonlyArray<{ id: string; displayName: string }>> {
+    responders.push(() => jsonResponse(payload));
+    return new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth });
+  }
+
+  it("bare array payload", async () => {
+    const out = await fetchWith([{ id: "a" }, { id: "b" }]);
+    expect(out).toEqual([
+      { id: "a", displayName: "a" },
+      { id: "b", displayName: "b" },
+    ]);
+  });
+
+  it("{ data } envelope", async () => {
+    const out = await fetchWith({ data: [{ id: "d1" }] });
+    expect(out).toEqual([{ id: "d1", displayName: "d1" }]);
+  });
+
+  it("{ models } envelope", async () => {
+    const out = await fetchWith({ models: [{ id: "mm" }] });
+    expect(out).toEqual([{ id: "mm", displayName: "mm" }]);
+  });
+
+  it("{ items } envelope", async () => {
+    const out = await fetchWith({ items: [{ id: "it" }] });
+    expect(out).toEqual([{ id: "it", displayName: "it" }]);
+  });
+
+  it("empty object envelope → empty list", async () => {
+    const out = await fetchWith({});
+    expect(out).toEqual([]);
+  });
+
+  it("displayName fallback: display_name > name > id", async () => {
+    const out = await fetchWith({
+      data: [
+        { id: "x1", display_name: "Display X", name: "name-x" },
+        { id: "x2", name: "name-x2" },
+        { id: "x3" },
+      ],
+    });
+    expect(out).toEqual([
+      { id: "x1", displayName: "Display X" },
+      { id: "x2", displayName: "name-x2" },
+      { id: "x3", displayName: "x3" },
+    ]);
+  });
+
+  it("trims id and skips entries with blank/missing id", async () => {
+    const out = await fetchWith({
+      data: [{ id: "  trimmed  " }, { id: "   " }, { name: "no-id" }, { id: "kept" }],
+    });
+    expect(out).toEqual([
+      { id: "trimmed", displayName: "trimmed" },
+      { id: "kept", displayName: "kept" },
+    ]);
+  });
+});
+
+describe("LlmModelListClient model-list failures", () => {
+  const auth: LlmProviderAuth = { kind: "apiKey", apiKey: "sk" };
+
+  it("empty modelListUrl → throws before any fetch", async () => {
+    await expect(
+      new LlmModelListClient().fetch({ modelListUrl: "   ", apiFormat, auth }),
+    ).rejects.toThrow(/model-list URL is empty/i);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("non-2xx → throws with status and credential-redacted body", async () => {
+    responders.push(() =>
+      new Response('upstream said: bearer eyLeaked.jwt.tok and apiKey=raw-leak-999', { status: 500 }),
+    );
+    let message = "";
+    try {
+      await new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth });
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("Model-list fetch failed (500)");
+    expect(message).not.toContain("eyLeaked.jwt.tok");
+    expect(message).not.toContain("raw-leak-999");
+    expect(message).toContain("[REDACTED]");
+  });
+
+  it("non-JSON body → throws 'not valid JSON'", async () => {
+    responders.push(() => new Response("<html>not json</html>", { status: 200 }));
+    await expect(
+      new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth }),
+    ).rejects.toThrow("Model-list response was not valid JSON");
+  });
+
+  it("timeout (TimeoutError) → wrapped friendly timeout message", async () => {
+    responders.push(() => {
+      const err = new Error("aborted");
+      err.name = "TimeoutError";
+      throw err;
+    });
+    await expect(
+      new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth }),
+    ).rejects.toThrow(/Model-list fetch timed out after \d+ms/);
+  });
+
+  it("generic transport error → wrapped failure message", async () => {
+    responders.push(() => {
+      throw new Error("network down");
+    });
+    await expect(
+      new LlmModelListClient().fetch({ modelListUrl: MODEL_LIST_URL, apiFormat, auth }),
+    ).rejects.toThrow(/Model-list fetch failed: network down/);
+  });
+});

--- a/ornn-api/src/clients/sandboxClient.test.ts
+++ b/ornn-api/src/clients/sandboxClient.test.ts
@@ -99,3 +99,255 @@ describe("SandboxClient SSRF preflight (#811)", () => {
     expect(fetchCalls[0]).toBe("http://rebind.test/execute");
   });
 });
+
+// ── #883: behavioural coverage for the request/response paths ──────────
+//
+// These reuse the same host-aware dns stub above. Each test allowlists
+// `rebind.test` so the SSRF preflight passes and the request reaches a
+// per-test fetch responder, letting us assert request bodies, response
+// mapping, error wrapping, and the SSE parser. The fetch spy is replaced
+// per test via `setResponder` (restored by the outer `afterEach`).
+
+interface SbCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+let sbCalls: SbCall[];
+type SbResponder = (call: SbCall) => Response;
+
+function setResponder(responder: SbResponder): void {
+  sbCalls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const call: SbCall = { url, init };
+    sbCalls.push(call);
+    return responder(call);
+  }) as typeof fetch;
+}
+
+function bodyOf(call: SbCall | undefined): Record<string, unknown> {
+  return JSON.parse(String(call?.init?.body)) as Record<string, unknown>;
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Build a `text/event-stream` response from raw line chunks. Each entry
+ * is written verbatim (callers include their own `data: ` prefix and
+ * newlines) so we can exercise the parser's skip-on-non-`data:` and
+ * skip-on-unparseable branches.
+ */
+function sseResponse(chunks: string[], status = 200): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const enc = new TextEncoder();
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+async function collect(gen: AsyncGenerator<unknown>): Promise<unknown[]> {
+  const out: unknown[] = [];
+  for await (const ev of gen) out.push(ev);
+  return out;
+}
+
+describe("SandboxClient.execute (#883)", () => {
+  beforeEach(() => {
+    process.env[ALLOWLIST_ENV] = "rebind.test";
+  });
+
+  it("maps params to snake_case body with defaults and returns the result", async () => {
+    setResponder(() => jsonResponse({ success: true, output: { exit_code: 0, execution_time_ms: 12 } }));
+    const res = await makeClient().execute({ script: "print(1)", language: "python" });
+    expect(res.success).toBe(true);
+    expect(sbCalls).toHaveLength(1);
+    expect(sbCalls[0]?.url).toBe("http://rebind.test/execute");
+    const body = bodyOf(sbCalls[0]);
+    expect(body.script).toBe("print(1)");
+    expect(body.output_type).toBe("text");
+    expect(body.timeout_secs).toBe(60);
+    expect(body.network_enabled).toBe(true);
+    expect(body.env).toEqual({});
+    expect(body.dependencies).toEqual([]);
+    expect(body.retrieve_files).toEqual([]);
+    expect(body.input_files).toEqual([]);
+    expect(body.resources).toBeUndefined();
+    expect(body.image).toBeUndefined();
+  });
+
+  it("forwards explicit overrides incl. resources and image", async () => {
+    setResponder(() => jsonResponse({ success: true }));
+    await makeClient().execute({
+      script: "x",
+      language: "python",
+      outputType: "file",
+      timeoutSecs: 120,
+      networkEnabled: false,
+      resources: { cpu: "2", memory: "1Gi" },
+      image: "custom:tag",
+    });
+    const body = bodyOf(sbCalls[0]);
+    expect(body.output_type).toBe("file");
+    expect(body.timeout_secs).toBe(120);
+    expect(body.network_enabled).toBe(false);
+    expect(body.resources).toEqual({ cpu: "2", memory: "1Gi" });
+    expect(body.image).toBe("custom:tag");
+  });
+
+  it("returns a failure result without throwing (warn branch)", async () => {
+    setResponder(() =>
+      jsonResponse({ success: false, error: { code: "RUNTIME", message: "boom" } }),
+    );
+    const res = await makeClient().execute({ script: "1/0", language: "python" });
+    expect(res.success).toBe(false);
+    expect(res.error?.code).toBe("RUNTIME");
+  });
+
+  it("non-2xx → throws a 'Sandbox service error'", async () => {
+    setResponder(() => new Response("upstream exploded", { status: 502 }));
+    await expect(
+      makeClient().execute({ script: "x", language: "python" }),
+    ).rejects.toThrow(/Sandbox service error \(502\)/);
+  });
+});
+
+describe("SandboxClient sessions (#883)", () => {
+  beforeEach(() => {
+    process.env[ALLOWLIST_ENV] = "rebind.test";
+  });
+
+  it("createSession maps body + defaults and returns the session", async () => {
+    setResponder(() =>
+      jsonResponse({ session_id: "sess-1", status: "ready", expires_at: 999 }),
+    );
+    const res = await makeClient().createSession({
+      language: "python",
+      ttlSecs: 300,
+      resources: { cpu: "1" },
+      image: "img:1",
+    });
+    expect(res.session_id).toBe("sess-1");
+    expect(sbCalls[0]?.url).toBe("http://rebind.test/sessions");
+    const body = bodyOf(sbCalls[0]);
+    expect(body.language).toBe("python");
+    expect(body.network_enabled).toBe(true);
+    expect(body.dependencies).toEqual([]);
+    expect(body.ttl_secs).toBe(300);
+    expect(body.resources).toEqual({ cpu: "1" });
+    expect(body.image).toBe("img:1");
+  });
+
+  it("createSession non-2xx → throws", async () => {
+    setResponder(() => new Response("nope", { status: 500 }));
+    await expect(makeClient().createSession({ language: "python" })).rejects.toThrow(
+      /Sandbox service error \(500\)/,
+    );
+  });
+
+  it("sessionExecute success maps body + returns result", async () => {
+    setResponder(() => jsonResponse({ success: true, output: { exit_code: 0 } }));
+    const res = await makeClient().sessionExecute("sess-2", { script: "y", language: "python" });
+    expect(res.success).toBe(true);
+    expect(sbCalls[0]?.url).toBe("http://rebind.test/sessions/sess-2/execute");
+    const body = bodyOf(sbCalls[0]);
+    expect(body.timeout_secs).toBe(60);
+    expect(body.output_type).toBe("text");
+  });
+
+  it("sessionExecute failure → returns result (warn branch)", async () => {
+    setResponder(() => jsonResponse({ success: false, error: { code: "E", message: "m" } }));
+    const res = await makeClient().sessionExecute("sess-3", { script: "z", language: "python" });
+    expect(res.success).toBe(false);
+  });
+
+  it("deleteSession ok resolves; non-2xx throws", async () => {
+    setResponder(() => new Response(null, { status: 204 }));
+    await expect(makeClient().deleteSession("sess-4")).resolves.toBeUndefined();
+    expect(sbCalls[0]?.init?.method).toBe("DELETE");
+
+    setResponder(() => new Response("missing", { status: 404 }));
+    await expect(makeClient().deleteSession("sess-5")).rejects.toThrow(
+      /Delete session failed \(404\)/,
+    );
+  });
+
+  it("listSessions ok returns payload; non-2xx throws", async () => {
+    setResponder(() => jsonResponse({ sessions: [{ session_id: "s" }] }));
+    const res = await makeClient().listSessions();
+    expect(res.sessions).toHaveLength(1);
+
+    setResponder(() => new Response("down", { status: 503 }));
+    await expect(makeClient().listSessions()).rejects.toThrow(/List sessions failed \(503\)/);
+  });
+});
+
+describe("SandboxClient streaming SSE (#883)", () => {
+  beforeEach(() => {
+    process.env[ALLOWLIST_ENV] = "rebind.test";
+  });
+
+  it("executeStream parses data: lines into the event sequence", async () => {
+    setResponder(() =>
+      sseResponse([
+        'data: {"type":"stdout","text":"hello"}\n',
+        'data: {"type":"complete","exit_code":0,"execution_time_ms":5}\n',
+      ]),
+    );
+    const events = await collect(makeClient().executeStream({ script: "p", language: "python" }));
+    expect(events).toEqual([
+      { type: "stdout", text: "hello" },
+      { type: "complete", exit_code: 0, execution_time_ms: 5 },
+    ]);
+    expect(sbCalls[0]?.url).toBe("http://rebind.test/execute/stream");
+  });
+
+  it("skips blank, non-data, and unparseable lines", async () => {
+    setResponder(() =>
+      sseResponse([
+        ": comment line\n",
+        "event: ping\n",
+        "data: \n",
+        "data: not-json{\n",
+        'data: {"type":"stderr","text":"warn"}\n',
+      ]),
+    );
+    const events = await collect(makeClient().executeStream({ script: "p", language: "python" }));
+    expect(events).toEqual([{ type: "stderr", text: "warn" }]);
+  });
+
+  it("sessionExecuteStream routes to the session stream path", async () => {
+    setResponder(() => sseResponse(['data: {"type":"stdout","text":"x"}\n']));
+    const events = await collect(
+      makeClient().sessionExecuteStream("sess-9", { script: "p", language: "python" }),
+    );
+    expect(events).toEqual([{ type: "stdout", text: "x" }]);
+    expect(sbCalls[0]?.url).toBe("http://rebind.test/sessions/sess-9/execute/stream");
+  });
+
+  it("non-ok stream response → throws before reading the body", async () => {
+    setResponder(() => new Response("bad", { status: 500 }));
+    await expect(
+      collect(makeClient().executeStream({ script: "p", language: "python" })),
+    ).rejects.toThrow(/Sandbox stream error \(500\)/);
+  });
+
+  it("missing response body → throws", async () => {
+    setResponder(() => new Response(null, { status: 200 }));
+    await expect(
+      collect(makeClient().executeStream({ script: "p", language: "python" })),
+    ).rejects.toThrow("No response body for SSE stream");
+  });
+});

--- a/ornn-api/src/infra/db/mongodb.test.ts
+++ b/ornn-api/src/infra/db/mongodb.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for `connectMongo` (#883 coverage).
+ *
+ * Happy path runs against a real `mongodb-memory-server` instance so the
+ * `client.connect()` → admin `ping` → `client.db(name)` sequence and the
+ * returned `close()` are exercised end-to-end with no network egress.
+ *
+ * The retry-exhaustion branch is driven by a deliberately unroutable URI
+ * with a sub-second `serverSelectionTimeoutMS` / `connectTimeoutMS` in
+ * the query string so each of the 5 attempts fails fast. We do NOT
+ * `mock.module("mongodb")`: that mock is process-global and would poison
+ * the memory-server happy path sharing this file.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { connectMongo } from "./mongodb";
+
+let mongo: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+});
+
+afterAll(async () => {
+  await mongo.stop();
+});
+
+describe("connectMongo", () => {
+  it("connects, pings, exposes the named db, and closes cleanly", async () => {
+    const conn = await connectMongo(mongo.getUri(), "mongodb_connect_test");
+    expect(conn.client).toBeDefined();
+    expect(conn.db.databaseName).toBe("mongodb_connect_test");
+
+    // The connection is live: a trivial command round-trips.
+    const pong = await conn.db.admin().ping();
+    expect(pong.ok).toBe(1);
+
+    await expect(conn.close()).resolves.toBeUndefined();
+  });
+
+  it("throws after exhausting retries when the server is unreachable", async () => {
+    // Reserved-for-documentation TEST-NET-1 address (RFC 5737) that never
+    // accepts connections; fast per-attempt timeouts keep total wall-clock
+    // bounded (5 attempts + exponential backoff ~15s).
+    const badUri =
+      "mongodb://192.0.2.1:27017/?serverSelectionTimeoutMS=50&connectTimeoutMS=50&socketTimeoutMS=50";
+    await expect(connectMongo(badUri, "unreachable_db")).rejects.toThrow(
+      /MongoDB connection failed after 5 attempts/,
+    );
+  }, 30_000);
+});


### PR DESCRIPTION
Closes #883

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-28808-30369`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
