### PR TITLE
chore: [CI/CD] chore(web): honest vitest coverage config — ornn-web/vitest.co

### DIFF
--- a/.changeset/test-884-honest-web-coverage.md
+++ b/.changeset/test-884-honest-web-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Honest vitest coverage config: v8 provider, all-files reporting over src/** with justified excludes (#884)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+coverage/
 .env
 .env.*
 !.env.sample.*

--- a/ornn-web/vitest.config.ts
+++ b/ornn-web/vitest.config.ts
@@ -11,6 +11,19 @@ export default mergeConfig(
       setupFiles: ["./src/test/setup.ts"],
       include: ["src/**/*.{test,spec}.{ts,tsx}"],
       css: false,
+      coverage: {
+        provider: "v8",
+        all: true,
+        include: ["src/**/*.{ts,tsx}"],
+        exclude: [
+          "src/test/**",
+          "src/**/*.{test,spec}.{ts,tsx}",
+          "src/**/*.d.ts",
+          "src/main.tsx",
+        ],
+        reporter: ["text", "lcov", "json-summary"],
+        reportsDirectory: "coverage",
+      },
     },
   }),
 );

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:sdk": "bun run --filter @chronoai/ornn-sdk test",
     "test:coverage": "bun run test:api:coverage && bun run test:web:coverage && bun run test:sdk:coverage",
     "test:api:coverage": "cd ornn-api && bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage",
-    "test:web:coverage": "cd ornn-web && bun run test -- --coverage --coverage.reporter=lcov --coverage.reportsDirectory=coverage",
+    "test:web:coverage": "cd ornn-web && bun run test -- --coverage",
     "test:sdk:coverage": "cd sdk/typescript && bun run test -- --coverage --coverage.reporter=lcov --coverage.reportsDirectory=coverage",
     "changeset": "changeset",
     "version-packages": "changeset version",


### PR DESCRIPTION
Closes #884

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-32562-14133`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
