### PR TITLE
chore: [Misc] test(web): utils + lib unit tests — raise ornn-web/src/utils/fo

### DIFF
--- a/.changeset/test-885-web-utils-coverage.md
+++ b/.changeset/test-885-web-utils-coverage.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Cover web utils and lib modules; drop two dead formatter exports (#885)

--- a/ornn-web/src/lib/analytics.test.ts
+++ b/ornn-web/src/lib/analytics.test.ts
@@ -62,6 +62,11 @@ async function freshModules() {
   return { consent, analytics };
 }
 
+// The frontend logger forwards `error` to `console.error` in the dev/test
+// branch (MODE !== "production"). Spy on it so swallow tests can assert the
+// failure was *logged with context*, not just silently absorbed.
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
   captureMock.mockClear();
   identifyMock.mockClear();
@@ -71,9 +76,11 @@ beforeEach(() => {
   optOutMock.mockClear();
   startReplayMock.mockClear();
   stopReplayMock.mockClear();
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
+  consoleErrorSpy.mockRestore();
   // A test may have swapped the `@/config` mock via `vi.doMock` + a paired
   // `vi.doUnmock`; the unmock only takes effect on the next module-registry
   // reset, so flush it here to keep config state from leaking forward.
@@ -191,6 +198,9 @@ describe("analytics wrapper", () => {
     // The wrapper catches the init failure; nothing should propagate.
     expect(() => analytics.initAnalytics()).not.toThrow();
     expect(initMock).toHaveBeenCalledTimes(1);
+    // ...and the failure is logged with context (logger.error → console.error).
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy.mock.calls.some((c) => String(c[0]).includes("init failed"))).toBe(true);
   });
 
   it("is a no-op on a second initAnalytics() call (initStarted guard)", async () => {
@@ -218,6 +228,12 @@ describe("analytics wrapper", () => {
     expect(() => analytics.track("login.completed")).not.toThrow();
     expect(() => analytics.identify("user-7")).not.toThrow();
     expect(() => analytics.reset()).not.toThrow();
+
+    // Each swallow path logs its own contextual error message.
+    const messages = consoleErrorSpy.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes("capture failed"))).toBe(true);
+    expect(messages.some((m) => m.includes("identify failed"))).toBe(true);
+    expect(messages.some((m) => m.includes("reset failed"))).toBe(true);
   });
 
   it("emits reset directly once consent is granted", async () => {
@@ -255,6 +271,12 @@ describe("analytics wrapper", () => {
 
     // Granting consent flushes the buffer; the throwing replay is caught.
     expect(() => consent.setConsent("granted")).not.toThrow();
+    // ...and the caught replay failure is logged with context.
+    expect(
+      consoleErrorSpy.mock.calls.some((c) =>
+        String(c[0]).includes("Buffered call replay failed"),
+      ),
+    ).toBe(true);
   });
 
   it("early-returns identify when userId is empty", async () => {

--- a/ornn-web/src/lib/analytics.test.ts
+++ b/ornn-web/src/lib/analytics.test.ts
@@ -74,6 +74,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // A test may have swapped the `@/config` mock via `vi.doMock` + a paired
+  // `vi.doUnmock`; the unmock only takes effect on the next module-registry
+  // reset, so flush it here to keep config state from leaking forward.
+  vi.resetModules();
   // Don't leak consent state into the next test file's localStorage.
   if (typeof window !== "undefined") {
     try {
@@ -157,6 +161,124 @@ describe("analytics wrapper", () => {
     expect(initMock).not.toHaveBeenCalled();
     expect(captureMock).not.toHaveBeenCalled();
 
-    vi.doUnmock("@/config");
+    // Restore the populated config mock. `vi.doUnmock` would unmask the real
+    // `@/config`, which reads empty runtime values under jsdom and leaks an
+    // unconfigured PostHog into later tests; re-`doMock` the configured one
+    // instead so ordering stays hermetic.
+    vi.doMock("@/config", () => ({
+      config: {
+        apiBaseUrl: "",
+        nyxidApiBaseUrl: "",
+        nyxidWebBaseUrl: "",
+        nyxidOauthAuthorizeUrl: "",
+        nyxidOauthTokenUrl: "",
+        nyxidOauthClientId: "",
+        nyxidOauthRedirectUri: "",
+        nyxidLogoutUrl: "",
+        nyxidSettingsUrl: "",
+        posthogApiKey: "phc_test_key",
+        posthogProjectId: "test-project",
+        posthogHost: "https://eu.i.posthog.com",
+      },
+    }));
+  });
+
+  it("swallows a throwing posthog.init without escaping", async () => {
+    initMock.mockImplementationOnce(() => {
+      throw new Error("init boom");
+    });
+    const { analytics } = await freshModules();
+    // The wrapper catches the init failure; nothing should propagate.
+    expect(() => analytics.initAnalytics()).not.toThrow();
+    expect(initMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op on a second initAnalytics() call (initStarted guard)", async () => {
+    const { analytics } = await freshModules();
+    analytics.initAnalytics();
+    analytics.initAnalytics();
+    expect(initMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows capture / identify / reset failures", async () => {
+    const { analytics, consent } = await freshModules();
+    analytics.initAnalytics();
+    consent.setConsent("granted");
+
+    captureMock.mockImplementationOnce(() => {
+      throw new Error("capture boom");
+    });
+    identifyMock.mockImplementationOnce(() => {
+      throw new Error("identify boom");
+    });
+    resetMock.mockImplementationOnce(() => {
+      throw new Error("reset boom");
+    });
+
+    expect(() => analytics.track("login.completed")).not.toThrow();
+    expect(() => analytics.identify("user-7")).not.toThrow();
+    expect(() => analytics.reset()).not.toThrow();
+  });
+
+  it("emits reset directly once consent is granted", async () => {
+    const { analytics, consent } = await freshModules();
+    analytics.initAnalytics();
+    consent.setConsent("granted");
+    resetMock.mockClear();
+
+    analytics.reset();
+    expect(resetMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("buffers reset before consent, then flushes it on grant", async () => {
+    const { analytics, consent } = await freshModules();
+    analytics.initAnalytics();
+
+    // Pre-consent reset is buffered, not emitted.
+    analytics.reset();
+    expect(resetMock).not.toHaveBeenCalled();
+
+    consent.setConsent("granted");
+    // flushBuffer replays the buffered reset.
+    expect(resetMock).toHaveBeenCalled();
+  });
+
+  it("survives a replay failure while flushing the buffer", async () => {
+    const { analytics, consent } = await freshModules();
+    analytics.initAnalytics();
+
+    // Buffer a track call before consent.
+    analytics.track("login.completed", { provider: "nyxid" });
+    captureMock.mockImplementationOnce(() => {
+      throw new Error("replay boom");
+    });
+
+    // Granting consent flushes the buffer; the throwing replay is caught.
+    expect(() => consent.setConsent("granted")).not.toThrow();
+  });
+
+  it("early-returns identify when userId is empty", async () => {
+    const { analytics, consent } = await freshModules();
+    analytics.initAnalytics();
+    consent.setConsent("granted");
+    identifyMock.mockClear();
+
+    analytics.identify("");
+    expect(identifyMock).not.toHaveBeenCalled();
+  });
+
+  it("stops recording, opts out, and resets on consent revoke", async () => {
+    const { analytics, consent } = await freshModules();
+    analytics.initAnalytics();
+    consent.setConsent("granted");
+
+    stopReplayMock.mockClear();
+    optOutMock.mockClear();
+    resetMock.mockClear();
+
+    consent.setConsent("denied");
+    expect(stopReplayMock).toHaveBeenCalledTimes(1);
+    expect(optOutMock).toHaveBeenCalledTimes(1);
+    expect(resetMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/ornn-web/src/lib/logger.test.ts
+++ b/ornn-web/src/lib/logger.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLogger } from "./logger";
+
+// Vitest runs with `import.meta.env.MODE === "test"`, so `IS_DEV` is true
+// and the dev branch (console forwarding) is exercised by the static import
+// above. The prod branch is covered via a stubbed-env dynamic re-import.
+
+describe("createLogger (dev branch)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards each level to its console method with a tag prefix", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    const logger = createLogger("mytag");
+    const data = { a: 1 };
+
+    logger.info("info msg", data);
+    logger.warn("warn msg", data);
+    logger.error("error msg", data);
+    logger.debug("debug msg", data);
+
+    expect(log).toHaveBeenCalledWith("[mytag] info msg", data);
+    expect(warn).toHaveBeenCalledWith("[mytag] warn msg", data);
+    expect(error).toHaveBeenCalledWith("[mytag] error msg", data);
+    expect(debug).toHaveBeenCalledWith("[mytag] debug msg", data);
+  });
+
+  it("substitutes an empty string when no data is passed", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    const logger = createLogger("tag2");
+    logger.info("a");
+    logger.warn("b");
+    logger.error("c");
+    logger.debug("d");
+
+    expect(log).toHaveBeenCalledWith("[tag2] a", "");
+    expect(warn).toHaveBeenCalledWith("[tag2] b", "");
+    expect(error).toHaveBeenCalledWith("[tag2] c", "");
+    expect(debug).toHaveBeenCalledWith("[tag2] d", "");
+  });
+});
+
+describe("createLogger (prod branch)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("returns no-op methods when MODE is production", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.resetModules();
+    const { createLogger: createProdLogger } = await import("./logger");
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    const logger = createProdLogger("prod");
+    logger.info("info", { x: 1 });
+    logger.warn("warn");
+    logger.error("error");
+    logger.debug("debug");
+
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    expect(debug).not.toHaveBeenCalled();
+  });
+});

--- a/ornn-web/src/utils/formatters.test.ts
+++ b/ornn-web/src/utils/formatters.test.ts
@@ -30,6 +30,11 @@ describe("formatFileSize", () => {
     expect(formatFileSize(1)).toBe("1 B");
   });
 
+  it("stays in bytes at the B→KB rollover boundary", () => {
+    // 1023 < 1024 → log/log floors to i === 0, so still raw bytes.
+    expect(formatFileSize(1023)).toBe("1023 B");
+  });
+
   it("renders kilobytes with one decimal", () => {
     expect(formatFileSize(1024)).toBe("1.0 KB");
     expect(formatFileSize(1536)).toBe("1.5 KB");

--- a/ornn-web/src/utils/formatters.test.ts
+++ b/ornn-web/src/utils/formatters.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { formatFileSize, formatNumber } from "./formatters";
+
+describe("formatNumber", () => {
+  it("renders millions with an M suffix", () => {
+    expect(formatNumber(1_000_000)).toBe("1.0M");
+    expect(formatNumber(2_500_000)).toBe("2.5M");
+  });
+
+  it("renders thousands with a K suffix", () => {
+    expect(formatNumber(1_000)).toBe("1.0K");
+    expect(formatNumber(12_300)).toBe("12.3K");
+  });
+
+  it("renders sub-thousand values with locale grouping", () => {
+    expect(formatNumber(0)).toBe("0");
+    expect(formatNumber(42)).toBe("42");
+    expect(formatNumber(999)).toBe("999");
+  });
+});
+
+describe("formatFileSize", () => {
+  it("returns the zero-byte early return", () => {
+    expect(formatFileSize(0)).toBe("0 B");
+  });
+
+  it("renders raw bytes without a fractional part", () => {
+    // i === 0 branch → toFixed(0).
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(1)).toBe("1 B");
+  });
+
+  it("renders kilobytes with one decimal", () => {
+    expect(formatFileSize(1024)).toBe("1.0 KB");
+    expect(formatFileSize(1536)).toBe("1.5 KB");
+  });
+
+  it("renders megabytes with one decimal", () => {
+    expect(formatFileSize(1024 * 1024)).toBe("1.0 MB");
+  });
+
+  it("renders gigabytes with one decimal", () => {
+    expect(formatFileSize(1024 * 1024 * 1024)).toBe("1.0 GB");
+  });
+});

--- a/ornn-web/src/utils/formatters.ts
+++ b/ornn-web/src/utils/formatters.ts
@@ -1,17 +1,3 @@
-/** Format a date string to a human-readable relative or absolute form */
-export function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 0) return "Today";
-  if (diffDays === 1) return "Yesterday";
-  if (diffDays < 30) return `${diffDays}d ago`;
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`;
-  return date.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
-}
-
 /** Format a number with commas */
 export function formatNumber(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -26,10 +12,4 @@ export function formatFileSize(bytes: number): string {
   const i = Math.floor(Math.log(bytes) / Math.log(1024));
   const value = bytes / Math.pow(1024, i);
   return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
-}
-
-/** Truncate a string to a max length with ellipsis */
-export function truncate(str: string, maxLength: number): string {
-  if (str.length <= maxLength) return str;
-  return str.slice(0, maxLength - 3) + "...";
 }

--- a/ornn-web/src/utils/translateError.test.ts
+++ b/ornn-web/src/utils/translateError.test.ts
@@ -25,6 +25,14 @@ describe("translateError", () => {
     );
   });
 
+  it("translates a key-only payload via the params ?? {} branch", () => {
+    // No `params` field → source calls t(key, parsed.params ?? {}). The stub
+    // receives an empty object, whose Object.keys(...).length is 0, so it
+    // returns the bare key (its no-params arm).
+    const msg = encodeErrorPayload({ key: "errors.foo" });
+    expect(translateError(new Error(msg))).toBe("errors.foo");
+  });
+
   it("falls through to raw text for non-payload JSON objects", () => {
     // Valid JSON object but no `key` field → not an ErrorPayload, and the
     // raw text doesn't look like an i18n key → returned verbatim.

--- a/ornn-web/src/utils/translateError.test.ts
+++ b/ornn-web/src/utils/translateError.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { encodeErrorPayload, translateError } from "./translateError";
+
+// `translateError.ts` imports the i18next *instance* (`@/i18n` default
+// export), not the react-i18next hook stubbed in `src/test/setup.ts`. Mock
+// that instance so `i18n.t` is a deterministic spy: bare key passthrough,
+// or `key:params` when interpolation params are present.
+vi.mock("@/i18n", () => ({
+  default: {
+    t: (key: string, params?: Record<string, unknown>) =>
+      params && Object.keys(params).length > 0
+        ? `${key}:${JSON.stringify(params)}`
+        : key,
+  },
+}));
+
+describe("translateError", () => {
+  it("translates an encoded JSON payload with its params", () => {
+    const msg = encodeErrorPayload({
+      key: "errors.api.quota.exceeded",
+      params: { limit: 5 },
+    });
+    expect(translateError(new Error(msg))).toBe(
+      `errors.api.quota.exceeded:${JSON.stringify({ limit: 5 })}`,
+    );
+  });
+
+  it("falls through to raw text for non-payload JSON objects", () => {
+    // Valid JSON object but no `key` field → not an ErrorPayload, and the
+    // raw text doesn't look like an i18n key → returned verbatim.
+    const raw = '{"foo":"bar"}';
+    expect(translateError(new Error(raw))).toBe(raw);
+  });
+
+  it("returns the raw message when JSON parsing throws", () => {
+    // Starts with "{" so the parse path is taken, but it's malformed →
+    // catch → fall through → raw passthrough.
+    const raw = "{not valid json";
+    expect(translateError(new Error(raw))).toBe(raw);
+  });
+
+  it("translates a dotted errors.* key on an Error", () => {
+    expect(translateError(new Error("errors.generic.unknown"))).toBe(
+      "errors.generic.unknown",
+    );
+  });
+
+  it("passes a plain Error message through unchanged", () => {
+    expect(translateError(new Error("Something broke"))).toBe("Something broke");
+  });
+
+  it("translates a string errors.* key", () => {
+    expect(translateError("errors.api.notFound")).toBe("errors.api.notFound");
+  });
+
+  it("passes a plain string through unchanged", () => {
+    expect(translateError("just a message")).toBe("just a message");
+  });
+
+  it("uses the provided fallback for null / non-Error input", () => {
+    expect(translateError(null, "fallback text")).toBe("fallback text");
+  });
+
+  it("falls back to errors.generic.unknown when no fallback is given", () => {
+    expect(translateError(undefined)).toBe("errors.generic.unknown");
+    expect(translateError(42)).toBe("errors.generic.unknown");
+  });
+});
+
+describe("encodeErrorPayload", () => {
+  it("round-trips through translateError", () => {
+    const payload = { key: "errors.foo.bar", params: { n: 1 } };
+    const encoded = encodeErrorPayload(payload);
+    expect(JSON.parse(encoded)).toEqual(payload);
+    expect(translateError(new Error(encoded))).toBe(
+      `errors.foo.bar:${JSON.stringify({ n: 1 })}`,
+    );
+  });
+});


### PR DESCRIPTION
Closes #885

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-36813-11268`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
