### PR TITLE
chore: [Misc] test(web): page + feature component tests — raise ornn-web/src/

### DIFF
--- a/.changeset/test-887-web-features.md
+++ b/.changeset/test-887-web-features.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Raise page/feature component coverage; drop a dead type re-export (#887)

--- a/ornn-web/src/components/admin/broadcasts/BroadcastEditDrawer.test.tsx
+++ b/ornn-web/src/components/admin/broadcasts/BroadcastEditDrawer.test.tsx
@@ -45,7 +45,41 @@ vi.mock("@/services/adminUsersApi", () => ({
   }),
 }));
 
+// Stub the recipient picker so the "specific audience" path can be
+// driven deterministically — a single button that pushes one userId
+// through `onChange`, no debounced search or network.
+vi.mock("@/components/admin/UserEmailPicker", () => ({
+  UserEmailPicker: ({
+    value,
+    onChange,
+  }: {
+    value: string[];
+    onChange: (next: string[]) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="add-recipient"
+      onClick={() => onChange([...value, "user-1"])}
+    >
+      add recipient ({value.length})
+    </button>
+  ),
+}));
+
+import type { AdminBroadcast } from "@/services/broadcastsApi";
 import { BroadcastEditDrawer } from "./BroadcastEditDrawer";
+
+const EDIT_BROADCAST: AdminBroadcast = {
+  id: "bc-123",
+  titleI18n: { en: "Existing title", zh: "现有标题" },
+  bodyMarkdownI18n: { en: "Existing body", zh: "现有正文" },
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+  createdBy: "admin-1",
+  updatedBy: "admin-1",
+  readCount: 0,
+  recipientUserIds: ["user-1", "user-2"],
+};
 
 function wrap(ui: ReactNode) {
   const qc = new QueryClient({
@@ -192,5 +226,190 @@ describe("BroadcastEditDrawer", () => {
     fireEvent.click(submitBtn!);
 
     expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["titleEn", { titleEn: "", titleZh: "标题", bodyEn: "Body", bodyZh: "正文" }],
+    ["titleZh", { titleEn: "Title", titleZh: "", bodyEn: "Body", bodyZh: "正文" }],
+    ["bodyEn", { titleEn: "Title", titleZh: "标题", bodyEn: "", bodyZh: "正文" }],
+    ["bodyZh", { titleEn: "Title", titleZh: "标题", bodyEn: "Body", bodyZh: "" }],
+  ] as const)(
+    "blocks submit when the %s field is empty",
+    async (_field, values) => {
+      wrap(
+        <BroadcastEditDrawer isOpen onClose={() => {}} broadcast={null} />,
+      );
+      fillBilingual(values);
+
+      const submitBtn = screen
+        .getAllByRole("button")
+        .find((b) => b.getAttribute("type") === "submit");
+      fireEvent.click(submitBtn!);
+
+      expect(createMutate).not.toHaveBeenCalled();
+    },
+  );
+
+  it("blocks submit when a title exceeds the 200-char cap", async () => {
+    wrap(<BroadcastEditDrawer isOpen onClose={() => {}} broadcast={null} />);
+    // jsdom doesn't enforce <input maxLength> on programmatic value=,
+    // so we can push a string past TITLE_MAX (200) to trip the cap rule.
+    fillBilingual({
+      titleEn: "a".repeat(201),
+      titleZh: "标题",
+      bodyEn: "Body",
+      bodyZh: "正文",
+    });
+
+    const submitBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("type") === "submit");
+    fireEvent.click(submitBtn!);
+
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit when a body exceeds the 20k-char cap", async () => {
+    wrap(<BroadcastEditDrawer isOpen onClose={() => {}} broadcast={null} />);
+    fillBilingual({
+      titleEn: "Title",
+      titleZh: "标题",
+      bodyEn: "a".repeat(20_001),
+      bodyZh: "正文",
+    });
+
+    const submitBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("type") === "submit");
+    fireEvent.click(submitBtn!);
+
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it("carries recipientUserIds in the payload for a specific audience", async () => {
+    createMutate.mockImplementation(
+      (_input: unknown, opts: { onSuccess?: () => void } = {}) => {
+        opts.onSuccess?.();
+      },
+    );
+
+    wrap(<BroadcastEditDrawer isOpen onClose={() => {}} broadcast={null} />);
+
+    fillBilingual({
+      titleEn: "Targeted",
+      titleZh: "定向",
+      bodyEn: "Hello",
+      bodyZh: "你好",
+    });
+
+    // Flip to "Specific users" and add a recipient via the stubbed picker.
+    const specificRadio = (screen.getAllByRole("radio") as HTMLInputElement[]).find(
+      (r) => (r.parentElement?.textContent ?? "").toLowerCase().includes("specific"),
+    );
+    fireEvent.click(specificRadio!);
+    fireEvent.click(screen.getByTestId("add-recipient"));
+
+    const submitBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("type") === "submit");
+    fireEvent.click(submitBtn!);
+
+    await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+    const [payload] = createMutate.mock.calls[0];
+    expect(payload).toEqual(
+      expect.objectContaining({ recipientUserIds: ["user-1"] }),
+    );
+  });
+
+  it("keeps the drawer open and toasts on a create error", async () => {
+    const onClose = vi.fn();
+    createMutate.mockImplementation(
+      (_input: unknown, opts: { onError?: (e: unknown) => void } = {}) => {
+        opts.onError?.(new Error("boom"));
+      },
+    );
+
+    wrap(<BroadcastEditDrawer isOpen onClose={onClose} broadcast={null} />);
+    fillBilingual({
+      titleEn: "Title",
+      titleZh: "标题",
+      bodyEn: "Body",
+      bodyZh: "正文",
+    });
+
+    const submitBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("type") === "submit");
+    fireEvent.click(submitBtn!);
+
+    await waitFor(() =>
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error" }),
+      ),
+    );
+    // The error branch never calls onClose — the drawer stays open.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the drawer when Escape is pressed", () => {
+    const onClose = vi.fn();
+    wrap(<BroadcastEditDrawer isOpen onClose={onClose} broadcast={null} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BroadcastEditDrawer — edit mode", () => {
+  it("prefills the form from the broadcast prop", () => {
+    wrap(
+      <BroadcastEditDrawer
+        isOpen
+        onClose={() => {}}
+        broadcast={EDIT_BROADCAST}
+      />,
+    );
+
+    const textboxes = screen.getAllByRole("textbox") as HTMLInputElement[];
+    const values = textboxes.map((el) => el.value);
+    expect(values).toContain("Existing title");
+    expect(values).toContain("现有标题");
+    expect(values).toContain("Existing body");
+    expect(values).toContain("现有正文");
+  });
+
+  it("submits an update with recipientUserIds stripped from the patch", async () => {
+    updateMutate.mockImplementation(
+      (_args: unknown, opts: { onSuccess?: () => void } = {}) => {
+        opts.onSuccess?.();
+      },
+    );
+    const onClose = vi.fn();
+
+    wrap(
+      <BroadcastEditDrawer
+        isOpen
+        onClose={onClose}
+        broadcast={EDIT_BROADCAST}
+      />,
+    );
+
+    const submitBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("type") === "submit");
+    fireEvent.click(submitBtn!);
+
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    const [args] = updateMutate.mock.calls[0];
+    expect(args.id).toBe("bc-123");
+    // PATCH carries title + body only — recipientUserIds must be absent.
+    expect(args.patch).not.toHaveProperty("recipientUserIds");
+    expect(args.patch).toEqual({
+      titleI18n: { en: "Existing title", zh: "现有标题" },
+      bodyMarkdownI18n: { en: "Existing body", zh: "现有正文" },
+    });
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/ornn-web/src/components/agentseal/AgentSealTrustBadge.test.tsx
+++ b/ornn-web/src/components/agentseal/AgentSealTrustBadge.test.tsx
@@ -1,16 +1,29 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
 
 // The badge imports `apiPost` from `@/services/apiClient` for the rescan
 // button. That module's transitive `authStore` import calls
 // `useAuthStore.getState().initialize()` at load time, which crashes
 // under jsdom because Zustand's persist middleware can't write to
 // localStorage. Render tests for the badge don't need either.
-vi.mock("@/services/apiClient", () => ({ apiPost: vi.fn() }));
+//
+// The toast store mock honours the `(s) => s.addToast` selector so the
+// rescan tests can capture toast calls; the spy is reset per-test.
+const apiPost = vi.fn();
+const addToast = vi.fn();
+
+vi.mock("@/services/apiClient", () => ({
+  apiPost: (...args: unknown[]) => apiPost(...args),
+}));
 vi.mock("@/stores/toastStore", () => ({
-  useToastStore: Object.assign(() => () => {}, {
-    getState: () => ({ addToast: () => {} }),
-  }),
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
 }));
 
 import { AgentSealTrustBadge } from "./AgentSealTrustBadge";
@@ -122,5 +135,240 @@ describe("AgentSealTrustBadge", () => {
     render(<AgentSealTrustBadge scan={makeScan({ score: -5 })} />);
     expect(screen.getAllByText(/0/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText(/Critical/i)).toBeInTheDocument();
+  });
+
+  describe("clean-100 explainer", () => {
+    it("uses the singular noun for a single scanned file", () => {
+      render(
+        <AgentSealTrustBadge
+          scan={makeScan({ score: 100, findings: [], scannedFiles: 1 })}
+        />,
+      );
+      // Explainer copy embeds "1 scanned file" (singular, no trailing s).
+      expect(
+        screen.getByText(/across 1 scanned file\./i),
+      ).toBeInTheDocument();
+      // The metadata line below also reads the singular noun.
+      expect(screen.getByText(/1 file$/)).toBeInTheDocument();
+    });
+
+    it("uses the plural noun for multiple scanned files", () => {
+      render(
+        <AgentSealTrustBadge
+          scan={makeScan({ score: 100, findings: [], scannedFiles: 3 })}
+        />,
+      );
+      expect(
+        screen.getByText(/across 3 scanned files\./i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/3 files/)).toBeInTheDocument();
+    });
+
+    it("omits the explainer when the score is below 100", () => {
+      render(
+        <AgentSealTrustBadge
+          scan={makeScan({ score: 92, findings: [], scannedFiles: 5 })}
+        />,
+      );
+      expect(
+        screen.queryByText(/No malicious patterns/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("severity tones", () => {
+    it("tags each finding row with its severity for tone styling", () => {
+      const scan = makeScan({
+        score: 20,
+        findings: [
+          { ruleId: "c", title: "C", severity: "critical", message: "c" },
+          { ruleId: "h", title: "H", severity: "high", message: "h" },
+          { ruleId: "m", title: "M", severity: "medium", message: "m" },
+          { ruleId: "l", title: "L", severity: "low", message: "l" },
+          { ruleId: "i", title: "I", severity: "info", message: "i" },
+        ],
+      });
+      render(<AgentSealTrustBadge scan={scan} />);
+      fireEvent.click(screen.getByRole("button", { name: /5 findings/i }));
+
+      const rows = screen.getAllByRole("listitem");
+      // Sorted worst-first, so the data-severity order is deterministic.
+      expect(rows.map((r) => r.getAttribute("data-severity"))).toEqual([
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info",
+      ]);
+    });
+  });
+
+  describe("rescan flow", () => {
+    beforeEach(() => {
+      apiPost.mockReset();
+      addToast.mockReset();
+    });
+    afterEach(() => cleanup());
+
+    const RESCAN_PROPS = {
+      canRescan: true,
+      skillIdOrName: "my-skill",
+      version: "1.2.3",
+    } as const;
+
+    it("renders the rescan button only when canRescan + ids + version are present", () => {
+      const { rerender } = render(
+        <AgentSealTrustBadge scan={makeScan()} {...RESCAN_PROPS} />,
+      );
+      expect(
+        screen.getByRole("button", { name: /rescan/i }),
+      ).toBeInTheDocument();
+
+      // Missing the admin flag — no button.
+      rerender(
+        <AgentSealTrustBadge
+          scan={makeScan()}
+          canRescan={false}
+          skillIdOrName="my-skill"
+          version="1.2.3"
+        />,
+      );
+      expect(
+        screen.queryByRole("button", { name: /rescan/i }),
+      ).not.toBeInTheDocument();
+
+      // Missing the version — no button even with the flag.
+      rerender(
+        <AgentSealTrustBadge
+          scan={makeScan()}
+          canRescan
+          skillIdOrName="my-skill"
+        />,
+      );
+      expect(
+        screen.queryByRole("button", { name: /rescan/i }),
+      ).not.toBeInTheDocument();
+
+      // Missing the skill id — no button.
+      rerender(
+        <AgentSealTrustBadge scan={makeScan()} canRescan version="1.2.3" />,
+      );
+      expect(
+        screen.queryByRole("button", { name: /rescan/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the rescan button on the unscanned variant too", () => {
+      render(<AgentSealTrustBadge scan={null} {...RESCAN_PROPS} />);
+      expect(
+        screen.getByRole("button", { name: /rescan/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("fires a success toast and onRescanned on a clean response", async () => {
+      apiPost.mockResolvedValue({ data: { scan: makeScan() }, error: null });
+      const onRescanned = vi.fn();
+      render(
+        <AgentSealTrustBadge
+          scan={makeScan()}
+          {...RESCAN_PROPS}
+          onRescanned={onRescanned}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /rescan/i }));
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "success" }),
+        ),
+      );
+      expect(apiPost).toHaveBeenCalledWith(
+        "/api/v1/admin/skills/my-skill/versions/1.2.3/agentseal-rescan",
+        {},
+      );
+      expect(onRescanned).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows the disabled-copy toast on an agentseal_disabled error", async () => {
+      apiPost.mockResolvedValue({
+        error: { code: "agentseal_disabled", message: "ignored" },
+      });
+      const onRescanned = vi.fn();
+      render(
+        <AgentSealTrustBadge
+          scan={makeScan()}
+          {...RESCAN_PROPS}
+          onRescanned={onRescanned}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /rescan/i }));
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "error",
+            message: expect.stringMatching(/not configured/i),
+          }),
+        ),
+      );
+      // The disabled branch never reports success.
+      expect(onRescanned).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the server error message on a generic error", async () => {
+      apiPost.mockResolvedValue({
+        error: { code: "rescan_failed", message: "Scanner is offline" },
+      });
+      render(<AgentSealTrustBadge scan={makeScan()} {...RESCAN_PROPS} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /rescan/i }));
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "error",
+            message: "Scanner is offline",
+          }),
+        ),
+      );
+    });
+
+    it("falls back to the translateError path on a thrown rejection", async () => {
+      apiPost.mockRejectedValue(new Error("Network down"));
+      render(<AgentSealTrustBadge scan={makeScan()} {...RESCAN_PROPS} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /rescan/i }));
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "error",
+            message: expect.stringMatching(/Network down/i),
+          }),
+        ),
+      );
+    });
+
+    it("disables the rescan button while the request is in flight", async () => {
+      let resolve!: (v: unknown) => void;
+      apiPost.mockReturnValue(
+        new Promise((r) => {
+          resolve = r;
+        }),
+      );
+      render(<AgentSealTrustBadge scan={makeScan()} {...RESCAN_PROPS} />);
+
+      const btn = screen.getByRole("button", { name: /rescan|scanning/i });
+      fireEvent.click(btn);
+
+      // The loading label switches and the button is disabled mid-flight.
+      await waitFor(() => expect(btn).toBeDisabled());
+
+      // Settle the request so the test doesn't leak a pending promise.
+      resolve({ data: { scan: makeScan() }, error: null });
+      await waitFor(() => expect(btn).not.toBeDisabled());
+    });
   });
 });

--- a/ornn-web/src/components/agentseal/AgentSealTrustBadge.tsx
+++ b/ornn-web/src/components/agentseal/AgentSealTrustBadge.tsx
@@ -20,7 +20,6 @@ import { useTranslation } from "react-i18next";
 import {
   styleForScore,
   formatAgentSealVersion,
-  type AgentSealBand,
 } from "@/lib/agentsealBand";
 import type { AgentSealScan, AgentSealFinding } from "@/types/domain";
 import { apiPost } from "@/services/apiClient";
@@ -476,5 +475,3 @@ function RescanButton({ onClick, loading }: RescanButtonProps) {
     </button>
   );
 }
-
-export type { AgentSealBand };

--- a/ornn-web/src/components/playground/ChatInput.test.tsx
+++ b/ornn-web/src/components/playground/ChatInput.test.tsx
@@ -115,3 +115,107 @@ describe("ChatInput length cap (#654)", () => {
     expect(sendBtn!.disabled).toBe(true);
   });
 });
+
+describe("ChatInput send + key handling", () => {
+  it("sends trimmed content on Enter and clears the textarea", () => {
+    const { textarea, onSend } = setup();
+    fireEvent.change(textarea, { target: { value: "  hello world  " } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith("hello world");
+    expect(textarea.value).toBe("");
+  });
+
+  it("sends on a send-button click", () => {
+    const { textarea, sendBtn, onSend } = setup();
+    fireEvent.change(textarea, { target: { value: "ping" } });
+    fireEvent.click(sendBtn!);
+    expect(onSend).toHaveBeenCalledWith("ping");
+  });
+
+  it("inserts a newline on Shift+Enter without sending", () => {
+    const { textarea, onSend } = setup();
+    fireEvent.change(textarea, { target: { value: "line one" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+    // The value is untouched — the browser would append the newline,
+    // and crucially we did not clear it.
+    expect(textarea.value).toBe("line one");
+  });
+
+  it("is a no-op for whitespace-only input", () => {
+    const { textarea, onSend, sendBtn } = setup();
+    fireEvent.change(textarea, { target: { value: "   \n  \t " } });
+    // Send button disabled and Enter does nothing.
+    expect(sendBtn!.disabled).toBe(true);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not send when disabled", () => {
+    const { textarea, onSend } = setup({ disabled: true });
+    fireEvent.change(textarea, { target: { value: "blocked" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChatInput streaming + abort", () => {
+  it("renders the stop button while streaming and fires onAbort", () => {
+    const { container, onAbort } = setup({ isStreaming: true, disabled: true });
+    // No send button in streaming mode.
+    expect(
+      container.querySelector('button[aria-label="chatInput.sendMessage"]'),
+    ).toBeNull();
+    const stopBtn = container.querySelector(
+      'button[aria-label="chatInput.stopGeneration"]',
+    ) as HTMLButtonElement;
+    expect(stopBtn).toBeTruthy();
+    fireEvent.click(stopBtn);
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ChatInput placeholder branches", () => {
+  it("uses the generating placeholder when disabled + streaming", () => {
+    const { textarea } = setup({ disabled: true, isStreaming: true });
+    expect(textarea.placeholder).toBe("chatInput.generating");
+  });
+
+  it("uses the awaiting-tool placeholder when disabled + not streaming", () => {
+    const { textarea } = setup({ disabled: true, isStreaming: false });
+    expect(textarea.placeholder).toBe("chatInput.awaitingTool");
+  });
+
+  it("uses the default placeholder when active", () => {
+    const { textarea } = setup({ disabled: false });
+    expect(textarea.placeholder).toBe("chatInput.placeholder");
+  });
+
+  it("prefers a custom placeholder over the default branches", () => {
+    const { textarea } = setup({
+      disabled: true,
+      isStreaming: true,
+      placeholder: "Pick a tool first",
+    });
+    expect(textarea.placeholder).toBe("Pick a tool first");
+  });
+});
+
+describe("ChatInput imperative handle", () => {
+  it("focuses the textarea via the focus handle", () => {
+    const { ref, textarea } = setup();
+    act(() => {
+      ref.current!.focus();
+    });
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("replaces the value via setValue", () => {
+    const { ref, textarea } = setup();
+    act(() => {
+      ref.current!.setValue("seeded prompt");
+    });
+    expect(textarea.value).toBe("seeded prompt");
+  });
+});

--- a/ornn-web/src/pages/skill/EditSkillPage.test.tsx
+++ b/ornn-web/src/pages/skill/EditSkillPage.test.tsx
@@ -17,7 +17,13 @@
  */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import type { SkillDetail } from "@/services/skillApi";
 
 // react-router's `useParams` is what gives the page its URL `:id`,
@@ -37,33 +43,48 @@ vi.mock("react-i18next", () => ({
   initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
+// Mutable hook state — each test seeds these before render so we can
+// exercise loading / not-found / visibility / upload branches without
+// re-declaring the mock per case.
+const refetchSpy = vi.fn();
+const updateMutateAsync = vi.fn();
+const updatePkgMutateAsync = vi.fn();
+let skillState: {
+  data: Partial<SkillDetail> | null | undefined;
+  isLoading: boolean;
+};
+
 // Spies that capture the `id` argument each write hook receives.
 const updateSpy = vi.fn<(id: string) => unknown>();
 const updatePkgSpy = vi.fn<(id: string) => unknown>();
 
 vi.mock("@/hooks/useSkills", () => ({
   useSkill: () => ({
-    data: {
-      guid: "abc-123-guid",
-      name: "my-public-skill",
-      description: "...",
-      isPrivate: false,
-    } satisfies Partial<SkillDetail>,
-    isLoading: false,
-    refetch: vi.fn(),
+    data: skillState.data,
+    isLoading: skillState.isLoading,
+    refetch: refetchSpy,
   }),
   useUpdateSkill: (id: string) => {
     updateSpy(id);
-    return { mutateAsync: vi.fn(), isPending: false };
+    return { mutateAsync: updateMutateAsync, isPending: false };
   },
   useUpdateSkillPackage: (id: string) => {
     updatePkgSpy(id);
-    return { mutateAsync: vi.fn(), isPending: false };
+    return { mutateAsync: updatePkgMutateAsync, isPending: false };
   },
 }));
 
+const addToast = vi.fn();
 vi.mock("@/stores/toastStore", () => ({
-  useToastStore: () => vi.fn(),
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
+}));
+
+// translateError pulls in `@/i18n`; the page only uses it on the error
+// branch. Stub it to echo the fallback so error-toast assertions stay
+// independent of the i18n init chain.
+vi.mock("@/utils/translateError", () => ({
+  translateError: (_err: unknown, fallback?: string) => fallback ?? "error",
 }));
 
 // Layout / UI bits don't matter for the contract — stub them to keep
@@ -79,11 +100,34 @@ vi.mock("@/components/layout/BackLink", () => ({
 
 import { EditSkillPage } from "./EditSkillPage";
 
-describe("EditSkillPage — write mutations receive skill.guid (#565)", () => {
-  beforeEach(() => {
-    updateSpy.mockClear();
-    updatePkgSpy.mockClear();
+const PUBLIC_SKILL: Partial<SkillDetail> = {
+  guid: "abc-123-guid",
+  name: "my-public-skill",
+  description: "...",
+  isPrivate: false,
+};
+
+function resetState() {
+  updateSpy.mockClear();
+  updatePkgSpy.mockClear();
+  refetchSpy.mockReset();
+  updateMutateAsync.mockReset();
+  updatePkgMutateAsync.mockReset();
+  addToast.mockReset();
+  updateMutateAsync.mockResolvedValue(undefined);
+  updatePkgMutateAsync.mockResolvedValue(undefined);
+  skillState = { data: { ...PUBLIC_SKILL }, isLoading: false };
+}
+
+/** Build a fake .zip File for the upload-flow tests. */
+function makeZip(name = "skill.zip"): File {
+  return new File(["PK fake zip bytes"], name, {
+    type: "application/zip",
   });
+}
+
+describe("EditSkillPage — write mutations receive skill.guid (#565)", () => {
+  beforeEach(resetState);
   afterEach(() => cleanup());
 
   it("hands skill.guid (not the URL :id) to useUpdateSkill", () => {
@@ -101,5 +145,160 @@ describe("EditSkillPage — write mutations receive skill.guid (#565)", () => {
       updatePkgSpy.mock.calls[updatePkgSpy.mock.calls.length - 1]?.[0];
     expect(lastCall).toBe("abc-123-guid");
     expect(lastCall).not.toBe("my-public-skill");
+  });
+});
+
+describe("EditSkillPage — load states", () => {
+  beforeEach(resetState);
+  afterEach(() => cleanup());
+
+  it("renders the skeleton while the skill is loading", () => {
+    skillState = { data: undefined, isLoading: true };
+    const { container } = render(<EditSkillPage />);
+    // The Skeleton renders `lines` shimmer bars; no form headings yet.
+    expect(container.querySelector(".skeleton-shimmer")).toBeTruthy();
+    expect(screen.queryByText(/Visibility/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the not-found message when the skill is missing", () => {
+    skillState = { data: null, isLoading: false };
+    render(<EditSkillPage />);
+    expect(screen.getByText(/Skill not found/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Update Package/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("EditSkillPage — visibility toggle", () => {
+  beforeEach(resetState);
+  afterEach(() => cleanup());
+
+  it("toggles a public skill to private with a success toast + refetch", async () => {
+    skillState = { data: { ...PUBLIC_SKILL, isPrivate: false }, isLoading: false };
+    render(<EditSkillPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Make Private/i }));
+
+    await waitFor(() =>
+      expect(updateMutateAsync).toHaveBeenCalledWith({ isPrivate: true }),
+    );
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "success",
+        message: expect.stringMatching(/private/i),
+      }),
+    );
+    expect(refetchSpy).toHaveBeenCalled();
+  });
+
+  it("toggles a private skill to public with the public-copy toast", async () => {
+    skillState = { data: { ...PUBLIC_SKILL, isPrivate: true }, isLoading: false };
+    render(<EditSkillPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Make Public/i }));
+
+    await waitFor(() =>
+      expect(updateMutateAsync).toHaveBeenCalledWith({ isPrivate: false }),
+    );
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "success",
+        message: expect.stringMatching(/public/i),
+      }),
+    );
+  });
+
+  it("shows an error toast and skips refetch when the toggle rejects", async () => {
+    updateMutateAsync.mockRejectedValue(new Error("boom"));
+    render(<EditSkillPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Make Private/i }));
+
+    await waitFor(() =>
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error" }),
+      ),
+    );
+    expect(refetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("EditSkillPage — package upload", () => {
+  beforeEach(resetState);
+  afterEach(() => cleanup());
+
+  function selectZip(container: HTMLElement) {
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [makeZip()] } });
+    return fileInput;
+  }
+
+  it("reveals the Upload button once a file is selected", () => {
+    const { container } = render(<EditSkillPage />);
+    expect(
+      screen.queryByRole("button", { name: /Upload Package/i }),
+    ).not.toBeInTheDocument();
+
+    selectZip(container);
+
+    expect(screen.getByText("skill.zip")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Upload Package/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("uploads, fires a success toast, clears the picker and refetches", async () => {
+    const { container } = render(<EditSkillPage />);
+    selectZip(container);
+
+    fireEvent.click(screen.getByRole("button", { name: /Upload Package/i }));
+
+    await waitFor(() =>
+      expect(updatePkgMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ zipFile: expect.any(File) }),
+      ),
+    );
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(refetchSpy).toHaveBeenCalled();
+    // The picker clears — selected filename + Upload button gone.
+    await waitFor(() =>
+      expect(screen.queryByText("skill.zip")).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: /Upload Package/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an error toast and keeps the file when the upload rejects", async () => {
+    updatePkgMutateAsync.mockRejectedValue(new Error("upload failed"));
+    const { container } = render(<EditSkillPage />);
+    selectZip(container);
+
+    fireEvent.click(screen.getByRole("button", { name: /Upload Package/i }));
+
+    await waitFor(() =>
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error" }),
+      ),
+    );
+    expect(refetchSpy).not.toHaveBeenCalled();
+    // File stays selected so the user can retry.
+    expect(screen.getByText("skill.zip")).toBeInTheDocument();
+  });
+
+  it("clears the selected file via the Remove control", () => {
+    const { container } = render(<EditSkillPage />);
+    selectZip(container);
+    expect(screen.getByText("skill.zip")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Remove/i }));
+
+    expect(screen.queryByText("skill.zip")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Upload Package/i }),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #887

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-45643-2346`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
