### PR TITLE
chore: [CI/CD] ci: enforce coverage floor — add a CI check that fails when or

### DIFF
--- a/.changeset/ci-889-coverage-floors.md
+++ b/.changeset/ci-889-coverage-floors.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+Enforce per-package line-coverage floors (api 75%, web 12% ratchet) and split the pooled Codecov flag (#889)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,18 +29,52 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bun run test:coverage
-      # Codecov upload (#471). No token needed for public repos.
-      # `directory: ./coverage` picks up the per-package lcov files
-      # that bun test --coverage writes into each workspace.
-      - name: Upload coverage to Codecov
+      # ornn-api line-coverage floor (#889). Bun's bunfig `coverageThreshold`
+      # is silently ignored on the pinned Bun (1.3.x) — it prints the table
+      # but never fails the run — so the floor is enforced here by summing
+      # LH/LF across the lcov that `test:coverage` just wrote. ornn-web's
+      # floor is enforced inside the run by vitest `thresholds.lines` in
+      # ornn-web/vitest.config.ts. Floor = operator's ≥75% gate; ratchet up
+      # in a reviewed one-line diff as real coverage rises (measured 96.6%).
+      - name: Enforce ornn-api line-coverage floor (>=75%)
+        run: |
+          awk -F: '
+            /^LF:/ { lf += $2 }
+            /^LH:/ { lh += $2 }
+            END {
+              if (lf == 0) { print "no lines found in lcov"; exit 1 }
+              pct = 100 * lh / lf
+              printf "ornn-api line coverage: %.2f%% (%d/%d), floor 75%%\n", pct, lh, lf
+              if (pct < 75) { print "::error::ornn-api line coverage below 75% floor"; exit 1 }
+            }
+          ' ornn-api/coverage/lcov.info
+      # Codecov upload (#471, #889). No token needed for public repos.
+      # The pooled `bun` flag was split per-package so each workspace's
+      # lcov is attributed to its own flag (`api` / `web` / `sdk-ts`) and
+      # judged on its own target in codecov.yml. One upload step per flag
+      # because a single codecov-action invocation applies one flag set to
+      # every file it uploads.
+      - name: Upload ornn-api coverage to Codecov
         uses: codecov/codecov-action@v4
         if: ${{ !cancelled() }}
         with:
-          flags: bun
+          flags: api
           fail_ci_if_error: false
-          # Per-package lcov files land under coverage/ in each
-          # workspace; codecov-action recurses by default.
-          files: ./ornn-api/coverage/lcov.info,./ornn-web/coverage/lcov.info,./sdk/typescript/coverage/lcov.info
+          files: ./ornn-api/coverage/lcov.info
+      - name: Upload ornn-web coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: ${{ !cancelled() }}
+        with:
+          flags: web
+          fail_ci_if_error: false
+          files: ./ornn-web/coverage/lcov.info
+      - name: Upload TS SDK coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: ${{ !cancelled() }}
+        with:
+          flags: sdk-ts
+          fail_ci_if_error: false
+          files: ./sdk/typescript/coverage/lcov.info
 
   python-sdk-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
           deps += cfg['project']['optional-dependencies']['dev']
           subprocess.check_call([sys.executable, '-m', 'pip', 'install', *deps])
           "
+          # pip itself is in the audited env — keep it current (PYSEC-2026-196, #935)
+          python -m pip install --upgrade pip
           pip install pip-audit
       - name: Audit dependencies
         working-directory: sdk/python

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,35 +1,68 @@
 # Codecov configuration for chrono-ornn (#471).
 #
 # Reports are uploaded from two CI jobs:
-#   - `test`            → flag `bun` (per-workspace lcov)
+#   - `test`            → flags `api`, `web`, `sdk-ts` (one per workspace lcov)
 #   - `python-sdk-test` → flag `python` (sdk/python coverage.xml)
 #
-# Target is realistic-not-aspirational: 70% project coverage as the
-# initial commitment. Files that are deliberately not covered today
-# (god-files, generation prompts, infra shims) are excluded so the
-# headline number reflects code that's reasonably testable.
+# The pooled `bun` flag was split per-package (#889) so each surface is
+# judged on its own honest coverage rather than a blended headline that
+# lets a well-tested package mask a thin one. Per-flag status targets are
+# the real signal; the global project default is kept as a coarse backstop.
+#
+# Files that are deliberately not covered today (god-files, generation
+# prompts, infra shims) are excluded so each number reflects code that's
+# reasonably testable.
 
 coverage:
   status:
     project:
+      # Coarse backstop across all flags. Per-flag targets below are the
+      # signal that actually gates each package honestly.
       default:
         target: 70%
         threshold: 1%
         if_ci_failed: error
+      # ornn-api is well covered today — hold it near its real number.
+      api:
+        flags:
+          - api
+        target: 90%
+        threshold: 2%
+        if_ci_failed: error
+      # ornn-web is early — floor it at its measured level, ratchet later.
+      web:
+        flags:
+          - web
+        target: 14%
+        threshold: 2%
+        if_ci_failed: error
+      # TS SDK — informational until it has a real test suite.
+      sdk-ts:
+        flags:
+          - sdk-ts
+        target: auto
+        informational: true
     patch:
       default:
         target: 80%
         threshold: 5%
         if_ci_failed: error
 
-# Source-of-truth flags. Codecov sums across flags by default; both
-# are surfaced separately in the PR comment so a regression in one
-# language is obvious.
+# Source-of-truth flags. Each Bun workspace uploads under its own flag so
+# a regression in one package is isolated and visible (#889). Codecov sums
+# across flags for the headline; per-flag carryforward keeps a package's
+# last-known coverage when its upload is absent from a given PR.
 flags:
-  bun:
+  api:
     paths:
       - ornn-api/src/
+    carryforward: true
+  web:
+    paths:
       - ornn-web/src/
+    carryforward: true
+  sdk-ts:
+    paths:
       - sdk/typescript/src/
     carryforward: true
   python:

--- a/ornn-web/vitest.config.ts
+++ b/ornn-web/vitest.config.ts
@@ -23,6 +23,8 @@ export default mergeConfig(
         ],
         reporter: ["text", "lcov", "json-summary"],
         reportsDirectory: "coverage",
+        // Floor only — measured 14.88% at introduction (#889). Raise deliberately, never auto-track.
+        thresholds: { lines: 12 },
       },
     },
   }),

--- a/ornn-web/vitest.config.ts
+++ b/ornn-web/vitest.config.ts
@@ -24,6 +24,7 @@ export default mergeConfig(
         reporter: ["text", "lcov", "json-summary"],
         reportsDirectory: "coverage",
         // Floor only — measured 14.88% at introduction (#889). Raise deliberately, never auto-track.
+      // NOTE: growing the exclude list above shrinks this denominator — exclude additions are review-gated (#884/#889).
         thresholds: { lines: 12 },
       },
     },


### PR DESCRIPTION
Closes #889

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-56279-1444`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.



Closes #935.