### PR TITLE
[Bug] admin-users list: invalid sort/dir returns 500 internal_error instead of 400

### DIFF
--- a/.changeset/fix-908-sort-dir-400.md
+++ b/.changeset/fix-908-sort-dir-400.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Admin users list: invalid sort/dir query params now return 400 invalid_sort/invalid_dir instead of 500 (#908)

--- a/ornn-api/src/domains/admin-users/routes.test.ts
+++ b/ornn-api/src/domains/admin-users/routes.test.ts
@@ -153,18 +153,23 @@ describe("GET /admin/users", () => {
     expect(listCalls[0]!.dir).toBe("asc");
   });
 
-  test("invalid sort currently escapes as 500 internal_error (KNOWN DEFECT — should be 400; tracked in #908)", async () => {
-    // Documents current buggy behavior: the route calls raw `sortKeySchema.parse`
-    // (and `dirSchema.parse`) on the `sort`/`dir` query params. A bad value makes
-    // zod throw a ZodError, which carries no `statusCode`/`code`, so it escapes to
-    // the bootstrap's non-AppError→500 mapper instead of being a client error.
-    // Target fix: mirror the `role` param's `safeParse` guard and raise a 400
-    // `invalid_sort` / `invalid_dir` AppError. Until that lands we pin the
-    // current 500 so the regression is visible and the fix flips this assertion.
+  test("invalid sort → 400 invalid_sort; service not called (#908)", async () => {
     const res = await app.request("/admin/users?sort=bogusColumn", {
       headers: authHeaders(),
     });
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_sort");
+    expect(listCalls.length).toBe(0);
+  });
+
+  test("invalid dir → 400 invalid_dir; service not called (#908)", async () => {
+    const res = await app.request("/admin/users?dir=sideways", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("invalid_dir");
     expect(listCalls.length).toBe(0);
   });
 

--- a/ornn-api/src/domains/admin-users/routes.ts
+++ b/ornn-api/src/domains/admin-users/routes.ts
@@ -55,11 +55,27 @@ export function createAdminUsersRoutes(
       const pageSize = Math.min(200, Math.max(1, Number(c.req.query("pageSize")) || 20));
       const q = (c.req.query("q") ?? "").trim() || undefined;
       const sortRaw = c.req.query("sort");
-      const sortKey: SortKey | undefined = sortRaw
-        ? sortKeySchema.parse(sortRaw)
-        : undefined;
+      let sortKey: SortKey | undefined;
+      if (sortRaw !== undefined) {
+        const sortParse = sortKeySchema.safeParse(sortRaw);
+        if (!sortParse.success) {
+          throw new AppError(
+            400,
+            "invalid_sort",
+            "sort must be one of: displayName, email, skillCount, lastActiveAt, activityCount, firstJoinedAt",
+          );
+        }
+        sortKey = sortParse.data;
+      }
       const dirRaw = c.req.query("dir");
-      const dir: SortDir | undefined = dirRaw ? dirSchema.parse(dirRaw) : undefined;
+      let dir: SortDir | undefined;
+      if (dirRaw !== undefined) {
+        const dirParse = dirSchema.safeParse(dirRaw);
+        if (!dirParse.success) {
+          throw new AppError(400, "invalid_dir", "dir must be 'asc' or 'desc'");
+        }
+        dir = dirParse.data;
+      }
 
       // exactOptionalPropertyTypes (#657): conditional spread on the
       // optional inputs so we don't pass `{ q: undefined }` to a

--- a/ornn-api/src/domains/admin-users/routes.ts
+++ b/ornn-api/src/domains/admin-users/routes.ts
@@ -62,7 +62,7 @@ export function createAdminUsersRoutes(
           throw new AppError(
             400,
             "invalid_sort",
-            "sort must be one of: displayName, email, skillCount, lastActiveAt, activityCount, firstJoinedAt",
+            `sort must be one of: ${sortKeySchema.options.join(", ")}`,
           );
         }
         sortKey = sortParse.data;


### PR DESCRIPTION
Closes #908

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-67298-14493`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
