### PR TITLE
[Bug] notifications feed: malformed ?limit (NaN) escapes both clamps and reaches Mongo cursor.limit

### DIFF
--- a/.changeset/fix-920-nan-limit.md
+++ b/.changeset/fix-920-nan-limit.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Malformed or empty ?limit on the notifications feed now falls back to the default page size instead of erroring (#920)

--- a/ornn-api/src/domains/notifications/routes.test.ts
+++ b/ornn-api/src/domains/notifications/routes.test.ts
@@ -14,8 +14,11 @@
  *   - `toFeedDto` for BOTH variants — the user variant with and without
  *     the optional `body` / `link` (the exactOptionalPropertyTypes
  *     conditional spread, #657) and the broadcast variant;
- *   - the `?unread=true` discriminator and the `?limit=` clamp
- *     (below-min, in-range, above-max);
+ *   - the `?unread=true` discriminator and `?limit=` parsing: the
+ *     route forwards the parsed value RAW to the service (no clamp —
+ *     the service owns the clamp authority, #920), and drops a
+ *     malformed/empty `?limit=` to `undefined` so the service falls
+ *     back to its default page size;
  *   - the `{ data, error: null }` success envelope (CONVENTIONS);
  *   - markRead of an unknown id → service throws AppError.notFound →
  *     404 application/problem+json.
@@ -209,7 +212,10 @@ describe("notification routes — GET /notifications", () => {
     expect(received?.unreadOnly).toBe(true);
   });
 
-  test("?limit below the floor clamps up to 1", async () => {
+  // The route NO LONGER clamps (#920) — it forwards the parsed value
+  // raw and lets the service apply the floor/ceiling. These assertions
+  // pin the forwarding contract, not the clamp.
+  test("?limit=0 forwards 0 raw (service clamps, not the route)", async () => {
     let received: { limit?: number } | undefined;
     const app = mountApp(
       fakeService({
@@ -220,10 +226,10 @@ describe("notification routes — GET /notifications", () => {
       }),
     );
     await app.request("/notifications?limit=0");
-    expect(received?.limit).toBe(1);
+    expect(received?.limit).toBe(0);
   });
 
-  test("?limit in range passes through unchanged", async () => {
+  test("?limit in range forwards the value unchanged", async () => {
     let received: { limit?: number } | undefined;
     const app = mountApp(
       fakeService({
@@ -237,7 +243,7 @@ describe("notification routes — GET /notifications", () => {
     expect(received?.limit).toBe(25);
   });
 
-  test("?limit above the ceiling clamps down to 200", async () => {
+  test("?limit above the ceiling forwards 9999 raw (service clamps)", async () => {
     let received: { limit?: number } | undefined;
     const app = mountApp(
       fakeService({
@@ -248,7 +254,37 @@ describe("notification routes — GET /notifications", () => {
       }),
     );
     await app.request("/notifications?limit=9999");
-    expect(received?.limit).toBe(200);
+    expect(received?.limit).toBe(9999);
+  });
+
+  test("?limit=abc (malformed) → 200 + limit undefined (service defaults) (#920)", async () => {
+    let received: { limit?: number } | undefined;
+    const app = mountApp(
+      fakeService({
+        listFeedForUser: async (_userId: string, opts: typeof received) => {
+          received = opts;
+          return [];
+        },
+      }),
+    );
+    const res = await app.request("/notifications?limit=abc");
+    expect(res.status).toBe(200);
+    expect(received?.limit).toBeUndefined();
+  });
+
+  test("?limit= (empty) → 200 + limit undefined (service defaults) (#920)", async () => {
+    let received: { limit?: number } | undefined;
+    const app = mountApp(
+      fakeService({
+        listFeedForUser: async (_userId: string, opts: typeof received) => {
+          received = opts;
+          return [];
+        },
+      }),
+    );
+    const res = await app.request("/notifications?limit=");
+    expect(res.status).toBe(200);
+    expect(received?.limit).toBeUndefined();
   });
 });
 

--- a/ornn-api/src/domains/notifications/routes.test.ts
+++ b/ornn-api/src/domains/notifications/routes.test.ts
@@ -30,9 +30,10 @@ import { describe, expect, test } from "bun:test";
 import { Hono } from "hono";
 import type { AuthVariables } from "../../middleware/nyxidAuth";
 import { AppError, buildProblemJsonBody } from "../../shared/types/index";
+import type { ListOptions, NotificationRepository } from "./repository";
 import { createNotificationRoutes } from "./routes";
-import type { NotificationService } from "./service";
-import type { FeedItem } from "./types";
+import { NotificationService } from "./service";
+import type { FeedItem, NotificationDocument } from "./types";
 
 const USER_ID = "u-router";
 
@@ -354,5 +355,89 @@ describe("notification routes — POST /notifications/mark-all-read", () => {
     const body = (await res.json()) as { data: { updated: number }; error: null };
     expect(body.data.updated).toBe(4);
     expect(body.error).toBeNull();
+  });
+});
+
+/**
+ * Wired end-to-end seam: HTTP route → REAL NotificationService → fake
+ * repo (#920). Every other test in this file stubs the service with a
+ * Proxy, so they pin only what the *route* forwards (`?limit=0` → raw
+ * 0, malformed → undefined) and the clamp lives unverified across the
+ * seam. The clamp itself is covered in service.test.ts at the service
+ * boundary. Neither side proves the *composition*: that the route's raw
+ * forward + the service's clamp actually meet on one request. These
+ * tests mount the route over a genuine `NotificationService` backed by
+ * a minimal repo that captures the `limit` the service ultimately hands
+ * the repo — pinning that `GET /notifications?limit=<x>` lands the
+ * expected clamped value at the persistence boundary, in one path.
+ *
+ * The fake repo only implements `list` (the sole method this seam
+ * touches) + captures `lastListOptions`; the rest throw if reached so
+ * the assertions stay honest about which repo calls the handler makes.
+ */
+class CapturingNotificationRepo {
+  /** Captures the `list` options the service forwards, so the seam test
+   *  can read the clamped `limit` at the persistence boundary. */
+  lastListOptions: ListOptions | undefined;
+
+  async list(_userId: string, options: ListOptions = {}): Promise<NotificationDocument[]> {
+    this.lastListOptions = options;
+    return [];
+  }
+
+  async create(): Promise<NotificationDocument> {
+    throw new Error("unexpected NotificationRepository.create call");
+  }
+
+  async countUnread(): Promise<number> {
+    throw new Error("unexpected NotificationRepository.countUnread call");
+  }
+
+  async markRead(): Promise<NotificationDocument | null> {
+    throw new Error("unexpected NotificationRepository.markRead call");
+  }
+
+  async markAllRead(): Promise<number> {
+    throw new Error("unexpected NotificationRepository.markAllRead call");
+  }
+}
+
+describe("notification routes — wired clamp seam (route → service → repo) (#920)", () => {
+  // Mirror the (unexported) service constant so the assertion reads
+  // intent-first. Keep in sync with service.ts MERGED_FEED_LIMIT_DEFAULT.
+  const MERGED_FEED_LIMIT_DEFAULT = 50;
+
+  function mountWired(): { app: Hono<{ Variables: AuthVariables }>; repo: CapturingNotificationRepo } {
+    const repo = new CapturingNotificationRepo();
+    // No broadcastRepo — the seam under test is the per-user `list`
+    // limit, which the service derives before touching either source.
+    const service = new NotificationService({
+      notificationRepo: repo as unknown as NotificationRepository,
+    });
+    return { app: mountApp(service), repo };
+  }
+
+  test("?limit=0 → 200 AND repo receives clamped limit 1 (route forwards raw 0, service floors)", async () => {
+    const { app, repo } = mountWired();
+    const res = await app.request("/notifications?limit=0");
+    expect(res.status).toBe(200);
+    // Route forwarded raw 0 → service clamped up to the floor (1).
+    expect(repo.lastListOptions?.limit).toBe(1);
+  });
+
+  test("?limit=-50 → 200 AND repo receives clamped limit 1 (negative-finite floor)", async () => {
+    const { app, repo } = mountWired();
+    const res = await app.request("/notifications?limit=-50");
+    expect(res.status).toBe(200);
+    // -50 is finite, so the route forwards it raw; the service floors it.
+    expect(repo.lastListOptions?.limit).toBe(1);
+  });
+
+  test("?limit=abc → 200 AND repo receives the default page size (route drops NaN → service default)", async () => {
+    const { app, repo } = mountWired();
+    const res = await app.request("/notifications?limit=abc");
+    expect(res.status).toBe(200);
+    // Malformed → route drops to undefined → service falls back to default.
+    expect(repo.lastListOptions?.limit).toBe(MERGED_FEED_LIMIT_DEFAULT);
   });
 });

--- a/ornn-api/src/domains/notifications/routes.ts
+++ b/ornn-api/src/domains/notifications/routes.ts
@@ -89,8 +89,14 @@ export function createNotificationRoutes(
   app.get("/notifications", auth, async (c) => {
     const authCtx = getAuth(c);
     const unreadOnly = c.req.query("unread") === "true";
+    // Parse + finite-validate only. The clamp authority lives in the
+    // service (single source of truth) — a malformed/empty `?limit=`
+    // (e.g. `abc`, ``) yields NaN here, which we drop to `undefined` so
+    // the service falls back to its default page size instead of
+    // erroring (#920).
     const limitParam = c.req.query("limit");
-    const limit = limitParam ? Math.max(1, Math.min(200, Number.parseInt(limitParam, 10))) : undefined;
+    const parsed = limitParam !== undefined ? Number.parseInt(limitParam, 10) : NaN;
+    const limit = Number.isFinite(parsed) ? parsed : undefined;
     const items = await notificationService.listFeedForUser(authCtx.userId, {
       unreadOnly,
       // exactOptionalPropertyTypes (#657)

--- a/ornn-api/src/domains/notifications/service.test.ts
+++ b/ornn-api/src/domains/notifications/service.test.ts
@@ -41,6 +41,9 @@ class FakeNotificationRepo {
   created: CreateNotificationInput[] = [];
   /** When true, `create` rejects — exercises the emit swallow-on-reject path. */
   createShouldReject = false;
+  /** Captures the most recent `list` options so clamp tests can pin the
+   *  `limit` the service forwards to the repo (#920). */
+  lastListOptions: ListOptions | undefined;
 
   async create(input: CreateNotificationInput): Promise<NotificationDocument> {
     if (this.createShouldReject) {
@@ -63,6 +66,7 @@ class FakeNotificationRepo {
   }
 
   async list(userId: string, options: ListOptions = {}): Promise<NotificationDocument[]> {
+    this.lastListOptions = options;
     let out = this.rows.filter((r) => r.userId === userId);
     if (options.unreadOnly) out = out.filter((r) => !r.readAt);
     out = [...out].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
@@ -352,6 +356,61 @@ describe("NotificationService — merged feed (#500)", () => {
     expect(feed[0]?.source).toBe("user");
     expect(await svc.countUnread("u1")).toBe(1);
     expect(await svc.markAllRead("u1")).toBe(1);
+  });
+});
+
+describe("NotificationService — listFeedForUser limit clamp authority (#920)", () => {
+  // Mirror the (unexported) service constants so the assertions read
+  // intent-first. Keep in sync with service.ts.
+  const MERGED_FEED_LIMIT_DEFAULT = 50;
+  const MERGED_FEED_LIMIT_MAX = 200;
+
+  test("limit: NaN falls back to the default page size", async () => {
+    const { svc, notificationRepo } = makeService();
+    await svc.listFeedForUser("u1", { limit: NaN });
+    const captured = notificationRepo.lastListOptions?.limit;
+    expect(captured).toBe(MERGED_FEED_LIMIT_DEFAULT);
+    expect(Number.isFinite(captured)).toBe(true);
+  });
+
+  test("limit: undefined falls back to the default page size", async () => {
+    const { svc, notificationRepo } = makeService();
+    // Pass an explicit-`undefined` limit. The service signature uses
+    // exactOptionalPropertyTypes (no `undefined` in the value position),
+    // so the literal is funnelled through `unknown` at the call
+    // boundary — at runtime this exercises the same
+    // `options.limit === undefined` branch the route hits when it drops
+    // a malformed `?limit=` to undefined (#920).
+    const opts = { limit: undefined } as unknown as { limit?: number };
+    await svc.listFeedForUser("u1", opts);
+    const captured = notificationRepo.lastListOptions?.limit;
+    expect(captured).toBe(MERGED_FEED_LIMIT_DEFAULT);
+    expect(Number.isFinite(captured)).toBe(true);
+  });
+
+  test("limit: 0 clamps up to the floor (1)", async () => {
+    const { svc, notificationRepo } = makeService();
+    await svc.listFeedForUser("u1", { limit: 0 });
+    const captured = notificationRepo.lastListOptions?.limit;
+    expect(captured).toBe(1);
+    expect(Number.isFinite(captured)).toBe(true);
+  });
+
+  test("limit: 9999 clamps down to the ceiling", async () => {
+    const { svc, notificationRepo } = makeService();
+    await svc.listFeedForUser("u1", { limit: 9999 });
+    const captured = notificationRepo.lastListOptions?.limit;
+    expect(captured).toBe(MERGED_FEED_LIMIT_MAX);
+    expect(Number.isFinite(captured)).toBe(true);
+  });
+
+  test("limit: Infinity clamps down to the ceiling (finite guard)", async () => {
+    const { svc, notificationRepo } = makeService();
+    await svc.listFeedForUser("u1", { limit: Number.POSITIVE_INFINITY });
+    const captured = notificationRepo.lastListOptions?.limit;
+    // Infinity is not finite → defaults → still within [1, MAX].
+    expect(captured).toBe(MERGED_FEED_LIMIT_DEFAULT);
+    expect(Number.isFinite(captured)).toBe(true);
   });
 });
 

--- a/ornn-api/src/domains/notifications/service.ts
+++ b/ornn-api/src/domains/notifications/service.ts
@@ -97,10 +97,16 @@ export class NotificationService {
     userId: string,
     options: { limit?: number; unreadOnly?: boolean } = {},
   ): Promise<FeedItem[]> {
-    const limit = Math.max(
-      1,
-      Math.min(MERGED_FEED_LIMIT_MAX, options.limit ?? MERGED_FEED_LIMIT_DEFAULT),
-    );
+    // Single clamp authority for the merged feed (#920). The route only
+    // parses + finite-validates; everything else — missing, NaN, ±Inf,
+    // below floor, above ceiling — is normalised here so every caller
+    // (route, MCP, internal) gets the same guardrails.
+    const requested = options.limit;
+    const safe =
+      typeof requested === "number" && Number.isFinite(requested)
+        ? requested
+        : MERGED_FEED_LIMIT_DEFAULT;
+    const limit = Math.max(1, Math.min(MERGED_FEED_LIMIT_MAX, safe));
     // Pull `limit` from each source, then take the top `limit` after
     // merging — guarantees we don't drop a newer item from one source
     // because the other source had `limit` older items.


### PR DESCRIPTION
Closes #920

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-70817-16361`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
