### PR TITLE
[Misc] Backfill reset/derivation tests for remaining #888 effect refactors

### DIFF
--- a/.changeset/test-931-backfill.md
+++ b/.changeset/test-931-backfill.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Backfill per-component reset/derivation tests for the #888 effect refactors (#931)

--- a/ornn-web/src/components/admin/announcements/AnnouncementEditDrawer.test.tsx
+++ b/ornn-web/src/components/admin/announcements/AnnouncementEditDrawer.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * AnnouncementEditDrawer tests — entity-switch reset via key remount (#888).
+ *
+ * The inner form is keyed on `announcement?.id ?? "new"` so its
+ * lazy-initialised state resets by construction when the open drawer
+ * switches from announcement A to announcement B without closing. Without
+ * the key, A's edited (dirty) state would survive and bleed into B.
+ *
+ * STALE-STATE-FIRST oracle: open on A, DIRTY a field (type new text), then
+ * switch the `announcement` prop to B while the drawer stays open →
+ * B's values render and A's dirt is gone (the remount discarded it).
+ *
+ * Mocks the mutation hooks + toast store directly so the test doesn't pull
+ * in the apiClient / auth store init chain. framer-motion is stubbed
+ * pass-through so the slide AnimatePresence doesn't gate mount/unmount.
+ * react-i18next is stubbed globally in src/test/setup.ts.
+ *
+ * @module components/admin/announcements/AnnouncementEditDrawer.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { AdminAnnouncement } from "@/services/announcementsApi";
+
+const createMutate = vi.fn();
+const updateMutate = vi.fn();
+const useCreateAnnouncement = vi.fn();
+const useUpdateAnnouncement = vi.fn();
+const addToast = vi.fn();
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+vi.mock("@/hooks/useAnnouncements", () => ({
+  useCreateAnnouncement: () => useCreateAnnouncement(),
+  useUpdateAnnouncement: () => useUpdateAnnouncement(),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
+}));
+
+import { AnnouncementEditDrawer } from "./AnnouncementEditDrawer";
+
+const ANNOUNCEMENT_A: AdminAnnouncement = {
+  id: "a-1",
+  titleEn: "Alpha title",
+  titleZh: "阿尔法标题",
+  bodyMarkdownEn: "Alpha body",
+  bodyMarkdownZh: "阿尔法正文",
+  ctaLabelEn: null,
+  ctaLabelZh: null,
+  ctaUrl: null,
+  enabled: true,
+  startsAt: null,
+  endsAt: null,
+  createdBy: "admin-1",
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
+const ANNOUNCEMENT_B: AdminAnnouncement = {
+  id: "b-2",
+  titleEn: "Bravo title",
+  titleZh: "布拉沃标题",
+  bodyMarkdownEn: "Bravo body",
+  bodyMarkdownZh: "布拉沃正文",
+  ctaLabelEn: null,
+  ctaLabelZh: null,
+  ctaUrl: null,
+  enabled: false,
+  startsAt: null,
+  endsAt: null,
+  createdBy: "admin-1",
+  createdAt: "2026-05-02T00:00:00.000Z",
+  updatedAt: "2026-05-02T00:00:00.000Z",
+};
+
+function inputValues(): string[] {
+  return (screen.getAllByRole("textbox") as HTMLInputElement[]).map((el) => el.value);
+}
+
+/** Locate the "Title (EN)" input by its label text via the Input primitive. */
+function titleEnInput(): HTMLInputElement {
+  return screen.getByDisplayValue("Alpha title") as HTMLInputElement;
+}
+
+beforeEach(() => {
+  createMutate.mockReset();
+  updateMutate.mockReset();
+  addToast.mockReset();
+  useCreateAnnouncement.mockReturnValue({ mutate: createMutate, isPending: false });
+  useUpdateAnnouncement.mockReturnValue({ mutate: updateMutate, isPending: false });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AnnouncementEditDrawer — entity-switch reset", () => {
+  it("prefills the form from the announcement prop in edit mode", () => {
+    render(
+      <AnnouncementEditDrawer
+        isOpen
+        onClose={() => {}}
+        announcement={ANNOUNCEMENT_A}
+      />,
+    );
+    const values = inputValues();
+    expect(values).toContain("Alpha title");
+    expect(values).toContain("阿尔法标题");
+  });
+
+  it("drops A's DIRTY edits and shows B's values when the prop switches without closing", () => {
+    const { rerender } = render(
+      <AnnouncementEditDrawer
+        isOpen
+        onClose={() => {}}
+        announcement={ANNOUNCEMENT_A}
+      />,
+    );
+
+    // Force the wrong state: dirty A's title field with a value that matches
+    // neither A nor B's original.
+    fireEvent.change(titleEnInput(), { target: { value: "DIRTY EDIT" } });
+    expect(inputValues()).toContain("DIRTY EDIT");
+
+    // Switch entity WITHOUT closing (isOpen stays true). The key flips from
+    // "a-1" to "b-2" → the inner form remounts and re-inits from B.
+    rerender(
+      <AnnouncementEditDrawer
+        isOpen
+        onClose={() => {}}
+        announcement={ANNOUNCEMENT_B}
+      />,
+    );
+
+    const values = inputValues();
+    // B's values are shown…
+    expect(values).toContain("Bravo title");
+    expect(values).toContain("布拉沃标题");
+    // …and A's dirt + A's originals are gone (the remount discarded them).
+    expect(values).not.toContain("DIRTY EDIT");
+    expect(values).not.toContain("Alpha title");
+  });
+
+  it("resets to the empty 'new' form when switching from an entity to create mode", () => {
+    const { rerender } = render(
+      <AnnouncementEditDrawer
+        isOpen
+        onClose={() => {}}
+        announcement={ANNOUNCEMENT_A}
+      />,
+    );
+    fireEvent.change(titleEnInput(), { target: { value: "DIRTY EDIT" } });
+
+    // Switch to create mode (announcement = null → key "new").
+    rerender(
+      <AnnouncementEditDrawer isOpen onClose={() => {}} announcement={null} />,
+    );
+
+    const values = inputValues();
+    expect(values).not.toContain("DIRTY EDIT");
+    expect(values).not.toContain("Alpha title");
+    // The empty form's title input renders as an empty string.
+    expect(values).toContain("");
+  });
+});

--- a/ornn-web/src/components/admin/redemption-codes/MintRedemptionCodeModal.test.tsx
+++ b/ornn-web/src/components/admin/redemption-codes/MintRedemptionCodeModal.test.tsx
@@ -15,6 +15,37 @@ const mintMutateAsync = vi.fn();
 const useMintCode = vi.fn();
 const addToast = vi.fn();
 
+// Pass-through framer-motion so the Modal's AnimatePresence honours
+// unmounting synchronously — required by the reopen-reset case below, where
+// the keyed form must actually unmount on close and remount on reopen. The
+// existing cases render with isOpen=true throughout, so pass-through is a
+// no-op for them.
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
 vi.mock("@/hooks/useRedemptionCodes", () => ({
   useMintCode: () => useMintCode(),
 }));
@@ -113,5 +144,33 @@ describe("MintRedemptionCodeModal", () => {
     expect(addToast).toHaveBeenCalledWith(
       expect.objectContaining({ type: "success" }),
     );
+  });
+
+  it("resets dirty form state to defaults on close + reopen (#888)", () => {
+    // Pins the `key={isOpen ? "open" : "closed"}` remount on the inner form.
+    // The form's state has no reset effect — it relies entirely on the keyed
+    // unmount/remount. STALE-STATE-FIRST: dirty a field, close (key → "closed"
+    // → form unmounts), reopen (key → "open" → fresh construction) and assert
+    // the field is back to its default rather than carrying the stale edit.
+    const { rerender } = render(
+      <MintRedemptionCodeModal isOpen={true} onClose={() => {}} />,
+    );
+
+    const amount = screen.getByLabelText(/grant 1 amount/i) as HTMLInputElement;
+    expect(amount.value).toBe("100"); // EMPTY_GRANT default
+    fireEvent.change(amount, { target: { value: "999" } });
+    expect(
+      (screen.getByLabelText(/grant 1 amount/i) as HTMLInputElement).value,
+    ).toBe("999");
+
+    // Close — the keyed form unmounts (AnimatePresence is pass-through here).
+    rerender(<MintRedemptionCodeModal isOpen={false} onClose={() => {}} />);
+    expect(screen.queryByLabelText(/grant 1 amount/i)).not.toBeInTheDocument();
+
+    // Reopen — a brand-new form is constructed; the dirty 999 is gone.
+    rerender(<MintRedemptionCodeModal isOpen={true} onClose={() => {}} />);
+    expect(
+      (screen.getByLabelText(/grant 1 amount/i) as HTMLInputElement).value,
+    ).toBe("100");
   });
 });

--- a/ornn-web/src/components/admin/settings/ProviderEditDrawer.test.tsx
+++ b/ornn-web/src/components/admin/settings/ProviderEditDrawer.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * ProviderEditDrawer tests — entity-switch reset via key remount (#888).
+ *
+ * The inner form is keyed on `provider?._id ?? "new"` so its
+ * lazy-initialised state resets by construction when the open drawer
+ * switches from provider A to provider B without closing. Without the key,
+ * A's edited (dirty) connection fields would survive into B's form.
+ *
+ * STALE-STATE-FIRST oracle: open on A, DIRTY the Name field, then switch
+ * the `provider` prop to B while the drawer stays open → B's values render
+ * and A's dirt is gone.
+ *
+ * Mocks the toast store directly + wraps in a QueryClientProvider (the
+ * drawer's save mutation is built inline with `useMutation`). The mutation
+ * never fires in these tests — we only assert form state across the prop
+ * switch — so the network functions are never reached. framer-motion is
+ * stubbed pass-through. react-i18next is stubbed globally in
+ * src/test/setup.ts.
+ *
+ * @module components/admin/settings/ProviderEditDrawer.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { LlmProvider } from "@/services/settingsApi";
+
+const addToast = vi.fn();
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
+}));
+
+// Stub the settings API module so importing the drawer doesn't pull in the
+// apiClient → authStore init chain (which writes to localStorage on module
+// load). The mutation never fires in these tests; only `isSecretPreserveValue`
+// is read by the SecretField at render time, so it's the one behaviour we
+// preserve.
+vi.mock("@/services/settingsApi", () => ({
+  createLlmProvider: vi.fn(),
+  updateLlmProvider: vi.fn(),
+  isSecretPreserveValue: (v: string) => v.includes("•"),
+}));
+
+import { ProviderEditDrawer } from "./ProviderEditDrawer";
+
+const PROVIDER_A: LlmProvider = {
+  _id: "prov-a",
+  name: "Alpha Gateway",
+  gatewayUrl: "https://alpha.example.com/v1",
+  modelListUrl: "https://alpha.example.com/v1/models",
+  apiFormat: "chat-completion",
+  auth: { kind: "apiKey", apiKey: "alpha-key" },
+  models: [],
+  maxOutputTokens: 4096,
+  defaultTemperature: 0.7,
+};
+
+const PROVIDER_B: LlmProvider = {
+  _id: "prov-b",
+  name: "Bravo Gateway",
+  gatewayUrl: "https://bravo.example.com/v1",
+  modelListUrl: "https://bravo.example.com/v1/models",
+  apiFormat: "responses",
+  auth: { kind: "apiKey", apiKey: "bravo-key" },
+  models: [],
+  maxOutputTokens: 8192,
+  defaultTemperature: 1.0,
+};
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+function inputValues(): string[] {
+  return (screen.getAllByRole("textbox") as HTMLInputElement[]).map((el) => el.value);
+}
+
+beforeEach(() => {
+  addToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ProviderEditDrawer — entity-switch reset", () => {
+  it("prefills the form from the provider prop in edit mode", () => {
+    wrap(<ProviderEditDrawer isOpen onClose={() => {}} provider={PROVIDER_A} />);
+    const values = inputValues();
+    expect(values).toContain("Alpha Gateway");
+    expect(values).toContain("https://alpha.example.com/v1");
+    expect(values).toContain("alpha-key");
+  });
+
+  it("drops A's DIRTY edits and shows B's values when the prop switches without closing", () => {
+    const { rerender } = wrap(
+      <ProviderEditDrawer isOpen onClose={() => {}} provider={PROVIDER_A} />,
+    );
+
+    // Force the wrong state: dirty A's Name field.
+    const nameInput = screen.getByDisplayValue("Alpha Gateway") as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "DIRTY NAME" } });
+    expect(inputValues()).toContain("DIRTY NAME");
+
+    // Switch entity WITHOUT closing — key flips "prov-a" → "prov-b", the
+    // inner form remounts and re-inits from B.
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    rerender(
+      <QueryClientProvider client={qc}>
+        <ProviderEditDrawer isOpen onClose={() => {}} provider={PROVIDER_B} />
+      </QueryClientProvider>,
+    );
+
+    const values = inputValues();
+    // B's values are shown…
+    expect(values).toContain("Bravo Gateway");
+    expect(values).toContain("https://bravo.example.com/v1");
+    expect(values).toContain("bravo-key");
+    // …and A's dirt + A's originals are gone.
+    expect(values).not.toContain("DIRTY NAME");
+    expect(values).not.toContain("Alpha Gateway");
+    expect(values).not.toContain("alpha-key");
+  });
+
+  it("resets to the empty 'new' form when switching from an entity to create mode", () => {
+    const { rerender } = wrap(
+      <ProviderEditDrawer isOpen onClose={() => {}} provider={PROVIDER_A} />,
+    );
+    const nameInput = screen.getByDisplayValue("Alpha Gateway") as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "DIRTY NAME" } });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    rerender(
+      <QueryClientProvider client={qc}>
+        <ProviderEditDrawer isOpen onClose={() => {}} provider={null} />
+      </QueryClientProvider>,
+    );
+
+    const values = inputValues();
+    expect(values).not.toContain("DIRTY NAME");
+    expect(values).not.toContain("Alpha Gateway");
+    // The empty 'new' form's Name field renders empty.
+    expect(values).toContain("");
+  });
+});

--- a/ornn-web/src/components/analytics/CookieConsentBanner.test.tsx
+++ b/ornn-web/src/components/analytics/CookieConsentBanner.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * CookieConsentBanner tests — useSyncExternalStore wiring (#888).
+ *
+ * The banner replaced a mount effect (that set visibility + wired a
+ * listener) with a single `useSyncExternalStore(onConsentChange,
+ * isUndecided, isUndecided)`. Visibility is therefore a pure read of the
+ * consent store: visible exactly while undecided. When the store flips to
+ * a decided state and notifies subscribers, React re-reads the snapshot
+ * and the banner hides — with NO prop change / parent rerender.
+ *
+ * STALE-STATE-FIRST oracle: mount while the store is undecided (banner
+ * visible), then flip the controllable store to "decided" and fire the
+ * captured `onConsentChange` subscriber → the banner self-hides on the
+ * next snapshot read, proving the subscribe/getSnapshot wiring is live and
+ * not a one-shot mount read.
+ *
+ * `@/lib/cookieConsent` is mocked with a controllable in-test store so we
+ * can drive `isUndecided` + capture the subscriber. react-i18next (incl.
+ * Trans) is stubbed globally in src/test/setup.ts.
+ *
+ * @module components/analytics/CookieConsentBanner.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Controllable consent store. `undecided` drives `isUndecided`; the
+// subscriber fn registered by useSyncExternalStore is captured so the test
+// can fire it on demand (simulating a store notification) without touching
+// the real localStorage-backed module.
+const store = {
+  undecided: true,
+  subscribers: new Set<(granted: boolean) => void>(),
+};
+
+const setConsent = vi.fn((state: "granted" | "denied") => {
+  store.undecided = false;
+  for (const fn of store.subscribers) fn(state === "granted");
+});
+
+vi.mock("@/lib/cookieConsent", () => ({
+  isUndecided: () => store.undecided,
+  setConsent: (state: "granted" | "denied") => setConsent(state),
+  onConsentChange: (fn: (granted: boolean) => void) => {
+    store.subscribers.add(fn);
+    return () => store.subscribers.delete(fn);
+  },
+}));
+
+import { CookieConsentBanner } from "./CookieConsentBanner";
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <CookieConsentBanner />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  store.undecided = true;
+  store.subscribers.clear();
+  setConsent.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CookieConsentBanner — useSyncExternalStore visibility", () => {
+  it("is visible when mounted in the undecided state", () => {
+    renderBanner();
+    expect(screen.getByTestId("cookie-consent-banner")).toBeInTheDocument();
+    // The store registered a live subscriber via useSyncExternalStore.
+    expect(store.subscribers.size).toBeGreaterThan(0);
+  });
+
+  it("hides after the store flips decided and notifies — WITHOUT a prop rerender", () => {
+    renderBanner();
+    expect(screen.getByTestId("cookie-consent-banner")).toBeInTheDocument();
+
+    // Force the wrong state directly on the store, then fire the captured
+    // subscriber — exactly how an external decision (e.g. another component
+    // calling setConsent) would notify. No prop change, no rerender call.
+    // Wrapped in act() so React flushes the useSyncExternalStore update that
+    // the out-of-band notification schedules.
+    act(() => {
+      store.undecided = false;
+      for (const fn of store.subscribers) fn(true);
+    });
+
+    // React re-reads the snapshot (now decided) and the banner unmounts.
+    expect(screen.queryByTestId("cookie-consent-banner")).not.toBeInTheDocument();
+  });
+
+  it("hides when the user clicks Accept (drives setConsent → notify)", () => {
+    renderBanner();
+    expect(screen.getByTestId("cookie-consent-banner")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+
+    expect(setConsent).toHaveBeenCalledWith("granted");
+    expect(screen.queryByTestId("cookie-consent-banner")).not.toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/components/docs/DocsSidebar.test.tsx
+++ b/ornn-web/src/components/docs/DocsSidebar.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * DocsSidebar tests — auto-expand-active + additive-collapse guard (#888).
+ *
+ * The sidebar lazy-initialises its expanded set to the section that
+ * contains the active doc, then re-runs an "adjust state during render"
+ * guard whenever the active doc moves to a different section. That guard
+ * is PURELY ADDITIVE: it expands the new active section but never
+ * collapses anything, so a sibling group the user manually collapsed
+ * stays collapsed across active-doc changes.
+ *
+ * STALE-STATE-FIRST oracle: force the wrong expansion state (manually
+ * collapse a non-active group, or start with the active doc in a
+ * collapsed group) and assert the component self-corrects (active group
+ * expands) WITHOUT un-collapsing the other group.
+ *
+ * react-i18next is stubbed globally in src/test/setup.ts; the component
+ * doesn't use it but the global mock is harmless.
+ *
+ * @module components/docs/DocsSidebar.test
+ */
+
+import { describe, expect, it, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { DocSection } from "@/lib/docsContent";
+import { DocsSidebar } from "./DocsSidebar";
+
+const SECTIONS: DocSection[] = [
+  {
+    id: "getting-started",
+    label: "Getting Started",
+    children: [
+      { id: "intro", label: "Introduction" },
+      { id: "install", label: "Install" },
+    ],
+  },
+  {
+    id: "guides",
+    label: "Guides",
+    children: [
+      { id: "search", label: "Search" },
+      { id: "publish", label: "Publish" },
+    ],
+  },
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DocsSidebar — auto-expand active section", () => {
+  it("expands the section that owns the active doc on mount", () => {
+    render(<DocsSidebar sections={SECTIONS} activeId="intro" onSelect={() => {}} />);
+    // The active doc lives in "Getting Started" → its children are visible.
+    expect(screen.getByText("Introduction")).toBeInTheDocument();
+    expect(screen.getByText("Install")).toBeInTheDocument();
+    // The other group starts collapsed — its children are not rendered.
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+  });
+
+  it("auto-expands a collapsed group when the active doc moves into it", () => {
+    // Active doc starts in "Getting Started"; "Guides" is collapsed.
+    const { rerender } = render(
+      <DocsSidebar sections={SECTIONS} activeId="intro" onSelect={() => {}} />,
+    );
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+
+    // Active doc jumps to a child of the collapsed "Guides" group — the
+    // render-time guard must expand it so the active item is visible.
+    rerender(
+      <DocsSidebar sections={SECTIONS} activeId="publish" onSelect={() => {}} />,
+    );
+    expect(screen.getByText("Search")).toBeInTheDocument();
+    expect(screen.getByText("Publish")).toBeInTheDocument();
+  });
+
+  it("keeps a manually-collapsed OTHER group collapsed when the active doc changes", () => {
+    // Start with active doc in "Getting Started" (auto-expanded). Manually
+    // expand "Guides", then collapse it again. Now the active doc moves to
+    // a sibling WITHIN "Getting Started" — the additive guard must NOT
+    // re-expand the manually-collapsed "Guides".
+    const { rerender } = render(
+      <DocsSidebar sections={SECTIONS} activeId="intro" onSelect={() => {}} />,
+    );
+
+    // Manually expand "Guides".
+    fireEvent.click(screen.getByText("Guides"));
+    expect(screen.getByText("Search")).toBeInTheDocument();
+    // Manually collapse "Guides" again.
+    fireEvent.click(screen.getByText("Guides"));
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+
+    // Active doc changes but stays inside "Getting Started" (intro → install).
+    // The activeSectionId is unchanged, so the guard does nothing — and even
+    // if it fired, it would only union the active section, never "Guides".
+    rerender(
+      <DocsSidebar sections={SECTIONS} activeId="install" onSelect={() => {}} />,
+    );
+
+    // "Getting Started" stays open; "Guides" stays collapsed.
+    expect(screen.getByText("Install")).toBeInTheDocument();
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/components/layout/Navbar.test.tsx
+++ b/ornn-web/src/components/layout/Navbar.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Navbar tests — close-menu-on-navigation guard (#888).
+ *
+ * The mobile menu (and user menu) close on route change via the "adjust
+ * state during render" pattern: the component tracks the previous
+ * `location.pathname` and, when it differs from the current one, flips
+ * both menus shut during render — no route-change effect. Critically a
+ * rerender that does NOT change the path must leave an open menu OPEN.
+ *
+ * STALE-STATE-FIRST oracle: open the mobile menu (force the "wrong" state
+ * for a fresh route), then drive a route change → the render-time guard
+ * self-corrects and the menu closes. Contrast: a same-path rerender keeps
+ * it open.
+ *
+ * The toggle button exposes `aria-expanded` and the panel carries
+ * `data-open`, so both are observable without poking internal state.
+ *
+ * Auth/theme stores, activity logging and the notification bell are mocked
+ * so the test renders an anonymous navbar without the apiClient / auth
+ * init chain. react-i18next is stubbed globally in src/test/setup.ts.
+ *
+ * @module components/layout/Navbar.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+// Anonymous session — keeps NotificationBell + user-menu groups out of the
+// tree and dodges the apiClient/auth init chain.
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: Object.assign(() => ({}), {
+    getState: () => ({ logout: vi.fn() }),
+  }),
+  useIsAuthenticated: () => false,
+  useCurrentUser: () => null,
+}));
+
+vi.mock("@/stores/themeStore", () => ({
+  useThemeStore: () => ({ theme: "dark", toggle: vi.fn() }),
+}));
+
+vi.mock("@/services/activityApi", () => ({
+  logActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/components/notifications/NotificationBell", () => ({
+  NotificationBell: () => null,
+}));
+
+import { Navbar } from "./Navbar";
+
+/**
+ * Harness with a button that programmatically navigates, so we can trigger
+ * a real router location change from within the same Router as the Navbar.
+ */
+function Nav({ to }: { to: string }) {
+  const navigate = useNavigate();
+  return (
+    <>
+      <Navbar />
+      <button type="button" data-testid="go" onClick={() => navigate(to)}>
+        go
+      </button>
+    </>
+  );
+}
+
+function mobileToggle(): HTMLButtonElement {
+  // The hamburger toggle is the button carrying aria-expanded (md:hidden).
+  return screen
+    .getAllByRole("button")
+    .find((b) => b.hasAttribute("aria-expanded")) as HTMLButtonElement;
+}
+
+function mobilePanel(): HTMLElement {
+  return document.getElementById("app-mobile-nav-panel") as HTMLElement;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Navbar — menu closes on navigation", () => {
+  it("opens the mobile menu on toggle click", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Nav to="/news" />
+      </MemoryRouter>,
+    );
+
+    const toggle = mobileToggle();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(mobilePanel().getAttribute("data-open")).toBe("false");
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(mobilePanel().getAttribute("data-open")).toBe("true");
+  });
+
+  it("closes the open menu when the route changes", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Nav to="/news" />
+      </MemoryRouter>,
+    );
+
+    // Force the wrong state: open the menu, then navigate to a new path.
+    fireEvent.click(mobileToggle());
+    expect(mobilePanel().getAttribute("data-open")).toBe("true");
+
+    fireEvent.click(screen.getByTestId("go")); // navigate "/" → "/news"
+
+    // The render-time prevPath guard self-corrects: the menu is now closed.
+    expect(mobileToggle().getAttribute("aria-expanded")).toBe("false");
+    expect(mobilePanel().getAttribute("data-open")).toBe("false");
+  });
+
+  it("does NOT close the menu on a same-path navigation/rerender", () => {
+    render(
+      <MemoryRouter initialEntries={["/news"]}>
+        <Nav to="/news" />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(mobileToggle());
+    expect(mobilePanel().getAttribute("data-open")).toBe("true");
+
+    // Navigate to the SAME path — location.pathname is unchanged, so the
+    // prevPath guard must not fire and the open menu survives the rerender.
+    fireEvent.click(screen.getByTestId("go")); // "/news" → "/news"
+    expect(mobilePanel().getAttribute("data-open")).toBe("true");
+    expect(mobileToggle().getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/ornn-web/src/components/models/ModelPicker.test.tsx
+++ b/ornn-web/src/components/models/ModelPicker.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * ModelPicker tests — activeIndex re-seed/clear guard (#888).
+ *
+ * The highlighted option (`activeIndex`) is seeded during render whenever
+ * the menu toggles open (to the currently-selected model's position) and
+ * cleared to -1 on close. Because the seed reads `options` + the resolved
+ * `effectiveModelId` at the moment the menu opens, a model that MOVED or
+ * DISAPPEARED across a list change must not leave a stale index behind —
+ * the next open re-seeds against the fresh list.
+ *
+ * STALE-STATE-FIRST oracle: open the menu against list A (seeds the active
+ * row to the selected model at index N), close, swap to list B where the
+ * selected model now sits at a DIFFERENT index, reopen → the highlighted
+ * row tracks the model's NEW position, not the stale N.
+ *
+ * `usePreferredModel` is mocked so the test controls `options` +
+ * `effectiveModelId` directly without the apiClient / auth / localStorage
+ * chain. react-i18next is stubbed globally in src/test/setup.ts.
+ *
+ * @module components/models/ModelPicker.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import type { PickerModel } from "@/services/modelsApi";
+
+const usePreferredModel = vi.fn();
+const setPreferred = vi.fn();
+
+vi.mock("@/hooks/useModels", () => ({
+  usePreferredModel: (surface: string) => usePreferredModel(surface),
+}));
+
+import { ModelPicker } from "./ModelPicker";
+
+function model(id: string, displayName: string, isDefault = false): PickerModel {
+  return { modelId: id, displayName, isDefault };
+}
+
+/** Default mock return — three models, "beta" selected. */
+function seed(options: PickerModel[], effectiveModelId: string | null) {
+  usePreferredModel.mockReturnValue({
+    options,
+    effectiveModelId,
+    setPreferred,
+    storedModelId: effectiveModelId,
+    defaultModelId: options[0]?.modelId ?? null,
+    isLoading: false,
+    isEmpty: options.length === 0,
+  });
+}
+
+/**
+ * The currently-highlighted (activeIndex) option carries the exact
+ * `bg-elevated text-strong` active class. Note the inactive rows carry
+ * `hover:bg-elevated/70`, so we must match the unprefixed active fragment
+ * rather than a loose `bg-elevated` substring.
+ */
+function activeOptionLabel(): string | null {
+  const opts = screen.queryAllByRole("option");
+  const active = opts.find((o) => /(?:^|\s)bg-elevated(?:\s|$)/.test(o.className));
+  return active ? (active.textContent ?? "").trim() : null;
+}
+
+beforeEach(() => {
+  usePreferredModel.mockReset();
+  setPreferred.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ModelPicker — activeIndex seed/reset on toggle", () => {
+  it("seeds the active row to the selected model when the menu opens, clears on close", () => {
+    const opts = [model("alpha", "Alpha"), model("beta", "Beta"), model("gamma", "Gamma")];
+    seed(opts, "beta");
+    render(<ModelPicker surface="playground" />);
+
+    // Closed → no listbox rendered.
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    // Open → the active row is the SELECTED model (Beta), not the first.
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(activeOptionLabel()).toBe("Beta");
+
+    // Close → menu unmounts, activeIndex cleared to -1 (no active row).
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("re-seeds against the fresh list on reopen when the selected model MOVED", () => {
+    // List A: Beta selected at index 1.
+    const listA = [model("alpha", "Alpha"), model("beta", "Beta"), model("gamma", "Gamma")];
+    seed(listA, "beta");
+    const { rerender } = render(<ModelPicker surface="playground" />);
+
+    // Open against list A — active row seeds to index 1 (Beta).
+    fireEvent.click(screen.getByRole("button"));
+    expect(activeOptionLabel()).toBe("Beta");
+    // Close so the next open triggers a fresh render-time re-seed.
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    // List B: the SAME selected model (Beta) is now at index 0 — a model
+    // ahead of it was dropped, so the prior index 1 is now stale.
+    const listB = [model("beta", "Beta"), model("gamma", "Gamma")];
+    seed(listB, "beta");
+    rerender(<ModelPicker surface="playground" />);
+
+    // Reopen — the seed must track Beta's NEW position (index 0), not the
+    // stale index 1 (which would highlight Gamma).
+    fireEvent.click(screen.getByRole("button"));
+    expect(activeOptionLabel()).toBe("Beta");
+    expect(activeOptionLabel()).not.toBe("Gamma");
+  });
+
+  it("seeds to the first row when the selected model DISAPPEARED from the list", () => {
+    // List A: Gamma selected at index 2.
+    const listA = [model("alpha", "Alpha"), model("beta", "Beta"), model("gamma", "Gamma")];
+    seed(listA, "gamma");
+    const { rerender } = render(<ModelPicker surface="playground" />);
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(activeOptionLabel()).toBe("Gamma");
+    fireEvent.click(screen.getByRole("button"));
+
+    // List B drops Gamma; the resolver falls back to the default (Alpha).
+    const listB = [model("alpha", "Alpha"), model("beta", "Beta")];
+    seed(listB, "alpha");
+    rerender(<ModelPicker surface="playground" />);
+
+    fireEvent.click(screen.getByRole("button"));
+    // findIndex of the (now-default) selected model resolves to index 0 →
+    // first row active; never a stale index 2 (which is out of bounds).
+    expect(activeOptionLabel()).toBe("Alpha");
+  });
+
+  it("marks the selected option via aria-selected even after the list changes", () => {
+    const listA = [model("alpha", "Alpha"), model("beta", "Beta")];
+    seed(listA, "beta");
+    const { rerender } = render(<ModelPicker surface="playground" />);
+
+    fireEvent.click(screen.getByRole("button"));
+    const listbox1 = screen.getByRole("listbox");
+    const selected1 = within(listbox1)
+      .getAllByRole("option")
+      .find((o) => o.getAttribute("aria-selected") === "true");
+    expect(selected1?.textContent).toContain("Beta");
+    fireEvent.click(screen.getByRole("button"));
+
+    // Swap to a list where alpha is now selected.
+    const listB = [model("alpha", "Alpha"), model("beta", "Beta")];
+    seed(listB, "alpha");
+    rerender(<ModelPicker surface="playground" />);
+
+    fireEvent.click(screen.getByRole("button"));
+    const listbox2 = screen.getByRole("listbox");
+    const selected2 = within(listbox2)
+      .getAllByRole("option")
+      .find((o) => o.getAttribute("aria-selected") === "true");
+    expect(selected2?.textContent).toContain("Alpha");
+  });
+});

--- a/ornn-web/src/components/skill/AdvancedOptionsModal.test.tsx
+++ b/ornn-web/src/components/skill/AdvancedOptionsModal.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * AdvancedOptionsModal tests — prop→internal-state sync guards (#888).
+ *
+ * Two inner panels each carry an "adjust state during render" guard that
+ * syncs local state to a changing `skill` prop:
+ *
+ *   - NyxidServiceBindingPanel: `selectedId` follows `skill.nyxidServiceId`.
+ *   - GithubLinkPanel: `url` (+ cleared preview) follows the derived
+ *     `initialUrl` from `skill.source`.
+ *
+ * Without the guards, switching the modal's `skill` prop from A to B (the
+ * drawer stays open) would leave the picker / URL field pinned to A's
+ * stale value.
+ *
+ * STALE-STATE-FIRST oracle: render with skill A (panel reflects A's bound
+ * service / linked URL), switch the `skill` prop to B WITHOUT closing →
+ * the panel's internal state syncs to B, not the stale A.
+ *
+ * All data/mutation hooks + toast store are mocked; framer-motion (Modal
+ * AnimatePresence) + VersionDiffView are stubbed. react-i18next is global.
+ *
+ * @module components/skill/AdvancedOptionsModal.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { SkillDetail } from "@/types/domain";
+import type { MyNyxidService } from "@/services/meApi";
+
+const useMyNyxidServices = vi.fn();
+const addToast = vi.fn();
+
+// Pass-through framer-motion. The motion proxy CACHES one component per
+// tag so the element TYPE is stable across rerenders — otherwise React sees
+// a fresh `motion.div` function each render and remounts the whole subtree,
+// wiping the inner panel state these tests rely on persisting.
+vi.mock("framer-motion", () => {
+  const cache = new Map<string, React.FC<Record<string, unknown> & { children?: React.ReactNode }>>();
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    motion: new Proxy(
+      {},
+      {
+        get: (_t, tag: string) => {
+          const cached = cache.get(tag);
+          if (cached) return cached;
+          const Comp: React.FC<Record<string, unknown> & { children?: React.ReactNode }> = ({
+            children,
+            initial: _i,
+            animate: _a,
+            exit: _e,
+            transition: _tr,
+            ...rest
+          }) => {
+            void _i;
+            void _a;
+            void _e;
+            void _tr;
+            const Tag = tag as keyof React.JSX.IntrinsicElements;
+            return <Tag {...rest}>{children}</Tag>;
+          };
+          cache.set(tag, Comp);
+          return Comp;
+        },
+      },
+    ),
+  };
+});
+
+vi.mock("@/hooks/useMe", () => ({
+  useMyNyxidServices: () => useMyNyxidServices(),
+}));
+
+const mutationStub = () => ({ mutateAsync: vi.fn(), isPending: false });
+vi.mock("@/hooks/useSkills", () => ({
+  useTieSkillToNyxidService: () => mutationStub(),
+  useSetSkillSource: () => mutationStub(),
+  usePreviewSkillRefresh: () => mutationStub(),
+  useRefreshSkillFromSource: () => mutationStub(),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
+}));
+
+vi.mock("@/components/skill/VersionDiffView", () => ({
+  VersionDiffView: () => <div data-testid="diff" />,
+}));
+
+import { AdvancedOptionsModal } from "./AdvancedOptionsModal";
+
+const SERVICES: MyNyxidService[] = [
+  { id: "svc-personal-1", slug: "alpha", label: "Alpha Service", tier: "personal" },
+  { id: "svc-personal-2", slug: "bravo", label: "Bravo Service", tier: "personal" },
+];
+
+function skill(overrides: Partial<SkillDetail>): SkillDetail {
+  return {
+    guid: "skill-guid",
+    name: "demo-skill",
+    description: "",
+    createdBy: "u1",
+    createdOn: "2026-05-01T00:00:00.000Z",
+    isPrivate: false,
+    tags: [],
+    updatedOn: "2026-05-01T00:00:00.000Z",
+    presignedPackageUrl: "",
+    metadata: {},
+    version: "1.0.0",
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    nyxidServiceId: null,
+    ...overrides,
+  } as SkillDetail;
+}
+
+/** The selected ServiceOption button carries the `border-accent/60` class. */
+function selectedServiceLabel(): string | null {
+  const btns = screen.getAllByRole("button");
+  const sel = btns.find((b) => b.className.includes("border-accent/60"));
+  if (!sel) return null;
+  // The label is the first child span's text.
+  return sel.querySelector("span")?.textContent ?? null;
+}
+
+beforeEach(() => {
+  useMyNyxidServices.mockReset();
+  addToast.mockReset();
+  useMyNyxidServices.mockReturnValue({ data: SERVICES, isLoading: false });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AdvancedOptionsModal — NyxID binding panel syncs to the skill prop", () => {
+  it("reflects skill A's bound service on open", () => {
+    render(
+      <AdvancedOptionsModal
+        isOpen
+        onClose={() => {}}
+        skill={skill({ nyxidServiceId: "svc-personal-1" })}
+      />,
+    );
+    expect(selectedServiceLabel()).toBe("Alpha Service");
+  });
+
+  it("syncs the picker to B's bound service when the skill prop switches", () => {
+    const { rerender } = render(
+      <AdvancedOptionsModal
+        isOpen
+        onClose={() => {}}
+        skill={skill({ nyxidServiceId: "svc-personal-1" })}
+      />,
+    );
+    expect(selectedServiceLabel()).toBe("Alpha Service");
+
+    // Switch the skill prop WITHOUT closing the modal — the render-time
+    // guard must re-point `selectedId` at B's bound service.
+    rerender(
+      <AdvancedOptionsModal
+        isOpen
+        onClose={() => {}}
+        skill={skill({ guid: "skill-guid", nyxidServiceId: "svc-personal-2" })}
+      />,
+    );
+    expect(selectedServiceLabel()).toBe("Bravo Service");
+    expect(selectedServiceLabel()).not.toBe("Alpha Service");
+  });
+});
+
+describe("AdvancedOptionsModal — GitHub link panel syncs to the skill prop", () => {
+  function openGithubPanel() {
+    // Switch the left rail to the "Link to GitHub" setting.
+    fireEvent.click(screen.getByRole("button", { name: /link to github/i }));
+  }
+
+  function githubUrlInput(): HTMLInputElement {
+    return screen.getByLabelText(/github folder url/i) as HTMLInputElement;
+  }
+
+  const sourceA = {
+    type: "github" as const,
+    repo: "owner/repo-a",
+    ref: "main",
+    path: "skills/a",
+  };
+  const sourceB = {
+    type: "github" as const,
+    repo: "owner/repo-b",
+    ref: "main",
+    path: "skills/b",
+  };
+
+  it("reflects skill A's linked URL on open", () => {
+    render(
+      <AdvancedOptionsModal isOpen onClose={() => {}} skill={skill({ source: sourceA })} />,
+    );
+    openGithubPanel();
+    expect(githubUrlInput().value).toContain("repo-a");
+  });
+
+  it("syncs the URL field to B's linked source when the skill prop switches", () => {
+    const { rerender } = render(
+      <AdvancedOptionsModal isOpen onClose={() => {}} skill={skill({ source: sourceA })} />,
+    );
+    openGithubPanel();
+    expect(githubUrlInput().value).toContain("repo-a");
+
+    // Switch the skill prop — the derived `initialUrl` changes, so the
+    // render-time guard re-seeds the URL field to B's source.
+    rerender(
+      <AdvancedOptionsModal
+        isOpen
+        onClose={() => {}}
+        skill={skill({ guid: "skill-guid", source: sourceB })}
+      />,
+    );
+    // The rail selection is preserved (only the skill prop changed), so the
+    // GitHub panel is still shown and now reflects B.
+    expect(githubUrlInput().value).toContain("repo-b");
+    expect(githubUrlInput().value).not.toContain("repo-a");
+  });
+});

--- a/ornn-web/src/components/skill/SkillFileBrowser.test.tsx
+++ b/ornn-web/src/components/skill/SkillFileBrowser.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * SkillFileBrowser tests — per-file dirty-buffer reset on switch (#888).
+ *
+ * The editor holds a single `editedContent` buffer plus a derived
+ * `selectedFileId`. When the selected file changes, the "adjust state
+ * during render" guard resets `editedContent` to null so the new file
+ * shows ITS original content — the dirty buffer is per-session, not
+ * per-file, and must not bleed across a file switch.
+ *
+ * STALE-STATE-FIRST oracle: select file A, enter edit mode and DIRTY its
+ * buffer, then switch to file B → B shows its OWN original content (the
+ * dirty A buffer was discarded), and switching back to A shows A's
+ * original too (no per-file dirt was retained).
+ *
+ * The file-tree query is internal (`useFileTree`/`useUpdateFile` via
+ * TanStack Query), so we mock `@/services/apiClient` to feed a fixed tree +
+ * contents and wrap in a QueryClientProvider. toastStore + framer-motion
+ * (FileTree's AnimatePresence) are stubbed. react-i18next is global.
+ *
+ * @module components/skill/SkillFileBrowser.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const apiGet = vi.fn();
+const apiPut = vi.fn();
+const addToast = vi.fn();
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+vi.mock("@/services/apiClient", () => ({
+  apiGet: (...args: unknown[]) => apiGet(...args),
+  apiPut: (...args: unknown[]) => apiPut(...args),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
+}));
+
+import { SkillFileBrowser } from "./SkillFileBrowser";
+
+const A_ORIGINAL = "# Skill A original content";
+const B_ORIGINAL = "#!/bin/sh\necho original-b";
+
+function fileTreeResponse() {
+  return {
+    data: {
+      tree: [
+        { path: "SKILL.md", type: "file", viewable: true, size: 100 },
+        { path: "scripts", type: "folder", viewable: false, size: 0 },
+        { path: "scripts/run.sh", type: "file", viewable: true, size: 50 },
+      ],
+      contents: {
+        "SKILL.md": A_ORIGINAL,
+        "scripts/run.sh": B_ORIGINAL,
+      },
+    },
+  };
+}
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+/** The viewer's content area — a <pre> in view mode, a <textarea> in edit. */
+function viewerText(): string {
+  const pre = document.querySelector("pre");
+  if (pre) return pre.textContent ?? "";
+  const ta = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  return ta?.value ?? "";
+}
+
+/** Enter edit mode on the currently-open file (toggles the Edit button). */
+function enterEditMode() {
+  // The viewer header's edit toggle has title "Edit".
+  const editBtn = screen.getByTitle("Edit");
+  fireEvent.click(editBtn);
+}
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiPut.mockReset();
+  addToast.mockReset();
+  apiGet.mockResolvedValue(fileTreeResponse());
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillFileBrowser — per-file dirty-buffer reset", () => {
+  it("discards file A's dirty buffer when switching to file B, and back to A shows the original", async () => {
+    wrap(<SkillFileBrowser skillId="skill-1" version="1.0.0" isOwner={true} />);
+
+    // Wait for the tree to load, then expand the scripts folder so run.sh
+    // (file B) is reachable for selection.
+    await waitFor(() => expect(screen.getByText("SKILL.md")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("scripts"));
+
+    // Explicitly select file A (SKILL.md) so the test doesn't depend on the
+    // default-file resolution, then assert its original content shows.
+    fireEvent.click(screen.getByText("SKILL.md"));
+    await waitFor(() => expect(viewerText()).toContain("Skill A original"));
+
+    // Dirty A: enter edit mode and type into the textarea.
+    enterEditMode();
+    const textareaA = document.querySelector("textarea") as HTMLTextAreaElement;
+    fireEvent.change(textareaA, { target: { value: "DIRTY A EDIT" } });
+    expect(viewerText()).toBe("DIRTY A EDIT");
+    // Dirty state surfaces the Save button.
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+
+    // Switch to run.sh (file B).
+    fireEvent.click(screen.getByText("run.sh"));
+
+    // The file switch reset `editedContent` → B shows ITS original content,
+    // not A's dirty buffer. (Viewer drops back to view mode for the new file.)
+    await waitFor(() => expect(viewerText()).toContain("original-b"));
+    expect(viewerText()).not.toContain("DIRTY A EDIT");
+    // No dirty buffer carried over → no Save button.
+    expect(
+      screen.queryByRole("button", { name: /save changes/i }),
+    ).not.toBeInTheDocument();
+
+    // Switch back to A → its ORIGINAL content (the dirty edit was never
+    // retained per-file).
+    fireEvent.click(screen.getByText("SKILL.md"));
+    await waitFor(() => expect(viewerText()).toContain("Skill A original"));
+    expect(viewerText()).not.toContain("DIRTY A EDIT");
+    expect(
+      screen.queryByRole("button", { name: /save changes/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a selected file's content from the loaded tree", async () => {
+    wrap(<SkillFileBrowser skillId="skill-1" version="1.0.0" isOwner={false} />);
+    await waitFor(() => expect(screen.getByText("SKILL.md")).toBeInTheDocument());
+    // Explicitly select SKILL.md; its content shows in the viewer pane.
+    fireEvent.click(screen.getByText("SKILL.md"));
+    await waitFor(() => {
+      const pre = document.querySelector("pre") as HTMLElement;
+      expect(within(pre).getByText(/Skill A original/)).toBeInTheDocument();
+    });
+  });
+});

--- a/ornn-web/src/components/skill/SkillPackagePreview.test.tsx
+++ b/ornn-web/src/components/skill/SkillPackagePreview.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * SkillPackagePreview tests — derived selection fallback (#888).
+ *
+ * The viewer derives the effective file selection during render instead
+ * of seeding it via an effect: `userSelectedFileId` wins only while its
+ * contents still exist in `fileContents`; otherwise it falls back to the
+ * default file (SKILL.md, else first file). So a user pick that vanishes
+ * across a version-switch / delete must silently degrade to the default
+ * without crashing.
+ *
+ * STALE-STATE-FIRST oracle: select a non-default file (so the explicit
+ * pick is "wrong" relative to the default), then rerender with that file
+ * removed from `fileContents` → the derived selection self-corrects to
+ * the default and the viewer renders the default's content, no crash.
+ *
+ * FileTree wraps folder children in framer-motion AnimatePresence; we use
+ * top-level files only AND stub framer-motion pass-through so nothing is
+ * gated behind an unresolved exit animation. react-i18next is stubbed
+ * globally in src/test/setup.ts.
+ *
+ * @module components/skill/SkillPackagePreview.test
+ */
+
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { FileNode } from "@/components/editor/FileTree";
+import type { SkillMetadata } from "@/types/skillPackage";
+
+// Pass-through framer-motion so AnimatePresence honours unmount synchronously
+// (see FileTree.test.tsx for the rationale — the real one keeps exiting
+// children mounted without rAF in jsdom).
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+import { SkillPackagePreview } from "./SkillPackagePreview";
+
+const FILES: FileNode[] = [
+  { id: "SKILL.md", name: "SKILL.md", type: "file" },
+  { id: "reference.md", name: "reference.md", type: "file" },
+];
+
+function contents(map: Record<string, string>): Map<string, string> {
+  return new Map(Object.entries(map));
+}
+
+const METADATA: SkillMetadata = {
+  name: "demo-skill",
+  description: "A demo skill",
+  metadata: { category: "utility", tag: ["demo"] },
+} as unknown as SkillMetadata;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillPackagePreview — derived selection fallback", () => {
+  it("defaults to SKILL.md content on first render", () => {
+    render(
+      <SkillPackagePreview
+        files={FILES}
+        fileContents={contents({
+          "SKILL.md": "# Skill doc",
+          "reference.md": "# Reference",
+        })}
+        metadata={METADATA}
+      />,
+    );
+    // SKILL.md is the default; its content is shown in the viewer.
+    expect(screen.getByText("# Skill doc")).toBeInTheDocument();
+  });
+
+  it("falls back to the default when the user's picked file is removed", () => {
+    const { rerender } = render(
+      <SkillPackagePreview
+        files={FILES}
+        fileContents={contents({
+          "SKILL.md": "# Skill doc",
+          "reference.md": "# Reference",
+        })}
+        metadata={METADATA}
+      />,
+    );
+
+    // Explicitly pick the NON-default file (reference.md) so the derived
+    // selection is driven by the user pick, diverging from the default.
+    fireEvent.click(screen.getByText("reference.md"));
+    expect(screen.getByText("# Reference")).toBeInTheDocument();
+
+    // Version-switch: reference.md disappears from both the tree and the
+    // contents map. The explicit pick now points at a vanished file.
+    const nextFiles: FileNode[] = [{ id: "SKILL.md", name: "SKILL.md", type: "file" }];
+    rerender(
+      <SkillPackagePreview
+        files={nextFiles}
+        fileContents={contents({ "SKILL.md": "# Skill doc v2" })}
+        metadata={METADATA}
+      />,
+    );
+
+    // Derived selection self-corrects to SKILL.md — its (new) content shows,
+    // and the stale reference.md content is gone. No crash.
+    expect(screen.getByText("# Skill doc v2")).toBeInTheDocument();
+    expect(screen.queryByText("# Reference")).not.toBeInTheDocument();
+  });
+
+  it("renders the empty-selection placeholder when no files exist", () => {
+    render(
+      <SkillPackagePreview
+        files={[]}
+        fileContents={contents({})}
+        metadata={METADATA}
+      />,
+    );
+    // findDefaultFileId returns undefined → no file selected → placeholder.
+    expect(
+      screen.getByText("Select a file to view its content"),
+    ).toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/pages/admin/MirrorPage.test.tsx
+++ b/ornn-web/src/pages/admin/MirrorPage.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * MirrorPage tests — re-seed-on-refetch guard (#888).
+ *
+ * Both forms (repo settings + App credentials) seed from `status` using
+ * the "adjust state during render" guard keyed on the server object
+ * IDENTITY. A refetch that returns a NEW status object re-seeds the
+ * fields; a same-reference rerender preserves the admin's in-flight edits.
+ *
+ * STALE-STATE-FIRST oracle: load v1 (seeds the owner/repo/branch +
+ * appId/etc. fields), DIRTY a field, then (a) same-ref rerender → the edit
+ * survives; (b) new-ref refetch → the field re-seeds to the server value.
+ *
+ * Hooks + toast store + apiClient (for `ApiClientError`) are mocked so the
+ * page renders without the live auth/network chain. framer-motion (used by
+ * PageTransition + MirrorSetupHelp) is stubbed pass-through. react-i18next
+ * is stubbed globally in src/test/setup.ts.
+ *
+ * @module pages/admin/MirrorPage.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { MirrorStatus } from "@/services/githubMirrorApi";
+
+const useMirrorStatus = vi.fn();
+const useTriggerReconcile = vi.fn();
+const useUpdateMirrorConfig = vi.fn();
+const addToast = vi.fn();
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          variants: _v,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          void _v;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+vi.mock("@/hooks/useGithubMirror", () => ({
+  useMirrorStatus: () => useMirrorStatus(),
+  useTriggerReconcile: () => useTriggerReconcile(),
+  useUpdateMirrorConfig: () => useUpdateMirrorConfig(),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
+}));
+
+// Stub apiClient so importing `ApiClientError` doesn't drag in the
+// authStore localStorage init chain on module load.
+vi.mock("@/services/apiClient", () => ({
+  ApiClientError: class ApiClientError extends Error {
+    code: string | null = null;
+  },
+}));
+
+import { MirrorPage } from "./MirrorPage";
+
+function status(owner: string, branch = "main"): MirrorStatus {
+  return {
+    enabled: true,
+    repo: { owner, repo: "ornn-skills", branch },
+    appId: "123456",
+    installationId: "78901234",
+    appPrivateKey: "•••masked•••",
+    counts: {
+      eligible: 10,
+      synced: 8,
+      lagging: 1,
+      neverSynced: 1,
+      oldestUnsyncedAt: null,
+    },
+    scheduledRun: {
+      status: "succeeded",
+      lastRunAt: null,
+      lastFinishedAt: "2026-05-01T00:00:00.000Z",
+      lastDurationMs: 1234,
+      lastError: null,
+      nextRunAt: null,
+    },
+  };
+}
+
+function loading() {
+  return { data: undefined, isLoading: false, isError: false } as const;
+}
+function loaded(data: MirrorStatus) {
+  return { data, isLoading: false, isError: false } as const;
+}
+
+function ownerInput(): HTMLInputElement {
+  return screen.getByPlaceholderText("ChronoAIProject") as HTMLInputElement;
+}
+
+beforeEach(() => {
+  useMirrorStatus.mockReset();
+  useTriggerReconcile.mockReset();
+  useUpdateMirrorConfig.mockReset();
+  addToast.mockReset();
+  useTriggerReconcile.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+  useUpdateMirrorConfig.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MirrorPage — re-seed on refetch", () => {
+  it("seeds the repo form once the status arrives", () => {
+    // Guard initialises prevStatus to `status` on the first render; the seed
+    // only fires on the undefined → v1 transition (real query lifecycle).
+    useMirrorStatus.mockReturnValue(loading());
+    const { rerender } = render(<MirrorPage />);
+
+    useMirrorStatus.mockReturnValue(loaded(status("ChronoAIProject")));
+    rerender(<MirrorPage />);
+    expect(ownerInput().value).toBe("ChronoAIProject");
+  });
+
+  it("preserves a dirty owner edit across a same-reference rerender", () => {
+    const v1 = status("ChronoAIProject");
+    useMirrorStatus.mockReturnValue(loading());
+    const { rerender } = render(<MirrorPage />);
+    useMirrorStatus.mockReturnValue(loaded(v1));
+    rerender(<MirrorPage />);
+
+    // Force the wrong state relative to the server.
+    fireEvent.change(ownerInput(), { target: { value: "DirtyOwner" } });
+    expect(ownerInput().value).toBe("DirtyOwner");
+
+    // Same status ref (e.g. a poll that returned an identical cached object
+    // reference) → guard does not re-seed; the edit survives.
+    useMirrorStatus.mockReturnValue(loaded(v1));
+    rerender(<MirrorPage />);
+    expect(ownerInput().value).toBe("DirtyOwner");
+  });
+
+  it("re-seeds when a refetch produces a new status object", () => {
+    const v1 = status("ChronoAIProject");
+    useMirrorStatus.mockReturnValue(loading());
+    const { rerender } = render(<MirrorPage />);
+    useMirrorStatus.mockReturnValue(loaded(v1));
+    rerender(<MirrorPage />);
+
+    fireEvent.change(ownerInput(), { target: { value: "DirtyOwner" } });
+    expect(ownerInput().value).toBe("DirtyOwner");
+
+    // Refetch: NEW object identity with a different owner → re-seed wins,
+    // discarding the local edit.
+    useMirrorStatus.mockReturnValue(loaded(status("AnotherOrg")));
+    rerender(<MirrorPage />);
+    expect(ownerInput().value).toBe("AnotherOrg");
+  });
+});

--- a/ornn-web/src/pages/admin/PlatformSettingsPage.test.tsx
+++ b/ornn-web/src/pages/admin/PlatformSettingsPage.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * PlatformSettingsPage tests — re-seed-on-refetch guard (#888).
+ *
+ * The threshold input is seeded from the loaded settings using the "adjust
+ * state during render" guard keyed on the server object IDENTITY (not its
+ * value): a refetch that produces a NEW settings object re-seeds the
+ * input, but a same-reference rerender preserves the admin's in-flight
+ * local edit.
+ *
+ * STALE-STATE-FIRST oracle: seed from v1, DIRTY the input (force a value
+ * that diverges from the server), then (a) rerender with the SAME settings
+ * ref → the dirty edit survives; (b) rerender with a NEW settings ref
+ * (refetch) → the input re-seeds to the server value, discarding the edit.
+ *
+ * Hooks + toast store are mocked so the page renders without the apiClient
+ * chain. PageTransition's framer-motion is stubbed pass-through.
+ * react-i18next is stubbed globally in src/test/setup.ts.
+ *
+ * @module pages/admin/PlatformSettingsPage.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { PlatformSettings } from "@/services/platformSettingsApi";
+
+const usePlatformSettings = vi.fn();
+const useUpdatePlatformSettings = vi.fn();
+const addToast = vi.fn();
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          variants: _v,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          void _v;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+vi.mock("@/hooks/usePlatformSettings", () => ({
+  usePlatformSettings: () => usePlatformSettings(),
+  useUpdatePlatformSettings: () => useUpdatePlatformSettings(),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
+    selector({ addToast }),
+}));
+
+import { PlatformSettingsPage } from "./PlatformSettingsPage";
+
+function settings(threshold: number): PlatformSettings {
+  return { auditWaiverThreshold: threshold };
+}
+
+function thresholdInput(): HTMLInputElement {
+  return screen.getByLabelText(/audit waiver threshold/i) as HTMLInputElement;
+}
+
+/** Loading-state query return (data not yet arrived). */
+function loading() {
+  return { data: undefined, isLoading: true, isError: false } as const;
+}
+
+function loaded(data: PlatformSettings) {
+  return { data, isLoading: false, isError: false } as const;
+}
+
+beforeEach(() => {
+  usePlatformSettings.mockReset();
+  useUpdatePlatformSettings.mockReset();
+  addToast.mockReset();
+  useUpdatePlatformSettings.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PlatformSettingsPage — re-seed on refetch", () => {
+  it("seeds the input once the settings arrive", () => {
+    // The guard initialises prevSettings to whatever `data` is on the FIRST
+    // render, so the seed only fires when data transitions undefined → v1
+    // (the real query lifecycle). Render loading first, then loaded.
+    usePlatformSettings.mockReturnValue(loading());
+    const { rerender } = render(<PlatformSettingsPage />);
+
+    usePlatformSettings.mockReturnValue(loaded(settings(6)));
+    rerender(<PlatformSettingsPage />);
+    expect(thresholdInput().value).toBe("6");
+  });
+
+  it("preserves a dirty edit across a same-reference rerender", () => {
+    const v1 = settings(6);
+    usePlatformSettings.mockReturnValue(loading());
+    const { rerender } = render(<PlatformSettingsPage />);
+    usePlatformSettings.mockReturnValue(loaded(v1));
+    rerender(<PlatformSettingsPage />);
+
+    // Force the wrong state relative to the server: dirty the input.
+    fireEvent.change(thresholdInput(), { target: { value: "9.5" } });
+    expect(thresholdInput().value).toBe("9.5");
+
+    // Same settings ref → guard sees `settings === prevSettings`, does not
+    // re-seed; the dirty edit survives.
+    usePlatformSettings.mockReturnValue(loaded(v1));
+    rerender(<PlatformSettingsPage />);
+    expect(thresholdInput().value).toBe("9.5");
+  });
+
+  it("re-seeds when a refetch produces a new settings object", () => {
+    const v1 = settings(6);
+    usePlatformSettings.mockReturnValue(loading());
+    const { rerender } = render(<PlatformSettingsPage />);
+    usePlatformSettings.mockReturnValue(loaded(v1));
+    rerender(<PlatformSettingsPage />);
+
+    fireEvent.change(thresholdInput(), { target: { value: "9.5" } });
+    expect(thresholdInput().value).toBe("9.5");
+
+    // Refetch: NEW object identity with a different server value → the
+    // render-time guard re-seeds, discarding the local edit.
+    usePlatformSettings.mockReturnValue(loaded(settings(7)));
+    rerender(<PlatformSettingsPage />);
+    expect(thresholdInput().value).toBe("7");
+  });
+});

--- a/ornn-web/src/pages/admin/QuotaManagementPage.test.tsx
+++ b/ornn-web/src/pages/admin/QuotaManagementPage.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * QuotaManagementPage tests — deep-link grant-modal guard (#888).
+ *
+ * The `?userId=` deep-link opens the GrantQuotaModal as soon as the
+ * matching row arrives, using the "adjust state during render" guard
+ * (tracked by `consumedDeepLink`) so it fires exactly ONCE, then an effect
+ * strips the `userId` param so a refresh doesn't re-trigger. A row that
+ * never matches (stale / missing userId) must NOT open the modal and must
+ * not crash.
+ *
+ * STALE-STATE-FIRST oracle: mount with `?userId=X` already in the URL
+ * (the modal is initially closed despite the param) → the guard
+ * self-corrects on the render where the matching row is present, opening
+ * the modal once and stripping the param. A subsequent rerender does NOT
+ * reopen it (consumedDeepLink latches).
+ *
+ * The data hook + debounce are mocked; the heavy child components
+ * (QuotaTable, drawers, modal, banner, pagination) are stubbed to tiny
+ * markers so the test isolates the page's deep-link orchestration.
+ * react-i18next is stubbed globally in src/test/setup.ts.
+ *
+ * @module pages/admin/QuotaManagementPage.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { AdminQuotaRow, AdminQuotaPage } from "@/services/quotaApi";
+
+const useAdminQuotaUsers = vi.fn();
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+vi.mock("@/hooks/useQuota", () => ({
+  useAdminQuotaUsers: (params: unknown) => useAdminQuotaUsers(params),
+}));
+
+// Debounce is identity in tests so the filter value flows through without
+// fake timers.
+vi.mock("@/hooks/useDebounce", () => ({
+  useDebounce: <T,>(value: T) => value,
+}));
+
+// Stub the heavy children. GrantQuotaModal renders a marker only when open,
+// carrying the user id so we can assert which row drove the open.
+vi.mock("@/components/admin/quota/QuotaTable", () => ({
+  QuotaTable: () => <div data-testid="quota-table" />,
+}));
+vi.mock("@/components/admin/quota/QuotaUserDetailDrawer", () => ({
+  QuotaUserDetailDrawer: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="detail-drawer" /> : null,
+}));
+vi.mock("@/components/admin/quota/GrantQuotaModal", () => ({
+  GrantQuotaModal: ({
+    isOpen,
+    user,
+  }: {
+    isOpen: boolean;
+    user: { userId: string } | null;
+  }) =>
+    isOpen ? (
+      <div data-testid="grant-modal" data-user={user?.userId ?? ""} />
+    ) : null,
+}));
+vi.mock("@/components/admin/quota/CalendarPeriodBanner", () => ({
+  CalendarPeriodBanner: () => <div data-testid="banner" />,
+}));
+vi.mock("@/components/ui/Pagination", () => ({
+  Pagination: () => <div data-testid="pagination" />,
+}));
+
+import { QuotaManagementPage } from "./QuotaManagementPage";
+
+function row(userId: string): AdminQuotaRow {
+  return {
+    userId,
+    email: `${userId}@example.com`,
+    displayName: userId,
+    isAdmin: false,
+    defaultAllotment: 100,
+    adminGrant: 0,
+    used: 10,
+    remaining: 90,
+  };
+}
+
+function page(rows: AdminQuotaRow[]): AdminQuotaPage {
+  return {
+    items: rows,
+    banner: {
+      monthMarker: "2026-05",
+      monthStart: "2026-05-01T00:00:00.000Z",
+      monthEnd: "2026-05-31T23:59:59.000Z",
+    },
+    page: 1,
+    pageSize: 20,
+    total: rows.length,
+    totalPages: 1,
+  };
+}
+
+function renderAt(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/quota${search}`]}>
+      <QuotaManagementPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  useAdminQuotaUsers.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("QuotaManagementPage — deep-link grant modal", () => {
+  it("opens the grant modal once for a matching ?userId row", () => {
+    useAdminQuotaUsers.mockReturnValue({
+      data: page([row("u-1"), row("u-2")]),
+      isLoading: false,
+      error: null,
+    });
+
+    renderAt("?userId=u-2");
+
+    const modal = screen.getByTestId("grant-modal");
+    expect(modal).toBeInTheDocument();
+    // The modal opened for the matching row (u-2), not the first row.
+    expect(modal.getAttribute("data-user")).toBe("u-2");
+  });
+
+  it("strips the userId param after consuming the deep-link", () => {
+    useAdminQuotaUsers.mockReturnValue({
+      data: page([row("u-2")]),
+      isLoading: false,
+      error: null,
+    });
+
+    renderAt("?userId=u-2&surface=playground");
+
+    // The grant modal stays open (consumedDeepLink latched), and the
+    // userId param was stripped by the effect — proven by a rerender NOT
+    // re-firing the open guard (covered below). Here we just confirm the
+    // modal is open and didn't crash with the surface param present.
+    expect(screen.getByTestId("grant-modal")).toBeInTheDocument();
+  });
+
+  it("does not re-fire the open guard on a plain rerender (consumedDeepLink latches)", () => {
+    useAdminQuotaUsers.mockReturnValue({
+      data: page([row("u-2")]),
+      isLoading: false,
+      error: null,
+    });
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={["/admin/quota?userId=u-2"]}>
+        <QuotaManagementPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getAllByTestId("grant-modal")).toHaveLength(1);
+
+    // A plain rerender with the same hook data — RTL's rerender reuses the
+    // existing root, so component state is preserved. The param was already
+    // stripped and consumedDeepLink === "u-2", so the render-time guard does
+    // NOT re-fire (no spurious re-open / duplicate). Exactly one modal node.
+    rerender(
+      <MemoryRouter initialEntries={["/admin/quota?userId=u-2"]}>
+        <QuotaManagementPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getAllByTestId("grant-modal")).toHaveLength(1);
+    expect(screen.getByTestId("grant-modal").getAttribute("data-user")).toBe("u-2");
+  });
+
+  it("closes (no open) when the deep-link userId is absent from the URL", () => {
+    useAdminQuotaUsers.mockReturnValue({
+      data: page([row("u-2")]),
+      isLoading: false,
+      error: null,
+    });
+
+    renderAt(""); // no userId param
+
+    // Rows present but no deep-link param → deepLinkUserId is null → the
+    // guard never fires. The open is driven purely by the param.
+    expect(screen.queryByTestId("grant-modal")).not.toBeInTheDocument();
+    expect(screen.getByTestId("quota-table")).toBeInTheDocument();
+  });
+
+  it("does not open the modal (and does not crash) when the userId has no matching row", () => {
+    useAdminQuotaUsers.mockReturnValue({
+      data: page([row("u-1"), row("u-2")]),
+      isLoading: false,
+      error: null,
+    });
+
+    renderAt("?userId=does-not-exist");
+
+    // No matching row → deepLinkRow is null → guard never fires.
+    expect(screen.queryByTestId("grant-modal")).not.toBeInTheDocument();
+    // Page still rendered (no crash).
+    expect(screen.getByTestId("quota-table")).toBeInTheDocument();
+  });
+
+  it("does not open the modal while the data is still loading", () => {
+    useAdminQuotaUsers.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    renderAt("?userId=u-2");
+
+    // usersQuery.data is undefined → deepLinkRow stays null → no open, no crash.
+    expect(screen.queryByTestId("grant-modal")).not.toBeInTheDocument();
+    expect(screen.getByTestId("quota-table")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #931

Automated change by `/auto` (run `20260605T062632Z-30147`, runner `auto-runner-20260605T062632Z-30147-74429-25150`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
