### PR TITLE
[Bug] Backend /skills upload accepts large uncompressed ZIPs — mirror #443 cap server-side

### DIFF
--- a/.changeset/fix-632-zipbomb-chokepoint.md
+++ b/.changeset/fix-632-zipbomb-chokepoint.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Server-side ZIP-bomb guards (cumulative/per-entry uncompressed caps, file-count, compression-ratio) are now enforced at the skill-ingestion chokepoint — covering both direct upload and the GitHub pull/refresh paths that previously bypassed the route-layer guard. Caps are env-overridable (#632)

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -88,8 +88,11 @@ Optional: `detail`, `errors[]`.
 | Code | HTTP | Meaning |
 |---|---|---|
 | `validation_error` | 400 | Body / query / path param validation failed — details in `errors[]` |
+| `invalid_zip` | 400 | Uploaded payload is not a parseable ZIP (malformed / unreadable) |
 | `unsupported_media_type` | 415 | Request `Content-Type` not accepted |
 | `payload_too_large` | 413 | Upload exceeds max size |
+| `uncompressed_too_large` | 413 | Uncompressed size or compression ratio of skill ZIP exceeds caps (zip-bomb guard) |
+| `too_many_files` | 413 | Skill ZIP entry count exceeds `MAX_PACKAGE_FILE_COUNT` |
 | `authentication_required` | 401 | No valid identity |
 | `permission_denied` | 403 | Authenticated but lacks required permission |
 | `resource_not_found` | 404 | Target resource does not exist or not visible to caller |

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -36,7 +36,7 @@ The pre-#585 `SCREAMING_SNAKE_CASE` shape (`SKILL_NOT_FOUND`, `INVALID_BODY`, �
 ## validation_error
 
 **HTTP:** `400 Bad Request`
-**Common subcodes (lowercase post-#585):** `invalid_body`, `invalid_query`, `invalid_params`, `invalid_*` (per-field), `empty_body`, `missing_*`, `frontmatter_validation_failed`, `invalid_permissions`, …
+**Common subcodes (lowercase post-#585):** `invalid_body`, `invalid_query`, `invalid_params`, `invalid_*` (per-field), `empty_body`, `missing_*`, `frontmatter_validation_failed`, `invalid_permissions`, `invalid_zip`, …
 
 Request body, query string, or path parameter failed validation. Per-field details are in `errors[]`.
 
@@ -58,6 +58,12 @@ Content-Type: application/problem+json
 ```
 
 **Client action:** fix the offending field(s) listed in `errors[]` and retry. Do not retry the same payload without changes.
+
+### invalid_zip
+
+The uploaded payload is not a parseable ZIP — a malformed or unreadable archive.
+
+**Client action:** re-create the ZIP and re-upload; do not retry the same bytes.
 
 ---
 
@@ -108,11 +114,23 @@ The request collides with current state — a duplicate skill name on create, a 
 ## payload_too_large
 
 **HTTP:** `413 Payload Too Large`
-**Common subcodes (lowercase post-#585):** `payload_too_large`
+**Common subcodes (lowercase post-#585):** `payload_too_large`, `uncompressed_too_large`, `too_many_files`
 
 The upload exceeds the per-endpoint size cap (currently 5 MB on `/skills` upload; see `ornn-api/src/middleware/uploadLimit.ts`).
 
 **Client action:** trim the payload (smaller ZIP, fewer attachments) or split into multiple requests where the endpoint supports it.
+
+### uncompressed_too_large
+
+The uploaded skill ZIP's cumulative or per-entry **uncompressed** size exceeds the server cap (`MAX_PACKAGE_UNCOMPRESSED_BYTES`, default 50 MiB / `MAX_ENTRY_UNCOMPRESSED_BYTES`, default 25 MiB), or its compression ratio exceeds `MAX_COMPRESSION_RATIO` (default 100×) — a zip-bomb guard.
+
+**Client action:** reduce the unpacked size of the archive contents; do not retry the same ZIP.
+
+### too_many_files
+
+The skill ZIP contains more entries than `MAX_PACKAGE_FILE_COUNT` (default 1000).
+
+**Client action:** prune unneeded files from the archive and re-upload.
 
 ---
 

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -470,6 +470,12 @@ export async function bootstrap(
       (await settingsService.getNyxid()).chronoStorageBucket,
     analyticsEmitter,
     agentsealScanner,
+    // Zip-bomb caps (#632) — env-driven, enforced at the ingestion
+    // chokepoint so upload + GitHub pull/refresh share the same limits.
+    maxPackageUncompressedBytes: config.maxPackageUncompressedBytes,
+    maxEntryUncompressedBytes: config.maxEntryUncompressedBytes,
+    maxPackageFileCount: config.maxPackageFileCount,
+    maxCompressionRatio: config.maxCompressionRatio,
   });
 
   // ---- Domain: Notifications + Broadcasts ----

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -26,7 +26,6 @@ import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import { AppError } from "../../../shared/types/index";
 import { canReadSkill, canManageSkill, buildActorContext } from "./authorize";
 import { parseGithubUrl } from "./utils/githubPull";
-import { enforceZipLimits } from "../../../shared/utils/zipLimits";
 import { rateLimit } from "../../../middleware/rateLimit";
 import { createLogger } from "../../../shared/logger";
 const deprecationPatchSchema = z.object({
@@ -282,12 +281,11 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const zipBuffer = new Uint8Array(body);
 
-      // Zip-bomb defense (#633). Walks the central directory without
-      // extracting; throws 413 (`uncompressed_too_large` / `too_many_files`
-      // / `invalid_zip`) before validateZipFormat / storage upload /
-      // AgentSeal subprocess. Cheap, runs ahead of every expensive
-      // side-effect.
-      await enforceZipLimits(zipBuffer);
+      // Zip-bomb defense (#632/#633) now runs at the service ingestion
+      // chokepoint (`createSkill`), so it also covers the GitHub pull
+      // path that bypasses this route. The cheap compressed-size early-out
+      // above (`body.byteLength > maxFileSize`) stays here to reject
+      // oversized payloads before we even allocate the buffer.
 
       const userEmail = authCtx.email || undefined;
       const userDisplayName = authCtx.displayName || undefined;
@@ -993,12 +991,10 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         throw AppError.badRequest("no_update", "No update data provided. Send a ZIP file and/or isPrivate field.");
       }
 
-      // Zip-bomb defense (#633) — same gate as the create path. Only
-      // when a ZIP is actually being replaced; a privacy-only PUT
-      // doesn't hit this.
-      if (zipBuffer !== undefined) {
-        await enforceZipLimits(zipBuffer);
-      }
+      // Zip-bomb defense (#632/#633) now runs at the service chokepoint
+      // (`updateSkill`, only when a ZIP is actually being replaced), so it
+      // also covers the GitHub refresh path that bypasses this route. The
+      // cheap compressed-size early-out above stays here.
 
       logger.info({ guid, userId: authCtx.userId }, "Skill update via API");
       const result = await skillService.updateSkill(guid, authCtx.userId, {

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -1126,6 +1126,100 @@ describe("SkillService.setSkillSource / refresh / preview (globalThis.fetch swap
   });
 });
 
+// ======================================================================
+// #632 — zip-bomb guard is enforced at the SkillService ingestion
+// chokepoint (`createSkill` / `updateSkill`), NOT only at the route
+// layer. The GitHub pull path (`createSkillFromGitHub` → `createSkill`)
+// and refresh path (`refreshSkillFromSource` → `updateSkill`) used to
+// bypass the route-layer guard entirely. These seam-lock tests prove
+// the bypass is closed by hammering the service methods directly.
+//
+// The guard is a DoS defense, not format validation, so it MUST fire
+// even when `skipValidation: true` (the "import as-is" toggle). The
+// tests assert exactly that — skipValidation does NOT disarm the guard.
+//
+// A >1000-entry ZIP trips `too_many_files` against the baked-in default
+// file-count cap (the fake deps pass no caps, so defaults apply). Tiny
+// entries keep the fixture fast and deterministic — no multi-MiB
+// allocation needed to exercise the seam.
+// ======================================================================
+
+/** Build a ZIP whose entry count exceeds the default 1000-file cap. */
+async function buildTooManyFilesZip(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  const folder = zip.folder("demo-skill")!;
+  folder.file("SKILL.md", "---\nname: demo-skill\n---\nbody");
+  for (let i = 0; i < 1001; i++) {
+    folder.file(`assets/f${i}.txt`, `c${i}`);
+  }
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+describe("SkillService zip-bomb chokepoint (#632)", () => {
+  it("createSkill throws 413 too_many_files even with skipValidation=true", async () => {
+    const { deps, state } = makeFakeDeps();
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.createSkill(await buildTooManyFilesZip(), "owner-1", {
+        skipValidation: true,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(413);
+    expect((thrown as AppError).code).toBe("too_many_files");
+    // Guard fires BEFORE storage upload — nothing was persisted.
+    expect(state.uploads).toHaveLength(0);
+    expect(state.versions).toHaveLength(0);
+  });
+
+  it("updateSkill (refresh seam) throws 413 too_many_files even with skipValidation=true", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", isPrivate: false, latestVersion: "1.0" });
+    const { deps, state } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 })],
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.updateSkill("guid-1", "owner-1", {
+        zipBuffer: await buildTooManyFilesZip(),
+        skipValidation: true,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(413);
+    expect((thrown as AppError).code).toBe("too_many_files");
+    // No new version blob uploaded — the guard short-circuited the seam.
+    expect(state.uploads).toHaveLength(0);
+  });
+
+  it("env-driven caps override the defaults at the chokepoint", async () => {
+    // Wire a tight 5-file cap through the deps (mirrors what bootstrap
+    // threads from config). A 6-entry ZIP that would pass the default
+    // 1000-file cap now trips — proving the deps are honored.
+    const { deps } = makeFakeDeps();
+    const service = new SkillService({ ...deps, maxPackageFileCount: 5 });
+    const zip = new JSZip();
+    const folder = zip.folder("demo-skill")!;
+    folder.file("SKILL.md", "---\nname: demo-skill\n---\nbody");
+    for (let i = 0; i < 6; i++) folder.file(`assets/f${i}.txt`, `c${i}`);
+    let thrown: unknown;
+    try {
+      await service.createSkill(await zip.generateAsync({ type: "uint8array" }), "owner-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("too_many_files");
+    expect((thrown as AppError).message).toContain("limit is 5");
+  });
+});
+
 describe("SkillService.validateZipFormat", () => {
   it("flags a non-ZIP buffer", async () => {
     const { deps } = makeFakeDeps();

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -36,6 +36,7 @@ import {
   SKILL_NAME_MAX,
 } from "../../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../../shared/utils/zip";
+import { enforceZipLimits, type ZipLimitsConfig } from "../../../shared/utils/zipLimits";
 import { parseVersion, isGreater } from "./version";
 import { diffSkillInterface, type InterfaceChange } from "./interfaceDiff";
 import type { AnalyticsEmitter } from "../../../infra/analytics";
@@ -127,6 +128,17 @@ export interface SkillServiceDeps {
    * never block the publish path.
    */
   agentsealScanner?: IAgentSealScanner;
+
+  // ---- Zip-bomb defense caps (#632) — env-overridable. ----
+  // Threaded down from `loadConfig()` so the ingestion chokepoint
+  // (`createSkill` / `updateSkill`, which every upload + GitHub
+  // pull/refresh funnels through) enforces the same caps the route layer
+  // used to. All optional (exactOptionalPropertyTypes): when omitted the
+  // guard falls back to the baked-in defaults in `zipLimits.ts`.
+  maxPackageUncompressedBytes?: number;
+  maxEntryUncompressedBytes?: number;
+  maxPackageFileCount?: number;
+  maxCompressionRatio?: number;
 }
 
 export class SkillService {
@@ -137,6 +149,11 @@ export class SkillService {
   // exactOptionalPropertyTypes (#657): widen to `T | undefined`.
   private readonly analyticsEmitter: AnalyticsEmitter | undefined;
   private readonly agentsealScanner: IAgentSealScanner | undefined;
+  // Zip-bomb caps (#632) — undefined means "use zipLimits.ts defaults".
+  private readonly maxPackageUncompressedBytes: number | undefined;
+  private readonly maxEntryUncompressedBytes: number | undefined;
+  private readonly maxPackageFileCount: number | undefined;
+  private readonly maxCompressionRatio: number | undefined;
 
   constructor(deps: SkillServiceDeps) {
     this.skillRepo = deps.skillRepo;
@@ -145,6 +162,50 @@ export class SkillService {
     this.storageBucketResolver = deps.storageBucketResolver;
     this.analyticsEmitter = deps.analyticsEmitter;
     this.agentsealScanner = deps.agentsealScanner;
+    this.maxPackageUncompressedBytes = deps.maxPackageUncompressedBytes;
+    this.maxEntryUncompressedBytes = deps.maxEntryUncompressedBytes;
+    this.maxPackageFileCount = deps.maxPackageFileCount;
+    this.maxCompressionRatio = deps.maxCompressionRatio;
+  }
+
+  /**
+   * Map the configured caps onto the `ZipLimitsConfig` shape consumed by
+   * `enforceZipLimits`. Any cap left undefined falls through to the
+   * baked-in default inside `zipLimits.ts` (50 MiB / 25 MiB / 1000 / 100×).
+   *
+   * exactOptionalPropertyTypes (#657): build the object conditionally so
+   * we never assign `undefined` to an optional field — `enforceZipLimits`
+   * already `?? DEFAULT`s any missing key.
+   */
+  private zipLimitsConfig(): ZipLimitsConfig {
+    const cfg: ZipLimitsConfig = {};
+    if (this.maxPackageUncompressedBytes !== undefined) {
+      cfg.maxTotalUncompressedBytes = this.maxPackageUncompressedBytes;
+    }
+    if (this.maxEntryUncompressedBytes !== undefined) {
+      cfg.maxEntryUncompressedBytes = this.maxEntryUncompressedBytes;
+    }
+    if (this.maxPackageFileCount !== undefined) {
+      cfg.maxFileCount = this.maxPackageFileCount;
+    }
+    if (this.maxCompressionRatio !== undefined) {
+      cfg.maxCompressionRatio = this.maxCompressionRatio;
+    }
+    return cfg;
+  }
+
+  /**
+   * Public zip-bomb guard for standalone read paths that don't flow
+   * through `createSkill`/`updateSkill` — today only the
+   * `POST /skill-format/validate` endpoint, which parses a ZIP without
+   * persisting it. Delegates to {@link enforceZipLimits} with the same
+   * env-driven caps the ingestion chokepoint uses, so the validate path
+   * can't be slowed down by a pathological ZIP that the publish path
+   * would reject. Throws `AppError.payloadTooLarge` (413) on any
+   * violation; `invalid_zip` (400) on an unparseable buffer.
+   */
+  async enforceZipLimits(zipBuffer: Uint8Array): Promise<void> {
+    await enforceZipLimits(zipBuffer, this.zipLimitsConfig());
   }
 
   async createSkill(
@@ -160,6 +221,16 @@ export class SkillService {
       source?: import("../../../shared/types/index").SkillSource | undefined;
     },
   ): Promise<{ guid: string }> {
+    // 0. Zip-bomb defense (#632) — the ingestion chokepoint. EVERY upload
+    //    AND every GitHub pull (`createSkillFromGitHub` → here) funnels
+    //    through this method, so enforcing the caps here closes the
+    //    route-layer bypass. Runs REGARDLESS of skipValidation: it's a
+    //    DoS guard, not format validation, so an "import as-is" toggle
+    //    must not disarm it. Walks the central directory without
+    //    extracting; throws 413 before any storage upload / AgentSeal
+    //    subprocess. We never log payload bytes.
+    await enforceZipLimits(zipBuffer, this.zipLimitsConfig());
+
     // 1. Validate ZIP format rules
     if (!options?.skipValidation) {
       const violations = await this.validateZipFormat(zipBuffer);
@@ -583,6 +654,14 @@ export class SkillService {
     const updateData: UpdateSkillData = { updatedBy: userId };
 
     if (options.zipBuffer) {
+      // Zip-bomb defense (#632) — same chokepoint guard as createSkill.
+      // The GitHub refresh path (`refreshSkillFromSource` → here) and
+      // admin re-upload both land here, so the route-layer bypass is
+      // closed for updates too. Runs REGARDLESS of skipValidation
+      // (DoS guard, not format validation), ahead of storage upload /
+      // AgentSeal. No payload bytes are logged.
+      await enforceZipLimits(options.zipBuffer, this.zipLimitsConfig());
+
       if (!options.skipValidation) {
         const violations = await this.validateZipFormat(options.zipBuffer);
         if (violations.length > 0) {

--- a/ornn-api/src/domains/skills/format/routes.ts
+++ b/ornn-api/src/domains/skills/format/routes.ts
@@ -16,7 +16,6 @@ import {
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
 import { skillFrontmatterSchema } from "../../../shared/schemas/skillFrontmatter";
-import { enforceZipLimits } from "../../../shared/utils/zipLimits";
 
 /** Canonical skill format rules per the ornn platform spec. Updated with output-type. */
 export const SKILL_FORMAT_RULES = `# Ornn Skill Package Format Rules
@@ -146,11 +145,14 @@ export function createFormatRoutes(config: FormatRoutesConfig): Hono<{ Variables
 
       const zipBuffer = new Uint8Array(body);
 
-      // Zip-bomb defense (#633) — same gate as the publish path. The
+      // Zip-bomb defense (#632/#633) — same caps as the publish path. The
       // /skill-format/validate endpoint is authenticated but otherwise
       // unrestricted, so an attacker can still slow us down here with
-      // pathological ZIPs unless we cap before extraction.
-      await enforceZipLimits(zipBuffer);
+      // pathological ZIPs unless we cap before extraction. This is a
+      // standalone read path (no create/update service seam), so we call
+      // the service's public guard, which applies the SAME env-driven caps
+      // the ingestion chokepoint uses.
+      await skillService.enforceZipLimits(zipBuffer);
 
       // `validateZipFormat` returns the full list of rule violations.
       // An empty array means the package is valid; anything non-empty is what

--- a/ornn-api/src/infra/config.ts
+++ b/ornn-api/src/infra/config.ts
@@ -38,6 +38,19 @@ export interface SkillConfig {
   // Skill package upload limit (image-baked operational constant).
   readonly maxPackageSizeBytes: number;
 
+  // Zip-bomb defense caps (#632/#633). Bound what an uploaded/pulled ZIP
+  // is allowed to uncompress to BEFORE extraction, so a tiny compressed
+  // payload can't be coerced into exhausting memory/disk in an extraction
+  // loop or AgentSeal subprocess. Env-overridable operational constants.
+  /** Cumulative uncompressed size cap across all entries (default 50 MiB). */
+  readonly maxPackageUncompressedBytes: number;
+  /** Per-entry uncompressed size cap (default 25 MiB). */
+  readonly maxEntryUncompressedBytes: number;
+  /** Maximum number of files an uploaded ZIP may contain (default 1000). */
+  readonly maxPackageFileCount: number;
+  /** Compression-ratio sanity cap — classic zip-bomb signature (default 100×). */
+  readonly maxCompressionRatio: number;
+
   // CORS
   /**
    * Allow-listed origins for cross-origin requests with credentials.
@@ -96,6 +109,14 @@ const envSchema = z.object({
   MONGODB_DB: z.string().min(1).default("ornn"),
 
   MAX_PACKAGE_SIZE_BYTES: z.coerce.number().int().positive().default(52428800),
+
+  // ---- Zip-bomb defense caps (#632/#633) — env-overridable. ----
+  // Defaults mirror the constants baked into `shared/utils/zipLimits.ts`
+  // (50 MiB cumulative / 25 MiB per-entry / 1000 files / 100× ratio).
+  MAX_PACKAGE_UNCOMPRESSED_BYTES: z.coerce.number().int().positive().default(52428800),
+  MAX_ENTRY_UNCOMPRESSED_BYTES: z.coerce.number().int().positive().default(26214400),
+  MAX_PACKAGE_FILE_COUNT: z.coerce.number().int().positive().default(1000),
+  MAX_COMPRESSION_RATIO: z.coerce.number().positive().default(100),
 
   /**
    * Comma-separated list of origins permitted for cross-origin requests
@@ -180,6 +201,11 @@ export function loadConfig(): SkillConfig {
     mongodbDb: env.MONGODB_DB,
 
     maxPackageSizeBytes: env.MAX_PACKAGE_SIZE_BYTES,
+
+    maxPackageUncompressedBytes: env.MAX_PACKAGE_UNCOMPRESSED_BYTES,
+    maxEntryUncompressedBytes: env.MAX_ENTRY_UNCOMPRESSED_BYTES,
+    maxPackageFileCount: env.MAX_PACKAGE_FILE_COUNT,
+    maxCompressionRatio: env.MAX_COMPRESSION_RATIO,
 
     allowedOrigins: env.ALLOWED_ORIGINS
       .split(",")

--- a/ornn-api/src/shared/utils/zipLimits.test.ts
+++ b/ornn-api/src/shared/utils/zipLimits.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 import { AppError } from "../types/index";
 import {
+  DEFAULT_MAX_COMPRESSION_RATIO,
   DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES,
   enforceZipLimits,
 } from "./zipLimits";
@@ -165,5 +166,36 @@ describe("enforceZipLimits (#633)", () => {
   test("defaults: 50 MiB / 25 MiB / 1000 files — sanity check the constants", async () => {
     // Verify the exported constant is what the issue scope said.
     expect(DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES).toBe(50 * 1024 * 1024);
+  });
+
+  test("default compression ratio is 100 (#632 regression guard)", () => {
+    // #632 bumped the no-arg fallback 50→100 to match criterion #4
+    // (">100 flags"). Lock it so a future tweak to the constant is a
+    // deliberate, test-breaking change rather than a silent drift.
+    expect(DEFAULT_MAX_COMPRESSION_RATIO).toBe(100);
+  });
+
+  test("a >100× synthetic bomb trips with NO cfg (default ratio fires)", async () => {
+    // 8 MiB of zeros deflates to ~8 KiB (~1000× on its own — deflate's
+    // per-block ceiling is ~1032:1). 5 KiB of random filler can't be
+    // compressed, so it pushes the total compressed buffer comfortably
+    // past the 4 KiB ratio-check floor while barely denting the aggregate
+    // ratio (still well above 100×). Caps are left at defaults (no cfg
+    // arg) so this asserts the baked-in fallback — not a passed-in
+    // override — catches the bomb. 8 MiB stays under the 50 MiB / 25 MiB
+    // size caps so the RATIO check is what fires, not the size caps.
+    const zeros = new Uint8Array(8 * 1024 * 1024);
+    const filler = new Uint8Array(5 * 1024);
+    crypto.getRandomValues(filler);
+    const zip = await buildZip({
+      "skill/SKILL.md": "tiny",
+      "skill/assets/zeros.bin": zeros,
+      "skill/assets/filler.bin": filler,
+    });
+    await expectAppError(enforceZipLimits(zip), {
+      status: 413,
+      code: "uncompressed_too_large",
+      messagePattern: /compression ratio.*exceeds 100.*zip-bomb signature/,
+    });
   });
 });

--- a/ornn-api/src/shared/utils/zipLimits.ts
+++ b/ornn-api/src/shared/utils/zipLimits.ts
@@ -17,7 +17,7 @@
  *   - per-entry uncompressed size (default 25 MiB)
  *   - file count (default 1000)
  *
- * Plus a compression-ratio sanity check (50:1) — the classic zip-bomb
+ * Plus a compression-ratio sanity check (100:1) — the classic zip-bomb
  * signature catches things the per-entry cap would miss when an
  * attacker spreads payload across many entries.
  *
@@ -37,13 +37,13 @@ export const DEFAULT_MAX_ENTRY_UNCOMPRESSED_BYTES = 25 * 1024 * 1024;
 export const DEFAULT_MAX_FILE_COUNT = 1000;
 
 /**
- * Compression-ratio sanity cap. `uncompressed / compressed > 50` is
+ * Compression-ratio sanity cap. `uncompressed / compressed > 100` is
  * the classic zip-bomb signature — legitimate text/code packages
- * compress around 3–10×, never 50×. Set high enough that a tiny
+ * compress around 3–10×, never 100×. Set high enough that a tiny
  * package with one near-empty entry doesn't false-positive (the
  * compressed lower bound below also gates this).
  */
-export const DEFAULT_MAX_COMPRESSION_RATIO = 50;
+export const DEFAULT_MAX_COMPRESSION_RATIO = 100;
 
 /**
  * Don't bother running the ratio check when the compressed payload

--- a/ornn-api/tests/integration/harness.ts
+++ b/ornn-api/tests/integration/harness.ts
@@ -112,6 +112,12 @@ export async function startHarness(
     mongodbUri: mongoUri,
     mongodbDb: "ornn-test",
     maxPackageSizeBytes: 10 * 1024 * 1024,
+    // Zip-bomb caps (#632) — mirror the production defaults so the
+    // ingestion-chokepoint guard behaves the same under integration.
+    maxPackageUncompressedBytes: 50 * 1024 * 1024,
+    maxEntryUncompressedBytes: 25 * 1024 * 1024,
+    maxPackageFileCount: 1000,
+    maxCompressionRatio: 100,
     allowedOrigins: [],
     ornnPublicOrigin: "http://test.invalid",
     encryptionKey: "test-encryption-key-32-chars-min-12345",

--- a/ornn-api/tests/integration/skillsCrud.test.ts
+++ b/ornn-api/tests/integration/skillsCrud.test.ts
@@ -21,6 +21,7 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import JSZip from "jszip";
 import { startHarness, authHeaders, type Harness } from "./harness";
 
 const OWNER = "user_crud_owner";
@@ -151,5 +152,69 @@ describe("integration: skills CRUD lifecycle spine", () => {
     expect(delRes.status).toBe(200);
     const after = await harness.db.collection("skills").countDocuments({ _id: GUID as never });
     expect(after).toBe(0);
+  });
+});
+
+/**
+ * #632 — server-side zip-bomb guard at the ingestion chokepoint.
+ *
+ * The guard now lives inside `SkillService.createSkill`, so it covers the
+ * raw upload route (`POST /api/v1/skills`) AND the GitHub pull path that
+ * bypasses the route. These end-to-end cases POST real synthetic bombs
+ * through the actual route → service stack and assert the 413 RFC-7807
+ * problem body — without ever touching chrono-storage, because the guard
+ * short-circuits BEFORE the storage upload (the harness points
+ * chrono-storage at an unreachable URL).
+ *
+ * Both fixtures compress to a tiny payload (highly-compressible content),
+ * so the cheap route-level `maxFileSize` early-out (10 MiB compressed in
+ * the harness) is cleared and the UNCOMPRESSED-side guard is what fires.
+ */
+describe("integration: zip-bomb guard at POST /skills (#632)", () => {
+  const headers = authHeaders({
+    userId: "user_bomb",
+    email: "user_bomb@test.local",
+    permissions: ["ornn:skill:create"],
+  });
+  const zipHeaders = { ...headers, "content-type": "application/zip" };
+
+  test("a >50 MiB-uncompressed ZIP → 413 uncompressed_too_large", async () => {
+    // SKILL.md + one 60 MiB entry of NUL bytes. Deflates to a few KiB, so
+    // the compressed body clears the route's maxFileSize check; the 60 MiB
+    // uncompressed size trips the per-entry / cumulative cap (both surface
+    // the same `uncompressed_too_large` code).
+    const zip = new JSZip();
+    const folder = zip.folder("bomb-skill")!;
+    folder.file("SKILL.md", "---\nname: bomb-skill\n---\nbody");
+    folder.file("assets/zeros.bin", "\0".repeat(60 * 1024 * 1024));
+    const bytes = await zip.generateAsync({ type: "uint8array", compression: "DEFLATE" });
+
+    const res = await harness.app.request("/api/v1/skills", {
+      method: "POST",
+      headers: zipHeaders,
+      body: bytes,
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("uncompressed_too_large");
+  });
+
+  test("a >1000-entry ZIP → 413 too_many_files", async () => {
+    const zip = new JSZip();
+    const folder = zip.folder("many-files-skill")!;
+    folder.file("SKILL.md", "---\nname: many-files-skill\n---\nbody");
+    for (let i = 0; i < 1001; i++) {
+      folder.file(`assets/f${i}.txt`, `c${i}`);
+    }
+    const bytes = await zip.generateAsync({ type: "uint8array", compression: "DEFLATE" });
+
+    const res = await harness.app.request("/api/v1/skills", {
+      method: "POST",
+      headers: zipHeaders,
+      body: bytes,
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("too_many_files");
   });
 });


### PR DESCRIPTION
Closes #632

Automated change by `/auto` (run `20260608T080453Z-73436`, runner `auto-runner-20260608T080453Z-73436-78177-12339`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
