### PR TITLE
[Bug] Fix 2 CodeQL high alerts surfaced in v0.9.0 (redemption-code modulo bias + SDK ReDoS regex)

### DIFF
--- a/.changeset/fix-757-redemption-code-randomint.md
+++ b/.changeset/fix-757-redemption-code-randomint.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Redemption-code generation now draws each character with crypto.randomInt for an unbiased uniform draw over the alphabet, clearing CodeQL js/biased-cryptographic-random (#757)

--- a/.changeset/fix-757-sdk-baseurl-redos.md
+++ b/.changeset/fix-757-sdk-baseurl-redos.md
@@ -1,0 +1,5 @@
+---
+"@chronoai/ornn-sdk": patch
+---
+
+TS SDK baseUrl normalization strips trailing slashes with a linear loop instead of a regex, removing a polynomial ReDoS vector on pathological all-slash inputs (#757)

--- a/ornn-api/src/domains/redemption-codes/service.test.ts
+++ b/ornn-api/src/domains/redemption-codes/service.test.ts
@@ -81,6 +81,35 @@ describe("RedemptionCodeService.mint", () => {
     expect(doc.createdBy).toEqual(ADMIN);
   });
 
+  // Codes are generated char-by-char with crypto.randomInt, which
+  // rejection-samples to a uniform index over the alphabet — no modulo
+  // bias (clears CodeQL js/biased-cryptographic-random, #757). We can't
+  // assert a flake-free statistical distribution, but over a large
+  // sample every char must be in-alphabet AND the observed glyphs must
+  // span almost the whole 31-char alphabet (a `% 256`-style truncation
+  // bug would still pass charset but a stuck/biased generator would
+  // collapse the distinct-glyph count).
+  test("draws code chars uniformly across the full alphabet", async () => {
+    const alphabet = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+    const charRe = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]$/;
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      const doc = await service.mint({
+        admin: ADMIN,
+        grants: [{ surface: "playground", amount: 1 }],
+        expiresAt: plusDays(7),
+      });
+      for (const ch of doc.code) {
+        expect(charRe.test(ch)).toBe(true);
+        seen.add(ch);
+      }
+    }
+    // 200 codes × 16 chars = 3200 draws over 31 glyphs; seeing < 28
+    // distinct would imply a badly skewed generator, not sampling noise.
+    expect(seen.size).toBeGreaterThanOrEqual(28);
+    expect(alphabet.length).toBe(31);
+  });
+
   test("rejects duplicate surface in grants", async () => {
     await expect(
       service.mint({

--- a/ornn-api/src/domains/redemption-codes/service.ts
+++ b/ornn-api/src/domains/redemption-codes/service.ts
@@ -16,7 +16,7 @@
  * @module domains/redemption-codes/service
  */
 
-import { randomBytes } from "node:crypto";
+import { randomInt } from "node:crypto";
 import { ObjectId } from "mongodb";
 import { createLogger } from "../../shared/logger";
 import { isDuplicateKeyError } from "../../shared/types/index";
@@ -112,19 +112,19 @@ export class RedemptionCodeService {
   }
 
   /**
-   * Generate one candidate code. The `% alphabet.length` step
-   * introduces a sub-1.5% modulo bias (256 % 31), which is harmless
-   * for human-shareable IDs since the unique index + retry loop
-   * absorbs collisions regardless.
+   * Generate one candidate code. Each character is drawn with
+   * `crypto.randomInt(alphabet.length)`, which rejection-samples
+   * internally to yield a uniform index over `[0, length)` — no modulo
+   * bias. The unique index + mint retry loop still absorbs the (now
+   * purely birthday-paradox) chance of a collision.
    */
   private generateCode(): string {
-    const bytes = randomBytes(REDEMPTION_CODE_LENGTH);
     let out = "";
     for (let i = 0; i < REDEMPTION_CODE_LENGTH; i++) {
-      // `randomBytes(N)` returns exactly N bytes — loop bound is N, so
-      // `bytes[i]` is always defined. `!` is safe under
-      // noUncheckedIndexedAccess (#450).
-      out += REDEMPTION_CODE_ALPHABET[bytes[i]! % REDEMPTION_CODE_ALPHABET.length];
+      // `randomInt(length)` returns an integer in `[0, length)`, so the
+      // index is always in-bounds; the `?? ""` satisfies
+      // noUncheckedIndexedAccess (#450) without a non-null assertion.
+      out += REDEMPTION_CODE_ALPHABET[randomInt(REDEMPTION_CODE_ALPHABET.length)] ?? "";
     }
     return out;
   }

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -67,7 +67,14 @@ export class OrnnClient {
     if (!options.baseUrl) {
       throw new Error("OrnnClient: baseUrl is required");
     }
-    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    // Strip ALL trailing slashes with a linear loop rather than a regex
+    // (`/\/+$/`) — the regex backtracks polynomially on a pathological
+    // all-slashes input, a ReDoS vector. The loop is O(n) regardless.
+    let normalizedBaseUrl = options.baseUrl;
+    while (normalizedBaseUrl.endsWith("/")) {
+      normalizedBaseUrl = normalizedBaseUrl.slice(0, -1);
+    }
+    this.baseUrl = normalizedBaseUrl;
     this.staticToken = options.token;
     this.tokenResolver = options.getToken;
     this.fetchImpl = options.fetch ?? globalThis.fetch;

--- a/sdk/typescript/src/tests/client.test.ts
+++ b/sdk/typescript/src/tests/client.test.ts
@@ -31,6 +31,23 @@ describe("OrnnClient", () => {
       .toBe("https://ornn.example.com/api/v1/ping");
   });
 
+  test("strips a pathological run of trailing slashes without ReDoS (#757)", async () => {
+    let capturedUrl = "";
+    const fetchMock = mockFetch((url) => {
+      capturedUrl = url;
+      return jsonResponse(200, { data: [], error: null });
+    });
+    // 100k trailing slashes would backtrack polynomially under a
+    // `/\/+$/` regex; the linear strip handles it in O(n). The test
+    // returning promptly (no timeout) is the assertion that matters.
+    const client = new OrnnClient({
+      baseUrl: "https://x" + "/".repeat(100_000),
+      fetch: fetchMock,
+    });
+    await client.request("GET", "/ping");
+    expect(capturedUrl).toBe("https://x/api/v1/ping");
+  });
+
   test("injects Bearer token from static option", async () => {
     let captured: Record<string, string> = {};
     const fetchMock = mockFetch((_url, init) => {


### PR DESCRIPTION
Closes #757

Automated change by `/auto` (run `20260608T080453Z-73436`, runner `auto-runner-20260608T080453Z-73436-85208-14936`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
