### PR TITLE
[Bug] [Playground Runtime] runtime / mixed skills do not execute sandbox tool when the LLM provider uses chat-completion format

### DIFF
--- a/.changeset/fix-608-chat-completion-tool-calls.md
+++ b/.changeset/fix-608-chat-completion-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Chat-completion providers now surface structured `execute_in_sandbox` tool calls in the Playground. `parseChatCompletionStream` accumulates streamed `choices[].delta.tool_calls[]` fragments per index and flushes each completed call as a `response.output_item.done` function_call event (the shape the playground consumer reads); the non-streamed `complete()` path maps `message.tool_calls[]` the same way; and the chat-completion request body now sends `tool_choice: "auto"` whenever tools are supplied. Previously tool calls were silently dropped so the sandbox never ran for `apiFormat=chat-completion` providers (#608)

--- a/ornn-api/src/clients/nyxid/llm.test.ts
+++ b/ornn-api/src/clients/nyxid/llm.test.ts
@@ -4,8 +4,10 @@
  * body, `chat-completion` hits `/chat/completions` with translated
  * body and normalizes text deltas back into Responses-API event shape.
  *
- * Tool-call delta normalization for chat-completion is out of scope here
- * (tracked in #608).
+ * #608: chat-completion tool-call normalization — streamed
+ * `delta.tool_calls[]` fragments accumulate into a single
+ * `response.output_item.done` function_call event, and the request body
+ * carries `tool_choice: "auto"` whenever tools are supplied.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -222,6 +224,206 @@ describe("NyxLlmClient.stream() routing on apiFormat", () => {
     ]);
   });
 
+  it("chat-completion sets tool_choice:auto when tools supplied", async () => {
+    fetchHandler = () => sseResponse([]);
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+      tools: [
+        {
+          type: "function",
+          name: "do_thing",
+          description: "does the thing",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    })) events.push(e);
+
+    expect((capturedRequests[0]!.body as Record<string, unknown>).tool_choice).toBe("auto");
+  });
+
+  it("chat-completion omits tool_choice when no tools supplied", async () => {
+    fetchHandler = () => sseResponse([]);
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+    })) events.push(e);
+
+    expect((capturedRequests[0]!.body as Record<string, unknown>).tool_choice).toBeUndefined();
+  });
+
+  it("chat-completion accumulates streamed tool_calls into one output_item.done", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_1",
+                    function: { name: "execute_in_sandbox", arguments: '{"sc' },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        JSON.stringify({
+          choices: [
+            { delta: { tool_calls: [{ index: 0, function: { arguments: 'ript":"x"}' } }] } },
+          ],
+        }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      ]);
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "run it" }],
+    })) events.push(e);
+
+    const itemDone = events.filter((e) => e.type === "response.output_item.done");
+    expect(itemDone).toHaveLength(1);
+    expect(itemDone[0]).toEqual({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "call_1",
+        call_id: "call_1",
+        name: "execute_in_sandbox",
+        arguments: '{"script":"x"}',
+      },
+    });
+  });
+
+  it("chat-completion still emits text deltas when interleaved with tool_calls", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({ choices: [{ delta: { content: "thinking " } }] }),
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_2",
+                    function: { name: "execute_in_sandbox", arguments: "{}" },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        JSON.stringify({ choices: [{ delta: { content: "more" } }] }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      ]);
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "run it" }],
+    })) events.push(e);
+
+    const textDeltas = events.filter((e) => e.type === "response.output_text.delta");
+    expect(textDeltas).toEqual([
+      { type: "response.output_text.delta", delta: "thinking " },
+      { type: "response.output_text.delta", delta: "more" },
+    ]);
+    const itemDone = events.filter((e) => e.type === "response.output_item.done");
+    expect(itemDone).toHaveLength(1);
+    expect((itemDone[0]!.item as { call_id: string }).call_id).toBe("call_2");
+  });
+
+  it("chat-completion flushes accumulated tool_calls on stream end without finish_reason", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_3",
+                    function: { name: "execute_in_sandbox", arguments: '{"a":1}' },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      ]);
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "run it" }],
+    })) events.push(e);
+
+    const itemDone = events.filter((e) => e.type === "response.output_item.done");
+    expect(itemDone).toHaveLength(1);
+    expect(itemDone[0]).toEqual({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "call_3",
+        call_id: "call_3",
+        name: "execute_in_sandbox",
+        arguments: '{"a":1}',
+      },
+    });
+  });
+
   it("flattens Responses-API content parts into a string for chat-completion", async () => {
     fetchHandler = () => sseResponse([]);
     const client = new NyxLlmClient({
@@ -398,5 +600,47 @@ describe("NyxLlmClient.complete() routing on apiFormat", () => {
       input: [{ role: "user", content: "say nothing" }],
     });
     expect(out).toEqual([]);
+  });
+
+  it("chat-completion maps message.tool_calls to function_call outputs", async () => {
+    fetchHandler = () =>
+      jsonResponse({
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "calling tool",
+              tool_calls: [
+                {
+                  id: "call_9",
+                  function: { name: "execute_in_sandbox", arguments: '{"script":"x"}' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+    const out = await client.complete({
+      model: "m",
+      input: [{ role: "user", content: "run it" }],
+    });
+    expect(out).toEqual([
+      { type: "message", content: [{ type: "output_text", text: "calling tool" }] },
+      {
+        type: "function_call",
+        id: "call_9",
+        call_id: "call_9",
+        name: "execute_in_sandbox",
+        arguments: '{"script":"x"}',
+      },
+    ]);
   });
 });

--- a/ornn-api/src/clients/nyxid/llm.ts
+++ b/ornn-api/src/clients/nyxid/llm.ts
@@ -14,8 +14,10 @@
  * the way in, so consumers (skill generation + playground) do not need
  * to branch on apiFormat (#574).
  *
- * Tool-call delta normalization for chat-completion is intentionally
- * out of scope here — tracked in #608.
+ * Chat-completion tool-call normalization is implemented: streamed
+ * `choices[].delta.tool_calls[]` fragments are accumulated and flushed
+ * as `response.output_item.done` function_call events, and non-streamed
+ * `choices[].message.tool_calls[]` map to `function_call` outputs (#608).
  *
  * Authenticates using a Service Account (SA) token obtained via
  * client_credentials grant when the resolved provider has no direct
@@ -186,21 +188,56 @@ async function* parseResponsesStream(
 }
 
 /**
- * Parse Chat Completions SSE and translate text deltas into
- * Responses-API event shape so consumers stay format-agnostic.
+ * Parse Chat Completions SSE and translate both text deltas and
+ * tool-call deltas into Responses-API event shape so consumers stay
+ * format-agnostic.
  *
- * For #574, only text deltas (`choices[].delta.content`) are
- * translated — emitted as `response.output_text.delta`. Tool-call
- * delta normalization is tracked in #608.
+ * Text deltas (`choices[].delta.content`) pass through as
+ * `response.output_text.delta`. Tool-call fragments
+ * (`choices[].delta.tool_calls[]`) arrive incrementally — `id`/`name`
+ * land on the first fragment, `function.arguments` streams across many
+ * — so we accumulate per `index` and flush each completed call as a
+ * single `response.output_item.done` function_call event (matching the
+ * Responses-API shape the playground consumer reads). We never parse the
+ * arguments mid-stream; the consumer parses the assembled JSON (#608).
  */
 async function* parseChatCompletionStream(
   response: Response,
 ): AsyncIterable<ResponsesApiStreamEvent> {
+  const toolCalls = new Map<number, { id: string; name: string; argsBuffer: string }>();
+  let flushed = false;
+
+  function* flush(): Generator<ResponsesApiStreamEvent> {
+    if (flushed) return;
+    flushed = true;
+    for (const index of [...toolCalls.keys()].sort((a, b) => a - b)) {
+      const call = toolCalls.get(index)!;
+      yield {
+        type: "response.output_item.done",
+        item: {
+          type: "function_call",
+          id: call.id,
+          call_id: call.id,
+          name: call.name,
+          arguments: call.argsBuffer,
+        },
+      };
+    }
+  }
+
   for await (const { data } of parseSSELines(response)) {
-    if (data === "[DONE]") return;
+    if (data === "[DONE]") break;
     let chunk: {
       choices?: Array<{
-        delta?: { content?: string | null };
+        delta?: {
+          content?: string | null;
+          tool_calls?: Array<{
+            index: number;
+            id?: string;
+            function?: { name?: string; arguments?: string };
+          }>;
+        };
+        finish_reason?: string;
       }>;
     };
     try {
@@ -209,10 +246,35 @@ async function* parseChatCompletionStream(
       logger.debug({ data: data.slice(0, 100) }, "Failed to parse chat-completion chunk");
       continue;
     }
-    const delta = chunk.choices?.[0]?.delta?.content;
-    if (typeof delta === "string" && delta.length > 0) {
-      yield { type: "response.output_text.delta", delta };
+
+    const choice = chunk.choices?.[0];
+    const textDelta = choice?.delta?.content;
+    if (typeof textDelta === "string" && textDelta.length > 0) {
+      yield { type: "response.output_text.delta", delta: textDelta };
     }
+
+    const fragments = choice?.delta?.tool_calls;
+    if (fragments) {
+      for (const frag of fragments) {
+        const existing = toolCalls.get(frag.index) ?? { id: "", name: "", argsBuffer: "" };
+        if (frag.id) existing.id = frag.id;
+        if (frag.function?.name) existing.name = frag.function.name;
+        if (typeof frag.function?.arguments === "string") {
+          existing.argsBuffer += frag.function.arguments;
+        }
+        toolCalls.set(frag.index, existing);
+      }
+    }
+
+    if (choice?.finish_reason === "tool_calls") {
+      yield* flush();
+    }
+  }
+
+  // Flush on stream end / [DONE] in case the upstream omitted the
+  // `finish_reason: "tool_calls"` chunk but still streamed tool calls.
+  if (toolCalls.size > 0) {
+    yield* flush();
   }
 }
 
@@ -268,6 +330,7 @@ function buildChatCompletionBody(
         parameters: t.parameters,
       },
     }));
+    body.tool_choice = "auto";
   }
   return body;
 }
@@ -443,12 +506,37 @@ export class NyxLlmClient {
 
     if (apiFormat === "chat-completion") {
       const result = (await response.json()) as {
-        choices?: Array<{ message?: { content?: string | null } }>;
+        choices?: Array<{
+          message?: {
+            content?: string | null;
+            tool_calls?: Array<{
+              id?: string;
+              function?: { name?: string; arguments?: string };
+            }>;
+          };
+        }>;
       };
-      const text = result.choices?.[0]?.message?.content ?? "";
-      return text
-        ? [{ type: "message", content: [{ type: "output_text", text }] }]
-        : [];
+      const message = result.choices?.[0]?.message;
+      const outputs: ResponsesApiOutput[] = [];
+
+      const text = message?.content ?? "";
+      if (text) {
+        outputs.push({ type: "message", content: [{ type: "output_text", text }] });
+      }
+
+      for (const call of message?.tool_calls ?? []) {
+        const id = call.id ?? "";
+        const fnCall: ResponsesApiOutput = {
+          type: "function_call",
+          id,
+          call_id: id,
+          name: call.function?.name ?? "",
+          arguments: call.function?.arguments ?? "",
+        };
+        outputs.push(fnCall);
+      }
+
+      return outputs;
     }
 
     const result = (await response.json()) as { output: ResponsesApiOutput[] };


### PR DESCRIPTION
Closes #608

Automated change by `/auto` (run `20260608T080453Z-73436`, runner `auto-runner-20260608T080453Z-73436-91896-23483`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
