### PR TITLE
删除 skill 后仍请求已删除技能导致 404

### DIFF
--- a/.changeset/fix-940-delete-skill-cache-removal.md
+++ b/.changeset/fix-940-delete-skill-cache-removal.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Deleting a skill now removes its detail/versions cache (predicate covers name- and guid-keyed entries) so the page no longer refetches the deleted skill → 404 (#940)

--- a/ornn-web/src/hooks/useSkillDetail.ts
+++ b/ornn-web/src/hooks/useSkillDetail.ts
@@ -73,7 +73,11 @@ export function useSkillDetail(idOrName: string | undefined) {
   const versionParam = searchParams.get("version") ?? undefined;
   const { data: skill, isLoading, error, refetch } = useSkill(idOrName ?? "", versionParam);
   const { data: versionList = [] } = useSkillVersions(idOrName ?? "");
-  const deleteMutation = useDeleteSkill();
+  // Two-id split (#940): wire the GUID (delete route is GUID-only) but
+  // pass the cache-key id (idOrName, often a NAME from the URL) so the
+  // deleted skill's detail/versions cache is removed before the broad
+  // list invalidation can refetch it → 404.
+  const deleteMutation = useDeleteSkill(skill?.guid ?? "", idOrName ?? "");
   const updatePackageMutation = useUpdateSkillPackage(skill?.guid ?? "");
   // Two-id split (#750): wire the GUID (version-write routes are GUID-only)
   // but keep the cache-key id (idOrName) for invalidation.
@@ -305,7 +309,7 @@ export function useSkillDetail(idOrName: string | undefined) {
   const handleDeleteConfirm = useCallback(async () => {
     if (!skill) return;
     try {
-      await deleteMutation.mutateAsync(skill.guid);
+      await deleteMutation.mutateAsync();
       addToast({ type: "success", message: t("skillDetail.deleteSuccess") });
       navigate("/registry");
     } catch {

--- a/ornn-web/src/hooks/useSkills.test.tsx
+++ b/ornn-web/src/hooks/useSkills.test.tsx
@@ -40,7 +40,7 @@ vi.mock("@/stores/authStore", () => ({
   },
 }));
 
-import { useDeleteSkillVersion, useSetVersionDeprecation } from "./useSkills";
+import { useDeleteSkill, useDeleteSkillVersion, useSetVersionDeprecation } from "./useSkills";
 
 const GUID = "11111111-2222-3333-4444-555555555555";
 const NAME = "my-skill";
@@ -58,10 +58,32 @@ function makeWrapper() {
     defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
   });
   const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const removeSpy = vi.spyOn(queryClient, "removeQueries");
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
-  return { wrapper, invalidateSpy };
+  return { wrapper, invalidateSpy, removeSpy, queryClient };
+}
+
+/**
+ * Did `removeQueries` fire with a predicate that matches this queryKey?
+ * #940 removes the deleted skill's caches with a predicate (covering both
+ * name- and guid-keyed entries), not a literal queryKey, so we exercise
+ * the predicate against a synthetic key.
+ */
+function removedKey(
+  spy: ReturnType<typeof vi.spyOn>,
+  key: readonly unknown[],
+): boolean {
+  return spy.mock.calls.some(
+    ([arg]) =>
+      arg != null &&
+      typeof arg === "object" &&
+      "predicate" in arg &&
+      (arg as { predicate: (q: { queryKey: readonly unknown[] }) => boolean }).predicate({
+        queryKey: key,
+      }),
+  );
 }
 
 /** Did `invalidateQueries` fire with exactly this queryKey? */
@@ -226,5 +248,72 @@ describe("useSetVersionDeprecation", () => {
     // Cache keys must never be the GUID when opened by name.
     expect(invalidatedKey(invalidateSpy, ["skills", GUID])).toBe(false);
     expect(invalidatedKey(invalidateSpy, ["skill-versions", GUID])).toBe(false);
+  });
+});
+
+describe("useDeleteSkill", () => {
+  // Backend DELETE returns 204; apiClient short-circuits on 204.
+  function stubDelete() {
+    return vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+  }
+
+  it("removes the deleted skill's detail + versions cache so no refetch can 404 (#940)", async () => {
+    stubDelete();
+    const { wrapper, removeSpy, invalidateSpy, queryClient } = makeWrapper();
+
+    // Seed the still-mounted detail + versions cache, keyed on the NAME
+    // (the Skill Detail URL id). A broad invalidate would prefix-match
+    // these and refetch the just-deleted skill → 404.
+    queryClient.setQueryData(["skills", NAME, "latest"], { guid: GUID, name: NAME });
+    queryClient.setQueryData(["skill-versions", NAME], [{ version: VERSION }]);
+
+    const { result } = renderHook(() => useDeleteSkill(GUID, NAME), { wrapper });
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // (a) removeQueries fired for the detail + versions keys.
+    expect(removedKey(removeSpy, ["skills", NAME, "latest"])).toBe(true);
+    expect(removedKey(removeSpy, ["skill-versions", NAME])).toBe(true);
+
+    // (b) the detail entry is actually gone — nothing left to refetch.
+    expect(queryClient.getQueryData(["skills", NAME, "latest"])).toBeUndefined();
+    expect(queryClient.getQueryData(["skill-versions", NAME])).toBeUndefined();
+
+    // (c) lists + counts still invalidate to drop the deleted card.
+    expect(invalidatedKey(invalidateSpy, ["skills"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["my-skills"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["skill-counts"])).toBe(true);
+  });
+
+  it("removes a GUID-keyed detail entry too (predicate covers both keyings)", async () => {
+    stubDelete();
+    const { wrapper, removeSpy, queryClient } = makeWrapper();
+
+    // MySkillsPage passes the card's GUID as the cache-key id; a detail
+    // entry keyed by GUID must be removed just like the name-keyed one.
+    queryClient.setQueryData(["skills", GUID, "latest"], { guid: GUID, name: NAME });
+
+    const { result } = renderHook(() => useDeleteSkill(GUID, GUID), { wrapper });
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(removedKey(removeSpy, ["skills", GUID, "latest"])).toBe(true);
+    expect(queryClient.getQueryData(["skills", GUID, "latest"])).toBeUndefined();
+  });
+
+  it("sends the GUID on the wire, not the cache id, when opened by name", async () => {
+    const fetchSpy = stubDelete();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkill(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const url = fetchedUrl(fetchSpy);
+    expect(url).toContain(`/skills/${encodeURIComponent(GUID)}`);
+    expect(url).not.toContain(`/skills/${encodeURIComponent(NAME)}`);
+    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ method: "DELETE" });
   });
 });

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -368,14 +368,47 @@ export function useTieSkillToNyxidService(idOrName: string) {
   });
 }
 
-/** Delete a skill */
-export function useDeleteSkill() {
+/**
+ * Delete an entire skill (every version).
+ *
+ * Two-id split (#750 shape): `guid` is the WIRE id — the delete route is
+ * GUID-only, so a name-opened Skill Detail must still send the GUID.
+ * `idOrName` is the CACHE-KEY id — the detail/versions read queries
+ * (`useSkill`, `useSkillVersions`) are keyed on `idOrName`, and callers
+ * pass either the GUID (MySkillsPage card) or a NAME (Skill Detail URL),
+ * so cache cleanup must cover BOTH keyings.
+ *
+ * #940 — onSuccess must REMOVE the deleted skill's detail + versions
+ * entries (not just invalidate). The detail query stays mounted through
+ * the delete (the `navigate("/registry")` in the caller runs AFTER this
+ * onSuccess, and RootLayout's breadcrumb re-subscribes), so a broad
+ * `invalidateQueries([SKILLS_KEY])` prefix-matches the still-mounted
+ * detail key and triggers a refetch of the just-deleted skill → 404.
+ * `removeQueries` drops the cache entry outright so nothing can refetch
+ * it; the list/count keys still invalidate to drop the deleted card.
+ * Removal is id-scoped (predicate on `guid`/`idOrName`) so only the
+ * deleted skill's caches are touched, never other skills'.
+ */
+export function useDeleteSkill(guid: string, idOrName: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => deleteSkill(id),
+    mutationFn: () => deleteSkill(guid),
     onSuccess: () => {
+      queryClient.removeQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === SKILLS_KEY &&
+          (q.queryKey[1] === guid || q.queryKey[1] === idOrName),
+      });
+      queryClient.removeQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === SKILL_VERSIONS_KEY &&
+          (q.queryKey[1] === guid || q.queryKey[1] === idOrName),
+      });
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [SKILL_COUNTS_KEY] });
     },
   });
 }

--- a/ornn-web/src/pages/skill/MySkillsPage.tsx
+++ b/ornn-web/src/pages/skill/MySkillsPage.tsx
@@ -46,7 +46,13 @@ export function MySkillsPage() {
 
   const debouncedSearch = useDebounce(searchInput, 300);
 
-  const deleteMutation = useDeleteSkill();
+  // Two-id split (#940): the list has no URL idOrName, so pass the card's
+  // own ids — `guid` on the wire (delete route is GUID-only), `name` as
+  // the cache-key id so the deleted skill's detail cache (which other
+  // surfaces may have keyed by name) is removed, not refetched → 404.
+  // `skillToDelete` is set before the confirm; the closed-over ids are
+  // current at mutateAsync() time.
+  const deleteMutation = useDeleteSkill(skillToDelete?.guid ?? "", skillToDelete?.name ?? "");
 
   const { data, isLoading } = useMySkills({
     query: debouncedSearch || undefined,
@@ -63,7 +69,7 @@ export function MySkillsPage() {
   const handleDeleteConfirm = async () => {
     if (!skillToDelete) return;
     try {
-      await deleteMutation.mutateAsync(skillToDelete.guid);
+      await deleteMutation.mutateAsync();
       addToast({ type: "success", message: t("mySkills.deleteSuccess") });
     } catch {
       addToast({ type: "error", message: t("mySkills.deleteFailed") });


### PR DESCRIPTION
Closes #940

Automated change by `/auto` (run `20260608T080453Z-73436`, runner `auto-runner-20260608T080453Z-73436-4364-19413`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
