### PR TITLE
删除 skill 后 My Skills 数量没有及时刷新

### DIFF
--- a/.changeset/fix-941-delete-skill-sidebar-counts.md
+++ b/.changeset/fix-941-delete-skill-sidebar-counts.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Deleting a skill now also refreshes the My-Skills filter-sidebar facet + grants-summary counts so they stay consistent without a full-page refresh (#941)

--- a/ornn-web/src/hooks/useSkills.test.tsx
+++ b/ornn-web/src/hooks/useSkills.test.tsx
@@ -316,4 +316,25 @@ describe("useDeleteSkill", () => {
     expect(url).not.toContain(`/skills/${encodeURIComponent(NAME)}`);
     expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ method: "DELETE" });
   });
+
+  it("refreshes the My-Skills sidebar facet + grants-summary counts (#941)", async () => {
+    stubDelete();
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkill(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The sidebar counts come from queries no #940 invalidation touches:
+    // the "mine" tag facet and the grants summary. Both must refresh so
+    // the chip counts stay consistent after a self-delete.
+    expect(invalidatedKey(invalidateSpy, ["skill-facets", "tags", "mine"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["me", "skills", "grants-summary"])).toBe(true);
+
+    // Scope guard: stay narrow. A self-delete can't change the public
+    // tag facet, and the broad ["me"] prefix would needlessly refetch
+    // orgs / nyxid-services — neither must be invalidated as a literal.
+    expect(invalidatedKey(invalidateSpy, ["skill-facets", "tags", "public"])).toBe(false);
+    expect(invalidatedKey(invalidateSpy, ["me"])).toBe(false);
+  });
 });

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -409,6 +409,17 @@ export function useDeleteSkill(guid: string, idOrName: string) {
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [SKILL_COUNTS_KEY] });
+      // #941 — the My-Skills filter sidebar counts come from SEPARATE
+      // queries that #940's invalidations don't touch: the "mine" tag
+      // facet (useSkillTagFacets("mine")) and the grants summary
+      // (useMySkillGrantsSummary). Refresh exactly those two so the
+      // per-tag chips + per-grantee/org "shared with" counts stay
+      // consistent after a self-delete without a full-page refresh.
+      // Narrow literals on purpose: the broad ["skill-facets"] prefix
+      // would refetch the public/system facets a self-delete can't
+      // change, and broad ["me"] would refetch orgs/nyxid-services.
+      queryClient.invalidateQueries({ queryKey: ["skill-facets", "tags", "mine"] });
+      queryClient.invalidateQueries({ queryKey: ["me", "skills", "grants-summary"] });
     },
   });
 }


### PR DESCRIPTION
Closes #941

Automated change by `/auto` (run `20260608T080453Z-73436`, runner `auto-runner-20260608T080453Z-73436-8748-7832`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
