### PR TITLE
[Bug] [Registry] Skill card dates still use English month names in Chinese mode after the #682 localization fix

### DIFF
--- a/.changeset/fix-752-skill-timestamp-locale.md
+++ b/.changeset/fix-752-skill-timestamp-locale.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+skill timestamps (registry card, version list, detail page) now follow the active UI language — Chinese mode no longer shows English month names (#752)

--- a/ornn-web/src/components/skill/SkillCard.tsx
+++ b/ornn-web/src/components/skill/SkillCard.tsx
@@ -6,6 +6,7 @@ import type { BadgeProps } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import type { SkillSearchResult } from "@/types/search";
 import { useMyOrgs } from "@/hooks/useMe";
+import { formatDateSGT } from "@/utils/formatters";
 
 const TAG_COLORS: NonNullable<BadgeProps["color"]>[] = ["cyan", "magenta", "yellow", "green"];
 
@@ -14,21 +15,6 @@ function getTagColor(tag: string): NonNullable<BadgeProps["color"]> {
   // `hash % TAG_COLORS.length` is always in-range for a non-empty
   // array. `!` is safe under noUncheckedIndexedAccess (#450).
   return TAG_COLORS[hash % TAG_COLORS.length]!;
-}
-
-/** Format a date string to exact SGT (Asia/Singapore) timestamp */
-function formatDateSGT(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleString("en-SG", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
 }
 
 export interface SkillCardProps {
@@ -81,7 +67,7 @@ export function SkillCard({
   className = "",
 }: SkillCardProps) {
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const isOwner = currentUserId && skill.createdBy === currentUserId;
 
@@ -197,7 +183,7 @@ export function SkillCard({
           )}
           <span className="truncate">{displayName}</span>
         </div>
-        <span className="shrink-0">{formatDateSGT(timestamp)}</span>
+        <span className="shrink-0">{formatDateSGT(timestamp, i18n.language, { withSeconds: true })}</span>
       </div>
 
       {showOwnerControls && isOwner && (

--- a/ornn-web/src/components/skill/SkillVersionList.tsx
+++ b/ornn-web/src/components/skill/SkillVersionList.tsx
@@ -5,20 +5,7 @@ import { Button } from "@/components/ui/Button";
 import { Modal } from "@/components/ui/Modal";
 import type { SkillVersionEntry } from "@/types/domain";
 import type { AuditRecord, AuditVerdict } from "@/types/audit";
-
-/** Format a date string to exact SGT (Asia/Singapore) timestamp. */
-function formatDateSGT(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleString("en-SG", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-}
+import { formatDateSGT } from "@/utils/formatters";
 
 export interface SkillVersionListProps {
   versions: SkillVersionEntry[];
@@ -99,7 +86,7 @@ export function SkillVersionList({
   auditSummary,
   className = "",
 }: SkillVersionListProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [modalTarget, setModalTarget] = useState<SkillVersionEntry | null>(null);
   const [noteDraft, setNoteDraft] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<SkillVersionEntry | null>(null);
@@ -187,7 +174,7 @@ export function SkillVersionList({
                     )}
                   </div>
                   <div className="mt-0.5 font-text text-xs text-meta truncate">
-                    {formatDateSGT(v.createdOn)}
+                    {formatDateSGT(v.createdOn, i18n.language)}
                     {v.createdByDisplayName ? ` · ${v.createdByDisplayName}` : ""}
                   </div>
                 </button>

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -43,25 +43,12 @@ import {
 import { SkillVersionsCard } from "@/components/skill/SkillVersionsCard";
 import { SkillVisibilityCard } from "@/components/skill/SkillVisibilityCard";
 import { useSkillDetail } from "@/hooks/useSkillDetail";
+import { formatDateSGT } from "@/utils/formatters";
 import { useTranslation } from "react-i18next";
-
-/** Format a date string to exact SGT (Asia/Singapore) timestamp. */
-function formatDateSGT(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleString("en-SG", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-}
 
 export function SkillDetailPage() {
   const { idOrName } = useParams<{ idOrName: string }>();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const addToast = useToastStore((s) => s.addToast);
   const detail = useSkillDetail(idOrName);
@@ -320,7 +307,7 @@ export function SkillDetailPage() {
                 {versionAuditRunning
                   ? t("skillDetail.auditRunningHint", "Scoring against the audit engine — this usually takes 30–60 seconds.")
                   : versionAudit?.completedAt
-                    ? t("skillDetail.auditLast", "Last audited {{date}}", { date: formatDateSGT(versionAudit.completedAt) })
+                    ? t("skillDetail.auditLast", "Last audited {{date}}", { date: formatDateSGT(versionAudit.completedAt, i18n.language) })
                     : t("skillDetail.auditNoneYet", "Not audited yet for this version.")}
               </p>
               <div className="mt-3.5 flex flex-col gap-2">
@@ -365,7 +352,7 @@ export function SkillDetailPage() {
             {versionList.length > 0 && (
               <SkillVersionsCard
                 currentVersion={skill.version}
-                publishedOnSGT={formatDateSGT(skill.createdOn)}
+                publishedOnSGT={formatDateSGT(skill.createdOn, i18n.language)}
                 totalVersions={versionList.length}
                 viewingLatest={Boolean(viewingLatest)}
                 onBrowseAll={() => setShowVersions(true)}
@@ -492,7 +479,7 @@ export function SkillDetailPage() {
                     {t("skillDetail.metaUpdated", "Updated")}
                   </dt>
                   <dd className="text-right font-mono text-xs text-strong">
-                    {formatDateSGT(skill.updatedOn)}
+                    {formatDateSGT(skill.updatedOn, i18n.language)}
                   </dd>
                 </div>
                 <div>

--- a/ornn-web/src/utils/formatters.test.ts
+++ b/ornn-web/src/utils/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatFileSize, formatNumber } from "./formatters";
+import { formatDateSGT, formatFileSize, formatNumber } from "./formatters";
 
 describe("formatNumber", () => {
   it("renders millions with an M suffix", () => {
@@ -46,5 +46,44 @@ describe("formatFileSize", () => {
 
   it("renders gigabytes with one decimal", () => {
     expect(formatFileSize(1024 * 1024 * 1024)).toBe("1.0 GB");
+  });
+});
+
+describe("formatDateSGT", () => {
+  // 03:43:42 UTC = 11:43:42 Asia/Singapore (+08:00) same day.
+  const ISO = "2026-05-25T03:43:42Z";
+  // 17:00 UTC = 01:00 next-day Asia/Singapore — locks the TZ offset.
+  const ISO2 = "2026-05-24T17:00:00Z";
+  const EN_MONTHS = /Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/;
+
+  it("renders Chinese-formatted output (no English months) in zh mode", () => {
+    const out = formatDateSGT(ISO, "zh", { withSeconds: true });
+    // The whole point of #752: zh must NOT silently fall back to English
+    // months. Bun is full-ICU so zh-CN resolves; if this assertion ever
+    // fails it means the locale fell back to en — a real regression.
+    expect(out).not.toMatch(EN_MONTHS);
+    expect(out).toMatch(/[年月日]/);
+  });
+
+  it("preserves the exact en-SG output (English parity, with seconds)", () => {
+    // Snapshot of the en-SG output for this ISO — locks byte-identical
+    // English-mode rendering for the SkillCard call site. The shared
+    // formatter uses the same option set as the old local copies, so the
+    // English path is unchanged. (The day/month-name/digit separator is
+    // ICU-version-dependent; this literal matches the test runtime's ICU.)
+    expect(formatDateSGT(ISO, "en", { withSeconds: true })).toBe("25 May 2026, 11:43:42");
+  });
+
+  it("omits seconds when withSeconds is unset (default = false)", () => {
+    const out = formatDateSGT(ISO, "en");
+    expect(out).toBe("25 May 2026, 11:43");
+    // 43:42 seconds must not leak through the default no-seconds path.
+    expect(out).not.toMatch(/:\d{2}:\d{2}/);
+  });
+
+  it("honours the Asia/Singapore offset across the day boundary", () => {
+    // 17:00 UTC on the 24th is 01:00 on the 25th in SGT.
+    expect(formatDateSGT(ISO2, "en")).toMatch(/25 May 2026/);
+    expect(formatDateSGT(ISO2, "zh")).toMatch(/25日/);
   });
 });

--- a/ornn-web/src/utils/formatters.ts
+++ b/ornn-web/src/utils/formatters.ts
@@ -13,3 +13,18 @@ export function formatFileSize(bytes: number): string {
   const value = bytes / Math.pow(1024, i);
   return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 }
+
+/** Format an ISO date to an exact Asia/Singapore timestamp in the active UI locale (#752). */
+export function formatDateSGT(dateStr: string, lang?: string, opts?: { withSeconds?: boolean }): string {
+  const locale = lang === "zh" ? "zh-CN" : "en-SG"; // zh→zh-CN (NewsPage precedent); en→en-SG preserves current output
+  return new Date(dateStr).toLocaleString(locale, {
+    timeZone: "Asia/Singapore",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    ...(opts?.withSeconds ? { second: "2-digit" as const } : {}),
+    hour12: false,
+  });
+}


### PR DESCRIPTION
Closes #752

Automated change by `/auto` (run `20260608T080453Z-73436`, runner `auto-runner-20260608T080453Z-73436-16218-32737`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
