### PR TITLE
chore: promote verified bug-fix run (9 fixes) → develop

### DIFF
--- a/.changeset/fix-608-chat-completion-tool-calls.md
+++ b/.changeset/fix-608-chat-completion-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Chat-completion providers now surface structured `execute_in_sandbox` tool calls in the Playground. `parseChatCompletionStream` accumulates streamed `choices[].delta.tool_calls[]` fragments per index and flushes each completed call as a `response.output_item.done` function_call event (the shape the playground consumer reads); the non-streamed `complete()` path maps `message.tool_calls[]` the same way; and the chat-completion request body now sends `tool_choice: "auto"` whenever tools are supplied. Previously tool calls were silently dropped so the sandbox never ran for `apiFormat=chat-completion` providers (#608)

--- a/.changeset/fix-632-zipbomb-chokepoint.md
+++ b/.changeset/fix-632-zipbomb-chokepoint.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Server-side ZIP-bomb guards (cumulative/per-entry uncompressed caps, file-count, compression-ratio) are now enforced at the skill-ingestion chokepoint — covering both direct upload and the GitHub pull/refresh paths that previously bypassed the route-layer guard. Caps are env-overridable (#632)

--- a/.changeset/fix-750-version-write-guid.md
+++ b/.changeset/fix-750-version-write-guid.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Fix version delete/deprecation 404 when Skill Detail is opened by name: the GUID-only version-write routes now always receive the skill GUID on the wire while cache invalidation stays keyed on idOrName (#750)

--- a/.changeset/fix-751-bell-refetch-on-open.md
+++ b/.changeset/fix-751-bell-refetch-on-open.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Notification bell dropdown now refetches the list when opened, so a new broadcast reflected in the badge also appears in the list without a manual refresh (#751)

--- a/.changeset/fix-752-skill-timestamp-locale.md
+++ b/.changeset/fix-752-skill-timestamp-locale.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+skill timestamps (registry card, version list, detail page) now follow the active UI language — Chinese mode no longer shows English month names (#752)

--- a/.changeset/fix-757-redemption-code-randomint.md
+++ b/.changeset/fix-757-redemption-code-randomint.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Redemption-code generation now draws each character with crypto.randomInt for an unbiased uniform draw over the alphabet, clearing CodeQL js/biased-cryptographic-random (#757)

--- a/.changeset/fix-757-sdk-baseurl-redos.md
+++ b/.changeset/fix-757-sdk-baseurl-redos.md
@@ -1,0 +1,5 @@
+---
+"@chronoai/ornn-sdk": patch
+---
+
+TS SDK baseUrl normalization strips trailing slashes with a linear loop instead of a regex, removing a polynomial ReDoS vector on pathological all-slash inputs (#757)

--- a/.changeset/fix-766-abort-after-billable-charge.md
+++ b/.changeset/fix-766-abort-after-billable-charge.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Playground chat: a client abort (or error) after billable output now commits the reserved quota slot instead of refunding it, closing the abort-after-first-token free-usage path (#766)

--- a/.changeset/fix-940-delete-skill-cache-removal.md
+++ b/.changeset/fix-940-delete-skill-cache-removal.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Deleting a skill now removes its detail/versions cache (predicate covers name- and guid-keyed entries) so the page no longer refetches the deleted skill → 404 (#940)

--- a/.changeset/fix-941-delete-skill-sidebar-counts.md
+++ b/.changeset/fix-941-delete-skill-sidebar-counts.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Deleting a skill now also refreshes the My-Skills filter-sidebar facet + grants-summary counts so they stay consistent without a full-page refresh (#941)

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -88,8 +88,11 @@ Optional: `detail`, `errors[]`.
 | Code | HTTP | Meaning |
 |---|---|---|
 | `validation_error` | 400 | Body / query / path param validation failed — details in `errors[]` |
+| `invalid_zip` | 400 | Uploaded payload is not a parseable ZIP (malformed / unreadable) |
 | `unsupported_media_type` | 415 | Request `Content-Type` not accepted |
 | `payload_too_large` | 413 | Upload exceeds max size |
+| `uncompressed_too_large` | 413 | Uncompressed size or compression ratio of skill ZIP exceeds caps (zip-bomb guard) |
+| `too_many_files` | 413 | Skill ZIP entry count exceeds `MAX_PACKAGE_FILE_COUNT` |
 | `authentication_required` | 401 | No valid identity |
 | `permission_denied` | 403 | Authenticated but lacks required permission |
 | `resource_not_found` | 404 | Target resource does not exist or not visible to caller |

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -36,7 +36,7 @@ The pre-#585 `SCREAMING_SNAKE_CASE` shape (`SKILL_NOT_FOUND`, `INVALID_BODY`, �
 ## validation_error
 
 **HTTP:** `400 Bad Request`
-**Common subcodes (lowercase post-#585):** `invalid_body`, `invalid_query`, `invalid_params`, `invalid_*` (per-field), `empty_body`, `missing_*`, `frontmatter_validation_failed`, `invalid_permissions`, …
+**Common subcodes (lowercase post-#585):** `invalid_body`, `invalid_query`, `invalid_params`, `invalid_*` (per-field), `empty_body`, `missing_*`, `frontmatter_validation_failed`, `invalid_permissions`, `invalid_zip`, …
 
 Request body, query string, or path parameter failed validation. Per-field details are in `errors[]`.
 
@@ -58,6 +58,12 @@ Content-Type: application/problem+json
 ```
 
 **Client action:** fix the offending field(s) listed in `errors[]` and retry. Do not retry the same payload without changes.
+
+### invalid_zip
+
+The uploaded payload is not a parseable ZIP — a malformed or unreadable archive.
+
+**Client action:** re-create the ZIP and re-upload; do not retry the same bytes.
 
 ---
 
@@ -108,11 +114,23 @@ The request collides with current state — a duplicate skill name on create, a 
 ## payload_too_large
 
 **HTTP:** `413 Payload Too Large`
-**Common subcodes (lowercase post-#585):** `payload_too_large`
+**Common subcodes (lowercase post-#585):** `payload_too_large`, `uncompressed_too_large`, `too_many_files`
 
 The upload exceeds the per-endpoint size cap (currently 5 MB on `/skills` upload; see `ornn-api/src/middleware/uploadLimit.ts`).
 
 **Client action:** trim the payload (smaller ZIP, fewer attachments) or split into multiple requests where the endpoint supports it.
+
+### uncompressed_too_large
+
+The uploaded skill ZIP's cumulative or per-entry **uncompressed** size exceeds the server cap (`MAX_PACKAGE_UNCOMPRESSED_BYTES`, default 50 MiB / `MAX_ENTRY_UNCOMPRESSED_BYTES`, default 25 MiB), or its compression ratio exceeds `MAX_COMPRESSION_RATIO` (default 100×) — a zip-bomb guard.
+
+**Client action:** reduce the unpacked size of the archive contents; do not retry the same ZIP.
+
+### too_many_files
+
+The skill ZIP contains more entries than `MAX_PACKAGE_FILE_COUNT` (default 1000).
+
+**Client action:** prune unneeded files from the archive and re-upload.
 
 ---
 

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -470,6 +470,12 @@ export async function bootstrap(
       (await settingsService.getNyxid()).chronoStorageBucket,
     analyticsEmitter,
     agentsealScanner,
+    // Zip-bomb caps (#632) — env-driven, enforced at the ingestion
+    // chokepoint so upload + GitHub pull/refresh share the same limits.
+    maxPackageUncompressedBytes: config.maxPackageUncompressedBytes,
+    maxEntryUncompressedBytes: config.maxEntryUncompressedBytes,
+    maxPackageFileCount: config.maxPackageFileCount,
+    maxCompressionRatio: config.maxCompressionRatio,
   });
 
   // ---- Domain: Notifications + Broadcasts ----

--- a/ornn-api/src/clients/nyxid/llm.test.ts
+++ b/ornn-api/src/clients/nyxid/llm.test.ts
@@ -4,8 +4,10 @@
  * body, `chat-completion` hits `/chat/completions` with translated
  * body and normalizes text deltas back into Responses-API event shape.
  *
- * Tool-call delta normalization for chat-completion is out of scope here
- * (tracked in #608).
+ * #608: chat-completion tool-call normalization — streamed
+ * `delta.tool_calls[]` fragments accumulate into a single
+ * `response.output_item.done` function_call event, and the request body
+ * carries `tool_choice: "auto"` whenever tools are supplied.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -222,6 +224,206 @@ describe("NyxLlmClient.stream() routing on apiFormat", () => {
     ]);
   });
 
+  it("chat-completion sets tool_choice:auto when tools supplied", async () => {
+    fetchHandler = () => sseResponse([]);
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+      tools: [
+        {
+          type: "function",
+          name: "do_thing",
+          description: "does the thing",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    })) events.push(e);
+
+    expect((capturedRequests[0]!.body as Record<string, unknown>).tool_choice).toBe("auto");
+  });
+
+  it("chat-completion omits tool_choice when no tools supplied", async () => {
+    fetchHandler = () => sseResponse([]);
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "go" }],
+    })) events.push(e);
+
+    expect((capturedRequests[0]!.body as Record<string, unknown>).tool_choice).toBeUndefined();
+  });
+
+  it("chat-completion accumulates streamed tool_calls into one output_item.done", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_1",
+                    function: { name: "execute_in_sandbox", arguments: '{"sc' },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        JSON.stringify({
+          choices: [
+            { delta: { tool_calls: [{ index: 0, function: { arguments: 'ript":"x"}' } }] } },
+          ],
+        }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      ]);
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "run it" }],
+    })) events.push(e);
+
+    const itemDone = events.filter((e) => e.type === "response.output_item.done");
+    expect(itemDone).toHaveLength(1);
+    expect(itemDone[0]).toEqual({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "call_1",
+        call_id: "call_1",
+        name: "execute_in_sandbox",
+        arguments: '{"script":"x"}',
+      },
+    });
+  });
+
+  it("chat-completion still emits text deltas when interleaved with tool_calls", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({ choices: [{ delta: { content: "thinking " } }] }),
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_2",
+                    function: { name: "execute_in_sandbox", arguments: "{}" },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        JSON.stringify({ choices: [{ delta: { content: "more" } }] }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      ]);
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "run it" }],
+    })) events.push(e);
+
+    const textDeltas = events.filter((e) => e.type === "response.output_text.delta");
+    expect(textDeltas).toEqual([
+      { type: "response.output_text.delta", delta: "thinking " },
+      { type: "response.output_text.delta", delta: "more" },
+    ]);
+    const itemDone = events.filter((e) => e.type === "response.output_item.done");
+    expect(itemDone).toHaveLength(1);
+    expect((itemDone[0]!.item as { call_id: string }).call_id).toBe("call_2");
+  });
+
+  it("chat-completion flushes accumulated tool_calls on stream end without finish_reason", async () => {
+    fetchHandler = () =>
+      sseResponse([
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_3",
+                    function: { name: "execute_in_sandbox", arguments: '{"a":1}' },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      ]);
+
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+
+    const events: ResponsesApiStreamEvent[] = [];
+    for await (const e of client.stream({
+      model: "m",
+      input: [{ role: "user", content: "run it" }],
+    })) events.push(e);
+
+    const itemDone = events.filter((e) => e.type === "response.output_item.done");
+    expect(itemDone).toHaveLength(1);
+    expect(itemDone[0]).toEqual({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "call_3",
+        call_id: "call_3",
+        name: "execute_in_sandbox",
+        arguments: '{"a":1}',
+      },
+    });
+  });
+
   it("flattens Responses-API content parts into a string for chat-completion", async () => {
     fetchHandler = () => sseResponse([]);
     const client = new NyxLlmClient({
@@ -398,5 +600,47 @@ describe("NyxLlmClient.complete() routing on apiFormat", () => {
       input: [{ role: "user", content: "say nothing" }],
     });
     expect(out).toEqual([]);
+  });
+
+  it("chat-completion maps message.tool_calls to function_call outputs", async () => {
+    fetchHandler = () =>
+      jsonResponse({
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "calling tool",
+              tool_calls: [
+                {
+                  id: "call_9",
+                  function: { name: "execute_in_sandbox", arguments: '{"script":"x"}' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+    const client = new NyxLlmClient({
+      resolver: makeResolver({
+        gatewayUrl: "https://api.example.com",
+        apiKey: "sk-x",
+        apiFormat: "chat-completion",
+      }),
+      saTokenProvider: STUB_SA_TOKEN,
+    });
+    const out = await client.complete({
+      model: "m",
+      input: [{ role: "user", content: "run it" }],
+    });
+    expect(out).toEqual([
+      { type: "message", content: [{ type: "output_text", text: "calling tool" }] },
+      {
+        type: "function_call",
+        id: "call_9",
+        call_id: "call_9",
+        name: "execute_in_sandbox",
+        arguments: '{"script":"x"}',
+      },
+    ]);
   });
 });

--- a/ornn-api/src/clients/nyxid/llm.ts
+++ b/ornn-api/src/clients/nyxid/llm.ts
@@ -14,8 +14,10 @@
  * the way in, so consumers (skill generation + playground) do not need
  * to branch on apiFormat (#574).
  *
- * Tool-call delta normalization for chat-completion is intentionally
- * out of scope here — tracked in #608.
+ * Chat-completion tool-call normalization is implemented: streamed
+ * `choices[].delta.tool_calls[]` fragments are accumulated and flushed
+ * as `response.output_item.done` function_call events, and non-streamed
+ * `choices[].message.tool_calls[]` map to `function_call` outputs (#608).
  *
  * Authenticates using a Service Account (SA) token obtained via
  * client_credentials grant when the resolved provider has no direct
@@ -186,21 +188,56 @@ async function* parseResponsesStream(
 }
 
 /**
- * Parse Chat Completions SSE and translate text deltas into
- * Responses-API event shape so consumers stay format-agnostic.
+ * Parse Chat Completions SSE and translate both text deltas and
+ * tool-call deltas into Responses-API event shape so consumers stay
+ * format-agnostic.
  *
- * For #574, only text deltas (`choices[].delta.content`) are
- * translated — emitted as `response.output_text.delta`. Tool-call
- * delta normalization is tracked in #608.
+ * Text deltas (`choices[].delta.content`) pass through as
+ * `response.output_text.delta`. Tool-call fragments
+ * (`choices[].delta.tool_calls[]`) arrive incrementally — `id`/`name`
+ * land on the first fragment, `function.arguments` streams across many
+ * — so we accumulate per `index` and flush each completed call as a
+ * single `response.output_item.done` function_call event (matching the
+ * Responses-API shape the playground consumer reads). We never parse the
+ * arguments mid-stream; the consumer parses the assembled JSON (#608).
  */
 async function* parseChatCompletionStream(
   response: Response,
 ): AsyncIterable<ResponsesApiStreamEvent> {
+  const toolCalls = new Map<number, { id: string; name: string; argsBuffer: string }>();
+  let flushed = false;
+
+  function* flush(): Generator<ResponsesApiStreamEvent> {
+    if (flushed) return;
+    flushed = true;
+    for (const index of [...toolCalls.keys()].sort((a, b) => a - b)) {
+      const call = toolCalls.get(index)!;
+      yield {
+        type: "response.output_item.done",
+        item: {
+          type: "function_call",
+          id: call.id,
+          call_id: call.id,
+          name: call.name,
+          arguments: call.argsBuffer,
+        },
+      };
+    }
+  }
+
   for await (const { data } of parseSSELines(response)) {
-    if (data === "[DONE]") return;
+    if (data === "[DONE]") break;
     let chunk: {
       choices?: Array<{
-        delta?: { content?: string | null };
+        delta?: {
+          content?: string | null;
+          tool_calls?: Array<{
+            index: number;
+            id?: string;
+            function?: { name?: string; arguments?: string };
+          }>;
+        };
+        finish_reason?: string;
       }>;
     };
     try {
@@ -209,10 +246,35 @@ async function* parseChatCompletionStream(
       logger.debug({ data: data.slice(0, 100) }, "Failed to parse chat-completion chunk");
       continue;
     }
-    const delta = chunk.choices?.[0]?.delta?.content;
-    if (typeof delta === "string" && delta.length > 0) {
-      yield { type: "response.output_text.delta", delta };
+
+    const choice = chunk.choices?.[0];
+    const textDelta = choice?.delta?.content;
+    if (typeof textDelta === "string" && textDelta.length > 0) {
+      yield { type: "response.output_text.delta", delta: textDelta };
     }
+
+    const fragments = choice?.delta?.tool_calls;
+    if (fragments) {
+      for (const frag of fragments) {
+        const existing = toolCalls.get(frag.index) ?? { id: "", name: "", argsBuffer: "" };
+        if (frag.id) existing.id = frag.id;
+        if (frag.function?.name) existing.name = frag.function.name;
+        if (typeof frag.function?.arguments === "string") {
+          existing.argsBuffer += frag.function.arguments;
+        }
+        toolCalls.set(frag.index, existing);
+      }
+    }
+
+    if (choice?.finish_reason === "tool_calls") {
+      yield* flush();
+    }
+  }
+
+  // Flush on stream end / [DONE] in case the upstream omitted the
+  // `finish_reason: "tool_calls"` chunk but still streamed tool calls.
+  if (toolCalls.size > 0) {
+    yield* flush();
   }
 }
 
@@ -268,6 +330,7 @@ function buildChatCompletionBody(
         parameters: t.parameters,
       },
     }));
+    body.tool_choice = "auto";
   }
   return body;
 }
@@ -443,12 +506,37 @@ export class NyxLlmClient {
 
     if (apiFormat === "chat-completion") {
       const result = (await response.json()) as {
-        choices?: Array<{ message?: { content?: string | null } }>;
+        choices?: Array<{
+          message?: {
+            content?: string | null;
+            tool_calls?: Array<{
+              id?: string;
+              function?: { name?: string; arguments?: string };
+            }>;
+          };
+        }>;
       };
-      const text = result.choices?.[0]?.message?.content ?? "";
-      return text
-        ? [{ type: "message", content: [{ type: "output_text", text }] }]
-        : [];
+      const message = result.choices?.[0]?.message;
+      const outputs: ResponsesApiOutput[] = [];
+
+      const text = message?.content ?? "";
+      if (text) {
+        outputs.push({ type: "message", content: [{ type: "output_text", text }] });
+      }
+
+      for (const call of message?.tool_calls ?? []) {
+        const id = call.id ?? "";
+        const fnCall: ResponsesApiOutput = {
+          type: "function_call",
+          id,
+          call_id: id,
+          name: call.function?.name ?? "",
+          arguments: call.function?.arguments ?? "",
+        };
+        outputs.push(fnCall);
+      }
+
+      return outputs;
     }
 
     const result = (await response.json()) as { output: ResponsesApiOutput[] };

--- a/ornn-api/src/domains/playground/routes.test.ts
+++ b/ornn-api/src/domains/playground/routes.test.ts
@@ -1,23 +1,48 @@
 /**
- * Route-level wiring test for the playground chat rate limit (#809).
+ * Route-level tests for the playground chat routes.
  *
- * Pins that `POST /playground/chat` carries the per-user 20/min limiter
- * (same cap + class as `/skills/generate`). The limiter's own behaviour
- * (RFC 9239 headers, per-user keying, window reset) is owned by
- * `middleware/rateLimit.test.ts` — this test only asserts the limiter is
- * mounted on this route, ahead of `validateBody`, so the 21st request
- * 429s before Zod and before any LLM cost.
+ * Two concerns live here:
+ *
+ *  1. Rate limit (#809) — pins that `POST /playground/chat` carries the
+ *     per-user 20/min limiter (same cap + class as `/skills/generate`).
+ *     The limiter's own behaviour (RFC 9239 headers, per-user keying,
+ *     window reset) is owned by `middleware/rateLimit.test.ts`; this test
+ *     only asserts the limiter is mounted ahead of `validateBody`.
+ *
+ *  2. Abort-after-billable charging (#766) — the reserve-then-reconcile
+ *     quota system (#808) reserves a slot in `checkAllowed` and commits
+ *     (success/skill_error) or releases (system_error) in the producer's
+ *     `finally`. A client abort yields `finish:"abort"`, which is NOT a
+ *     success/skill_error flip, so without #766 the slot was RELEASED even
+ *     though the LLM already billed for the streamed tokens — free usage.
+ *     The fix marks the run billable on the first non-empty text delta /
+ *     tool event and, in `finally`, upgrades a leftover `system_error` to
+ *     `skill_error` (commit) so the abused refund path is closed.
+ *
+ * Harness: the route returns the SSE `Response` synchronously while a
+ * background producer pumps `chatService.chat(...)` into the writer and
+ * charges in its `finally`. Draining the body via `res.text()` runs the
+ * producer to completion; the charge is awaited before the writer fully
+ * closes, so the captured `chargeOnCompletion` args are observable right
+ * after the drain (a microtask flush is added as a belt-and-braces guard).
  *
  * @module domains/playground/routes.test
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Hono } from "hono";
 import { AppError, buildProblemJsonBody } from "../../shared/types/index";
+import type { PlaygroundChatEvent } from "../../shared/types/index";
 import { __resetRateLimitForTests } from "../../middleware/rateLimit";
 import { createPlaygroundRoutes, type PlaygroundRoutesConfig } from "./routes";
+import type { ChargeOutcome } from "../quota/types";
+import type { ModelResolution } from "../settings/llmProviders/service";
 
-function makeApp() {
+// ---------------------------------------------------------------------------
+// Rate-limit wiring test (#809)
+// ---------------------------------------------------------------------------
+
+function makeRateLimitApp() {
   const app = new Hono();
   // Upstream auth stub. `nyxidAuthMiddleware` + `requirePermission` only
   // READ `c.get("auth")`; the real middleware never overwrites it, so this
@@ -58,7 +83,7 @@ describe("POST /playground/chat rate limit (#809)", () => {
   beforeEach(() => __resetRateLimitForTests());
 
   test("429s the 21st per-user request before validateBody", async () => {
-    const app = makeApp();
+    const app = makeRateLimitApp();
     const req = () =>
       app.request("/playground/chat", {
         method: "POST",
@@ -81,5 +106,312 @@ describe("POST /playground/chat rate limit (#809)", () => {
     expect(denied.headers.get("Retry-After")).not.toBeNull();
     const body = (await denied.json()) as { code: string };
     expect(body.code).toBe("rate_limited");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Abort-after-billable charging (#766)
+// ---------------------------------------------------------------------------
+
+const USER_ID = "user-1";
+const USE_PERM = "ornn:playground:use";
+const MODEL_ID = "resolved-model";
+
+// ---- Event frame helpers (PlaygroundChatEvent shapes) ----------------
+
+function textDelta(delta: string): PlaygroundChatEvent {
+  return { type: "text-delta", delta };
+}
+function toolCall(): PlaygroundChatEvent {
+  return { type: "tool-call", toolCall: { id: "tc-1", name: "load_skill", args: {} } };
+}
+function toolResult(): PlaygroundChatEvent {
+  return { type: "tool-result", toolCallId: "tc-1", result: "ok" };
+}
+function fileOutput(): PlaygroundChatEvent {
+  return {
+    type: "file-output",
+    file: { path: "out.png", content: "data", size: 4, mimeType: "image/png" },
+  };
+}
+function errorEvent(message: string): PlaygroundChatEvent {
+  return { type: "error", message };
+}
+function finish(reason: string): PlaygroundChatEvent {
+  return { type: "finish", finishReason: reason };
+}
+
+// ---- Fakes -----------------------------------------------------------
+
+interface ChargeCall {
+  userId: string;
+  permissions: readonly string[] | undefined;
+  surface: string;
+  outcome: ChargeOutcome;
+  modelId: string | null | undefined;
+  now: Date;
+}
+
+class FakeChatService {
+  /** Frames the `chat()` generator yields, in order. */
+  frames: PlaygroundChatEvent[] = [];
+  chatCalls = 0;
+
+  constructor(frames: PlaygroundChatEvent[]) {
+    this.frames = frames;
+  }
+
+  // Mirrors the real signature: chat(userId, request, signal, options).
+  async *chat(): AsyncGenerator<PlaygroundChatEvent> {
+    this.chatCalls += 1;
+    for (const f of this.frames) yield f;
+  }
+}
+
+class FakeQuotaService {
+  allowed = true;
+  checkAllowedCalls = 0;
+  charges: ChargeCall[] = [];
+
+  async checkAllowed(input: {
+    userId: string;
+    permissions: readonly string[] | undefined;
+    surface: string;
+    now: Date;
+  }): Promise<
+    | { allowed: true; isAdminBypass: boolean }
+    | { allowed: false; isAdminBypass: false; surface: "playground"; message: string }
+  > {
+    this.checkAllowedCalls += 1;
+    void input;
+    if (this.allowed) return { allowed: true, isAdminBypass: false };
+    return {
+      allowed: false,
+      isAdminBypass: false,
+      surface: "playground",
+      message: "Monthly playground quota exhausted",
+    };
+  }
+
+  async chargeOnCompletion(input: {
+    userId: string;
+    permissions: readonly string[] | undefined;
+    surface: string;
+    outcome: ChargeOutcome;
+    modelId?: string | null;
+    now?: Date;
+  }): Promise<void> {
+    this.charges.push({
+      userId: input.userId,
+      permissions: input.permissions,
+      surface: input.surface,
+      outcome: input.outcome,
+      modelId: input.modelId,
+      now: input.now ?? new Date(0),
+    });
+  }
+}
+
+class FakeLlmProvidersService {
+  resolution: ModelResolution = {
+    kind: "ok",
+    modelId: MODEL_ID,
+    displayName: "Resolved Model",
+    providerId: "prov-1",
+  };
+
+  async resolveModel(): Promise<ModelResolution> {
+    return this.resolution;
+  }
+}
+
+// ---- App builder -----------------------------------------------------
+
+function buildChatApp(
+  frames: PlaygroundChatEvent[],
+  opts: { permissions?: string[] } = {},
+): { app: Hono; quota: FakeQuotaService; chat: FakeChatService } {
+  const { permissions = [USE_PERM] } = opts;
+  const chat = new FakeChatService(frames);
+  const quota = new FakeQuotaService();
+  const llmProvidersService = new FakeLlmProvidersService();
+
+  const config = {
+    chatService: chat,
+    quotaService: quota,
+    llmProvidersService,
+    keepAliveIntervalMsResolver: async () => 15_000,
+  } as unknown as PlaygroundRoutesConfig;
+
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("auth" as never, { userId: USER_ID, permissions } as never);
+    await next();
+  });
+  app.route("/", createPlaygroundRoutes(config));
+  app.onError((err, c) => {
+    if (err instanceof AppError) {
+      const body = buildProblemJsonBody({
+        statusCode: err.statusCode,
+        code: err.code,
+        message: err.message,
+        instance: c.req.path,
+        requestId: null,
+      });
+      return c.json(body, err.statusCode as never, {
+        "Content-Type": "application/problem+json",
+      });
+    }
+    return c.json({ error: { code: "internal_error", message: String(err) } }, 500);
+  });
+
+  return { app, quota, chat };
+}
+
+/** Yield the event loop a few turns so the producer's post-close charge
+ *  microtasks settle before assertions, independent of body-drain timing. */
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+/** Drive the route + drain the SSE body so the background producer runs
+ *  its `finally` (which charges) to completion. */
+async function runChat(app: Hono): Promise<void> {
+  const res = await app.request("/playground/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+  });
+  expect(res.status).toBe(200);
+  await res.text(); // drain — runs the producer to completion
+  await flushAsync();
+}
+
+describe("POST /playground/chat abort-after-billable charging (#766)", () => {
+  beforeEach(() => __resetRateLimitForTests());
+  afterEach(() => __resetRateLimitForTests());
+
+  // -- Criterion 1: billable output then abort → COMMIT (skill_error) --
+
+  test("non-empty text-delta then finish:abort charges skill_error (commit)", async () => {
+    const { app, quota, chat } = buildChatApp([
+      textDelta("partial answer"),
+      finish("abort"),
+    ]);
+    await runChat(app);
+
+    expect(chat.chatCalls).toBe(1);
+    expect(quota.checkAllowedCalls).toBe(1);
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("skill_error");
+    expect(quota.charges[0]!.modelId).toBe(MODEL_ID);
+    expect(quota.charges[0]!.userId).toBe(USER_ID);
+    expect(quota.charges[0]!.permissions).toEqual([USE_PERM]);
+  });
+
+  test("tool-result then finish:abort charges skill_error (commit)", async () => {
+    // tool-result already flips outcome to skill_error directly; the abort
+    // doesn't undo it. This pins that a tool-side abort still commits.
+    const { app, quota } = buildChatApp([toolResult(), finish("abort")]);
+    await runChat(app);
+
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("skill_error");
+  });
+
+  test("tool-call then finish:abort charges skill_error (commit)", async () => {
+    // A tool-call (no tool-result) leaves outcome at system_error, but the
+    // run is billable — #766 upgrades it to skill_error on abort.
+    const { app, quota } = buildChatApp([toolCall(), finish("abort")]);
+    await runChat(app);
+
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("skill_error");
+  });
+
+  test("file-output then finish:abort charges skill_error (commit)", async () => {
+    const { app, quota } = buildChatApp([fileOutput(), finish("abort")]);
+    await runChat(app);
+
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("skill_error");
+  });
+
+  // -- Criterion 2: no billable output then error/abort → RELEASE --
+
+  test("error + finish:error with no billable event charges system_error (release)", async () => {
+    const { app, quota } = buildChatApp([
+      errorEvent("LLM gateway 502"),
+      finish("error"),
+    ]);
+    await runChat(app);
+
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("system_error");
+  });
+
+  test("error + finish:abort with no prior delta still charges system_error (release)", async () => {
+    const { app, quota } = buildChatApp([
+      errorEvent("Request aborted"),
+      finish("abort"),
+    ]);
+    await runChat(app);
+
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("system_error");
+  });
+
+  // -- Criterion 3: clean completion → SUCCESS --
+
+  test("text-delta then finish:stop charges success", async () => {
+    const { app, quota } = buildChatApp([
+      textDelta("full answer"),
+      finish("stop"),
+    ]);
+    await runChat(app);
+
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("success");
+  });
+
+  test("tool-call → tool-result → text-delta → finish:stop charges success (success wins)", async () => {
+    // tool-result flips to skill_error mid-stream; a clean finish:stop must
+    // override it. success > interim skill_error.
+    const { app, quota } = buildChatApp([
+      toolCall(),
+      toolResult(),
+      textDelta("done"),
+      finish("stop"),
+    ]);
+    await runChat(app);
+
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("success");
+  });
+
+  // -- Empty-stream guard: empty delta then abort → still release --
+
+  test("single empty-string text-delta then finish:abort holds at system_error (release)", async () => {
+    // An empty text-delta is a no-op flush, not billable output; the slot
+    // must still be refunded on abort.
+    const { app, quota } = buildChatApp([textDelta(""), finish("abort")]);
+    await runChat(app);
+
+    expect(quota.charges).toHaveLength(1);
+    expect(quota.charges[0]!.outcome).toBe("system_error");
+  });
+
+  // -- Exactly-once: one charge + one reserve per request --
+
+  test("charges exactly once and reserves exactly once per request", async () => {
+    const { app, quota } = buildChatApp([
+      textDelta("x"),
+      finish("stop"),
+    ]);
+    await runChat(app);
+
+    expect(quota.checkAllowedCalls).toBe(1);
+    expect(quota.charges).toHaveLength(1);
   });
 });

--- a/ornn-api/src/domains/playground/routes.ts
+++ b/ornn-api/src/domains/playground/routes.ts
@@ -183,6 +183,14 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
       // safe fallback — only flips to `success` if the stream
       // completes cleanly.
       let outcome: ChargeOutcome = "system_error";
+      // Tracks whether the provider produced any genuinely billable
+      // output before the run terminated (#766). The LLM bills for
+      // tokens the moment they stream, so a client abort (or any error)
+      // AFTER billable output must NOT refund the reserved slot —
+      // otherwise an abort-after-first-token loop yields free usage.
+      // Flipped true on the first non-empty text delta / tool event in
+      // the consume loop; consulted once in `finally` before charging.
+      let chargeableStarted = false;
 
       const encoder = new TextEncoder();
       const signal = c.req.raw.signal;
@@ -262,6 +270,21 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
             actor,
           })) {
             await writeEvent(event);
+            // #766 — mark the run billable on the first event that
+            // represents real provider output. A non-empty text delta
+            // means tokens were streamed (and billed); tool-call /
+            // tool-result / file-output mean the skill side actually
+            // ran. An empty text-delta is a no-op flush and stays
+            // refundable. Consulted in `finally` so an abort/error AFTER
+            // this point commits the slot instead of refunding it.
+            if (
+              (event.type === "text-delta" && event.delta.length > 0) ||
+              event.type === "tool-call" ||
+              event.type === "tool-result" ||
+              event.type === "file-output"
+            ) {
+              chargeableStarted = true;
+            }
             if (event.type === "tool-result") outcome = "skill_error";
             if (event.type === "finish") {
               const reason = (event as { finishReason?: string }).finishReason;
@@ -276,6 +299,13 @@ export function createPlaygroundRoutes(config: PlaygroundRoutesConfig): Hono<{ V
           signal.removeEventListener("abort", onAbort);
           clearInterval(keepAlive);
           await closeOnce();
+          if (chargeableStarted && outcome === "system_error") {
+            // Provider already produced billable output before the run
+            // aborted/errored; commit the reserved slot instead of
+            // refunding it (#766). The LLM bill is already incurred —
+            // a refund here would hand out free usage on abort-after-token.
+            outcome = "skill_error";
+          }
           await quotaService
             .chargeOnCompletion({
               userId: authCtx.userId,

--- a/ornn-api/src/domains/redemption-codes/service.test.ts
+++ b/ornn-api/src/domains/redemption-codes/service.test.ts
@@ -81,6 +81,35 @@ describe("RedemptionCodeService.mint", () => {
     expect(doc.createdBy).toEqual(ADMIN);
   });
 
+  // Codes are generated char-by-char with crypto.randomInt, which
+  // rejection-samples to a uniform index over the alphabet — no modulo
+  // bias (clears CodeQL js/biased-cryptographic-random, #757). We can't
+  // assert a flake-free statistical distribution, but over a large
+  // sample every char must be in-alphabet AND the observed glyphs must
+  // span almost the whole 31-char alphabet (a `% 256`-style truncation
+  // bug would still pass charset but a stuck/biased generator would
+  // collapse the distinct-glyph count).
+  test("draws code chars uniformly across the full alphabet", async () => {
+    const alphabet = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+    const charRe = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]$/;
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      const doc = await service.mint({
+        admin: ADMIN,
+        grants: [{ surface: "playground", amount: 1 }],
+        expiresAt: plusDays(7),
+      });
+      for (const ch of doc.code) {
+        expect(charRe.test(ch)).toBe(true);
+        seen.add(ch);
+      }
+    }
+    // 200 codes × 16 chars = 3200 draws over 31 glyphs; seeing < 28
+    // distinct would imply a badly skewed generator, not sampling noise.
+    expect(seen.size).toBeGreaterThanOrEqual(28);
+    expect(alphabet.length).toBe(31);
+  });
+
   test("rejects duplicate surface in grants", async () => {
     await expect(
       service.mint({

--- a/ornn-api/src/domains/redemption-codes/service.ts
+++ b/ornn-api/src/domains/redemption-codes/service.ts
@@ -16,7 +16,7 @@
  * @module domains/redemption-codes/service
  */
 
-import { randomBytes } from "node:crypto";
+import { randomInt } from "node:crypto";
 import { ObjectId } from "mongodb";
 import { createLogger } from "../../shared/logger";
 import { isDuplicateKeyError } from "../../shared/types/index";
@@ -112,19 +112,19 @@ export class RedemptionCodeService {
   }
 
   /**
-   * Generate one candidate code. The `% alphabet.length` step
-   * introduces a sub-1.5% modulo bias (256 % 31), which is harmless
-   * for human-shareable IDs since the unique index + retry loop
-   * absorbs collisions regardless.
+   * Generate one candidate code. Each character is drawn with
+   * `crypto.randomInt(alphabet.length)`, which rejection-samples
+   * internally to yield a uniform index over `[0, length)` — no modulo
+   * bias. The unique index + mint retry loop still absorbs the (now
+   * purely birthday-paradox) chance of a collision.
    */
   private generateCode(): string {
-    const bytes = randomBytes(REDEMPTION_CODE_LENGTH);
     let out = "";
     for (let i = 0; i < REDEMPTION_CODE_LENGTH; i++) {
-      // `randomBytes(N)` returns exactly N bytes — loop bound is N, so
-      // `bytes[i]` is always defined. `!` is safe under
-      // noUncheckedIndexedAccess (#450).
-      out += REDEMPTION_CODE_ALPHABET[bytes[i]! % REDEMPTION_CODE_ALPHABET.length];
+      // `randomInt(length)` returns an integer in `[0, length)`, so the
+      // index is always in-bounds; the `?? ""` satisfies
+      // noUncheckedIndexedAccess (#450) without a non-null assertion.
+      out += REDEMPTION_CODE_ALPHABET[randomInt(REDEMPTION_CODE_ALPHABET.length)] ?? "";
     }
     return out;
   }

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -26,7 +26,6 @@ import { validateBody, getValidatedBody } from "../../../middleware/validate";
 import { AppError } from "../../../shared/types/index";
 import { canReadSkill, canManageSkill, buildActorContext } from "./authorize";
 import { parseGithubUrl } from "./utils/githubPull";
-import { enforceZipLimits } from "../../../shared/utils/zipLimits";
 import { rateLimit } from "../../../middleware/rateLimit";
 import { createLogger } from "../../../shared/logger";
 const deprecationPatchSchema = z.object({
@@ -282,12 +281,11 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const zipBuffer = new Uint8Array(body);
 
-      // Zip-bomb defense (#633). Walks the central directory without
-      // extracting; throws 413 (`uncompressed_too_large` / `too_many_files`
-      // / `invalid_zip`) before validateZipFormat / storage upload /
-      // AgentSeal subprocess. Cheap, runs ahead of every expensive
-      // side-effect.
-      await enforceZipLimits(zipBuffer);
+      // Zip-bomb defense (#632/#633) now runs at the service ingestion
+      // chokepoint (`createSkill`), so it also covers the GitHub pull
+      // path that bypasses this route. The cheap compressed-size early-out
+      // above (`body.byteLength > maxFileSize`) stays here to reject
+      // oversized payloads before we even allocate the buffer.
 
       const userEmail = authCtx.email || undefined;
       const userDisplayName = authCtx.displayName || undefined;
@@ -993,12 +991,10 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         throw AppError.badRequest("no_update", "No update data provided. Send a ZIP file and/or isPrivate field.");
       }
 
-      // Zip-bomb defense (#633) — same gate as the create path. Only
-      // when a ZIP is actually being replaced; a privacy-only PUT
-      // doesn't hit this.
-      if (zipBuffer !== undefined) {
-        await enforceZipLimits(zipBuffer);
-      }
+      // Zip-bomb defense (#632/#633) now runs at the service chokepoint
+      // (`updateSkill`, only when a ZIP is actually being replaced), so it
+      // also covers the GitHub refresh path that bypasses this route. The
+      // cheap compressed-size early-out above stays here.
 
       logger.info({ guid, userId: authCtx.userId }, "Skill update via API");
       const result = await skillService.updateSkill(guid, authCtx.userId, {

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -1126,6 +1126,100 @@ describe("SkillService.setSkillSource / refresh / preview (globalThis.fetch swap
   });
 });
 
+// ======================================================================
+// #632 — zip-bomb guard is enforced at the SkillService ingestion
+// chokepoint (`createSkill` / `updateSkill`), NOT only at the route
+// layer. The GitHub pull path (`createSkillFromGitHub` → `createSkill`)
+// and refresh path (`refreshSkillFromSource` → `updateSkill`) used to
+// bypass the route-layer guard entirely. These seam-lock tests prove
+// the bypass is closed by hammering the service methods directly.
+//
+// The guard is a DoS defense, not format validation, so it MUST fire
+// even when `skipValidation: true` (the "import as-is" toggle). The
+// tests assert exactly that — skipValidation does NOT disarm the guard.
+//
+// A >1000-entry ZIP trips `too_many_files` against the baked-in default
+// file-count cap (the fake deps pass no caps, so defaults apply). Tiny
+// entries keep the fixture fast and deterministic — no multi-MiB
+// allocation needed to exercise the seam.
+// ======================================================================
+
+/** Build a ZIP whose entry count exceeds the default 1000-file cap. */
+async function buildTooManyFilesZip(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  const folder = zip.folder("demo-skill")!;
+  folder.file("SKILL.md", "---\nname: demo-skill\n---\nbody");
+  for (let i = 0; i < 1001; i++) {
+    folder.file(`assets/f${i}.txt`, `c${i}`);
+  }
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+describe("SkillService zip-bomb chokepoint (#632)", () => {
+  it("createSkill throws 413 too_many_files even with skipValidation=true", async () => {
+    const { deps, state } = makeFakeDeps();
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.createSkill(await buildTooManyFilesZip(), "owner-1", {
+        skipValidation: true,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(413);
+    expect((thrown as AppError).code).toBe("too_many_files");
+    // Guard fires BEFORE storage upload — nothing was persisted.
+    expect(state.uploads).toHaveLength(0);
+    expect(state.versions).toHaveLength(0);
+  });
+
+  it("updateSkill (refresh seam) throws 413 too_many_files even with skipValidation=true", async () => {
+    const skill = makeSkillDoc({ guid: "guid-1", isPrivate: false, latestVersion: "1.0" });
+    const { deps, state } = makeFakeDeps({
+      skills: new Map([["guid-1", skill]]),
+      byName: new Map([["demo-skill", skill]]),
+      versions: [versionDoc({ version: "1.0", majorVersion: 1, minorVersion: 0 })],
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.updateSkill("guid-1", "owner-1", {
+        zipBuffer: await buildTooManyFilesZip(),
+        skipValidation: true,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(413);
+    expect((thrown as AppError).code).toBe("too_many_files");
+    // No new version blob uploaded — the guard short-circuited the seam.
+    expect(state.uploads).toHaveLength(0);
+  });
+
+  it("env-driven caps override the defaults at the chokepoint", async () => {
+    // Wire a tight 5-file cap through the deps (mirrors what bootstrap
+    // threads from config). A 6-entry ZIP that would pass the default
+    // 1000-file cap now trips — proving the deps are honored.
+    const { deps } = makeFakeDeps();
+    const service = new SkillService({ ...deps, maxPackageFileCount: 5 });
+    const zip = new JSZip();
+    const folder = zip.folder("demo-skill")!;
+    folder.file("SKILL.md", "---\nname: demo-skill\n---\nbody");
+    for (let i = 0; i < 6; i++) folder.file(`assets/f${i}.txt`, `c${i}`);
+    let thrown: unknown;
+    try {
+      await service.createSkill(await zip.generateAsync({ type: "uint8array" }), "owner-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as AppError).code).toBe("too_many_files");
+    expect((thrown as AppError).message).toContain("limit is 5");
+  });
+});
+
 describe("SkillService.validateZipFormat", () => {
   it("flags a non-ZIP buffer", async () => {
     const { deps } = makeFakeDeps();

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -36,6 +36,7 @@ import {
   SKILL_NAME_MAX,
 } from "../../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../../shared/utils/zip";
+import { enforceZipLimits, type ZipLimitsConfig } from "../../../shared/utils/zipLimits";
 import { parseVersion, isGreater } from "./version";
 import { diffSkillInterface, type InterfaceChange } from "./interfaceDiff";
 import type { AnalyticsEmitter } from "../../../infra/analytics";
@@ -127,6 +128,17 @@ export interface SkillServiceDeps {
    * never block the publish path.
    */
   agentsealScanner?: IAgentSealScanner;
+
+  // ---- Zip-bomb defense caps (#632) — env-overridable. ----
+  // Threaded down from `loadConfig()` so the ingestion chokepoint
+  // (`createSkill` / `updateSkill`, which every upload + GitHub
+  // pull/refresh funnels through) enforces the same caps the route layer
+  // used to. All optional (exactOptionalPropertyTypes): when omitted the
+  // guard falls back to the baked-in defaults in `zipLimits.ts`.
+  maxPackageUncompressedBytes?: number;
+  maxEntryUncompressedBytes?: number;
+  maxPackageFileCount?: number;
+  maxCompressionRatio?: number;
 }
 
 export class SkillService {
@@ -137,6 +149,11 @@ export class SkillService {
   // exactOptionalPropertyTypes (#657): widen to `T | undefined`.
   private readonly analyticsEmitter: AnalyticsEmitter | undefined;
   private readonly agentsealScanner: IAgentSealScanner | undefined;
+  // Zip-bomb caps (#632) — undefined means "use zipLimits.ts defaults".
+  private readonly maxPackageUncompressedBytes: number | undefined;
+  private readonly maxEntryUncompressedBytes: number | undefined;
+  private readonly maxPackageFileCount: number | undefined;
+  private readonly maxCompressionRatio: number | undefined;
 
   constructor(deps: SkillServiceDeps) {
     this.skillRepo = deps.skillRepo;
@@ -145,6 +162,50 @@ export class SkillService {
     this.storageBucketResolver = deps.storageBucketResolver;
     this.analyticsEmitter = deps.analyticsEmitter;
     this.agentsealScanner = deps.agentsealScanner;
+    this.maxPackageUncompressedBytes = deps.maxPackageUncompressedBytes;
+    this.maxEntryUncompressedBytes = deps.maxEntryUncompressedBytes;
+    this.maxPackageFileCount = deps.maxPackageFileCount;
+    this.maxCompressionRatio = deps.maxCompressionRatio;
+  }
+
+  /**
+   * Map the configured caps onto the `ZipLimitsConfig` shape consumed by
+   * `enforceZipLimits`. Any cap left undefined falls through to the
+   * baked-in default inside `zipLimits.ts` (50 MiB / 25 MiB / 1000 / 100×).
+   *
+   * exactOptionalPropertyTypes (#657): build the object conditionally so
+   * we never assign `undefined` to an optional field — `enforceZipLimits`
+   * already `?? DEFAULT`s any missing key.
+   */
+  private zipLimitsConfig(): ZipLimitsConfig {
+    const cfg: ZipLimitsConfig = {};
+    if (this.maxPackageUncompressedBytes !== undefined) {
+      cfg.maxTotalUncompressedBytes = this.maxPackageUncompressedBytes;
+    }
+    if (this.maxEntryUncompressedBytes !== undefined) {
+      cfg.maxEntryUncompressedBytes = this.maxEntryUncompressedBytes;
+    }
+    if (this.maxPackageFileCount !== undefined) {
+      cfg.maxFileCount = this.maxPackageFileCount;
+    }
+    if (this.maxCompressionRatio !== undefined) {
+      cfg.maxCompressionRatio = this.maxCompressionRatio;
+    }
+    return cfg;
+  }
+
+  /**
+   * Public zip-bomb guard for standalone read paths that don't flow
+   * through `createSkill`/`updateSkill` — today only the
+   * `POST /skill-format/validate` endpoint, which parses a ZIP without
+   * persisting it. Delegates to {@link enforceZipLimits} with the same
+   * env-driven caps the ingestion chokepoint uses, so the validate path
+   * can't be slowed down by a pathological ZIP that the publish path
+   * would reject. Throws `AppError.payloadTooLarge` (413) on any
+   * violation; `invalid_zip` (400) on an unparseable buffer.
+   */
+  async enforceZipLimits(zipBuffer: Uint8Array): Promise<void> {
+    await enforceZipLimits(zipBuffer, this.zipLimitsConfig());
   }
 
   async createSkill(
@@ -160,6 +221,16 @@ export class SkillService {
       source?: import("../../../shared/types/index").SkillSource | undefined;
     },
   ): Promise<{ guid: string }> {
+    // 0. Zip-bomb defense (#632) — the ingestion chokepoint. EVERY upload
+    //    AND every GitHub pull (`createSkillFromGitHub` → here) funnels
+    //    through this method, so enforcing the caps here closes the
+    //    route-layer bypass. Runs REGARDLESS of skipValidation: it's a
+    //    DoS guard, not format validation, so an "import as-is" toggle
+    //    must not disarm it. Walks the central directory without
+    //    extracting; throws 413 before any storage upload / AgentSeal
+    //    subprocess. We never log payload bytes.
+    await enforceZipLimits(zipBuffer, this.zipLimitsConfig());
+
     // 1. Validate ZIP format rules
     if (!options?.skipValidation) {
       const violations = await this.validateZipFormat(zipBuffer);
@@ -583,6 +654,14 @@ export class SkillService {
     const updateData: UpdateSkillData = { updatedBy: userId };
 
     if (options.zipBuffer) {
+      // Zip-bomb defense (#632) — same chokepoint guard as createSkill.
+      // The GitHub refresh path (`refreshSkillFromSource` → here) and
+      // admin re-upload both land here, so the route-layer bypass is
+      // closed for updates too. Runs REGARDLESS of skipValidation
+      // (DoS guard, not format validation), ahead of storage upload /
+      // AgentSeal. No payload bytes are logged.
+      await enforceZipLimits(options.zipBuffer, this.zipLimitsConfig());
+
       if (!options.skipValidation) {
         const violations = await this.validateZipFormat(options.zipBuffer);
         if (violations.length > 0) {

--- a/ornn-api/src/domains/skills/format/routes.ts
+++ b/ornn-api/src/domains/skills/format/routes.ts
@@ -16,7 +16,6 @@ import {
 } from "../../../middleware/nyxidAuth";
 import { AppError } from "../../../shared/types/index";
 import { skillFrontmatterSchema } from "../../../shared/schemas/skillFrontmatter";
-import { enforceZipLimits } from "../../../shared/utils/zipLimits";
 
 /** Canonical skill format rules per the ornn platform spec. Updated with output-type. */
 export const SKILL_FORMAT_RULES = `# Ornn Skill Package Format Rules
@@ -146,11 +145,14 @@ export function createFormatRoutes(config: FormatRoutesConfig): Hono<{ Variables
 
       const zipBuffer = new Uint8Array(body);
 
-      // Zip-bomb defense (#633) — same gate as the publish path. The
+      // Zip-bomb defense (#632/#633) — same caps as the publish path. The
       // /skill-format/validate endpoint is authenticated but otherwise
       // unrestricted, so an attacker can still slow us down here with
-      // pathological ZIPs unless we cap before extraction.
-      await enforceZipLimits(zipBuffer);
+      // pathological ZIPs unless we cap before extraction. This is a
+      // standalone read path (no create/update service seam), so we call
+      // the service's public guard, which applies the SAME env-driven caps
+      // the ingestion chokepoint uses.
+      await skillService.enforceZipLimits(zipBuffer);
 
       // `validateZipFormat` returns the full list of rule violations.
       // An empty array means the package is valid; anything non-empty is what

--- a/ornn-api/src/infra/config.ts
+++ b/ornn-api/src/infra/config.ts
@@ -38,6 +38,19 @@ export interface SkillConfig {
   // Skill package upload limit (image-baked operational constant).
   readonly maxPackageSizeBytes: number;
 
+  // Zip-bomb defense caps (#632/#633). Bound what an uploaded/pulled ZIP
+  // is allowed to uncompress to BEFORE extraction, so a tiny compressed
+  // payload can't be coerced into exhausting memory/disk in an extraction
+  // loop or AgentSeal subprocess. Env-overridable operational constants.
+  /** Cumulative uncompressed size cap across all entries (default 50 MiB). */
+  readonly maxPackageUncompressedBytes: number;
+  /** Per-entry uncompressed size cap (default 25 MiB). */
+  readonly maxEntryUncompressedBytes: number;
+  /** Maximum number of files an uploaded ZIP may contain (default 1000). */
+  readonly maxPackageFileCount: number;
+  /** Compression-ratio sanity cap — classic zip-bomb signature (default 100×). */
+  readonly maxCompressionRatio: number;
+
   // CORS
   /**
    * Allow-listed origins for cross-origin requests with credentials.
@@ -96,6 +109,14 @@ const envSchema = z.object({
   MONGODB_DB: z.string().min(1).default("ornn"),
 
   MAX_PACKAGE_SIZE_BYTES: z.coerce.number().int().positive().default(52428800),
+
+  // ---- Zip-bomb defense caps (#632/#633) — env-overridable. ----
+  // Defaults mirror the constants baked into `shared/utils/zipLimits.ts`
+  // (50 MiB cumulative / 25 MiB per-entry / 1000 files / 100× ratio).
+  MAX_PACKAGE_UNCOMPRESSED_BYTES: z.coerce.number().int().positive().default(52428800),
+  MAX_ENTRY_UNCOMPRESSED_BYTES: z.coerce.number().int().positive().default(26214400),
+  MAX_PACKAGE_FILE_COUNT: z.coerce.number().int().positive().default(1000),
+  MAX_COMPRESSION_RATIO: z.coerce.number().positive().default(100),
 
   /**
    * Comma-separated list of origins permitted for cross-origin requests
@@ -180,6 +201,11 @@ export function loadConfig(): SkillConfig {
     mongodbDb: env.MONGODB_DB,
 
     maxPackageSizeBytes: env.MAX_PACKAGE_SIZE_BYTES,
+
+    maxPackageUncompressedBytes: env.MAX_PACKAGE_UNCOMPRESSED_BYTES,
+    maxEntryUncompressedBytes: env.MAX_ENTRY_UNCOMPRESSED_BYTES,
+    maxPackageFileCount: env.MAX_PACKAGE_FILE_COUNT,
+    maxCompressionRatio: env.MAX_COMPRESSION_RATIO,
 
     allowedOrigins: env.ALLOWED_ORIGINS
       .split(",")

--- a/ornn-api/src/shared/utils/zipLimits.test.ts
+++ b/ornn-api/src/shared/utils/zipLimits.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 import { AppError } from "../types/index";
 import {
+  DEFAULT_MAX_COMPRESSION_RATIO,
   DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES,
   enforceZipLimits,
 } from "./zipLimits";
@@ -165,5 +166,36 @@ describe("enforceZipLimits (#633)", () => {
   test("defaults: 50 MiB / 25 MiB / 1000 files — sanity check the constants", async () => {
     // Verify the exported constant is what the issue scope said.
     expect(DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES).toBe(50 * 1024 * 1024);
+  });
+
+  test("default compression ratio is 100 (#632 regression guard)", () => {
+    // #632 bumped the no-arg fallback 50→100 to match criterion #4
+    // (">100 flags"). Lock it so a future tweak to the constant is a
+    // deliberate, test-breaking change rather than a silent drift.
+    expect(DEFAULT_MAX_COMPRESSION_RATIO).toBe(100);
+  });
+
+  test("a >100× synthetic bomb trips with NO cfg (default ratio fires)", async () => {
+    // 8 MiB of zeros deflates to ~8 KiB (~1000× on its own — deflate's
+    // per-block ceiling is ~1032:1). 5 KiB of random filler can't be
+    // compressed, so it pushes the total compressed buffer comfortably
+    // past the 4 KiB ratio-check floor while barely denting the aggregate
+    // ratio (still well above 100×). Caps are left at defaults (no cfg
+    // arg) so this asserts the baked-in fallback — not a passed-in
+    // override — catches the bomb. 8 MiB stays under the 50 MiB / 25 MiB
+    // size caps so the RATIO check is what fires, not the size caps.
+    const zeros = new Uint8Array(8 * 1024 * 1024);
+    const filler = new Uint8Array(5 * 1024);
+    crypto.getRandomValues(filler);
+    const zip = await buildZip({
+      "skill/SKILL.md": "tiny",
+      "skill/assets/zeros.bin": zeros,
+      "skill/assets/filler.bin": filler,
+    });
+    await expectAppError(enforceZipLimits(zip), {
+      status: 413,
+      code: "uncompressed_too_large",
+      messagePattern: /compression ratio.*exceeds 100.*zip-bomb signature/,
+    });
   });
 });

--- a/ornn-api/src/shared/utils/zipLimits.ts
+++ b/ornn-api/src/shared/utils/zipLimits.ts
@@ -17,7 +17,7 @@
  *   - per-entry uncompressed size (default 25 MiB)
  *   - file count (default 1000)
  *
- * Plus a compression-ratio sanity check (50:1) — the classic zip-bomb
+ * Plus a compression-ratio sanity check (100:1) — the classic zip-bomb
  * signature catches things the per-entry cap would miss when an
  * attacker spreads payload across many entries.
  *
@@ -37,13 +37,13 @@ export const DEFAULT_MAX_ENTRY_UNCOMPRESSED_BYTES = 25 * 1024 * 1024;
 export const DEFAULT_MAX_FILE_COUNT = 1000;
 
 /**
- * Compression-ratio sanity cap. `uncompressed / compressed > 50` is
+ * Compression-ratio sanity cap. `uncompressed / compressed > 100` is
  * the classic zip-bomb signature — legitimate text/code packages
- * compress around 3–10×, never 50×. Set high enough that a tiny
+ * compress around 3–10×, never 100×. Set high enough that a tiny
  * package with one near-empty entry doesn't false-positive (the
  * compressed lower bound below also gates this).
  */
-export const DEFAULT_MAX_COMPRESSION_RATIO = 50;
+export const DEFAULT_MAX_COMPRESSION_RATIO = 100;
 
 /**
  * Don't bother running the ratio check when the compressed payload

--- a/ornn-api/tests/integration/harness.ts
+++ b/ornn-api/tests/integration/harness.ts
@@ -112,6 +112,12 @@ export async function startHarness(
     mongodbUri: mongoUri,
     mongodbDb: "ornn-test",
     maxPackageSizeBytes: 10 * 1024 * 1024,
+    // Zip-bomb caps (#632) — mirror the production defaults so the
+    // ingestion-chokepoint guard behaves the same under integration.
+    maxPackageUncompressedBytes: 50 * 1024 * 1024,
+    maxEntryUncompressedBytes: 25 * 1024 * 1024,
+    maxPackageFileCount: 1000,
+    maxCompressionRatio: 100,
     allowedOrigins: [],
     ornnPublicOrigin: "http://test.invalid",
     encryptionKey: "test-encryption-key-32-chars-min-12345",

--- a/ornn-api/tests/integration/skillsCrud.test.ts
+++ b/ornn-api/tests/integration/skillsCrud.test.ts
@@ -21,6 +21,7 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import JSZip from "jszip";
 import { startHarness, authHeaders, type Harness } from "./harness";
 
 const OWNER = "user_crud_owner";
@@ -151,5 +152,69 @@ describe("integration: skills CRUD lifecycle spine", () => {
     expect(delRes.status).toBe(200);
     const after = await harness.db.collection("skills").countDocuments({ _id: GUID as never });
     expect(after).toBe(0);
+  });
+});
+
+/**
+ * #632 — server-side zip-bomb guard at the ingestion chokepoint.
+ *
+ * The guard now lives inside `SkillService.createSkill`, so it covers the
+ * raw upload route (`POST /api/v1/skills`) AND the GitHub pull path that
+ * bypasses the route. These end-to-end cases POST real synthetic bombs
+ * through the actual route → service stack and assert the 413 RFC-7807
+ * problem body — without ever touching chrono-storage, because the guard
+ * short-circuits BEFORE the storage upload (the harness points
+ * chrono-storage at an unreachable URL).
+ *
+ * Both fixtures compress to a tiny payload (highly-compressible content),
+ * so the cheap route-level `maxFileSize` early-out (10 MiB compressed in
+ * the harness) is cleared and the UNCOMPRESSED-side guard is what fires.
+ */
+describe("integration: zip-bomb guard at POST /skills (#632)", () => {
+  const headers = authHeaders({
+    userId: "user_bomb",
+    email: "user_bomb@test.local",
+    permissions: ["ornn:skill:create"],
+  });
+  const zipHeaders = { ...headers, "content-type": "application/zip" };
+
+  test("a >50 MiB-uncompressed ZIP → 413 uncompressed_too_large", async () => {
+    // SKILL.md + one 60 MiB entry of NUL bytes. Deflates to a few KiB, so
+    // the compressed body clears the route's maxFileSize check; the 60 MiB
+    // uncompressed size trips the per-entry / cumulative cap (both surface
+    // the same `uncompressed_too_large` code).
+    const zip = new JSZip();
+    const folder = zip.folder("bomb-skill")!;
+    folder.file("SKILL.md", "---\nname: bomb-skill\n---\nbody");
+    folder.file("assets/zeros.bin", "\0".repeat(60 * 1024 * 1024));
+    const bytes = await zip.generateAsync({ type: "uint8array", compression: "DEFLATE" });
+
+    const res = await harness.app.request("/api/v1/skills", {
+      method: "POST",
+      headers: zipHeaders,
+      body: bytes,
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("uncompressed_too_large");
+  });
+
+  test("a >1000-entry ZIP → 413 too_many_files", async () => {
+    const zip = new JSZip();
+    const folder = zip.folder("many-files-skill")!;
+    folder.file("SKILL.md", "---\nname: many-files-skill\n---\nbody");
+    for (let i = 0; i < 1001; i++) {
+      folder.file(`assets/f${i}.txt`, `c${i}`);
+    }
+    const bytes = await zip.generateAsync({ type: "uint8array", compression: "DEFLATE" });
+
+    const res = await harness.app.request("/api/v1/skills", {
+      method: "POST",
+      headers: zipHeaders,
+      body: bytes,
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("too_many_files");
   });
 });

--- a/ornn-web/src/components/notifications/NotificationBell.test.tsx
+++ b/ornn-web/src/components/notifications/NotificationBell.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * NotificationBell tests — refetch-on-open guard (#751).
+ *
+ * The list query (useNotifications) stays mounted in the navbar forever
+ * and never remounts; the badge (useUnreadNotificationCount) polls on its
+ * own 30s tick. So a fresh broadcast bumps the badge while the dropdown
+ * still renders the stale cached list until the next poll — #728 was an
+ * incomplete fix. The fix: an `open`-keyed effect calls `refetch()` on
+ * each false→true open transition.
+ *
+ * STALE-STATE-FIRST oracle: mount the bell closed (one initial fetch),
+ * then open it and assert the list query fires AGAIN (Test 1). Test 2
+ * resolves an UPDATED list on the open-time refetch and asserts the new
+ * broadcast's text renders in the popover — proving the list is not stale
+ * on open.
+ *
+ * Harness notes:
+ *  - The auth store is mocked authed=true (so the query is `enabled`) and
+ *    to dodge the persist-middleware localStorage init chain on module
+ *    load (same trap useSkills.test.tsx / MirrorPage.test.tsx sidestep).
+ *  - notificationsApi is mocked so we count list fetches deterministically.
+ *  - framer-motion is collapsed to plain tags so the popover content is
+ *    synchronously present once `open` flips (no enter/exit animation gate).
+ *  - react-i18next is stubbed globally in src/test/setup.ts.
+ *  - Timers are NOT advanced — we never assert on the 30s interval.
+ *
+ * @module components/notifications/NotificationBell.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import type { Notification } from "@/types/notifications";
+
+// Authed=true so useNotifications/useUnreadNotificationCount are enabled.
+// Object.assign gives the store a `getState` for any incidental callers
+// while the named selector hooks return fixed values.
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: Object.assign(() => ({}), {
+    getState: () => ({
+      accessToken: null,
+      isAuthenticated: true,
+      ensureFreshToken: async () => {},
+      refreshToken: async () => {},
+    }),
+  }),
+  useIsAuthenticated: () => true,
+  useCurrentUser: () => null,
+}));
+
+// Collapse motion wrappers to plain tags so popover content is present
+// synchronously once `open` flips — no animation gate to await.
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+vi.mock("@/services/notificationsApi", () => ({
+  fetchNotifications: vi.fn(),
+  fetchUnreadCount: vi.fn(),
+  markNotificationRead: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+}));
+
+import { fetchNotifications, fetchUnreadCount } from "@/services/notificationsApi";
+import { NotificationBell } from "./NotificationBell";
+
+const fetchNotificationsMock = vi.mocked(fetchNotifications);
+const fetchUnreadCountMock = vi.mocked(fetchUnreadCount);
+
+function broadcast(id: string, en: string): Notification {
+  return {
+    _id: id,
+    source: "broadcast",
+    titleI18n: { en, zh: en },
+    bodyMarkdownI18n: { en: `Body ${en}`, zh: `Body ${en}` },
+    createdAt: "2026-06-08T00:00:00.000Z",
+    readAt: null,
+  };
+}
+
+/** Fresh client per test so cache + refetch state never leak across cases. */
+function renderBell() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <NotificationBell />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/** The bell toggle carries aria-label "Notifications" (from the i18n key). */
+function bellToggle(): HTMLButtonElement {
+  return screen.getByLabelText("Notifications") as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchUnreadCountMock.mockResolvedValue(1);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("NotificationBell — refetch on open (#751)", () => {
+  it("refetches the list when the dropdown is opened", async () => {
+    fetchNotificationsMock.mockResolvedValue([broadcast("n-1", "First broadcast")]);
+
+    renderBell();
+
+    // Mount fires the initial list fetch exactly once.
+    await waitFor(() => expect(fetchNotificationsMock).toHaveBeenCalledTimes(1));
+
+    // Open the dropdown → the open-keyed effect refetches the list.
+    fireEvent.click(bellToggle());
+
+    await waitFor(() => expect(fetchNotificationsMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows a newly-broadcast item that arrived after mount when opened", async () => {
+    // First fetch (mount): only the old item. The refetch fired by opening
+    // resolves the updated list including the new broadcast.
+    fetchNotificationsMock
+      .mockResolvedValueOnce([broadcast("n-1", "Old broadcast")])
+      .mockResolvedValue([
+        broadcast("n-2", "Fresh broadcast"),
+        broadcast("n-1", "Old broadcast"),
+      ]);
+
+    renderBell();
+
+    await waitFor(() => expect(fetchNotificationsMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(bellToggle());
+
+    // The refetch-on-open delivers the fresh item into the open popover —
+    // proving the list is not stale on open.
+    expect(await screen.findByText("Fresh broadcast")).toBeInTheDocument();
+    expect(screen.getByText("Old broadcast")).toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/components/notifications/NotificationBell.tsx
+++ b/ornn-web/src/components/notifications/NotificationBell.tsx
@@ -70,7 +70,7 @@ export function NotificationBell() {
   const { data: unread = 0 } = useUnreadNotificationCount();
   // Keep the popover list small — we don't want to pay for 200 items on every
   // navbar render. The full /notifications page has its own list.
-  const { data: items = [], isLoading } = useNotifications({ limit: POPOVER_ITEM_CAP });
+  const { data: items = [], isLoading, refetch } = useNotifications({ limit: POPOVER_ITEM_CAP });
   const markRead = useMarkNotificationRead();
   const markAll = useMarkAllNotificationsRead();
 
@@ -80,6 +80,17 @@ export function NotificationBell() {
   );
 
   const lang = i18n.language;
+
+  // Refetch the list every time the popover opens. The list query stays
+  // mounted in the navbar forever and never remounts, and the badge
+  // (useUnreadNotificationCount) polls on its own 30s tick — so a fresh
+  // broadcast can bump the badge while the dropdown still shows the stale
+  // cached list until the next poll lands (#728 was an incomplete fix,
+  // #751). `refetch` from React Query is referentially stable, so this
+  // fires exactly once per false→true open transition, not every render.
+  useEffect(() => {
+    if (open) void refetch();
+  }, [open, refetch]);
 
   // Close popover on outside click.
   useEffect(() => {

--- a/ornn-web/src/components/skill/SkillCard.tsx
+++ b/ornn-web/src/components/skill/SkillCard.tsx
@@ -6,6 +6,7 @@ import type { BadgeProps } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import type { SkillSearchResult } from "@/types/search";
 import { useMyOrgs } from "@/hooks/useMe";
+import { formatDateSGT } from "@/utils/formatters";
 
 const TAG_COLORS: NonNullable<BadgeProps["color"]>[] = ["cyan", "magenta", "yellow", "green"];
 
@@ -14,21 +15,6 @@ function getTagColor(tag: string): NonNullable<BadgeProps["color"]> {
   // `hash % TAG_COLORS.length` is always in-range for a non-empty
   // array. `!` is safe under noUncheckedIndexedAccess (#450).
   return TAG_COLORS[hash % TAG_COLORS.length]!;
-}
-
-/** Format a date string to exact SGT (Asia/Singapore) timestamp */
-function formatDateSGT(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleString("en-SG", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
 }
 
 export interface SkillCardProps {
@@ -81,7 +67,7 @@ export function SkillCard({
   className = "",
 }: SkillCardProps) {
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const isOwner = currentUserId && skill.createdBy === currentUserId;
 
@@ -197,7 +183,7 @@ export function SkillCard({
           )}
           <span className="truncate">{displayName}</span>
         </div>
-        <span className="shrink-0">{formatDateSGT(timestamp)}</span>
+        <span className="shrink-0">{formatDateSGT(timestamp, i18n.language, { withSeconds: true })}</span>
       </div>
 
       {showOwnerControls && isOwner && (

--- a/ornn-web/src/components/skill/SkillVersionList.tsx
+++ b/ornn-web/src/components/skill/SkillVersionList.tsx
@@ -5,20 +5,7 @@ import { Button } from "@/components/ui/Button";
 import { Modal } from "@/components/ui/Modal";
 import type { SkillVersionEntry } from "@/types/domain";
 import type { AuditRecord, AuditVerdict } from "@/types/audit";
-
-/** Format a date string to exact SGT (Asia/Singapore) timestamp. */
-function formatDateSGT(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleString("en-SG", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-}
+import { formatDateSGT } from "@/utils/formatters";
 
 export interface SkillVersionListProps {
   versions: SkillVersionEntry[];
@@ -99,7 +86,7 @@ export function SkillVersionList({
   auditSummary,
   className = "",
 }: SkillVersionListProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [modalTarget, setModalTarget] = useState<SkillVersionEntry | null>(null);
   const [noteDraft, setNoteDraft] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<SkillVersionEntry | null>(null);
@@ -187,7 +174,7 @@ export function SkillVersionList({
                     )}
                   </div>
                   <div className="mt-0.5 font-text text-xs text-meta truncate">
-                    {formatDateSGT(v.createdOn)}
+                    {formatDateSGT(v.createdOn, i18n.language)}
                     {v.createdByDisplayName ? ` · ${v.createdByDisplayName}` : ""}
                   </div>
                 </button>

--- a/ornn-web/src/hooks/useSkillDetail.ts
+++ b/ornn-web/src/hooks/useSkillDetail.ts
@@ -73,7 +73,11 @@ export function useSkillDetail(idOrName: string | undefined) {
   const versionParam = searchParams.get("version") ?? undefined;
   const { data: skill, isLoading, error, refetch } = useSkill(idOrName ?? "", versionParam);
   const { data: versionList = [] } = useSkillVersions(idOrName ?? "");
-  const deleteMutation = useDeleteSkill();
+  // Two-id split (#940): wire the GUID (delete route is GUID-only) but
+  // pass the cache-key id (idOrName, often a NAME from the URL) so the
+  // deleted skill's detail/versions cache is removed before the broad
+  // list invalidation can refetch it → 404.
+  const deleteMutation = useDeleteSkill(skill?.guid ?? "", idOrName ?? "");
   const updatePackageMutation = useUpdateSkillPackage(skill?.guid ?? "");
   // Two-id split (#750): wire the GUID (version-write routes are GUID-only)
   // but keep the cache-key id (idOrName) for invalidation.
@@ -305,7 +309,7 @@ export function useSkillDetail(idOrName: string | undefined) {
   const handleDeleteConfirm = useCallback(async () => {
     if (!skill) return;
     try {
-      await deleteMutation.mutateAsync(skill.guid);
+      await deleteMutation.mutateAsync();
       addToast({ type: "success", message: t("skillDetail.deleteSuccess") });
       navigate("/registry");
     } catch {

--- a/ornn-web/src/hooks/useSkillDetail.ts
+++ b/ornn-web/src/hooks/useSkillDetail.ts
@@ -75,8 +75,10 @@ export function useSkillDetail(idOrName: string | undefined) {
   const { data: versionList = [] } = useSkillVersions(idOrName ?? "");
   const deleteMutation = useDeleteSkill();
   const updatePackageMutation = useUpdateSkillPackage(skill?.guid ?? "");
-  const deprecationMutation = useSetVersionDeprecation(idOrName ?? "");
-  const deleteVersionMutation = useDeleteSkillVersion(idOrName ?? "");
+  // Two-id split (#750): wire the GUID (version-write routes are GUID-only)
+  // but keep the cache-key id (idOrName) for invalidation.
+  const deprecationMutation = useSetVersionDeprecation(skill?.guid ?? "", idOrName ?? "");
+  const deleteVersionMutation = useDeleteSkillVersion(skill?.guid ?? "", idOrName ?? "");
   const { data: auditSummaryByVersion } = useAuditSummaryByVersion(idOrName);
   // History for the version currently being viewed, so the audit card
   // can detect an in-flight (status: running) audit and show a loading

--- a/ornn-web/src/hooks/useSkills.test.tsx
+++ b/ornn-web/src/hooks/useSkills.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * useSkills — version-write hooks: GUID-on-the-wire / name-in-the-cache.
+ *
+ * #750 regression guard. Skill Detail can be opened by NAME (URL
+ * `idOrName`), but the version-delete / version-deprecation backend
+ * routes are GUID-only (`findByGuid`, CONVENTIONS §2.2). Before the fix
+ * the hooks sent the cache-key id (the name) on the wire → `findByGuid`
+ * 404 → version never deleted. The fix splits the two ids:
+ *
+ *   - WIRE id   = `guid`     → goes into the request URL.
+ *   - CACHE id  = `idOrName` → keys every `invalidateQueries`, so #699's
+ *                              All-versions modal still refreshes.
+ *
+ * Both matrices run: name-opened (`guid !== name`) and guid-opened
+ * (`guid === name`). The fetch layer is spied at `globalThis.fetch`
+ * because both `deleteSkillVersion` (via `apiDelete`) and
+ * `setSkillVersionDeprecation` (raw `fetch`) bottom out there.
+ *
+ * @module hooks/useSkills.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+// Stub the auth store so importing the api layer doesn't drag in the
+// persist-middleware localStorage init chain on module load (same trap
+// MirrorPage.test.tsx sidesteps). The hooks under test only need
+// `getState().accessToken` (null → no proactive token refresh, so the
+// fetch spy sees exactly one call).
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: {
+    getState: () => ({
+      accessToken: null,
+      isAuthenticated: false,
+      ensureFreshToken: async () => {},
+      refreshToken: async () => {},
+    }),
+  },
+}));
+
+import { useDeleteSkillVersion, useSetVersionDeprecation } from "./useSkills";
+
+const GUID = "11111111-2222-3333-4444-555555555555";
+const NAME = "my-skill";
+const VERSION = "1.0.0";
+
+/** Pull the request URL out of the first `fetch` call (URL or Request). */
+function fetchedUrl(spy: ReturnType<typeof vi.spyOn>): string {
+  const [input] = spy.mock.calls[0] ?? [];
+  return typeof input === "string" ? input : (input as Request).url;
+}
+
+/** Fresh client per test so invalidation spies don't leak across cases. */
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, invalidateSpy };
+}
+
+/** Did `invalidateQueries` fire with exactly this queryKey? */
+function invalidatedKey(
+  spy: ReturnType<typeof vi.spyOn>,
+  key: readonly unknown[],
+): boolean {
+  return spy.mock.calls.some(
+    ([arg]) =>
+      arg != null &&
+      typeof arg === "object" &&
+      "queryKey" in arg &&
+      JSON.stringify((arg as { queryKey?: unknown }).queryKey) === JSON.stringify(key),
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useDeleteSkillVersion", () => {
+  // Backend DELETE returns 204; apiClient short-circuits on 204.
+  function stubDelete() {
+    return vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+  }
+
+  it.each([
+    ["name-opened (guid !== name)", GUID, NAME],
+    ["guid-opened (guid === name)", GUID, GUID],
+  ])("sends the GUID on the wire, not the cache id — %s", async (_label, guid, cacheId) => {
+    const fetchSpy = stubDelete();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkillVersion(guid, cacheId), { wrapper });
+
+    await result.current.mutateAsync(VERSION);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const url = fetchedUrl(fetchSpy);
+    // 404-regression guard: the URL carries the GUID.
+    expect(url).toContain(encodeURIComponent(guid));
+    expect(url).toContain(`/versions/${encodeURIComponent(VERSION)}`);
+    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ method: "DELETE" });
+  });
+
+  it("does NOT put the name in the URL when opened by name", async () => {
+    const fetchSpy = stubDelete();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkillVersion(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync(VERSION);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The skill-segment of the path is the GUID, never the name (#750).
+    expect(fetchedUrl(fetchSpy)).toContain(`/skills/${encodeURIComponent(GUID)}/`);
+    expect(fetchedUrl(fetchSpy)).not.toContain(`/skills/${encodeURIComponent(NAME)}/`);
+  });
+
+  it("invalidates caches keyed on the name (#699 refresh guard)", async () => {
+    stubDelete();
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkillVersion(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync(VERSION);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // #699 — All-versions modal subscribes to [skill-versions, name].
+    expect(invalidatedKey(invalidateSpy, ["skill-versions", NAME])).toBe(true);
+    // Detail cache + collections.
+    expect(invalidatedKey(invalidateSpy, ["skills", NAME])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["skills"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["my-skills"])).toBe(true);
+    // Audit history (per-version) — predicate-keyed on the name.
+    const auditPredicateFired = invalidateSpy.mock.calls.some(
+      ([arg]) =>
+        arg != null &&
+        typeof arg === "object" &&
+        "predicate" in arg &&
+        (arg as { predicate: (q: { queryKey: unknown[] }) => boolean }).predicate({
+          queryKey: ["audit", NAME],
+        }),
+    );
+    expect(auditPredicateFired).toBe(true);
+  });
+
+  it("never keys invalidation on the GUID when opened by name", async () => {
+    stubDelete();
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkillVersion(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync(VERSION);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidatedKey(invalidateSpy, ["skill-versions", GUID])).toBe(false);
+    expect(invalidatedKey(invalidateSpy, ["skills", GUID])).toBe(false);
+  });
+});
+
+describe("useSetVersionDeprecation", () => {
+  // PATCH returns the updated row in a `{ data }` envelope.
+  function stubPatch() {
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            skillGuid: GUID,
+            skillName: NAME,
+            version: VERSION,
+            isDeprecated: true,
+            deprecationNote: null,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+  }
+
+  it.each([
+    ["name-opened (guid !== name)", GUID, NAME],
+    ["guid-opened (guid === name)", GUID, GUID],
+  ])("sends the GUID on the wire, not the cache id — %s", async (_label, guid, cacheId) => {
+    const fetchSpy = stubPatch();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSetVersionDeprecation(guid, cacheId), { wrapper });
+
+    await result.current.mutateAsync({ version: VERSION, isDeprecated: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const url = fetchedUrl(fetchSpy);
+    expect(url).toContain(encodeURIComponent(guid));
+    expect(url).toContain(`/versions/${encodeURIComponent(VERSION)}`);
+    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ method: "PATCH" });
+  });
+
+  it("does NOT put the name in the URL when opened by name", async () => {
+    const fetchSpy = stubPatch();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSetVersionDeprecation(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync({ version: VERSION, isDeprecated: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchedUrl(fetchSpy)).toContain(`/skills/${encodeURIComponent(GUID)}/`);
+    expect(fetchedUrl(fetchSpy)).not.toContain(`/skills/${encodeURIComponent(NAME)}/`);
+  });
+
+  it("invalidates caches keyed on the name", async () => {
+    stubPatch();
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useSetVersionDeprecation(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync({ version: VERSION, isDeprecated: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidatedKey(invalidateSpy, ["skills", NAME])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["skill-versions", NAME])).toBe(true);
+    // Cache keys must never be the GUID when opened by name.
+    expect(invalidatedKey(invalidateSpy, ["skills", GUID])).toBe(false);
+    expect(invalidatedKey(invalidateSpy, ["skill-versions", GUID])).toBe(false);
+  });
+});

--- a/ornn-web/src/hooks/useSkills.test.tsx
+++ b/ornn-web/src/hooks/useSkills.test.tsx
@@ -40,7 +40,7 @@ vi.mock("@/stores/authStore", () => ({
   },
 }));
 
-import { useDeleteSkillVersion, useSetVersionDeprecation } from "./useSkills";
+import { useDeleteSkill, useDeleteSkillVersion, useSetVersionDeprecation } from "./useSkills";
 
 const GUID = "11111111-2222-3333-4444-555555555555";
 const NAME = "my-skill";
@@ -58,10 +58,32 @@ function makeWrapper() {
     defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
   });
   const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const removeSpy = vi.spyOn(queryClient, "removeQueries");
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
-  return { wrapper, invalidateSpy };
+  return { wrapper, invalidateSpy, removeSpy, queryClient };
+}
+
+/**
+ * Did `removeQueries` fire with a predicate that matches this queryKey?
+ * #940 removes the deleted skill's caches with a predicate (covering both
+ * name- and guid-keyed entries), not a literal queryKey, so we exercise
+ * the predicate against a synthetic key.
+ */
+function removedKey(
+  spy: ReturnType<typeof vi.spyOn>,
+  key: readonly unknown[],
+): boolean {
+  return spy.mock.calls.some(
+    ([arg]) =>
+      arg != null &&
+      typeof arg === "object" &&
+      "predicate" in arg &&
+      (arg as { predicate: (q: { queryKey: readonly unknown[] }) => boolean }).predicate({
+        queryKey: key,
+      }),
+  );
 }
 
 /** Did `invalidateQueries` fire with exactly this queryKey? */
@@ -226,5 +248,72 @@ describe("useSetVersionDeprecation", () => {
     // Cache keys must never be the GUID when opened by name.
     expect(invalidatedKey(invalidateSpy, ["skills", GUID])).toBe(false);
     expect(invalidatedKey(invalidateSpy, ["skill-versions", GUID])).toBe(false);
+  });
+});
+
+describe("useDeleteSkill", () => {
+  // Backend DELETE returns 204; apiClient short-circuits on 204.
+  function stubDelete() {
+    return vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+  }
+
+  it("removes the deleted skill's detail + versions cache so no refetch can 404 (#940)", async () => {
+    stubDelete();
+    const { wrapper, removeSpy, invalidateSpy, queryClient } = makeWrapper();
+
+    // Seed the still-mounted detail + versions cache, keyed on the NAME
+    // (the Skill Detail URL id). A broad invalidate would prefix-match
+    // these and refetch the just-deleted skill → 404.
+    queryClient.setQueryData(["skills", NAME, "latest"], { guid: GUID, name: NAME });
+    queryClient.setQueryData(["skill-versions", NAME], [{ version: VERSION }]);
+
+    const { result } = renderHook(() => useDeleteSkill(GUID, NAME), { wrapper });
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // (a) removeQueries fired for the detail + versions keys.
+    expect(removedKey(removeSpy, ["skills", NAME, "latest"])).toBe(true);
+    expect(removedKey(removeSpy, ["skill-versions", NAME])).toBe(true);
+
+    // (b) the detail entry is actually gone — nothing left to refetch.
+    expect(queryClient.getQueryData(["skills", NAME, "latest"])).toBeUndefined();
+    expect(queryClient.getQueryData(["skill-versions", NAME])).toBeUndefined();
+
+    // (c) lists + counts still invalidate to drop the deleted card.
+    expect(invalidatedKey(invalidateSpy, ["skills"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["my-skills"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["skill-counts"])).toBe(true);
+  });
+
+  it("removes a GUID-keyed detail entry too (predicate covers both keyings)", async () => {
+    stubDelete();
+    const { wrapper, removeSpy, queryClient } = makeWrapper();
+
+    // MySkillsPage passes the card's GUID as the cache-key id; a detail
+    // entry keyed by GUID must be removed just like the name-keyed one.
+    queryClient.setQueryData(["skills", GUID, "latest"], { guid: GUID, name: NAME });
+
+    const { result } = renderHook(() => useDeleteSkill(GUID, GUID), { wrapper });
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(removedKey(removeSpy, ["skills", GUID, "latest"])).toBe(true);
+    expect(queryClient.getQueryData(["skills", GUID, "latest"])).toBeUndefined();
+  });
+
+  it("sends the GUID on the wire, not the cache id, when opened by name", async () => {
+    const fetchSpy = stubDelete();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkill(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const url = fetchedUrl(fetchSpy);
+    expect(url).toContain(`/skills/${encodeURIComponent(GUID)}`);
+    expect(url).not.toContain(`/skills/${encodeURIComponent(NAME)}`);
+    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ method: "DELETE" });
   });
 });

--- a/ornn-web/src/hooks/useSkills.test.tsx
+++ b/ornn-web/src/hooks/useSkills.test.tsx
@@ -316,4 +316,25 @@ describe("useDeleteSkill", () => {
     expect(url).not.toContain(`/skills/${encodeURIComponent(NAME)}`);
     expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({ method: "DELETE" });
   });
+
+  it("refreshes the My-Skills sidebar facet + grants-summary counts (#941)", async () => {
+    stubDelete();
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkill(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The sidebar counts come from queries no #940 invalidation touches:
+    // the "mine" tag facet and the grants summary. Both must refresh so
+    // the chip counts stay consistent after a self-delete.
+    expect(invalidatedKey(invalidateSpy, ["skill-facets", "tags", "mine"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["me", "skills", "grants-summary"])).toBe(true);
+
+    // Scope guard: stay narrow. A self-delete can't change the public
+    // tag facet, and the broad ["me"] prefix would needlessly refetch
+    // orgs / nyxid-services — neither must be invalidated as a literal.
+    expect(invalidatedKey(invalidateSpy, ["skill-facets", "tags", "public"])).toBe(false);
+    expect(invalidatedKey(invalidateSpy, ["me"])).toBe(false);
+  });
 });

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -207,8 +207,17 @@ export function useSkillVersionDiff(
   });
 }
 
-/** Toggle the deprecation flag on a specific published version. */
-export function useSetVersionDeprecation(idOrName: string) {
+/**
+ * Toggle the deprecation flag on a specific published version.
+ *
+ * Two-id split (#750): `guid` is the WIRE id — version-write routes are
+ * GUID-only (CONVENTIONS §2.2), so a name-opened Skill Detail must still
+ * send the GUID or the backend 404s. `idOrName` is the CACHE-KEY id —
+ * the read queries (`useSkill`, `useSkillVersions`) are keyed on
+ * `idOrName`, so invalidation MUST stay keyed on it (#699's All-versions
+ * modal refresh re-breaks otherwise).
+ */
+export function useSetVersionDeprecation(guid: string, idOrName: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({
@@ -220,7 +229,7 @@ export function useSetVersionDeprecation(idOrName: string) {
       isDeprecated: boolean;
       // exactOptionalPropertyTypes (#657)
       deprecationNote?: string | undefined;
-    }) => setSkillVersionDeprecation(idOrName, version, { isDeprecated, deprecationNote }),
+    }) => setSkillVersionDeprecation(guid, version, { isDeprecated, deprecationNote }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY, idOrName] });
       queryClient.invalidateQueries({ queryKey: [SKILL_VERSIONS_KEY, idOrName] });
@@ -374,11 +383,17 @@ export function useDeleteSkill() {
 /**
  * Delete one non-latest version of a skill. Refreshes the skill itself,
  * its versions list, and the audit history (which is keyed per version).
+ *
+ * Two-id split (#750): `guid` is the WIRE id — version-write routes are
+ * GUID-only (CONVENTIONS §2.2), so a name-opened Skill Detail must still
+ * send the GUID or the backend 404s and the version is never deleted.
+ * `idOrName` is the CACHE-KEY id — ALL invalidation below stays keyed on
+ * it so the read queries (and #699's All-versions modal) refresh.
  */
-export function useDeleteSkillVersion(idOrName: string) {
+export function useDeleteSkillVersion(guid: string, idOrName: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (version: string) => deleteSkillVersion(idOrName, version),
+    mutationFn: (version: string) => deleteSkillVersion(guid, version),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY, idOrName] });
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -368,14 +368,47 @@ export function useTieSkillToNyxidService(idOrName: string) {
   });
 }
 
-/** Delete a skill */
-export function useDeleteSkill() {
+/**
+ * Delete an entire skill (every version).
+ *
+ * Two-id split (#750 shape): `guid` is the WIRE id — the delete route is
+ * GUID-only, so a name-opened Skill Detail must still send the GUID.
+ * `idOrName` is the CACHE-KEY id — the detail/versions read queries
+ * (`useSkill`, `useSkillVersions`) are keyed on `idOrName`, and callers
+ * pass either the GUID (MySkillsPage card) or a NAME (Skill Detail URL),
+ * so cache cleanup must cover BOTH keyings.
+ *
+ * #940 — onSuccess must REMOVE the deleted skill's detail + versions
+ * entries (not just invalidate). The detail query stays mounted through
+ * the delete (the `navigate("/registry")` in the caller runs AFTER this
+ * onSuccess, and RootLayout's breadcrumb re-subscribes), so a broad
+ * `invalidateQueries([SKILLS_KEY])` prefix-matches the still-mounted
+ * detail key and triggers a refetch of the just-deleted skill → 404.
+ * `removeQueries` drops the cache entry outright so nothing can refetch
+ * it; the list/count keys still invalidate to drop the deleted card.
+ * Removal is id-scoped (predicate on `guid`/`idOrName`) so only the
+ * deleted skill's caches are touched, never other skills'.
+ */
+export function useDeleteSkill(guid: string, idOrName: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => deleteSkill(id),
+    mutationFn: () => deleteSkill(guid),
     onSuccess: () => {
+      queryClient.removeQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === SKILLS_KEY &&
+          (q.queryKey[1] === guid || q.queryKey[1] === idOrName),
+      });
+      queryClient.removeQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === SKILL_VERSIONS_KEY &&
+          (q.queryKey[1] === guid || q.queryKey[1] === idOrName),
+      });
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [SKILL_COUNTS_KEY] });
     },
   });
 }

--- a/ornn-web/src/hooks/useSkills.ts
+++ b/ornn-web/src/hooks/useSkills.ts
@@ -409,6 +409,17 @@ export function useDeleteSkill(guid: string, idOrName: string) {
       queryClient.invalidateQueries({ queryKey: [SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [MY_SKILLS_KEY] });
       queryClient.invalidateQueries({ queryKey: [SKILL_COUNTS_KEY] });
+      // #941 — the My-Skills filter sidebar counts come from SEPARATE
+      // queries that #940's invalidations don't touch: the "mine" tag
+      // facet (useSkillTagFacets("mine")) and the grants summary
+      // (useMySkillGrantsSummary). Refresh exactly those two so the
+      // per-tag chips + per-grantee/org "shared with" counts stay
+      // consistent after a self-delete without a full-page refresh.
+      // Narrow literals on purpose: the broad ["skill-facets"] prefix
+      // would refetch the public/system facets a self-delete can't
+      // change, and broad ["me"] would refetch orgs/nyxid-services.
+      queryClient.invalidateQueries({ queryKey: ["skill-facets", "tags", "mine"] });
+      queryClient.invalidateQueries({ queryKey: ["me", "skills", "grants-summary"] });
     },
   });
 }

--- a/ornn-web/src/pages/skill/MySkillsPage.tsx
+++ b/ornn-web/src/pages/skill/MySkillsPage.tsx
@@ -46,7 +46,13 @@ export function MySkillsPage() {
 
   const debouncedSearch = useDebounce(searchInput, 300);
 
-  const deleteMutation = useDeleteSkill();
+  // Two-id split (#940): the list has no URL idOrName, so pass the card's
+  // own ids — `guid` on the wire (delete route is GUID-only), `name` as
+  // the cache-key id so the deleted skill's detail cache (which other
+  // surfaces may have keyed by name) is removed, not refetched → 404.
+  // `skillToDelete` is set before the confirm; the closed-over ids are
+  // current at mutateAsync() time.
+  const deleteMutation = useDeleteSkill(skillToDelete?.guid ?? "", skillToDelete?.name ?? "");
 
   const { data, isLoading } = useMySkills({
     query: debouncedSearch || undefined,
@@ -63,7 +69,7 @@ export function MySkillsPage() {
   const handleDeleteConfirm = async () => {
     if (!skillToDelete) return;
     try {
-      await deleteMutation.mutateAsync(skillToDelete.guid);
+      await deleteMutation.mutateAsync();
       addToast({ type: "success", message: t("mySkills.deleteSuccess") });
     } catch {
       addToast({ type: "error", message: t("mySkills.deleteFailed") });

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -43,25 +43,12 @@ import {
 import { SkillVersionsCard } from "@/components/skill/SkillVersionsCard";
 import { SkillVisibilityCard } from "@/components/skill/SkillVisibilityCard";
 import { useSkillDetail } from "@/hooks/useSkillDetail";
+import { formatDateSGT } from "@/utils/formatters";
 import { useTranslation } from "react-i18next";
-
-/** Format a date string to exact SGT (Asia/Singapore) timestamp. */
-function formatDateSGT(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleString("en-SG", {
-    timeZone: "Asia/Singapore",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-}
 
 export function SkillDetailPage() {
   const { idOrName } = useParams<{ idOrName: string }>();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const addToast = useToastStore((s) => s.addToast);
   const detail = useSkillDetail(idOrName);
@@ -320,7 +307,7 @@ export function SkillDetailPage() {
                 {versionAuditRunning
                   ? t("skillDetail.auditRunningHint", "Scoring against the audit engine — this usually takes 30–60 seconds.")
                   : versionAudit?.completedAt
-                    ? t("skillDetail.auditLast", "Last audited {{date}}", { date: formatDateSGT(versionAudit.completedAt) })
+                    ? t("skillDetail.auditLast", "Last audited {{date}}", { date: formatDateSGT(versionAudit.completedAt, i18n.language) })
                     : t("skillDetail.auditNoneYet", "Not audited yet for this version.")}
               </p>
               <div className="mt-3.5 flex flex-col gap-2">
@@ -365,7 +352,7 @@ export function SkillDetailPage() {
             {versionList.length > 0 && (
               <SkillVersionsCard
                 currentVersion={skill.version}
-                publishedOnSGT={formatDateSGT(skill.createdOn)}
+                publishedOnSGT={formatDateSGT(skill.createdOn, i18n.language)}
                 totalVersions={versionList.length}
                 viewingLatest={Boolean(viewingLatest)}
                 onBrowseAll={() => setShowVersions(true)}
@@ -492,7 +479,7 @@ export function SkillDetailPage() {
                     {t("skillDetail.metaUpdated", "Updated")}
                   </dt>
                   <dd className="text-right font-mono text-xs text-strong">
-                    {formatDateSGT(skill.updatedOn)}
+                    {formatDateSGT(skill.updatedOn, i18n.language)}
                   </dd>
                 </div>
                 <div>

--- a/ornn-web/src/services/skillApi.ts
+++ b/ornn-web/src/services/skillApi.ts
@@ -42,9 +42,15 @@ export async function fetchSkillVersionDiff(
   return res.data!;
 }
 
-/** Toggle the deprecation flag on a specific published version. */
+/**
+ * Toggle the deprecation flag on a specific published version.
+ *
+ * First arg MUST be the skill GUID — version-write routes are GUID-only
+ * (CONVENTIONS §2.2). A name passed here resolves via `findByGuid` on
+ * the backend and 404s (#750).
+ */
 export async function setSkillVersionDeprecation(
-  idOrName: string,
+  guid: string,
   version: string,
   // exactOptionalPropertyTypes (#657)
   body: { isDeprecated: boolean; deprecationNote?: string | undefined },
@@ -63,7 +69,7 @@ export async function setSkillVersionDeprecation(
     headers["Authorization"] = `Bearer ${token}`;
   }
   const response = await fetch(
-    `${API_BASE}/api/v1/skills/${encodeURIComponent(idOrName)}/versions/${encodeURIComponent(version)}`,
+    `${API_BASE}/api/v1/skills/${encodeURIComponent(guid)}/versions/${encodeURIComponent(version)}`,
     {
       method: "PATCH",
       headers,
@@ -181,13 +187,17 @@ export async function deleteSkill(id: string): Promise<void> {
  * Hard-delete one non-latest version of a skill. Backend forbids deleting
  * the only version (use `deleteSkill`) or the current latest (publish a
  * newer version first).
+ *
+ * First arg MUST be the skill GUID — version-write routes are GUID-only
+ * (CONVENTIONS §2.2). A name passed here resolves via `findByGuid` on
+ * the backend and 404s (#750).
  */
 export async function deleteSkillVersion(
-  idOrName: string,
+  guid: string,
   version: string,
 ): Promise<void> {
   await apiDelete(
-    `/api/v1/skills/${encodeURIComponent(idOrName)}/versions/${encodeURIComponent(version)}`,
+    `/api/v1/skills/${encodeURIComponent(guid)}/versions/${encodeURIComponent(version)}`,
   );
 }
 

--- a/ornn-web/src/utils/formatters.test.ts
+++ b/ornn-web/src/utils/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatFileSize, formatNumber } from "./formatters";
+import { formatDateSGT, formatFileSize, formatNumber } from "./formatters";
 
 describe("formatNumber", () => {
   it("renders millions with an M suffix", () => {
@@ -46,5 +46,44 @@ describe("formatFileSize", () => {
 
   it("renders gigabytes with one decimal", () => {
     expect(formatFileSize(1024 * 1024 * 1024)).toBe("1.0 GB");
+  });
+});
+
+describe("formatDateSGT", () => {
+  // 03:43:42 UTC = 11:43:42 Asia/Singapore (+08:00) same day.
+  const ISO = "2026-05-25T03:43:42Z";
+  // 17:00 UTC = 01:00 next-day Asia/Singapore — locks the TZ offset.
+  const ISO2 = "2026-05-24T17:00:00Z";
+  const EN_MONTHS = /Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/;
+
+  it("renders Chinese-formatted output (no English months) in zh mode", () => {
+    const out = formatDateSGT(ISO, "zh", { withSeconds: true });
+    // The whole point of #752: zh must NOT silently fall back to English
+    // months. Bun is full-ICU so zh-CN resolves; if this assertion ever
+    // fails it means the locale fell back to en — a real regression.
+    expect(out).not.toMatch(EN_MONTHS);
+    expect(out).toMatch(/[年月日]/);
+  });
+
+  it("preserves the exact en-SG output (English parity, with seconds)", () => {
+    // Snapshot of the en-SG output for this ISO — locks byte-identical
+    // English-mode rendering for the SkillCard call site. The shared
+    // formatter uses the same option set as the old local copies, so the
+    // English path is unchanged. (The day/month-name/digit separator is
+    // ICU-version-dependent; this literal matches the test runtime's ICU.)
+    expect(formatDateSGT(ISO, "en", { withSeconds: true })).toBe("25 May 2026, 11:43:42");
+  });
+
+  it("omits seconds when withSeconds is unset (default = false)", () => {
+    const out = formatDateSGT(ISO, "en");
+    expect(out).toBe("25 May 2026, 11:43");
+    // 43:42 seconds must not leak through the default no-seconds path.
+    expect(out).not.toMatch(/:\d{2}:\d{2}/);
+  });
+
+  it("honours the Asia/Singapore offset across the day boundary", () => {
+    // 17:00 UTC on the 24th is 01:00 on the 25th in SGT.
+    expect(formatDateSGT(ISO2, "en")).toMatch(/25 May 2026/);
+    expect(formatDateSGT(ISO2, "zh")).toMatch(/25日/);
   });
 });

--- a/ornn-web/src/utils/formatters.ts
+++ b/ornn-web/src/utils/formatters.ts
@@ -13,3 +13,18 @@ export function formatFileSize(bytes: number): string {
   const value = bytes / Math.pow(1024, i);
   return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 }
+
+/** Format an ISO date to an exact Asia/Singapore timestamp in the active UI locale (#752). */
+export function formatDateSGT(dateStr: string, lang?: string, opts?: { withSeconds?: boolean }): string {
+  const locale = lang === "zh" ? "zh-CN" : "en-SG"; // zh→zh-CN (NewsPage precedent); en→en-SG preserves current output
+  return new Date(dateStr).toLocaleString(locale, {
+    timeZone: "Asia/Singapore",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    ...(opts?.withSeconds ? { second: "2-digit" as const } : {}),
+    hour12: false,
+  });
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -67,7 +67,14 @@ export class OrnnClient {
     if (!options.baseUrl) {
       throw new Error("OrnnClient: baseUrl is required");
     }
-    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    // Strip ALL trailing slashes with a linear loop rather than a regex
+    // (`/\/+$/`) — the regex backtracks polynomially on a pathological
+    // all-slashes input, a ReDoS vector. The loop is O(n) regardless.
+    let normalizedBaseUrl = options.baseUrl;
+    while (normalizedBaseUrl.endsWith("/")) {
+      normalizedBaseUrl = normalizedBaseUrl.slice(0, -1);
+    }
+    this.baseUrl = normalizedBaseUrl;
     this.staticToken = options.token;
     this.tokenResolver = options.getToken;
     this.fetchImpl = options.fetch ?? globalThis.fetch;

--- a/sdk/typescript/src/tests/client.test.ts
+++ b/sdk/typescript/src/tests/client.test.ts
@@ -31,6 +31,23 @@ describe("OrnnClient", () => {
       .toBe("https://ornn.example.com/api/v1/ping");
   });
 
+  test("strips a pathological run of trailing slashes without ReDoS (#757)", async () => {
+    let capturedUrl = "";
+    const fetchMock = mockFetch((url) => {
+      capturedUrl = url;
+      return jsonResponse(200, { data: [], error: null });
+    });
+    // 100k trailing slashes would backtrack polynomially under a
+    // `/\/+$/` regex; the linear strip handles it in O(n). The test
+    // returning promptly (no timeout) is the assertion that matters.
+    const client = new OrnnClient({
+      baseUrl: "https://x" + "/".repeat(100_000),
+      fetch: fetchMock,
+    });
+    await client.request("GET", "/ping");
+    expect(capturedUrl).toBe("https://x/api/v1/ping");
+  });
+
   test("injects Bearer token from static option", async () => {
     let captured: Record<string, string> = {};
     const fetchMock = mockFetch((_url, init) => {


### PR DESCRIPTION
Closes #960.

Promotes 9 verified bug fixes from `develop-auto` onto `develop`'s current tip (clean merge, no conflicts — the bug-fix surfaces are disjoint from develop's recent landing work).

| Issue | Area | Fix |
|---|---|---|
| #632 | api | Server-side ZIP-bomb caps at the ingestion chokepoint |
| #757 | api/sdk | CodeQL: unbiased redemption codes + SDK ReDoS trim |
| #766 | api | Charge playground quota on abort-after-billable-work |
| #608 | api | Parse chat-completion tool_calls → Playground sandbox runs |
| #750 | web | Version delete/deprecation send GUID to GUID-only routes |
| #751 | web | Notification dropdown refetches on open |
| #940 | web | Remove deleted skill's detail cache (no 404 refetch) |
| #941 | web | Refresh My-Skills sidebar counts on delete |
| #752 | web | Skill timestamps follow the active UI language |

**Verification:** cumulative tree green (ornn-api 1656 pass / ornn-web 337 pass / typechecks clean); all 9 source PRs CI-green at merge; acceptance criteria independently re-verified (high confidence).

**Excluded:** #803/#805 (NyxID identity verification) — escalated to #948.

⚠️ **Merge as a MERGE COMMIT, not squash** — preserves merge-base(develop, develop-auto) per CLAUDE.md.