### PR TITLE
docs: release notes for v0.11.0 (2026-06-09)

### DIFF
--- a/.changeset/release-notes-20260609.md
+++ b/.changeset/release-notes-20260609.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: release notes for v0.11.0 (docs-only, no version impact)

--- a/.github/release-notes-20260609.md
+++ b/.github/release-notes-20260609.md
@@ -1,0 +1,20 @@
+## Fixed
+
+- Runtime and mixed skills now run in Playground on more LLM providers.
+- Playground usage is charged correctly even when a chat is interrupted.
+- Deleting a non-latest skill version now works from name-based links.
+- The notification dropdown shows new broadcasts without a manual refresh.
+- Deleting a skill no longer leaves stale requests or incorrect counts.
+- Skill timestamps now follow the selected interface language.
+- Oversized (zip-bomb) skill uploads are now rejected server-side.
+- Few technical bugs fixed.
+
+## New Feature
+
+- Global announcement banner for launch and platform notices.
+- Skill-lifecycle ring on the landing hero.
+
+## Changed
+
+- Landing popups replaced by the unified announcement banner.
+- Technical enhancement.


### PR DESCRIPTION
Part of #963. Step 0 of the release procedure.

Adds `.github/release-notes-20260609.md` (the dated release-notes file the develop → main check-release-notes gate requires) + an empty changeset so check-changeset passes on this docs-only PR. User-facing bullets cover the 9 bug fixes, the #949 announcement-banner / skill-lifecycle-ring features, and the technical (coverage/lint/CI) work.