### PR TITLE
[Feature] Skill dependencies — declare prerequisite skills in metadata + closure resolver

### DIFF
--- a/.changeset/feat-968-skill-dependencies.md
+++ b/.changeset/feat-968-skill-dependencies.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"@chronoai/ornn-sdk": minor
+---
+
+Skill dependencies (#968). Skills can now declare other skills they depend on via the `metadata.depends-on` SKILL.md frontmatter field — each entry pins one skill by `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>` (no semver ranges, no self-references; max 50 direct deps). The full transitive closure is validated at publish time (`POST /skills`, `PUT /skills/:id`): missing dependencies, cycles, and conflicting versions of the same skill are rejected before the version is committed. A new `GET /api/v1/skills/:idOrName/closure` endpoint resolves and returns the full closure in deps-first topological order, scoped to what the caller may read. Three new error codes: `dependency_cycle` (409), `dependency_conflict` (409), `skill_dependency_not_found` (404). The TypeScript SDK gains `resolveClosure` / `pullClosure`; the Python SDK gains `resolve_closure` / `pull_closure`.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -159,6 +159,36 @@ Reserved action verbs per resource documented in `ornn-api/src/shared/reservedVe
 
 Both return the same collection shape (`{ items, meta }`).
 
+### 2.5 Skill dependency closure (#968)
+
+```
+GET /v1/skills/{idOrName}/closure[?version=<major.minor>|<dist-tag>]
+```
+
+Resolves the full **transitive** dependency closure of a skill version. A skill declares its direct dependencies in SKILL.md frontmatter via `metadata.depends-on` — an array of `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>` refs (no semver ranges). The endpoint walks that graph and returns every transitive dependency.
+
+- **Auth:** optional. Anonymous callers resolve against public skills only; a public skill that transitively depends on a private skill the caller can't read surfaces that node as `skill_dependency_not_found` (existence not leaked).
+- **Order:** items are returned in deps-first **topological order** — every dependency precedes the dependents that pin it, so installing in array order is always safe. Shared nodes (diamonds) appear exactly once.
+- **Response:** standard collection envelope.
+
+```json
+{
+  "data": {
+    "items": [
+      { "guid": "…", "name": "pdf-tools", "version": "1.0", "skillHash": "…", "depth": 1 },
+      { "guid": "…", "name": "report-gen", "version": "2.3", "skillHash": "…", "depth": 0 }
+    ]
+  },
+  "error": null
+}
+```
+
+- **Errors:** `dependency_cycle` (409) when the graph loops; `dependency_conflict` (409) when one skill is pinned to two versions in the same closure; `skill_dependency_not_found` (404) when a ref doesn't resolve or isn't visible. See `docs/ERRORS.md`.
+
+The same closure is validated at **publish time**: declaring a `depends-on` ref that can't be resolved, forms a cycle, or conflicts fails the create/update before the version is committed.
+
+SDK helpers: `client.resolveClosure(idOrName, { version })` / `client.pullClosure(...)` (TypeScript), `client.resolve_closure(...)` / `client.pull_closure(...)` (Python).
+
 ---
 
 ## 3. HTTP semantics

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -92,22 +92,40 @@ The caller is authenticated but lacks the permission required for this resource 
 ## resource_not_found
 
 **HTTP:** `404 Not Found`
-**Common subcodes (lowercase post-#585):** `skill_not_found`, `skill_version_not_found`, `org_not_found`, `provider_not_found`, `announcement_not_found`, `broadcast_not_found`, `notification_not_found`, `audit_not_found`, `redemption_code_not_found`, …
+**Common subcodes (lowercase post-#585):** `skill_not_found`, `skill_version_not_found`, `skill_dependency_not_found`, `org_not_found`, `provider_not_found`, `announcement_not_found`, `broadcast_not_found`, `notification_not_found`, `audit_not_found`, `redemption_code_not_found`, …
 
 The target resource does not exist, **or** it exists but is not visible to the caller (private skill outside their access scope). The two cases are intentionally not distinguished — disclosing existence is itself information.
 
 **Client action:** for known-good identifiers, this likely means a visibility issue. For typed identifiers, verify the GUID / name.
+
+### skill_dependency_not_found
+
+A skill in a dependency closure (#968) could not be resolved — either the referenced `<name-or-guid>@<version>` / `<name>@<dist-tag>` does not exist, or it is a private skill the caller cannot read. Surfaced at publish time (a new version declares a `depends-on` ref that won't resolve) and from `GET /api/v1/skills/{id}/closure`. As with every `resource_not_found`, "missing" and "not visible" are intentionally indistinguishable.
+
+**Client action:** verify each `depends-on` ref points at a published, readable skill version. Publish or share the dependency first, then retry.
 
 ---
 
 ## resource_conflict
 
 **HTTP:** `409 Conflict`
-**Common subcodes (lowercase post-#585):** `skill_name_exists`, `reconcile_already_running`, `redemption_code_expired`, `redemption_code_already_redeemed`, `redemption_code_already_invalidated`, `old_repo_not_confirmed`, …
+**Common subcodes (lowercase post-#585):** `skill_name_exists`, `dependency_cycle`, `dependency_conflict`, `reconcile_already_running`, `redemption_code_expired`, `redemption_code_already_redeemed`, `redemption_code_already_invalidated`, `old_repo_not_confirmed`, …
 
 The request collides with current state — a duplicate skill name on create, a concurrent modification, a job that's already running, etc.
 
 **Client action:** read `detail` to decide. For duplicates, prompt the user for a different value. For concurrent modifications, refetch and retry.
+
+### dependency_cycle
+
+The skill dependency graph (#968) contains a cycle — following `depends-on` refs eventually loops back to a skill already on the path. A closure with a cycle cannot be installed in any order. Surfaced at publish time and from `GET /api/v1/skills/{id}/closure`.
+
+**Client action:** break the cycle by removing one of the offending `depends-on` refs. The `detail` names a skill involved in the loop.
+
+### dependency_conflict
+
+Two different versions of the **same** skill appear in one dependency closure (#968) — e.g. `a` depends on `b@1.0` while `a`'s other dependency `c` depends on `b@2.0`. Only one version of a given skill can be installed in a closure.
+
+**Client action:** align the conflicting pins so every path resolves the skill to the same `<major.minor>` version, then retry.
 
 ---
 
@@ -216,6 +234,9 @@ Clients pinned to the old `SCREAMING_SNAKE_CASE` codes need to switch to the low
 | `SKILL_NAME_EXISTS` | 409 | `skill_name_exists` | `resource_conflict` |
 | `SKILL_NOT_FOUND` | 404 | `skill_not_found` | `resource_not_found` |
 | `SKILL_VERSION_NOT_FOUND` | 404 | `skill_version_not_found` | `resource_not_found` |
+| _(new in #968)_ | 404 | `skill_dependency_not_found` | `resource_not_found` |
+| _(new in #968)_ | 409 | `dependency_cycle` | `resource_conflict` |
+| _(new in #968)_ | 409 | `dependency_conflict` | `resource_conflict` |
 | `UPSTREAM_DOWN` | 502 | `upstream_down` | `upstream_unavailable` |
 
 Format rule for future codes: lowercase ASCII, words joined by `_`, no leading/trailing `_`. Pick from the parent §1.4 vocabulary when generic; add a specific subcode only when the caller needs to branch on it.

--- a/ornn-api/src/domains/skills/closure/resolver.test.ts
+++ b/ornn-api/src/domains/skills/closure/resolver.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure dependency-closure resolver tests (#968).
+ *
+ * The resolver is deliberately DB-free: it takes a `loadVersion(ref)`
+ * loader and walks the dependency graph with a three-color DFS. These
+ * tests exercise the five contract cases against an in-memory graph:
+ *
+ *   - linear chain      → topo order, deps before dependents
+ *   - diamond           → shared node deduped, still correctly ordered
+ *   - cycle             → `dependency_cycle` (409)
+ *   - version conflict  → `dependency_conflict` (409) when the same skill
+ *                         is pinned to two different versions in one graph
+ *   - missing dep       → `skill_dependency_not_found` (404)
+ *
+ * @module domains/skills/closure/resolver.test
+ */
+
+import { describe, expect, it } from "bun:test";
+import { resolveClosure, type ResolvedVersion, type LoadVersion } from "./resolver";
+import { AppError } from "../../../shared/types/index";
+
+/**
+ * Build a `loadVersion` over a static graph keyed by the canonical
+ * `<name>@<version>` ref. Each node declares the names+versions of its
+ * direct deps. `loadVersion` returns null for any ref not in the graph
+ * (the "missing dependency" signal). Dist-tag refs are resolved through
+ * an optional alias map so tests can exercise tag → version pinning.
+ */
+function makeLoader(
+  graph: Record<string, { name: string; version: string; deps: string[] }>,
+  aliases: Record<string, string> = {},
+): LoadVersion {
+  return async (ref: string): Promise<ResolvedVersion | null> => {
+    const resolvedRef = aliases[ref] ?? ref;
+    const node = graph[resolvedRef];
+    if (!node) return null;
+    return {
+      ref: `${node.name}@${node.version}`,
+      name: node.name,
+      version: node.version,
+      dependsOn: node.deps,
+    };
+  };
+}
+
+async function catchErr(fn: () => Promise<unknown>): Promise<AppError> {
+  try {
+    await fn();
+  } catch (err) {
+    return err as AppError;
+  }
+  throw new Error("expected the call to throw");
+}
+
+describe("resolveClosure (#968)", () => {
+  it("resolves a linear chain in deps-before-dependents order", async () => {
+    // a → b → c
+    const loadVersion = makeLoader({
+      "a@1.0": { name: "a", version: "1.0", deps: ["b@1.0"] },
+      "b@1.0": { name: "b", version: "1.0", deps: ["c@1.0"] },
+      "c@1.0": { name: "c", version: "1.0", deps: [] },
+    });
+    const result = await resolveClosure(["a@1.0"], { loadVersion });
+    const names = result.map((n) => n.name);
+    // c before b before a (reverse-postorder topological sort).
+    expect(names.indexOf("c")).toBeLessThan(names.indexOf("b"));
+    expect(names.indexOf("b")).toBeLessThan(names.indexOf("a"));
+    expect(names).toHaveLength(3);
+    // depth: roots at 0, deeper deps higher.
+    const byName = Object.fromEntries(result.map((n) => [n.name, n.depth]));
+    expect(byName.a).toBe(0);
+    expect(byName.b).toBe(1);
+    expect(byName.c).toBe(2);
+  });
+
+  it("dedupes a shared node in a diamond graph", async () => {
+    // a → b → d ; a → c → d. d appears once, before b and c.
+    const loadVersion = makeLoader({
+      "a@1.0": { name: "a", version: "1.0", deps: ["b@1.0", "c@1.0"] },
+      "b@1.0": { name: "b", version: "1.0", deps: ["d@1.0"] },
+      "c@1.0": { name: "c", version: "1.0", deps: ["d@1.0"] },
+      "d@1.0": { name: "d", version: "1.0", deps: [] },
+    });
+    const result = await resolveClosure(["a@1.0"], { loadVersion });
+    const names = result.map((n) => n.name);
+    expect(names).toHaveLength(4);
+    expect(names.filter((n) => n === "d")).toHaveLength(1);
+    expect(names.indexOf("d")).toBeLessThan(names.indexOf("b"));
+    expect(names.indexOf("d")).toBeLessThan(names.indexOf("c"));
+    expect(names.indexOf("b")).toBeLessThan(names.indexOf("a"));
+    expect(names.indexOf("c")).toBeLessThan(names.indexOf("a"));
+  });
+
+  it("throws dependency_cycle (409) on a back-edge", async () => {
+    // a → b → a
+    const loadVersion = makeLoader({
+      "a@1.0": { name: "a", version: "1.0", deps: ["b@1.0"] },
+      "b@1.0": { name: "b", version: "1.0", deps: ["a@1.0"] },
+    });
+    const err = await catchErr(() => resolveClosure(["a@1.0"], { loadVersion }));
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(409);
+    expect(err.code).toBe("dependency_cycle");
+  });
+
+  it("throws dependency_cycle on a self-loop reached via GUID ref", async () => {
+    // a depends on itself — the frontmatter self-ref guard can't catch
+    // a GUID-form self-ref, so the resolver's cycle check must.
+    const loadVersion = makeLoader({
+      "a@1.0": { name: "a", version: "1.0", deps: ["a@1.0"] },
+    });
+    const err = await catchErr(() => resolveClosure(["a@1.0"], { loadVersion }));
+    expect(err.code).toBe("dependency_cycle");
+  });
+
+  it("throws dependency_conflict (409) when one skill is pinned to two versions", async () => {
+    // a → b@1.0 ; a → c → b@2.0. Same skill `b`, two versions.
+    const loadVersion = makeLoader({
+      "a@1.0": { name: "a", version: "1.0", deps: ["b@1.0", "c@1.0"] },
+      "b@1.0": { name: "b", version: "1.0", deps: [] },
+      "b@2.0": { name: "b", version: "2.0", deps: [] },
+      "c@1.0": { name: "c", version: "1.0", deps: ["b@2.0"] },
+    });
+    const err = await catchErr(() => resolveClosure(["a@1.0"], { loadVersion }));
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(409);
+    expect(err.code).toBe("dependency_conflict");
+  });
+
+  it("throws skill_dependency_not_found (404) when a dep cannot be loaded", async () => {
+    // a → missing@1.0 (not in graph).
+    const loadVersion = makeLoader({
+      "a@1.0": { name: "a", version: "1.0", deps: ["missing@1.0"] },
+    });
+    const err = await catchErr(() => resolveClosure(["a@1.0"], { loadVersion }));
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(404);
+    expect(err.code).toBe("skill_dependency_not_found");
+  });
+
+  it("throws skill_dependency_not_found when a root ref cannot be loaded", async () => {
+    const loadVersion = makeLoader({});
+    const err = await catchErr(() => resolveClosure(["ghost@1.0"], { loadVersion }));
+    expect(err.code).toBe("skill_dependency_not_found");
+  });
+
+  it("resolves a dist-tag dependency to its concrete version", async () => {
+    // a → b@beta, where beta aliases to b@1.0.
+    const loadVersion = makeLoader(
+      {
+        "a@1.0": { name: "a", version: "1.0", deps: ["b@beta"] },
+        "b@1.0": { name: "b", version: "1.0", deps: [] },
+      },
+      { "b@beta": "b@1.0" },
+    );
+    const result = await resolveClosure(["a@1.0"], { loadVersion });
+    const b = result.find((n) => n.name === "b");
+    expect(b?.version).toBe("1.0");
+  });
+
+  it("returns an empty closure for a dependency-free root", async () => {
+    const loadVersion = makeLoader({
+      "a@1.0": { name: "a", version: "1.0", deps: [] },
+    });
+    const result = await resolveClosure(["a@1.0"], { loadVersion });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe("a");
+  });
+});

--- a/ornn-api/src/domains/skills/closure/resolver.ts
+++ b/ornn-api/src/domains/skills/closure/resolver.ts
@@ -1,0 +1,232 @@
+/**
+ * Pure skill dependency-closure resolver (#968).
+ *
+ * Given a set of root dependency refs and a `loadVersion(ref)` loader,
+ * walks the dependency graph and returns the full transitive closure in
+ * topological order (every dependency appears before the dependents that
+ * pin it). The module is DELIBERATELY pure — it imports no database, no
+ * storage, no Hono. The only side-effect surface is the injected
+ * `loadVersion`, which the caller wires to whatever source it has
+ * (Mongo at publish time, an authorized read at request time, an
+ * in-memory map in tests). That keeps the graph algorithm trivially
+ * unit-testable and reusable across every closure-shaped feature.
+ *
+ * Algorithm: a three-color (WHITE / GRAY / BLACK) depth-first search.
+ *   - WHITE  — not yet visited.
+ *   - GRAY   — on the current DFS stack (being explored).
+ *   - BLACK  — fully explored; its subtree is closed.
+ * A GRAY node reached again is a back-edge ⇒ a cycle. Nodes are emitted
+ * in DFS postorder (a node is appended only after all of its children
+ * have been fully explored), which is itself a valid topological order
+ * with dependencies before dependents — no reversal needed.
+ *
+ * Three failure modes map to the three lowercase error codes the
+ * contract mandates (see docs/ERRORS.md §11-13):
+ *   - cycle                     → `dependency_cycle`           (409)
+ *   - same skill, two versions  → `dependency_conflict`        (409)
+ *   - ref the loader can't find → `skill_dependency_not_found` (404)
+ *
+ * @module domains/skills/closure/resolver
+ */
+
+import { AppError } from "../../../shared/types/index";
+import { createLogger } from "../../../shared/logger";
+
+const logger = createLogger("closureResolver");
+
+/**
+ * A concrete, loaded skill version. The loader resolves a (possibly
+ * dist-tagged) ref into this shape; `ref` is re-canonicalized to
+ * `<name>@<version>` so two equivalent refs (e.g. `pdf@latest` and
+ * `pdf@1.0`) collapse onto one graph node.
+ */
+export interface ResolvedVersion {
+  /** Canonical `<name>@<version>` for this loaded node. */
+  ref: string;
+  /** Skill name. Used as the conflict key — one name may appear once. */
+  name: string;
+  /** Concrete `<major>.<minor>` version. */
+  version: string;
+  /** Stable skill GUID, when known. Surfaced in the closure output. */
+  guid?: string;
+  /** Package hash for the resolved version, when known. */
+  skillHash?: string;
+  /** Direct dependency refs declared by this version. */
+  dependsOn: string[];
+}
+
+/**
+ * Loader contract. Resolves a dependency ref (`<name-or-guid>@<version>`
+ * or `<name>@<dist-tag>`) to a {@link ResolvedVersion}, or `null` when no
+ * such version exists / is visible. Async so DB / network loaders fit.
+ */
+export type LoadVersion = (ref: string) => Promise<ResolvedVersion | null>;
+
+/** One node in the resolved closure, carrying its BFS-style depth. */
+export interface ClosureNode {
+  ref: string;
+  name: string;
+  version: string;
+  guid?: string;
+  skillHash?: string;
+  /** 0 for roots; max distance from any root for deeper deps. */
+  depth: number;
+}
+
+export interface ResolveClosureOptions {
+  loadVersion: LoadVersion;
+}
+
+export interface ResolveClosureSettings {
+  /**
+   * Hard ceiling on the number of distinct nodes in the closure. Guards
+   * against a pathological graph blowing up memory / time. Default 500.
+   */
+  maxNodes?: number;
+}
+
+const DEFAULT_MAX_NODES = 500;
+
+enum Color {
+  WHITE,
+  GRAY,
+  BLACK,
+}
+
+/**
+ * Resolve the full transitive dependency closure of `roots`.
+ *
+ * Returns nodes in DFS postorder (dependencies first), deduplicated by
+ * canonical ref. Each node carries the MAXIMUM depth at which it was
+ * reached, so a shared diamond node reports the deeper of its paths.
+ *
+ * Throws:
+ *   - `dependency_cycle` (409) on a back-edge.
+ *   - `dependency_conflict` (409) when one skill name resolves to two
+ *     distinct versions anywhere in the graph.
+ *   - `skill_dependency_not_found` (404) when `loadVersion` returns null
+ *     for any ref reached (root or transitive).
+ */
+export async function resolveClosure(
+  roots: string[],
+  options: ResolveClosureOptions,
+  settings: ResolveClosureSettings = {},
+): Promise<ClosureNode[]> {
+  const { loadVersion } = options;
+  const maxNodes = settings.maxNodes ?? DEFAULT_MAX_NODES;
+
+  // Canonical-ref → resolved version (graph node cache). One async load
+  // per distinct ref; later refs to the same node are served from here.
+  const loaded = new Map<string, ResolvedVersion>();
+  const color = new Map<string, Color>();
+  // name → version, to detect a same-skill / different-version conflict.
+  const pinnedVersion = new Map<string, string>();
+  // Canonical ref → max depth seen.
+  const depthOf = new Map<string, number>();
+  // Postorder accumulation (canonical refs).
+  const postorder: string[] = [];
+
+  /**
+   * Load a ref into a canonical {@link ResolvedVersion}, caching by both
+   * the requested ref AND the canonical ref so a dist-tag and its
+   * concrete version share one node. Throws `skill_dependency_not_found`
+   * when the loader can't resolve it.
+   */
+  async function resolve(ref: string): Promise<ResolvedVersion> {
+    const cached = loaded.get(ref);
+    if (cached) return cached;
+    const node = await loadVersion(ref);
+    if (!node) {
+      logger.error({ ref }, "Dependency ref could not be resolved");
+      throw AppError.notFound(
+        "skill_dependency_not_found",
+        `Skill dependency '${ref}' was not found or is not accessible.`,
+      );
+    }
+    // Cache under both the requested ref and the canonical ref so
+    // distinct aliases (e.g. `@beta` and `@1.0`) collapse onto one node.
+    loaded.set(ref, node);
+    loaded.set(node.ref, node);
+    return node;
+  }
+
+  async function visit(ref: string, depth: number): Promise<string> {
+    const node = await resolve(ref);
+    const canonical = node.ref;
+
+    // Conflict check: a single skill name may resolve to exactly one
+    // version across the whole closure. Two different versions of the
+    // same skill cannot be installed side by side.
+    const priorVersion = pinnedVersion.get(node.name);
+    if (priorVersion !== undefined && priorVersion !== node.version) {
+      logger.error(
+        { name: node.name, versions: [priorVersion, node.version] },
+        "Conflicting versions of the same skill in dependency closure",
+      );
+      throw AppError.conflict(
+        "dependency_conflict",
+        `Dependency '${node.name}' is pinned to conflicting versions ` +
+          `'${priorVersion}' and '${node.version}' within the same closure.`,
+      );
+    }
+    pinnedVersion.set(node.name, node.version);
+
+    // Track the deepest reach so diamond-shared nodes sort correctly.
+    const prevDepth = depthOf.get(canonical);
+    depthOf.set(canonical, prevDepth === undefined ? depth : Math.max(prevDepth, depth));
+
+    const state = color.get(canonical) ?? Color.WHITE;
+    if (state === Color.GRAY) {
+      logger.error({ ref: canonical }, "Cycle detected in dependency closure");
+      throw AppError.conflict(
+        "dependency_cycle",
+        `A dependency cycle was detected involving '${canonical}'.`,
+      );
+    }
+    if (state === Color.BLACK) {
+      // Already fully explored — nothing more to do (dedup).
+      return canonical;
+    }
+
+    color.set(canonical, Color.GRAY);
+    for (const childRef of node.dependsOn) {
+      await visit(childRef, depth + 1);
+      if (loaded.size > maxNodes) {
+        throw AppError.conflict(
+          "dependency_conflict",
+          `Dependency closure exceeded the maximum of ${maxNodes} nodes.`,
+        );
+      }
+    }
+    color.set(canonical, Color.BLACK);
+    postorder.push(canonical);
+    return canonical;
+  }
+
+  for (const root of roots) {
+    await visit(root, 0);
+  }
+
+  // Postorder already places dependencies before dependents (a node is
+  // pushed only after all its children). That IS the deps-first topo
+  // order — no reversal needed. Dedup is implicit: each canonical ref is
+  // pushed exactly once (guarded by the BLACK check).
+  const result: ClosureNode[] = postorder.map((canonical) => {
+    const node = loaded.get(canonical)!;
+    const out: ClosureNode = {
+      ref: node.ref,
+      name: node.name,
+      version: node.version,
+      depth: depthOf.get(canonical) ?? 0,
+    };
+    if (node.guid !== undefined) out.guid = node.guid;
+    if (node.skillHash !== undefined) out.skillHash = node.skillHash;
+    return out;
+  });
+
+  logger.info(
+    { roots, nodeCount: result.length },
+    "Dependency closure resolved",
+  );
+  return result;
+}

--- a/ornn-api/src/domains/skills/crud/routes.test.ts
+++ b/ornn-api/src/domains/skills/crud/routes.test.ts
@@ -502,6 +502,124 @@ describe("GET /skills/:idOrName/versions", () => {
 });
 
 // ======================================================================
+// GET /skills/:idOrName/closure (#968)
+// ======================================================================
+
+describe("GET /skills/:idOrName/closure", () => {
+  const linear = [
+    { guid: "g-c", name: "c", version: "1.0", skillHash: "h-c", depth: 1 },
+    { guid: "g-b", name: "b", version: "1.0", skillHash: "h-b", depth: 0 },
+  ];
+
+  test("200 returns the topo-ordered items envelope (linear chain)", async () => {
+    const captured: { idOrName: string | undefined; version: string | undefined; anon: boolean | undefined } = {
+      idOrName: undefined,
+      version: undefined,
+      anon: undefined,
+    };
+    const app = buildApp({
+      authenticated: true,
+      permissions: [READ],
+      service: {
+        resolveSkillClosure: async (...args: unknown[]) => {
+          captured.idOrName = args[0] as string;
+          captured.version = args[2] as string | undefined;
+          captured.anon = (args[1] as { userId: string }).userId === "";
+          return linear;
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/closure?version=1.0");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { items: typeof linear }; error: null };
+    expect(body.error).toBeNull();
+    expect(body.data.items.map((i) => i.name)).toEqual(["c", "b"]);
+    expect(captured.idOrName).toBe("demo-skill");
+    expect(captured.version).toBe("1.0");
+    expect(captured.anon).toBe(false);
+  });
+
+  test("200 with a deduped diamond closure", async () => {
+    const diamond = [
+      { guid: "g-d", name: "d", version: "1.0", skillHash: "h-d", depth: 2 },
+      { guid: "g-b", name: "b", version: "1.0", skillHash: "h-b", depth: 1 },
+      { guid: "g-c", name: "c", version: "1.0", skillHash: "h-c", depth: 1 },
+    ];
+    const app = buildApp({
+      authenticated: false,
+      service: { resolveSkillClosure: async () => diamond },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/closure");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { items: typeof diamond } };
+    // d (the shared leaf) appears once and sorts before its dependents.
+    expect(body.data.items.filter((i) => i.name === "d")).toHaveLength(1);
+    expect(body.data.items.map((i) => i.name).indexOf("d")).toBe(0);
+  });
+
+  test("passes an anonymous actor (userId='') when unauthenticated", async () => {
+    let anon: boolean | undefined;
+    const app = buildApp({
+      authenticated: false,
+      service: {
+        resolveSkillClosure: async (...args: unknown[]) => {
+          anon = (args[1] as { userId: string }).userId === "";
+          return [];
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/public-skill/closure");
+    expect(res.status).toBe(200);
+    expect(anon).toBe(true);
+  });
+
+  test("409 dependency_cycle propagates from the service", async () => {
+    const { AppError } = await import("../../../shared/types/index");
+    const app = buildApp({
+      authenticated: false,
+      service: {
+        resolveSkillClosure: async () => {
+          throw AppError.conflict("dependency_cycle", "cycle at a@1.0");
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/closure");
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { code: string }).code).toBe("dependency_cycle");
+  });
+
+  test("409 dependency_conflict propagates from the service", async () => {
+    const { AppError } = await import("../../../shared/types/index");
+    const app = buildApp({
+      authenticated: false,
+      service: {
+        resolveSkillClosure: async () => {
+          throw AppError.conflict("dependency_conflict", "b pinned to 1.0 and 2.0");
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/closure");
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { code: string }).code).toBe("dependency_conflict");
+  });
+
+  test("404 skill_dependency_not_found propagates from the service", async () => {
+    const { AppError } = await import("../../../shared/types/index");
+    const app = buildApp({
+      authenticated: false,
+      service: {
+        resolveSkillClosure: async () => {
+          throw AppError.notFound("skill_dependency_not_found", "missing dep");
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/closure");
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { code: string }).code).toBe("skill_dependency_not_found");
+  });
+});
+
+// ======================================================================
 // GET /skills/:idOrName/versions/:from/diff/:to
 // ======================================================================
 

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -674,6 +674,54 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
   );
 
   /**
+   * GET /skills/:idOrName/closure — Resolve the full transitive
+   * dependency closure of a skill version (#968).
+   *
+   * Query params:
+   *   - `version` (optional) — literal `<major>.<minor>` or a dist-tag.
+   *     When omitted, the skill's latest version is used.
+   *
+   * Returns the closure in deps-first topological order:
+   *   `{ data: { items: [{ guid, name, version, skillHash, depth }] }, error: null }`
+   *
+   * Auth: Optional. Anonymous callers resolve against public skills only —
+   * a public skill that transitively depends on a PRIVATE skill surfaces
+   * that node as `skill_dependency_not_found` rather than leaking it.
+   *
+   * Errors: `dependency_cycle` (409), `dependency_conflict` (409),
+   * `skill_dependency_not_found` (404), `skill_not_found` (404).
+   *
+   * Registered ABOVE `/skills/:idOrName` so the literal `/closure` segment
+   * wins the route match (mirrors `/skills/:idOrName/versions`).
+   */
+  app.get(
+    "/skills/:idOrName/closure",
+    optionalAuth,
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const version = c.req.query("version") || undefined;
+      const authCtx = c.get("auth");
+
+      // Build the visibility-scoped actor. Authenticated callers get their
+      // full org/admin context; anonymous callers get a read-only actor
+      // that can see public skills only.
+      const actor = authCtx
+        ? await buildActorContext(c)
+        : {
+            userId: "",
+            memberships: [],
+            isPlatformAdmin: false,
+            membershipsResolved: true,
+          };
+
+      logger.info({ idOrName, version: version ?? null, anon: !authCtx }, "Skill closure request");
+
+      const items = await skillService.resolveSkillClosure(idOrName, actor, version);
+      return c.json({ data: { items }, error: null });
+    },
+  );
+
+  /**
    * GET /skills/:idOrName — Read a skill by GUID or name.
    * Query params:
    *   - version: optional `<major>.<minor>` — when set, return that version's

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -497,18 +497,24 @@ function versionDoc(overrides: Partial<SkillVersionDocument> = {}): SkillVersion
 }
 
 /** Build a valid SKILL.md ZIP as raw bytes (for createSkill / updateSkill). */
-async function validSkillZip(opts: { name?: string; version?: string } = {}): Promise<Uint8Array> {
-  const { name = "demo-skill", version = "1.0" } = opts;
+async function validSkillZip(
+  opts: { name?: string; version?: string; dependsOn?: string[] } = {},
+): Promise<Uint8Array> {
+  const { name = "demo-skill", version = "1.0", dependsOn } = opts;
   const zip = new JSZip();
   const folder = zip.folder(name)!;
+  const metaLines = ["metadata:", "  category: plain"];
+  if (dependsOn && dependsOn.length > 0) {
+    metaLines.push("  depends-on:");
+    for (const dep of dependsOn) metaLines.push(`    - ${dep}`);
+  }
   folder.file(
     "SKILL.md",
     [
       "---",
       `name: ${name}`,
       "description: A demo skill used by service tests.",
-      "metadata:",
-      "  category: plain",
+      ...metaLines,
       `version: "${version}"`,
       "---",
       `# ${name}`,
@@ -586,12 +592,22 @@ function makeFakeDeps(seed?: Partial<FakeState>): { deps: SkillServiceDeps; stat
   } as unknown as SkillRepository;
 
   const skillVersionRepo = {
-    create: async (data: { version: string; majorVersion: number; minorVersion: number }) => {
+    create: async (data: {
+      skillGuid?: string;
+      version: string;
+      majorVersion: number;
+      minorVersion: number;
+      metadata?: SkillVersionDocument["metadata"];
+    }) => {
       const v = versionDoc({
-        _id: `guid-1@${data.version}`,
+        _id: `${data.skillGuid ?? "guid-1"}@${data.version}`,
+        ...(data.skillGuid ? { skillGuid: data.skillGuid } : {}),
         version: data.version,
         majorVersion: data.majorVersion,
         minorVersion: data.minorVersion,
+        // Capture the metadata the service passed so dependsOn round-trips
+        // (#968) — the previous fake discarded it.
+        ...(data.metadata ? { metadata: data.metadata } : {}),
       });
       state.versions.push(v);
       return v;
@@ -787,6 +803,322 @@ describe("SkillService.updateSkill", () => {
       thrown = err;
     }
     expect((thrown as AppError).code).toBe("skill_not_found");
+  });
+});
+
+describe("SkillService skill dependencies — persistence + publish validation (#968)", () => {
+  /**
+   * Seed an already-published dependency skill `pdf-tools@1.0` so the
+   * closure loader can resolve refs against it. Returns the seed maps for
+   * `makeFakeDeps`.
+   */
+  function seedDep(opts: { dependsOn?: string[]; isPrivate?: boolean } = {}) {
+    const depSkill = makeSkillDoc({
+      guid: "dep-guid",
+      name: "pdf-tools",
+      latestVersion: "1.0",
+      isPrivate: opts.isPrivate ?? false,
+    });
+    const depVersion = versionDoc({
+      _id: "dep-guid@1.0",
+      skillGuid: "dep-guid",
+      version: "1.0",
+      majorVersion: 1,
+      minorVersion: 0,
+      metadata: { category: "plain", ...(opts.dependsOn ? { dependsOn: opts.dependsOn } : {}) },
+    });
+    return {
+      skills: new Map([["dep-guid", depSkill]]),
+      byName: new Map([["pdf-tools", depSkill]]),
+      versions: [depVersion],
+    };
+  }
+
+  it("round-trips depends-on from frontmatter into the persisted version metadata", async () => {
+    const { deps, state } = makeFakeDeps(seedDep());
+    const service = new SkillService(deps);
+    await service.createSkill(
+      await validSkillZip({ name: "report-gen", dependsOn: ["pdf-tools@1.0"] }),
+      "owner-1",
+    );
+    const created = state.versions.find((v) => v.skillGuid !== "dep-guid");
+    expect(created?.metadata.dependsOn).toEqual(["pdf-tools@1.0"]);
+  });
+
+  it("a version published without deps reads back with dependsOn absent (legacy-clean)", async () => {
+    const { deps, state } = makeFakeDeps();
+    const service = new SkillService(deps);
+    await service.createSkill(await validSkillZip({ name: "no-deps" }), "owner-1");
+    const created = state.versions[0]!;
+    expect(created.metadata.dependsOn).toBeUndefined();
+  });
+
+  it("createSkill succeeds for a valid single dependency", async () => {
+    const { deps } = makeFakeDeps(seedDep());
+    const service = new SkillService(deps);
+    const { guid } = await service.createSkill(
+      await validSkillZip({ name: "report-gen", dependsOn: ["pdf-tools@1.0"] }),
+      "owner-1",
+    );
+    expect(guid).toBeTruthy();
+  });
+
+  it("createSkill throws skill_dependency_not_found for a missing dependency", async () => {
+    const { deps, state } = makeFakeDeps();
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.createSkill(
+        await validSkillZip({ name: "report-gen", dependsOn: ["ghost-skill@1.0"] }),
+        "owner-1",
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("skill_dependency_not_found");
+    // Failed before any storage write.
+    expect(state.uploads).toHaveLength(0);
+  });
+
+  it("createSkill throws dependency_cycle when a transitive dep loops back", async () => {
+    // The seeded dependency `pdf-tools@1.0` itself depends on
+    // `report-gen@1.0`. report-gen isn't published yet, but the closure
+    // resolver walks pdf-tools' declared deps and `report-gen@1.0` can't
+    // be loaded — so this actually surfaces as skill_dependency_not_found,
+    // NOT a cycle, because report-gen has no published version yet.
+    //
+    // To exercise a real cycle we seed two mutually-dependent PUBLISHED
+    // skills and resolve a NEW skill that depends on one of them.
+    const aSkill = makeSkillDoc({ guid: "a-guid", name: "skill-a", latestVersion: "1.0" });
+    const bSkill = makeSkillDoc({ guid: "b-guid", name: "skill-b", latestVersion: "1.0" });
+    const aVersion = versionDoc({
+      _id: "a-guid@1.0",
+      skillGuid: "a-guid",
+      version: "1.0",
+      metadata: { category: "plain", dependsOn: ["skill-b@1.0"] },
+    });
+    const bVersion = versionDoc({
+      _id: "b-guid@1.0",
+      skillGuid: "b-guid",
+      version: "1.0",
+      metadata: { category: "plain", dependsOn: ["skill-a@1.0"] },
+    });
+    const { deps } = makeFakeDeps({
+      skills: new Map([
+        ["a-guid", aSkill],
+        ["b-guid", bSkill],
+      ]),
+      byName: new Map([
+        ["skill-a", aSkill],
+        ["skill-b", bSkill],
+      ]),
+      versions: [aVersion, bVersion],
+    });
+    const service = new SkillService(deps);
+    let thrown: unknown;
+    try {
+      await service.createSkill(
+        await validSkillZip({ name: "consumer", dependsOn: ["skill-a@1.0"] }),
+        "owner-1",
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("dependency_cycle");
+    expect((thrown as AppError).statusCode).toBe(409);
+  });
+
+  it("createSkill succeeds for a valid diamond closure", async () => {
+    // d (leaf) ← b, c ← consumer(root via b@1.0, c@1.0).
+    const dSkill = makeSkillDoc({ guid: "d-guid", name: "leaf-d", latestVersion: "1.0" });
+    const bSkill = makeSkillDoc({ guid: "b-guid", name: "mid-b", latestVersion: "1.0" });
+    const cSkill = makeSkillDoc({ guid: "c-guid", name: "mid-c", latestVersion: "1.0" });
+    const dVersion = versionDoc({
+      _id: "d-guid@1.0",
+      skillGuid: "d-guid",
+      version: "1.0",
+      metadata: { category: "plain" },
+    });
+    const bVersion = versionDoc({
+      _id: "b-guid@1.0",
+      skillGuid: "b-guid",
+      version: "1.0",
+      metadata: { category: "plain", dependsOn: ["leaf-d@1.0"] },
+    });
+    const cVersion = versionDoc({
+      _id: "c-guid@1.0",
+      skillGuid: "c-guid",
+      version: "1.0",
+      metadata: { category: "plain", dependsOn: ["leaf-d@1.0"] },
+    });
+    const { deps } = makeFakeDeps({
+      skills: new Map([
+        ["d-guid", dSkill],
+        ["b-guid", bSkill],
+        ["c-guid", cSkill],
+      ]),
+      byName: new Map([
+        ["leaf-d", dSkill],
+        ["mid-b", bSkill],
+        ["mid-c", cSkill],
+      ]),
+      versions: [dVersion, bVersion, cVersion],
+    });
+    const service = new SkillService(deps);
+    const { guid } = await service.createSkill(
+      await validSkillZip({ name: "diamond-root", dependsOn: ["mid-b@1.0", "mid-c@1.0"] }),
+      "owner-1",
+    );
+    expect(guid).toBeTruthy();
+  });
+
+  it("resolveSkillClosure returns the topo-ordered closure for a published skill", async () => {
+    const { deps } = makeFakeDeps(seedDep());
+    const service = new SkillService(deps);
+    await service.createSkill(
+      await validSkillZip({ name: "report-gen", dependsOn: ["pdf-tools@1.0"] }),
+      "owner-1",
+    );
+    const closure = await service.resolveSkillClosure("report-gen", SYSTEM_ACTOR);
+    expect(closure.map((n) => n.name)).toEqual(["pdf-tools"]);
+    // The closure excludes the skill itself; its direct dependencies are
+    // the roots of the walk → depth 0.
+    expect(closure[0]!.depth).toBe(0);
+    expect(closure[0]!.guid).toBe("dep-guid");
+  });
+
+  // ==========================================================================
+  // Per-node visibility gate in buildVersionLoader (#806/#968).
+  //
+  // A PUBLIC skill may transitively depend on a PRIVATE skill. When an
+  // anonymous / under-privileged caller resolves the public root's closure,
+  // the private node MUST NOT leak. The loader (service.ts buildVersionLoader)
+  // returns `null` for an unreadable node; the resolver (closure/resolver.ts
+  // `resolve()`) turns a null load into a hard `skill_dependency_not_found`
+  // (404) — existence is never disclosed. These two tests lock that branch:
+  // an unauthorized caller hits the error, an authorized caller still sees
+  // the node. Delete the `canReadSkill` guard and the negative test breaks
+  // (the closure would resolve successfully and leak the private dep).
+  // ==========================================================================
+
+  /**
+   * Seed a PUBLIC root `report-gen@1.0` that depends on a PRIVATE
+   * `pdf-tools@1.0`, both already published. Returns the seed maps for
+   * `makeFakeDeps` so the closure loader resolves real docs (no createSkill
+   * round-trip — the root must be public, which the fake's create() isn't).
+   */
+  function seedPublicRootPrivateDep() {
+    const rootSkill = makeSkillDoc({
+      guid: "root-guid",
+      name: "report-gen",
+      latestVersion: "1.0",
+      isPrivate: false,
+      createdBy: "owner-1",
+    });
+    const privateDep = makeSkillDoc({
+      guid: "dep-guid",
+      name: "pdf-tools",
+      latestVersion: "1.0",
+      isPrivate: true,
+      createdBy: "owner-1",
+    });
+    const rootVersion = versionDoc({
+      _id: "root-guid@1.0",
+      skillGuid: "root-guid",
+      version: "1.0",
+      metadata: { category: "plain", dependsOn: ["pdf-tools@1.0"] },
+    });
+    const depVersion = versionDoc({
+      _id: "dep-guid@1.0",
+      skillGuid: "dep-guid",
+      version: "1.0",
+      metadata: { category: "plain" },
+    });
+    return {
+      skills: new Map([
+        ["root-guid", rootSkill],
+        ["dep-guid", privateDep],
+      ]),
+      byName: new Map([
+        ["report-gen", rootSkill],
+        ["pdf-tools", privateDep],
+      ]),
+      versions: [rootVersion, depVersion],
+    };
+  }
+
+  // Anonymous caller: a logged-out request. `userId: ""` matches neither the
+  // private dep's `createdBy` ("owner-1") nor its (empty) ACLs, and is not a
+  // platform admin → cannot read pdf-tools.
+  const ANON: ActorContext = {
+    userId: "",
+    memberships: [],
+    isPlatformAdmin: false,
+    membershipsResolved: true,
+  };
+
+  it("resolveSkillClosure hides a private transitive dep from an anonymous caller (skill_dependency_not_found)", async () => {
+    const { deps } = makeFakeDeps(seedPublicRootPrivateDep());
+    const service = new SkillService(deps);
+    // The PUBLIC root passes resolveSkillClosure's own entry gate; the walk
+    // then reaches the PRIVATE pdf-tools, whose loader returns null for an
+    // unreadable node → resolver throws skill_dependency_not_found. The
+    // private skill's existence is never disclosed.
+    let thrown: unknown;
+    try {
+      await service.resolveSkillClosure("report-gen", ANON);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("skill_dependency_not_found");
+    expect((thrown as AppError).statusCode).toBe(404);
+  });
+
+  it("resolveSkillClosure hides a private transitive dep from a non-owner non-admin caller", async () => {
+    const { deps } = makeFakeDeps(seedPublicRootPrivateDep());
+    const service = new SkillService(deps);
+    // A different authenticated user who is neither the author, on the ACL,
+    // nor a platform admin — same outcome as anonymous.
+    const stranger: ActorContext = {
+      userId: "intruder-9",
+      memberships: [],
+      isPlatformAdmin: false,
+      membershipsResolved: true,
+    };
+    let thrown: unknown;
+    try {
+      await service.resolveSkillClosure("report-gen", stranger);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("skill_dependency_not_found");
+    expect((thrown as AppError).statusCode).toBe(404);
+  });
+
+  it("resolveSkillClosure exposes the same private transitive dep to an authorized caller", async () => {
+    const { deps } = makeFakeDeps(seedPublicRootPrivateDep());
+    const service = new SkillService(deps);
+    // SYSTEM_ACTOR (and equivalently the owner / platform admin) CAN read the
+    // private dep, so the gate hides it only from unauthorized callers — no
+    // over-correction. The closure resolves and includes pdf-tools.
+    const closure = await service.resolveSkillClosure("report-gen", SYSTEM_ACTOR);
+    expect(closure.map((n) => n.name)).toEqual(["pdf-tools"]);
+    expect(closure[0]!.guid).toBe("dep-guid");
+
+    // The owning author sees it too (the gate keys on identity, not just the
+    // SYSTEM bypass).
+    const owner: ActorContext = {
+      userId: "owner-1",
+      memberships: [],
+      isPlatformAdmin: false,
+      membershipsResolved: true,
+    };
+    const ownerClosure = await service.resolveSkillClosure("report-gen", owner);
+    expect(ownerClosure.map((n) => n.name)).toEqual(["pdf-tools"]);
   });
 });
 

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -14,7 +14,13 @@ import { AppError } from "../../../shared/types/index";
 import { fetchSkillFromGitHub, parseGithubUrl, type GitHubPullInput } from "./utils/githubPull";
 import { computeVersionDiff, type VersionDiffResult } from "./utils/versionDiff";
 import { isReservedVerb } from "../../../shared/reservedVerbs";
-import { canReadSkill, isMemberOfOrg, type ActorContext } from "./authorize";
+import { canReadSkill, isMemberOfOrg, SYSTEM_ACTOR, type ActorContext } from "./authorize";
+import {
+  resolveClosure,
+  type LoadVersion,
+  type ResolvedVersion,
+  type ClosureNode,
+} from "../closure/resolver";
 
 /**
  * Convert the stored hex `skillHash` into npm-style Subresource Integrity
@@ -34,6 +40,8 @@ import {
   validateSkillFrontmatter,
   SKILL_NAME_REGEX,
   SKILL_NAME_MAX,
+  SKILL_VERSION_REGEX,
+  DEPENDS_ON_REF_REGEX,
 } from "../../../shared/schemas/skillFrontmatter";
 import { resolveZipRoot } from "../../../shared/utils/zip";
 import { enforceZipLimits, type ZipLimitsConfig } from "../../../shared/utils/zipLimits";
@@ -265,6 +273,12 @@ export class SkillService {
     if (existing) {
       throw AppError.conflict("skill_name_exists", `Skill '${name}' already exists`);
     }
+
+    // 3c. Skill-dependency validation (#968). Resolve the closure of the
+    //     declared `depends-on` refs BEFORE any storage write so a missing
+    //     dependency / cycle / version conflict fails the publish early.
+    //     No-op when the skill declares no dependencies.
+    await this.validatePublishDependencies(metadata, { name, version });
 
     // 4. Generate GUID and hash
     const guid = randomUUID();
@@ -699,6 +713,11 @@ export class SkillService {
           );
         }
       }
+
+      // Skill-dependency validation (#968) — same gate as createSkill,
+      // applied to the new version's declared deps before any storage
+      // write. No-op when the version declares no dependencies.
+      await this.validatePublishDependencies(metadata, { name, version });
 
       const skillHash = createHash("sha256").update(options.zipBuffer).digest("hex");
 
@@ -1478,6 +1497,161 @@ export class SkillService {
   }
 
   // ==========================================================================
+  // Dependency closure (#968)
+  // ==========================================================================
+
+  /**
+   * Build a {@link LoadVersion} loader over the live skill collections,
+   * scoped to what `actor` may read. Resolves a dependency ref
+   * (`<name-or-guid>@<major.minor>` or `<name>@<dist-tag>`) into a
+   * {@link ResolvedVersion} the closure resolver can walk, or `null` when
+   * the skill / version doesn't exist OR isn't visible to the actor.
+   *
+   * Per-node `canReadSkill` (#806/#968): an anonymous or under-privileged
+   * caller resolving the closure of a public skill that transitively
+   * depends on a PRIVATE skill gets `null` for that node, surfaced as
+   * `skill_dependency_not_found` — existence isn't leaked. Trusted
+   * callers (publish-time validation) pass `SYSTEM_ACTOR`.
+   */
+  private buildVersionLoader(actor: ActorContext): LoadVersion {
+    return async (ref: string): Promise<ResolvedVersion | null> => {
+      const at = ref.lastIndexOf("@");
+      if (at <= 0 || at === ref.length - 1) return null;
+      const idOrName = ref.slice(0, at);
+      const versionOrTag = ref.slice(at + 1);
+
+      const skill =
+        (await this.skillRepo.findByGuid(idOrName)) ??
+        (await this.skillRepo.findByName(idOrName));
+      if (!skill) return null;
+
+      // Visibility gate (#806) — a node the actor cannot read is invisible
+      // (returns null), not a hard error, so the closure of a public skill
+      // never leaks the existence of a private dependency.
+      if (!canReadSkill(skill, actor)) return null;
+
+      // Resolve a dist-tag to a literal version; a literal passes through.
+      // Dist-tag refs use the `<name>@<tag>` grammar; map them via the
+      // skill's distTags. `resolveDistTag` expects an `@`-prefixed tag, so
+      // detect the literal-version shape first.
+      let literalVersion: string;
+      if (SKILL_VERSION_REGEX.test(versionOrTag)) {
+        literalVersion = versionOrTag;
+      } else {
+        const resolved = skill.distTags?.[versionOrTag];
+        if (resolved) {
+          literalVersion = resolved;
+        } else if (versionOrTag === "latest") {
+          literalVersion = skill.latestVersion;
+        } else {
+          return null;
+        }
+      }
+
+      const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(
+        skill.guid,
+        literalVersion,
+      );
+      if (!versionDoc) return null;
+
+      const node: ResolvedVersion = {
+        ref: `${skill.name}@${versionDoc.version}`,
+        name: skill.name,
+        version: versionDoc.version,
+        guid: skill.guid,
+        skillHash: versionDoc.skillHash,
+        dependsOn: versionDoc.metadata?.dependsOn ?? [],
+      };
+      return node;
+    };
+  }
+
+  /**
+   * Resolve the full transitive dependency closure of a skill version,
+   * scoped to what `actor` may read (#968).
+   *
+   * The roots are the skill's own direct `depends-on` refs at the
+   * requested version (NOT the skill itself — the closure describes what
+   * the skill *needs*). Returns nodes in deps-first topological order.
+   *
+   * Throws `skill_not_found` (404) when the root skill / version is
+   * unknown, and `dependency_cycle` / `dependency_conflict` /
+   * `skill_dependency_not_found` from the resolver.
+   */
+  async resolveSkillClosure(
+    idOrName: string,
+    actor: ActorContext,
+    version?: string,
+  ): Promise<ClosureNode[]> {
+    const skill = await this.findSkillByIdOrName(idOrName);
+    if (!canReadSkill(skill, actor)) {
+      throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+    }
+
+    const resolvedVersion =
+      version === undefined || version.length === 0
+        ? skill.latestVersion
+        : resolveDistTag(skill, version) ?? skill.latestVersion;
+    parseVersion(resolvedVersion);
+
+    const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(
+      skill.guid,
+      resolvedVersion,
+    );
+    if (!versionDoc) {
+      throw AppError.notFound(
+        "skill_version_not_found",
+        `Version '${resolvedVersion}' not found for skill '${skill.name}'`,
+      );
+    }
+
+    const roots = versionDoc.metadata?.dependsOn ?? [];
+    if (roots.length === 0) {
+      logger.info({ idOrName, version: resolvedVersion }, "Closure resolved: no dependencies");
+      return [];
+    }
+
+    const closure = await resolveClosure(roots, {
+      loadVersion: this.buildVersionLoader(actor),
+    });
+    logger.info(
+      { idOrName, version: resolvedVersion, nodeCount: closure.length },
+      "Skill dependency closure resolved",
+    );
+    return closure;
+  }
+
+  /**
+   * Publish-time dependency validation (#968). Walks the closure of the
+   * just-extracted `dependsOn` refs to guarantee, BEFORE the version is
+   * committed, that every dependency exists, is readable to the author,
+   * the graph is acyclic, and no two versions of one skill collide.
+   *
+   * Runs as `SYSTEM_ACTOR` deliberately: the author may legitimately
+   * depend on a private skill they own / were granted; the closure is
+   * computed over the full graph and the route layer does NOT expose
+   * these results — it only gates the publish. A missing / unresolvable
+   * dependency surfaces as `skill_dependency_not_found`, a cycle as
+   * `dependency_cycle`, a conflict as `dependency_conflict`.
+   *
+   * No-op when the new version declares no dependencies.
+   */
+  private async validatePublishDependencies(
+    metadata: SkillMetadata,
+    context: { name: string; version: string },
+  ): Promise<void> {
+    const roots = metadata.dependsOn ?? [];
+    if (roots.length === 0) return;
+    await resolveClosure(roots, {
+      loadVersion: this.buildVersionLoader(SYSTEM_ACTOR),
+    });
+    logger.info(
+      { name: context.name, version: context.version, depCount: roots.length },
+      "Publish-time dependencies validated",
+    );
+  }
+
+  // ==========================================================================
   // Private helpers
   // ==========================================================================
 
@@ -1592,6 +1766,15 @@ export class SkillService {
       metadata.tags = rawMeta.tag;
     }
 
+    // Skill dependencies (#968). Map the kebab `depends-on` frontmatter
+    // field onto the camelCase `dependsOn` metadata field. The Zod schema
+    // already validated grammar + self-ref + the 50-entry cap, so this is
+    // a straight copy. Only set the key when non-empty so legacy / no-dep
+    // versions read back clean (absent, not `[]`).
+    if (rawMeta["depends-on"].length > 0) {
+      metadata.dependsOn = rawMeta["depends-on"];
+    }
+
     // Author-supplied changelog lives next to the formal frontmatter but isn't
     // part of the Zod schema — kept permissive so missing/older SKILL.md files
     // just report null instead of hard-failing. Accepts either `release-notes`
@@ -1696,6 +1879,30 @@ export class SkillService {
 
     const metadata: SkillMetadata = { category };
     if (tags && tags.length > 0) metadata.tags = tags;
+
+    // Skill dependencies (#968) under skipValidation. The strict Zod
+    // schema was bypassed, so we re-apply the grammar regex here and keep
+    // only well-formed refs (self-refs by name dropped too). A malformed
+    // ref is silently discarded rather than failing the import — same
+    // best-effort posture as `tags` above. This keeps the closure
+    // resolver's input invariant ("every persisted ref parses") even on
+    // the lenient path; the dropped refs are logged for diagnosis.
+    if (Array.isArray(rawMeta["depends-on"])) {
+      const validDeps = (rawMeta["depends-on"] as unknown[]).filter(
+        (d): d is string =>
+          typeof d === "string" &&
+          DEPENDS_ON_REF_REGEX.test(d) &&
+          d.slice(0, d.indexOf("@")) !== name,
+      );
+      const dropped = (rawMeta["depends-on"] as unknown[]).length - validDeps.length;
+      if (dropped > 0) {
+        logger.info(
+          { name, dropped },
+          "skipValidation: dropped malformed/self depends-on entries",
+        );
+      }
+      if (validDeps.length > 0) metadata.dependsOn = validDeps.slice(0, 50);
+    }
 
     const rawReleaseNotes = raw["release-notes"] ?? raw["releaseNotes"];
     let releaseNotes: string | null = null;

--- a/ornn-api/src/domains/skills/format/routes.ts
+++ b/ornn-api/src/domains/skills/format/routes.ts
@@ -60,6 +60,7 @@ export const SKILL_FORMAT_RULES = `# Ornn Skill Package Format Rules
   - **runtime-env-var** (array, optional): environment variable names in UPPER_SNAKE_CASE.
   - **tool-list** (array): required when category is \`tool-based\` or \`mixed\`. Array of tool name strings.
   - **tag** (array, optional): array of lowercase kebab-case tags.
+  - **depends-on** (array, optional): other skills this skill depends on, max 50. Each entry pins one skill by \`<name-or-guid>@<major.minor>\` (e.g. \`pdf-tools@1.0\`) or \`<name>@<dist-tag>\` (e.g. \`pdf-tools@beta\`). Semver ranges (\`^1.0\`, \`~1.0\`, \`1.2.3\`) are **not** allowed. A skill must not depend on itself. The full transitive closure is validated at publish time (no missing deps, no cycles, no conflicting versions of the same skill) and can be read via \`GET /api/v1/skills/{id}/closure\`.
 
 ### Optional Frontmatter Fields
 

--- a/ornn-api/src/shared/schemas/skillFrontmatter.test.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.test.ts
@@ -123,3 +123,106 @@ describe("validateSkillFrontmatter — actionable errors (#649)", () => {
     expect(r.success).toBe(true);
   });
 });
+
+describe("validateSkillFrontmatter — depends-on grammar (#968)", () => {
+  const GUID = "11111111-2222-4333-8444-555555555555";
+
+  test("accepts <name>@<major.minor>", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": ["pdf-tools@1.0"] } }),
+    );
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.data.metadata["depends-on"]).toEqual(["pdf-tools@1.0"]);
+  });
+
+  test("accepts <guid>@<major.minor>", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": [`${GUID}@2.3`] } }),
+    );
+    expect(r.success).toBe(true);
+  });
+
+  test("accepts <name>@<dist-tag>", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": ["pdf-tools@beta"] } }),
+    );
+    expect(r.success).toBe(true);
+  });
+
+  test("accepts <guid>@<dist-tag>", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": [`${GUID}@stable`] } }),
+    );
+    expect(r.success).toBe(true);
+  });
+
+  test("defaults to [] when omitted", () => {
+    const r = validateSkillFrontmatter(base());
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.data.metadata["depends-on"]).toEqual([]);
+  });
+
+  test("rejects 3-digit semver (name@1.2.3)", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": ["pdf-tools@1.2.3"] } }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.depends-on.0")?.message ?? "";
+    expect(msg).toContain("no semver ranges");
+  });
+
+  test("rejects caret range (name@^1.0)", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": ["pdf-tools@^1.0"] } }),
+    );
+    expect(r.success).toBe(false);
+  });
+
+  test("rejects tilde range (name@~1.0)", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": ["pdf-tools@~1.0"] } }),
+    );
+    expect(r.success).toBe(false);
+  });
+
+  test("rejects a bare name with no @version", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": ["pdf-tools"] } }),
+    );
+    expect(r.success).toBe(false);
+  });
+
+  test("rejects a self-reference by name", () => {
+    const r = validateSkillFrontmatter(
+      base({
+        name: "qa-sample",
+        metadata: { category: "plain", "depends-on": ["qa-sample@1.0"] },
+      }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.depends-on.0")?.message ?? "";
+    expect(msg).toContain("cannot depend on itself");
+  });
+
+  test("rejects more than 50 direct dependencies", () => {
+    const deps = Array.from({ length: 51 }, (_, i) => `dep-${i}@1.0`);
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": deps } }),
+    );
+    expect(r.success).toBe(false);
+  });
+
+  test("rejects a null list item", () => {
+    const r = validateSkillFrontmatter(
+      base({ metadata: { category: "plain", "depends-on": [null] } }),
+    );
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const msg = r.errors.find((e) => e.field === "metadata.depends-on.0")?.message ?? "";
+    expect(msg).toContain("depends-on entries must be non-empty");
+  });
+});

--- a/ornn-api/src/shared/schemas/skillFrontmatter.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.ts
@@ -70,6 +70,45 @@ const dependencyItemSchema = z
   .min(1, "runtime-dependency entries must not be empty")
   .max(200, "runtime-dependency entries must be at most 200 characters");
 
+// Skill-dependency item (#968).
+//
+// Grammar: `<name-or-guid>@<major.minor>` OR `<name>@<dist-tag>`. No semver
+// ranges, no `^`/`~`/`>=` — a dependency pins to one concrete published
+// surface (a literal version) or to a moving dist-tag the owner controls.
+//
+// The three alternatives below reuse the canonical regex *bodies* so the
+// dependency grammar can never drift from the name / version rules enforced
+// elsewhere:
+//   1. `<name>@<major.minor>`  — kebab name + 2-digit version
+//   2. `<guid>@<major.minor>`  — UUID v4 + 2-digit version
+//   3. `<name|guid>@<dist-tag>` — kebab name OR UUID + npm-style dist-tag
+//      (lowercase, leading letter, hyphens; same rule as DIST_TAG_NAME_RE in
+//      the CRUD service). The leading-letter rule keeps a dist-tag from
+//      looking like a version number, so the literal-version and dist-tag
+//      forms never collide.
+const DEPENDS_ON_NAME_BODY = "[a-z0-9][a-z0-9-]*";
+const DEPENDS_ON_GUID_BODY =
+  "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+const DEPENDS_ON_VERSION_BODY = "(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)";
+const DEPENDS_ON_DIST_TAG_BODY = "[a-z][a-z0-9-]{0,49}";
+export const DEPENDS_ON_REF_REGEX = new RegExp(
+  `^(?:${DEPENDS_ON_NAME_BODY}|${DEPENDS_ON_GUID_BODY})@(?:${DEPENDS_ON_VERSION_BODY}|${DEPENDS_ON_DIST_TAG_BODY})$`,
+);
+
+const dependsOnItemSchema = z
+  .string({
+    error: (issue) =>
+      issue.code === "invalid_type"
+        ? 'depends-on entries must be non-empty strings of the form `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>`, e.g. `depends-on: [pdf-tools@1.0]` — an empty `- ` line in YAML parses as `null`.'
+        : undefined,
+  })
+  .min(1, "depends-on entries must not be empty")
+  .max(115, "depends-on entries must be at most 115 characters")
+  .regex(
+    DEPENDS_ON_REF_REGEX,
+    "depends-on entries must be `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>` (no semver ranges like ^1.0 or 1.2.3)",
+  );
+
 // Metadata sub-schema (base, before refinement)
 export const metadataSchema = z.object({
   category: z.enum(FRONTMATTER_CATEGORIES),
@@ -79,6 +118,13 @@ export const metadataSchema = z.object({
   "runtime-env-var": z.array(envVarItemSchema).max(30).default([]),
   "tool-list": z.array(toolItemSchema).max(50).default([]),
   tag: z.array(tagItemSchema).max(10).default([]),
+  // Skill dependencies (#968). Each entry pins another skill by
+  // `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>`. Capped at 50
+  // direct deps per version — the transitive closure can be much larger,
+  // but a single SKILL.md declaring >50 direct deps is almost certainly a
+  // mistake. Self-references are rejected at the top-level schema (where
+  // the skill's own `name` is in scope).
+  "depends-on": z.array(dependsOnItemSchema).max(50).default([]),
 });
 
 export type MetadataInput = z.input<typeof metadataSchema>;
@@ -173,8 +219,8 @@ export const SKILL_VERSION_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 export const SKILL_NAME_REGEX = /^[a-z0-9][a-z0-9-]*$/;
 export const SKILL_NAME_MAX = 64;
 
-// Full frontmatter schema
-export const skillFrontmatterSchema = z.object({
+// Full frontmatter schema (base, before the top-level refinement).
+const baseSkillFrontmatterSchema = z.object({
   name: z.string().min(1).max(SKILL_NAME_MAX).regex(SKILL_NAME_REGEX, "Name must be kebab-case"),
   description: z.string().min(1).max(1024),
   // YAML parses `version: 0.1` (unquoted) as a float and `1.0` as an
@@ -210,6 +256,34 @@ export const skillFrontmatterSchema = z.object({
   agent: z.string().max(100).optional(),
   "argument-hint": z.string().max(500).optional(),
   hooks: z.record(z.string(), z.unknown()).optional(),
+});
+
+/**
+ * Top-level frontmatter schema. Wraps the base object with a
+ * `superRefine` that enforces cross-field rules where both the skill's
+ * own `name` and `metadata.depends-on` are in scope.
+ *
+ * Self-reference (#968): a skill MUST NOT depend on itself. We reject any
+ * `depends-on` entry whose `<name-or-guid>` segment equals the skill's
+ * own `name`. (GUID-form self-refs can't be detected here — the skill's
+ * GUID isn't known at frontmatter-parse time — so they're caught later by
+ * the closure resolver's cycle check at publish time.)
+ */
+export const skillFrontmatterSchema = baseSkillFrontmatterSchema.superRefine((data, ctx) => {
+  const dependsOn = data.metadata?.["depends-on"] ?? [];
+  for (let i = 0; i < dependsOn.length; i++) {
+    const ref = dependsOn[i];
+    if (typeof ref !== "string") continue;
+    const at = ref.indexOf("@");
+    const target = at === -1 ? ref : ref.slice(0, at);
+    if (target === data.name) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["metadata", "depends-on", i],
+        message: `A skill cannot depend on itself ('${data.name}'). Remove the self-reference '${ref}'.`,
+      });
+    }
+  }
 });
 
 export type SkillFrontmatterInput = z.input<typeof skillFrontmatterSchema>;

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -294,6 +294,16 @@ export interface SkillMetadata {
     "mcp-servers"?: Array<{ mcp: string; version: string }>;
   }>;
   tags?: string[];
+  /**
+   * Skill dependencies (#968). Each entry pins another skill by
+   * `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>` (the
+   * `metadata.depends-on` frontmatter field, kebab→camel mapped on
+   * extract). Persisted per immutable version inside
+   * `SkillVersionDocument.metadata`, so no new version-doc field or
+   * migration is needed — a version published before #968 simply reads
+   * back with `dependsOn` absent. Empty/omitted = no dependencies.
+   */
+  dependsOn?: string[];
 }
 
 export interface SkillDetailResponse {

--- a/sdk/python/src/ornn_sdk/__init__.py
+++ b/sdk/python/src/ornn_sdk/__init__.py
@@ -21,6 +21,8 @@ All requests go through ``/api/v1/*``. Errors raise :class:`OrnnError`.
 from .client import OrnnClient
 from .errors import OrnnError
 from .types import (
+    ClosureNode,
+    ClosureResult,
     SearchMode,
     SearchScope,
     SkillDetail,
@@ -33,6 +35,8 @@ from .types import (
 )
 
 __all__ = [
+    "ClosureNode",
+    "ClosureResult",
     "OrnnClient",
     "OrnnError",
     "SearchMode",

--- a/sdk/python/src/ornn_sdk/client.py
+++ b/sdk/python/src/ornn_sdk/client.py
@@ -22,6 +22,8 @@ import httpx
 
 from .errors import OrnnError
 from .types import (
+    ClosureNode,
+    ClosureResult,
     SearchMode,
     SearchScope,
     SkillDetail,
@@ -147,6 +149,45 @@ class OrnnClient:
         # stub annotates it as Any. Cast explicitly so strict mypy is
         # happy without disabling the rule.
         return bytes(res.content)
+
+    def resolve_closure(
+        self, guid_or_name: str, *, version: str | None = None
+    ) -> ClosureResult:
+        """Resolve the full transitive dependency closure of a skill (#968).
+
+        Returns the closure in deps-first topological order — every
+        dependency precedes the dependents that pin it. Raises
+        :class:`OrnnError` with code ``dependency_cycle`` /
+        ``dependency_conflict`` / ``skill_dependency_not_found`` when the
+        graph can't be resolved.
+        """
+        suffix = (
+            f"?version={httpx.QueryParams({'version': version})['version']}"
+            if version
+            else ""
+        )
+        data = self.request("GET", f"/skills/{_quote(guid_or_name)}/closure{suffix}")
+        return ClosureResult.from_dict(data)
+
+    def pull_closure(
+        self, guid_or_name: str, *, version: str | None = None
+    ) -> tuple[ClosureResult, list[tuple[ClosureNode, bytes]]]:
+        """Resolve a skill's closure and download every package (#968).
+
+        Convenience over :meth:`resolve_closure` + :meth:`download_package`:
+        downloads in the closure's topological order (dependencies first)
+        so a caller can install each ZIP as it arrives. Does NOT include
+        the root skill itself.
+
+        Returns ``(closure, packages)`` where ``packages`` is a list of
+        ``(node, zip_bytes)`` pairs in topological order.
+        """
+        closure = self.resolve_closure(guid_or_name, version=version)
+        packages: list[tuple[ClosureNode, bytes]] = []
+        for node in closure.items:
+            data = self.download_package(node.guid, node.version)
+            packages.append((node, data))
+        return closure, packages
 
     def publish(self, zip_bytes: bytes, *, skip_validation: bool = False) -> SkillDetail:
         """Publish a new skill from a ZIP package (raw bytes)."""

--- a/sdk/python/src/ornn_sdk/client.py
+++ b/sdk/python/src/ornn_sdk/client.py
@@ -150,9 +150,7 @@ class OrnnClient:
         # happy without disabling the rule.
         return bytes(res.content)
 
-    def resolve_closure(
-        self, guid_or_name: str, *, version: str | None = None
-    ) -> ClosureResult:
+    def resolve_closure(self, guid_or_name: str, *, version: str | None = None) -> ClosureResult:
         """Resolve the full transitive dependency closure of a skill (#968).
 
         Returns the closure in deps-first topological order — every
@@ -161,11 +159,7 @@ class OrnnClient:
         ``dependency_conflict`` / ``skill_dependency_not_found`` when the
         graph can't be resolved.
         """
-        suffix = (
-            f"?version={httpx.QueryParams({'version': version})['version']}"
-            if version
-            else ""
-        )
+        suffix = f"?version={httpx.QueryParams({'version': version})['version']}" if version else ""
         data = self.request("GET", f"/skills/{_quote(guid_or_name)}/closure{suffix}")
         return ClosureResult.from_dict(data)
 

--- a/sdk/python/src/ornn_sdk/types.py
+++ b/sdk/python/src/ornn_sdk/types.py
@@ -146,6 +146,44 @@ class SkillSearchResult:
 
 
 @dataclass
+class ClosureNode:
+    """One node in a resolved dependency closure (#968).
+
+    Mirrors the items returned by
+    ``GET /api/v1/skills/{id_or_name}/closure``. Nodes arrive in
+    deps-first topological order — every dependency precedes the
+    dependents that pin it.
+    """
+
+    guid: str
+    name: str
+    version: str
+    depth: int
+    skill_hash: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> ClosureNode:
+        return cls(
+            guid=raw.get("guid", ""),
+            name=raw["name"],
+            version=raw["version"],
+            depth=int(raw.get("depth", 0)),
+            skill_hash=raw.get("skillHash"),
+        )
+
+
+@dataclass
+class ClosureResult:
+    """Result of :meth:`OrnnClient.resolve_closure` — the ordered closure."""
+
+    items: list[ClosureNode]
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> ClosureResult:
+        return cls(items=[ClosureNode.from_dict(i) for i in raw.get("items") or []])
+
+
+@dataclass
 class UpdateSkillMetadata:
     """Partial metadata update payload. Omit fields you don't want to change."""
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -286,6 +286,85 @@ class TestDownload:
         assert excinfo.value.code == "resource_not_found"
 
 
+class TestClosure:
+    @respx.mock
+    def test_resolve_closure_parses_topo_items(self) -> None:
+        route = respx.get(f"{BASE}/api/v1/skills/report-gen/closure").respond(
+            200,
+            json={
+                "data": {
+                    "items": [
+                        {"guid": "g-c", "name": "c", "version": "1.0", "skillHash": "h-c", "depth": 1},
+                        {"guid": "g-b", "name": "b", "version": "1.0", "skillHash": "h-b", "depth": 0},
+                    ],
+                },
+                "error": None,
+            },
+        )
+        with make_client() as ornn:
+            result = ornn.resolve_closure("report-gen", version="1.0")
+        assert [n.name for n in result.items] == ["c", "b"]
+        assert result.items[0].depth == 1
+        assert result.items[0].guid == "g-c"
+        # version query is forwarded.
+        assert route.calls.last.request.url.params["version"] == "1.0"
+
+    @respx.mock
+    def test_resolve_closure_omits_version_when_absent(self) -> None:
+        route = respx.get(f"{BASE}/api/v1/skills/report-gen/closure").respond(
+            200, json={"data": {"items": []}, "error": None}
+        )
+        with make_client() as ornn:
+            ornn.resolve_closure("report-gen")
+        assert "version" not in route.calls.last.request.url.params
+
+    @respx.mock
+    def test_resolve_closure_raises_on_dependency_cycle(self) -> None:
+        respx.get(f"{BASE}/api/v1/skills/a/closure").respond(
+            409,
+            json={
+                "type": "https://github.com/.../ERRORS.md#resource_conflict",
+                "title": "Conflict",
+                "status": 409,
+                "code": "dependency_cycle",
+                "detail": "cycle at a@1.0",
+            },
+        )
+        with make_client() as ornn:
+            with pytest.raises(OrnnError) as excinfo:
+                ornn.resolve_closure("a")
+        assert excinfo.value.status == 409
+        assert excinfo.value.code == "dependency_cycle"
+
+    @respx.mock
+    def test_pull_closure_downloads_in_topo_order(self) -> None:
+        respx.get(f"{BASE}/api/v1/skills/report-gen/closure").respond(
+            200,
+            json={
+                "data": {
+                    "items": [
+                        {"guid": "g-c", "name": "c", "version": "1.0", "skillHash": "h-c", "depth": 1},
+                        {"guid": "g-b", "name": "b", "version": "1.0", "skillHash": "h-b", "depth": 0},
+                    ],
+                },
+                "error": None,
+            },
+        )
+        dl_c = respx.get(f"{BASE}/api/v1/skills/g-c/versions/1.0/download").respond(
+            200, content=b"PKc", headers={"Content-Type": "application/zip"}
+        )
+        dl_b = respx.get(f"{BASE}/api/v1/skills/g-b/versions/1.0/download").respond(
+            200, content=b"PKb", headers={"Content-Type": "application/zip"}
+        )
+        with make_client() as ornn:
+            closure, packages = ornn.pull_closure("report-gen")
+        assert [n.name for n in closure.items] == ["c", "b"]
+        # Downloads follow the closure order — c (deps-first) before b.
+        assert [node.name for node, _ in packages] == ["c", "b"]
+        assert packages[0][1] == b"PKc"
+        assert dl_c.called and dl_b.called
+
+
 class TestPublish:
     @respx.mock
     def test_publish_sends_zip_bytes(self) -> None:

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -294,8 +294,20 @@ class TestClosure:
             json={
                 "data": {
                     "items": [
-                        {"guid": "g-c", "name": "c", "version": "1.0", "skillHash": "h-c", "depth": 1},
-                        {"guid": "g-b", "name": "b", "version": "1.0", "skillHash": "h-b", "depth": 0},
+                        {
+                            "guid": "g-c",
+                            "name": "c",
+                            "version": "1.0",
+                            "skillHash": "h-c",
+                            "depth": 1,
+                        },
+                        {
+                            "guid": "g-b",
+                            "name": "b",
+                            "version": "1.0",
+                            "skillHash": "h-b",
+                            "depth": 0,
+                        },
                     ],
                 },
                 "error": None,
@@ -343,8 +355,20 @@ class TestClosure:
             json={
                 "data": {
                     "items": [
-                        {"guid": "g-c", "name": "c", "version": "1.0", "skillHash": "h-c", "depth": 1},
-                        {"guid": "g-b", "name": "b", "version": "1.0", "skillHash": "h-b", "depth": 0},
+                        {
+                            "guid": "g-c",
+                            "name": "c",
+                            "version": "1.0",
+                            "skillHash": "h-c",
+                            "depth": 1,
+                        },
+                        {
+                            "guid": "g-b",
+                            "name": "b",
+                            "version": "1.0",
+                            "skillHash": "h-b",
+                            "depth": 0,
+                        },
                     ],
                 },
                 "error": None,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -17,6 +17,8 @@
 
 import { OrnnError, type OrnnErrorPayload } from "./errors";
 import type {
+  ClosureNode,
+  ClosureResult,
   PublishOptions,
   SkillDetail,
   SkillSearchParams,
@@ -178,6 +180,56 @@ export class OrnnClient {
       throw await parseError(res);
     }
     return res.arrayBuffer();
+  }
+
+  /**
+   * Resolve the full transitive dependency closure of a skill (#968).
+   *
+   * Returns the closure in deps-first topological order — every
+   * dependency precedes the dependents that pin it, so iterating the
+   * `items` array installs in a safe order. Throws `OrnnError` with code
+   * `dependency_cycle` / `dependency_conflict` / `skill_dependency_not_found`
+   * when the graph can't be resolved.
+   */
+  async resolveClosure(
+    guidOrName: string,
+    options: { version?: string } = {},
+  ): Promise<ClosureResult> {
+    const suffix = options.version
+      ? `?version=${encodeURIComponent(options.version)}`
+      : "";
+    return this.request<ClosureResult>(
+      "GET",
+      `/skills/${encodeURIComponent(guidOrName)}/closure${suffix}`,
+    );
+  }
+
+  /**
+   * Resolve a skill's dependency closure and download every package in
+   * the closure (#968). Convenience over {@link resolveClosure} +
+   * {@link downloadPackage}: downloads in the closure's topological order
+   * (dependencies first) so a caller can install each ZIP as it arrives.
+   *
+   * Returns the ordered closure plus the downloaded bytes per node,
+   * keyed by `<name>@<version>`. Does NOT include the root skill itself —
+   * pull that separately via {@link downloadPackage} if needed.
+   */
+  async pullClosure(
+    guidOrName: string,
+    options: { version?: string } = {},
+  ): Promise<{
+    closure: ClosureResult;
+    packages: Array<{ node: ClosureNode; bytes: ArrayBuffer }>;
+  }> {
+    const closure = await this.resolveClosure(guidOrName, options);
+    const packages: Array<{ node: ClosureNode; bytes: ArrayBuffer }> = [];
+    // Sequential, in topo order — dependencies download before their
+    // dependents so a consumer can install incrementally.
+    for (const node of closure.items) {
+      const bytes = await this.downloadPackage(node.guid, node.version);
+      packages.push({ node, bytes });
+    }
+    return { closure, packages };
   }
 
   /** Publish a new skill from a ZIP package. */

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -22,6 +22,8 @@
 export { OrnnClient, type OrnnClientOptions } from "./client";
 export { OrnnError, type OrnnErrorPayload } from "./errors";
 export type {
+  ClosureNode,
+  ClosureResult,
   PublishOptions,
   SearchScope,
   SkillDetail,

--- a/sdk/typescript/src/tests/client.test.ts
+++ b/sdk/typescript/src/tests/client.test.ts
@@ -255,6 +255,87 @@ describe("OrnnClient", () => {
     expect(err.code).toBe("resource_not_found");
   });
 
+  test("resolveClosure(): parses the topo-ordered items envelope (#968)", async () => {
+    let capturedUrl = "";
+    const fetchMock = mockFetch((url) => {
+      capturedUrl = url;
+      return jsonResponse(200, {
+        data: {
+          items: [
+            { guid: "g-c", name: "c", version: "1.0", skillHash: "h-c", depth: 1 },
+            { guid: "g-b", name: "b", version: "1.0", skillHash: "h-b", depth: 0 },
+          ],
+        },
+        error: null,
+      });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const result = await client.resolveClosure("report-gen", { version: "1.0" });
+    expect(capturedUrl).toBe("https://x/api/v1/skills/report-gen/closure?version=1.0");
+    expect(result.items.map((i) => i.name)).toEqual(["c", "b"]);
+    expect(result.items[0]!.depth).toBe(1);
+  });
+
+  test("resolveClosure(): omits the version query when not provided", async () => {
+    let capturedUrl = "";
+    const fetchMock = mockFetch((url) => {
+      capturedUrl = url;
+      return jsonResponse(200, { data: { items: [] }, error: null });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    await client.resolveClosure("report-gen");
+    expect(capturedUrl).toBe("https://x/api/v1/skills/report-gen/closure");
+  });
+
+  test("resolveClosure(): throws OrnnError on dependency_cycle (409)", async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(409, {
+        type: "https://github.com/.../ERRORS.md#resource_conflict",
+        title: "Conflict",
+        status: 409,
+        code: "dependency_cycle",
+        detail: "cycle at a@1.0",
+      }),
+    );
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const err = (await client.resolveClosure("a").catch((e) => e)) as OrnnError;
+    expect(err).toBeInstanceOf(OrnnError);
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("dependency_cycle");
+  });
+
+  test("pullClosure(): downloads each package in topological order (#968)", async () => {
+    const downloadOrder: string[] = [];
+    const fetchMock = mockFetch((url) => {
+      if (url.includes("/closure")) {
+        return jsonResponse(200, {
+          data: {
+            items: [
+              { guid: "g-c", name: "c", version: "1.0", skillHash: "h-c", depth: 1 },
+              { guid: "g-b", name: "b", version: "1.0", skillHash: "h-b", depth: 0 },
+            ],
+          },
+          error: null,
+        });
+      }
+      // download path: /skills/:guid/versions/:version/download
+      const match = url.match(/\/skills\/([^/]+)\/versions\//);
+      downloadOrder.push(match?.[1] ?? "?");
+      return new Response(new Uint8Array([80, 75, 3, 4]), {
+        status: 200,
+        headers: { "Content-Type": "application/zip" },
+      });
+    });
+    const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
+    const { closure, packages } = await client.pullClosure("report-gen");
+    expect(closure.items).toHaveLength(2);
+    // Downloads follow the closure order — c (deps-first) before b.
+    expect(downloadOrder).toEqual(["g-c", "g-b"]);
+    expect(packages).toHaveLength(2);
+    expect(packages[0]!.node.name).toBe("c");
+    expect(packages[0]!.bytes.byteLength).toBe(4);
+  });
+
   test("update() with metadata sends JSON body", async () => {
     let captured: { contentType: string; body: string } = { contentType: "", body: "" };
     const fetchMock = mockFetch((_url, init) => {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -88,6 +88,26 @@ export interface SkillSearchResult {
   };
 }
 
+/**
+ * One node in a resolved dependency closure (#968). Mirrors the items
+ * returned by `GET /api/v1/skills/:idOrName/closure`. Nodes arrive in
+ * deps-first topological order — every dependency precedes the
+ * dependents that pin it, so installing in array order is always safe.
+ */
+export interface ClosureNode {
+  readonly guid: string;
+  readonly name: string;
+  readonly version: string;
+  readonly skillHash?: string;
+  /** 0 for the skill's direct dependencies; deeper for transitive deps. */
+  readonly depth: number;
+}
+
+/** Result of {@link OrnnClient.resolveClosure} — the ordered closure. */
+export interface ClosureResult {
+  readonly items: readonly ClosureNode[];
+}
+
 export interface UpdateSkillMetadata {
   readonly name?: string;
   readonly description?: string;

--- a/skills/ornn-agent-manual-cli/references/api-reference.md
+++ b/skills/ornn-agent-manual-cli/references/api-reference.md
@@ -162,6 +162,9 @@ The codes below appear across many endpoints. Per-endpoint sections list any add
 | `AUDIT_NOT_FOUND` | 404 | No audit has been run for the requested skill / version. |
 | `ORG_NOT_FOUND` | 404 | Org id does not resolve, or NyxID will not return it to the caller. |
 | `SKILL_VERSION_NOT_FOUND` | 404 | Version string does not exist on the skill. |
+| `skill_dependency_not_found` | 404 | A `depends-on` ref in a dependency closure doesn't resolve or isn't visible (#968). |
+| `dependency_cycle` | 409 | The dependency closure graph loops back on itself (#968). |
+| `dependency_conflict` | 409 | One skill is pinned to two versions within the same closure (#968). |
 | `SAME_VERSION` | 400 | `from` and `to` parameters in a diff are identical. |
 | `INVALID_CONTENT_TYPE` | 400 | Endpoint expected `application/zip` (or `application/octet-stream`) and got something else. |
 | `EMPTY_BODY` | 400 | Request body was zero-length when the endpoint required bytes. |
@@ -520,6 +523,41 @@ Response 200:
 | Code | Status | Cause |
 |---|---|---|
 | `SKILL_NOT_FOUND` | 404 | Same as §3.4. |
+
+### 3.6a Resolve dependency closure — `GET /api/v1/skills/:idOrName/closure`
+
+Resolve the full **transitive** dependency closure of a skill version (#968). A skill declares direct dependencies in SKILL.md frontmatter under `metadata.depends-on` (an array of `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>` refs — no semver ranges, no self-references). This endpoint walks that graph and returns every transitive dependency.
+
+**Auth: optional.** Anonymous callers resolve against public skills only; a public skill that transitively depends on a private skill you can't read surfaces that node as `skill_dependency_not_found` (existence is not leaked).
+
+Path param: `:idOrName`. Query param: `version` (optional) — literal `<major>.<minor>` or a dist-tag; defaults to the skill's latest.
+
+Items come back in **deps-first topological order** — every dependency precedes the dependents that pin it, so installing in array order is always safe. Shared nodes (diamonds) appear exactly once.
+
+Response 200:
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "guid": "skl_...", "name": "pdf-tools",  "version": "1.0", "skillHash": "sha256:...", "depth": 1 },
+      { "guid": "skl_...", "name": "report-base", "version": "2.3", "skillHash": "sha256:...", "depth": 0 }
+    ]
+  },
+  "error": null
+}
+```
+
+| Code | Status | Cause |
+|---|---|---|
+| `dependency_cycle` | 409 | The dependency graph loops back on itself. |
+| `dependency_conflict` | 409 | One skill is pinned to two versions within the closure. |
+| `skill_dependency_not_found` | 404 | A dependency ref doesn't resolve or isn't visible. |
+| `skill_not_found` | 404 | The root skill / version is unknown (or not visible). |
+
+The same closure is validated at **publish time** (`POST /skills`, `PUT /skills/:id`): a `depends-on` ref that won't resolve, forms a cycle, or conflicts fails the publish before the version is committed.
+
+SDK: `client.resolveClosure(idOrName, { version })` and `client.pullClosure(idOrName, { version })` (TypeScript); `client.resolve_closure(...)` and `client.pull_closure(...)` (Python). `pullClosure` / `pull_closure` resolves the closure and downloads each package in topological order.
 
 ### 3.7 Diff versions — `GET /api/v1/skills/:idOrName/versions/:fromVersion/diff/:toVersion`
 

--- a/skills/ornn-agent-manual-http/references/api-reference.md
+++ b/skills/ornn-agent-manual-http/references/api-reference.md
@@ -160,6 +160,9 @@ The codes below appear across many endpoints. Per-endpoint sections list any add
 | `AUDIT_NOT_FOUND` | 404 | No audit has been run for the requested skill / version. |
 | `ORG_NOT_FOUND` | 404 | Org id does not resolve, or NyxID will not return it to the caller. |
 | `SKILL_VERSION_NOT_FOUND` | 404 | Version string does not exist on the skill. |
+| `skill_dependency_not_found` | 404 | A `depends-on` ref in a dependency closure doesn't resolve or isn't visible (#968). |
+| `dependency_cycle` | 409 | The dependency closure graph loops back on itself (#968). |
+| `dependency_conflict` | 409 | One skill is pinned to two versions within the same closure (#968). |
 | `SAME_VERSION` | 400 | `from` and `to` parameters in a diff are identical. |
 | `INVALID_CONTENT_TYPE` | 400 | Endpoint expected `application/zip` (or `application/octet-stream`) and got something else. |
 | `EMPTY_BODY` | 400 | Request body was zero-length when the endpoint required bytes. |
@@ -510,6 +513,41 @@ Response 200:
 | Code | Status | Cause |
 |---|---|---|
 | `SKILL_NOT_FOUND` | 404 | Same as §3.4. |
+
+### 3.6a Resolve dependency closure — `GET /api/v1/skills/:idOrName/closure`
+
+Resolve the full **transitive** dependency closure of a skill version (#968). A skill declares direct dependencies in SKILL.md frontmatter under `metadata.depends-on` (an array of `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>` refs — no semver ranges, no self-references). This endpoint walks that graph and returns every transitive dependency.
+
+**Auth: optional.** Anonymous callers resolve against public skills only; a public skill that transitively depends on a private skill you can't read surfaces that node as `skill_dependency_not_found` (existence is not leaked).
+
+Path param: `:idOrName`. Query param: `version` (optional) — literal `<major>.<minor>` or a dist-tag; defaults to the skill's latest.
+
+Items come back in **deps-first topological order** — every dependency precedes the dependents that pin it, so installing in array order is always safe. Shared nodes (diamonds) appear exactly once.
+
+Response 200:
+
+```jsonc
+{
+  "data": {
+    "items": [
+      { "guid": "skl_...", "name": "pdf-tools",  "version": "1.0", "skillHash": "sha256:...", "depth": 1 },
+      { "guid": "skl_...", "name": "report-base", "version": "2.3", "skillHash": "sha256:...", "depth": 0 }
+    ]
+  },
+  "error": null
+}
+```
+
+| Code | Status | Cause |
+|---|---|---|
+| `dependency_cycle` | 409 | The dependency graph loops back on itself. |
+| `dependency_conflict` | 409 | One skill is pinned to two versions within the closure. |
+| `skill_dependency_not_found` | 404 | A dependency ref doesn't resolve or isn't visible. |
+| `skill_not_found` | 404 | The root skill / version is unknown (or not visible). |
+
+The same closure is validated at **publish time** (`POST /skills`, `PUT /skills/:id`): a `depends-on` ref that won't resolve, forms a cycle, or conflicts fails the publish before the version is committed.
+
+SDK: `client.resolveClosure(idOrName, { version })` and `client.pullClosure(idOrName, { version })` (TypeScript); `client.resolve_closure(...)` and `client.pull_closure(...)` (Python). `pullClosure` / `pull_closure` resolves the closure and downloads each package in topological order.
 
 ### 3.7 Diff versions — `GET /api/v1/skills/:idOrName/versions/:fromVersion/diff/:toVersion`
 


### PR DESCRIPTION
Closes #968

Automated change by `/auto` (run `20260609T061849Z-71017`, runner `auto-runner-20260609T061849Z-71017-76381-9598`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
