### PR TITLE
[Feature] Skillset web UI — full ornn-web surface covering 100% of the skillset API

### DIFF
--- a/.changeset/feat-1059-skillset-web-ui.md
+++ b/.changeset/feat-1059-skillset-web-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+Skillset web UI (#1059). A full web surface for the #969 skillsets backend, mirroring the existing skills UI. Browse skillsets at `/skillsets` (one page, tabs Public / Mine / Shared-with-me via `?scope`, with `kind` + `tag` filters and pagination), open a skillset at `/skillsets/:idOrName` (`?version` resolves a specific published version; the page surfaces the name, description, kind, the rendered master prompt, the member list, the server-flattened dependency closure, visibility, and a version picker), create at `/skillsets/new`, publish a new version at `/skillsets/:id/edit` (name locked, version required + bumped), and manage your own at `/my-skillsets`. Owners get a per-skillset permissions editor (public / org / user grants) and a delete flow. The member picker enforces the v1 rules client-side (2–100 members, no nested `skillset:` refs, no self-reference), and the master-prompt editor enforces the required, trimmed 1–8000-char body. New nav entries: "Skillsets" in the top nav and "My Skillsets" in the account menu. All copy is keyed under `skillset*` i18n namespaces in both English and Chinese.

--- a/ornn-api/src/domains/assistant/kb/digest.generated.md
+++ b/ornn-api/src/domains/assistant/kb/digest.generated.md
@@ -3,13 +3,13 @@
   Produced by ornn-api/scripts/build-assistant-kb.ts (#970).
   Re-run: `bun run scripts/build-assistant-kb.ts` from ornn-api/.
   budgetTokens: 18000
-  estimatedTokens: 10761
+  estimatedTokens: 10994
   sources:
   - readme: ~1883 tok
   - claude-positioning: ~272 tok
   - architecture: ~219 tok
   - agent-manual-http: ~5486 tok (clipped)
-  - conventions: ~2366 tok
+  - conventions: ~2599 tok (clipped)
   - design-overview: ~487 tok
 -->
 
@@ -719,150 +719,67 @@ Reserved action verbs per resource documented in `ornn-api/src/shared/reservedVe
 
 Both return the same collection shape (`{ items, meta }`).
 
----
-
-## 3. HTTP semantics
-
-### 3.1 Methods
-
-| Method | Semantics |
-|---|---|
-| `GET` | Safe, idempotent read |
-| `POST` | Create, or custom action |
-| `PUT` | Full replace of a resource (idempotent) |
-| `PATCH` | Partial update |
-| `DELETE` | Remove (idempotent) |
-
-Partial updates MUST use `PATCH`. `PUT` MUST accept a complete representation.
-
-### 3.2 Status codes
-
-| Code | Use |
-|---|---|
-| `200 OK` | Successful read / update returning a body |
-| `201 Created` | Successful create. MUST include `Location: /v1/{resource}/{id}` header |
-| `202 Accepted` | Async job accepted (not currently used) |
-| `204 No Content` | Successful delete, or update with no body to return |
-| `400` | `validation_error` |
-| `401` | `authentication_required` |
-| `403` | `permission_denied` |
-| `404` | `resource_not_found` |
-| `409` | `resource_conflict` |
-| `413` | `payload_too_large` |
-| `415` | `unsupported_media_type` |
-| `429` | `rate_limited` |
-| `500` | `internal_error` |
-| `502` / `503` | `upstream_unavailable` |
-
-### 3.3 Content negotiation
-
-When a resource has multiple representations, select via `Accept`:
+### 2.5 Skill dependency closure (#968)
 
 ```
-GET /v1/skills/abc
-Accept: application/json           → JSON metadata + file contents
-Accept: application/zip            → raw ZIP package
+GET /v1/skills/{idOrName}/closure[?version=<major.minor>|<dist-tag>]
 ```
 
-Do not encode representation in the URL path (no `/skills/:id/json`).
+Resolves the full **transitive** dependency closure of a skill version. A skill declares its direct dependencies in SKILL.md frontmatter via `metadata.depends-on` — an array of `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>` refs (no semver ranges). The endpoint walks that graph and returns every transitive dependency.
 
-### 3.4 Idempotency
+- **Auth:** optional. Anonymous callers resolve against public skills only; a public skill that transitively depends on a private skill the caller can't read surfaces that node as `skill_dependency_not_found` (existence not leaked).
+- **Order:** items are returned in deps-first **topological order** — every dependency precedes the dependents that pin it, so installing in array order is always safe. Shared nodes (diamonds) appear exactly once.
+- **Response:** standard collection envelope.
 
-`POST` creates accept optional `Idempotency-Key: <uuid>` header. Server persists the key + response for 24h and returns the cached response on retry. Implementation: middleware layer in `ornn-api/src/middleware/idempotency.ts`.
-
-### 3.5 Bulk operations
-
-Bulk-capable endpoints are symmetric:
-
-```
-POST   /v1/{parent}/{id}/{child}  { <child>Ids: [...] }   # add
-DELETE /v1/{parent}/{id}/{child}  { <child>Ids: [...] }   # remove (body)
-```
-
-Single-item convenience endpoints MAY exist alongside.
-
----
-
-## 4. Query parameters
-
-### 4.1 Naming
-
-- `camelCase` everywhere (matches JSON body convention).
-- Search query param is `q` (never `query`).
-- Booleans are `true` / `false` — omit for "any".
-
-### 4.2 Arrays — repeated keys
-
-```
-?sharedWithOrgs=a&sharedWithOrgs=b&sharedWithOrgs=c
+```json
+{
+  "data": {
+    "items": [
+      { "guid": "…", "name": "pdf-tools", "version": "1.0", "skillHash": "…", "depth": 1 },
+      { "guid": "…", "name": "report-gen", "version": "2.3", "skillHash": "…", "depth": 0 }
+    ]
+  },
+  "error": null
+}
 ```
 
-Never CSV. Never bracket notation. Handler: `c.req.queries('sharedWithOrgs')` returns `string[]`.
+- **Errors:** `dependency_cycle` (409) when the graph loops; `dependency_conflict` (409) when one skill is pinned to two versions in the same closure; `skill_dependency_not_found` (404) when a ref doesn't resolve or isn't visible. See `docs/ERRORS.md`.
 
-### 4.3 Pagination — cursor-only
+The same closure is validated at **publish time**: declaring a `depends-on` ref that can't be resolved, forms a cycle, or conflicts fails the create/update before the version is committed.
+
+SDK helpers: `client.resolveClosure(idOrName, { version })` / `client.pullClosure(...)` (TypeScript), `client.resolve_closure(...)` / `client.pull_closure(...)` (Python).
+
+### 2.6 Skillsets (#969)
+
+A **skillset** is a named, versioned, owned, visibility-scoped meta-package that references N member skills and carries a `kind`. One call resolves + delivers the whole set — including each member's dependency closure (§2.5). The ownership / visibility / immutable-versioning model mirrors skills verbatim; permission scopes **reuse** the existing `ornn:skill:{create,read,update,delete}` (see §5.2 — a dedicated `ornn:skillset:*` scope split is a tracked follow-up).
 
 ```
-?cursor=<opaque>&limit=<1-100>
+POST   /v1/skillsets                       — create (ornn:skill:create; private by default)
+GET    /v1/skillsets/{idOrName}            — read   (optional auth; anon sees public only)
+GET    /v1/skillsets/{idOrName}/versions   — list versions (optional auth)
+GET    /v1/skillsets/{idOrName}/closure    — one-call resolve (optional auth)
+PUT    /v1/skillsets/{id}                  — publish a new immutable version (ornn:skill:update)
+PUT    /v1/skillsets/{id}/permissions      — visibility / sharing (ornn:skill:update)
+DELETE /v1/skillsets/{id}                  — delete + cascade versions (ornn:skill:delete)
+GET    /v1/skillset-search                 — discovery by kind / tags / scope (optional auth)
 ```
 
-- `cursor` is opaque (base64-encoded server-chosen payload). Clients MUST NOT parse.
-- `limit` defaults per-endpoint (typically 20), max 100.
-- Absence of `cursor` = first page.
-- Response `meta.nextCursor` feeds the next request.
-- **Total counts** are NOT part of pagination. Endpoints needing a count expose a sibling (e.g. `GET /v1/skills/counts`) or fold the count into list `meta`.
+- **`kind`:** enum, v1 `{ "generic", "consensus-supported" }` (extensible). Default `generic`. `consensus-supported` is an author **claim** that the members are an independent, comparable set suitable for agent-side consensus — **not a guarantee** (stated honestly; Ornn packages + delivers the set, the agent runs any consensus in its own runtime).
+- **`members`:** 2..N skill refs, each `<name-or-guid>@<major.minor>` or `<name>@<dist-tag>` (the **same** grammar as `depends-on`, §2.5). No nested skillsets in v1 — a skillset references skills only. Validated on publish: every member must resolve to a readable skill version, and the union dependency closure must be conflict-free.
+- **`instructions` (master prompt, #978):** a **REQUIRED**, versioned markdown body telling an agent **HOW** to use the set (orchestration, ordering, which member to pick when). 1..8000 chars (trimmed server-side; a whitespace-only body is rejected). Distinct from `description` (a short ≤1024-char human summary). **Required on BOTH create and publish, with NO carry-forward** — unlike `description`/`kind`/`tags` (which a publish may omit to inherit the prior version's value), every published version must explicitly state its own master prompt. Stored opaque — Ornn does not render, sanitize, template, lint, or search-index it. Surfaced verbatim on `GET /v1/skillsets/{idOrName}` and as a root field on `/closure`.
+- **Create / publish bodies (JSON):**
 
-### 4.4 Filters
+```json
+POST /v1/skillsets
+{ "name": "review-set", "description": "…",
+  "instructions": "Run pdf-tools first, then feed its output to csv-tools…",
+  "kind": "consensus-supported",
+  "tags": ["review"], "members": ["pdf-tools@1.0", "csv-tools@2.1"], "version": "1.0" }
+```
 
-Endpoint-specific. Rules:
+`GET /v1/skillsets/{idOrName}` returns the detail object including the version's `instructions`.
 
-- Orthogonal filters are separate params. Do NOT overload (avoid `scope=shared-with-me|mine|...`).
-- Booleans instead of tri-state enums when possible.
-- For `/v1/skills`:
-  - `visibility` — `public | private` (omit for "any" within caller's reach)
-  - `owner` — `me | others` (omit for "any")
-  - `sharedWith` — `me` (filters to skills shared with caller)
-  - `isSystem` — boolean (omit for "any")
-
----
-
-## 6. SSE streaming
-
-### 6.1 Event naming
-
-Format: `<resource>_<event>`, snake_case.
-
-Shared event vocabulary across endpoints:
-
-| Suffix | Meaning |
-|---|---|
-| `_start` | Stream opened |
-| `_text_delta` | Incremental text content |
-| `_tool_call` | Model requests tool invocation |
-| `_tool_result` | Tool output |
-| `_file_output` | File produced during run |
-| `_validation_error` | Recoverable validation failure |
-| `_error` | Terminal error |
-| `_complete` / `_finish` | Stream ended normally |
-
-Endpoints pick a subset and MAY add endpoint-specific events with the same prefix.
-
-### 6.2 Current endpoint mapping
-
-| Endpoint | Events |
-|---|---|
-| `POST /v1/skills/generate` | `generation_start`, `generation_delta`, `generation_validation_error`, `generation_error`, `generation_complete` |
-| `POST /v1/playground/chat` | `chat_start`, `chat_text_delta`, `chat_tool_call`, `chat_tool_result`, `chat_file_output`, `chat_error`, `chat_finish` |
-| `POST /v1/assistant/chat` | `chat_start`, `chat_text_delta`, `chat_error`, `chat_finish` |
-
-### 6.3 Transport rules
-
-- `Content-Type: text/event-stream`
-- Each event has a `type` field in the JSON payload plus SSE-native `event:` line set to the same value
-- Keep-alive events every `config.sseKeepAliveIntervalMs` milliseconds (JSON `{ type: "keepalive" }`)
-- Clients abort via `AbortSignal` / closing the connection
-- `Last-Event-ID` reconnection: **not supported** in v1; clients start over on reconnect
-
----
+- **Closure:** `GET /v1/skillsets/{idOrName}/closure` resolves `roots = members` through the **same** §2.5 resolver — the union of all members plus each member's transitive dependency closure, deduplicated and topo-sorted (deps-first). The success body carries the version's master prompt as a **root sibling** of `items`: `{ "data": { "instructions": "…", "items": [ … ] }, "error": null }` (the skill `/skills/:id/closure` envelope stays `{ items }`, unchanged). Same error codes as §2.5: `dependency_cycle` (409), `dependency_conflict` (409), `skill_dependency_not_found` (404). Anonymous callers resolving a public skillset whose member transitively pins a private skill get `skill_dependency_not_found`
 
 ---
 

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -124,6 +124,21 @@ const PlaygroundPage = lazy(() =>
 const MySkillsPage = lazy(() =>
   import("@/pages/skill/MySkillsPage").then((m) => ({ default: m.MySkillsPage })),
 );
+const SkillsetExplorePage = lazy(() =>
+  import("@/pages/SkillsetExplorePage").then((m) => ({ default: m.SkillsetExplorePage })),
+);
+const SkillsetDetailPage = lazy(() =>
+  import("@/pages/SkillsetDetailPage").then((m) => ({ default: m.SkillsetDetailPage })),
+);
+const SkillsetNewPage = lazy(() =>
+  import("@/pages/SkillsetNewPage").then((m) => ({ default: m.SkillsetNewPage })),
+);
+const SkillsetEditPage = lazy(() =>
+  import("@/pages/SkillsetEditPage").then((m) => ({ default: m.SkillsetEditPage })),
+);
+const MySkillsetsPage = lazy(() =>
+  import("@/pages/MySkillsetsPage").then((m) => ({ default: m.MySkillsetsPage })),
+);
 const ServiceDetailPage = lazy(() =>
   import("@/pages/ServiceDetailPage").then((m) => ({ default: m.ServiceDetailPage })),
 );
@@ -259,6 +274,11 @@ const router = createBrowserRouter(
           path="/skills/:idOrName/audits"
           element={<SkillAuditHistoryPage />}
         />
+        {/* Skillsets registry (#1059). `/skillsets/new` + `/skillsets/:id/edit`
+            are auth-guarded below; static segments win the match over the
+            `:idOrName` capture regardless of declaration group. */}
+        <Route path="/skillsets" element={<SkillsetExplorePage />} />
+        <Route path="/skillsets/:idOrName" element={<SkillsetDetailPage />} />
       </Route>
 
       {/* Protected routes */}
@@ -273,6 +293,12 @@ const router = createBrowserRouter(
           <Route path="/playground" element={<PlaygroundPage />} />
 
           <Route path="/my-skills" element={<MySkillsPage />} />
+
+          {/* Skillsets create/edit/mine (#1059) — auth-guarded. */}
+          <Route path="/skillsets/new" element={<SkillsetNewPage />} />
+          <Route path="/skillsets/:id/edit" element={<SkillsetEditPage />} />
+          <Route path="/my-skillsets" element={<MySkillsetsPage />} />
+
           <Route path="/services/:id" element={<ServiceDetailPage />} />
           <Route path="/notifications" element={<NotificationsPage />} />
           <Route path="/settings" element={<SettingsPage />} />

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -67,6 +67,7 @@ const NAV_ITEMS = [
   { i18nKey: "nav.news", path: "/news", requiresAuth: false },
   { i18nKey: "nav.build", path: "/skills/new", requiresAuth: true },
   { i18nKey: "nav.registry", path: "/registry", requiresAuth: false, exact: true },
+  { i18nKey: "nav.skillsets", path: "/skillsets", requiresAuth: false },
   { i18nKey: "nav.docs", path: "/docs", requiresAuth: false },
   { i18nKey: "nav.contact", path: "/contact", requiresAuth: false },
 ] as const;

--- a/ornn-web/src/components/layout/NavbarSkillsets.test.tsx
+++ b/ornn-web/src/components/layout/NavbarSkillsets.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Navbar — the Skillsets nav entry (#1059).
+ *
+ * The top nav must expose a "Skillsets" link pointing at `/skillsets`,
+ * sitting alongside the existing Registry entry. It is a public link
+ * (no auth gate), so it renders for anonymous visitors too.
+ *
+ * The auth/theme/activity/bell deps are mocked exactly as in Navbar.test.tsx
+ * so the component renders without the apiClient/auth init chain. react-i18next
+ * is stubbed globally in src/test/setup.ts (the "Skillsets" label resolves from
+ * en.json `nav.skillsets`).
+ *
+ * @module components/layout/NavbarSkillsets.test
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          initial: _i,
+          animate: _a,
+          exit: _e,
+          transition: _tr,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          void _i;
+          void _a;
+          void _e;
+          void _tr;
+          const Tag = tag as keyof React.JSX.IntrinsicElements;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    },
+  ),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: Object.assign(() => ({}), { getState: () => ({ logout: vi.fn() }) }),
+  useIsAuthenticated: () => false,
+  useCurrentUser: () => null,
+}));
+
+vi.mock("@/stores/themeStore", () => ({
+  useThemeStore: () => ({ theme: "dark", toggle: vi.fn() }),
+}));
+
+vi.mock("@/services/activityApi", () => ({ logActivity: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock("@/components/notifications/NotificationBell", () => ({ NotificationBell: () => null }));
+
+import { Navbar } from "./Navbar";
+
+afterEach(() => cleanup());
+
+describe("Navbar — Skillsets entry", () => {
+  it("renders a 'Skillsets' link pointing at /skillsets", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Navbar />
+      </MemoryRouter>,
+    );
+    // Two surfaces (desktop strip + mobile panel) each render the link.
+    const links = screen.getAllByRole("link", { name: "Skillsets" });
+    expect(links.length).toBeGreaterThan(0);
+    links.forEach((link) => expect(link).toHaveAttribute("href", "/skillsets"));
+  });
+
+  it("still renders the existing Registry link (Skillsets is additive)", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Navbar />
+      </MemoryRouter>,
+    );
+    const registry = screen.getAllByRole("link", { name: "Registry" });
+    expect(registry.length).toBeGreaterThan(0);
+    registry.forEach((link) => expect(link).toHaveAttribute("href", "/registry"));
+  });
+});

--- a/ornn-web/src/components/skill/VersionPicker.tsx
+++ b/ornn-web/src/components/skill/VersionPicker.tsx
@@ -1,12 +1,23 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AnimatePresence, motion } from "framer-motion";
-import type { SkillVersionEntry } from "@/types/domain";
 import { formatVersionLabel } from "@/lib/versionLabel";
+
+/**
+ * Minimal version shape the picker needs. Structurally satisfied by both
+ * `SkillVersionEntry` (skills) and `SkillsetVersionEntry` (skillsets, #1059) —
+ * skillset versions carry no `isDeprecated` flag, so it's optional here. The
+ * picker reads only `version` (required) and `isDeprecated` (for the label).
+ */
+export interface VersionPickerEntry {
+  version: string;
+  // exactOptionalPropertyTypes (#657)
+  isDeprecated?: boolean | undefined;
+}
 
 export interface VersionPickerProps {
   /** All available versions, already sorted newest-first. */
-  versions: SkillVersionEntry[];
+  versions: VersionPickerEntry[];
   /** Version currently shown on the page (may be latest or a specific pick). */
   currentVersion: string;
   /**
@@ -60,7 +71,9 @@ export function VersionPicker({
   const buttonLabel = current
     ? formatVersionLabel(current.version, {
         isLatest: current.version === latestVersion,
-        isDeprecated: current.isDeprecated,
+        // Skillset versions carry no `isDeprecated` flag (optional in
+        // `VersionPickerEntry`); default to false for the label flags.
+        isDeprecated: current.isDeprecated ?? false,
         latestText: t("skillDetail.latest"),
         deprecatedText: t("skillDetail.deprecated"),
       })
@@ -118,7 +131,7 @@ export function VersionPicker({
               const isCurrent = v.version === currentVersion;
               const label = formatVersionLabel(v.version, {
                 isLatest: v.version === latestVersion,
-                isDeprecated: v.isDeprecated,
+                isDeprecated: v.isDeprecated ?? false,
                 latestText: t("skillDetail.latest"),
                 deprecatedText: t("skillDetail.deprecated"),
               });

--- a/ornn-web/src/components/skillset/KindBadge.tsx
+++ b/ornn-web/src/components/skillset/KindBadge.tsx
@@ -1,0 +1,40 @@
+/**
+ * KindBadge — renders a skillset's `kind` as a Forge-styled Badge.
+ *
+ *   generic              → muted   ("Bundle")
+ *   consensus-supported  → cyan/ember ("Consensus")
+ *
+ * `consensus-supported` is an author CLAIM (not a platform guarantee), so the
+ * label reads as a typed tag, not a trust badge — the detail page carries the
+ * fuller "author asserts" framing.
+ *
+ * @module components/skillset/KindBadge
+ */
+
+import { useTranslation } from "react-i18next";
+import { Badge } from "@/components/ui/Badge";
+import type { BadgeProps } from "@/components/ui/Badge";
+import type { SkillsetKind } from "@/types/skillset";
+
+export interface KindBadgeProps {
+  kind: SkillsetKind;
+  className?: string | undefined;
+}
+
+const KIND_COLOR: Record<SkillsetKind, NonNullable<BadgeProps["color"]>> = {
+  generic: "muted",
+  "consensus-supported": "cyan",
+};
+
+export function KindBadge({ kind, className = "" }: KindBadgeProps) {
+  const { t } = useTranslation();
+  const label =
+    kind === "consensus-supported"
+      ? t("skillsetKind.consensusSupported", "Consensus")
+      : t("skillsetKind.generic", "Bundle");
+  return (
+    <Badge color={KIND_COLOR[kind]} className={className}>
+      {label}
+    </Badge>
+  );
+}

--- a/ornn-web/src/components/skillset/MasterPromptEditor.test.tsx
+++ b/ornn-web/src/components/skillset/MasterPromptEditor.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * MasterPromptEditor — required trimmed 1–8000 validation + char count.
+ *
+ * The #978 contract: the master prompt is REQUIRED, trim-then-bound so a
+ * whitespace-only body is invalid, and capped at 8000 chars. The exported
+ * `validateMasterPrompt` is the unit under test for the boundary cases; the
+ * rendered editor surfaces a live count + over-limit warning.
+ *
+ * @module components/skillset/MasterPromptEditor.test
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MasterPromptEditor, validateMasterPrompt } from "./MasterPromptEditor";
+import { SKILLSET_INSTRUCTIONS_MAX } from "@/types/skillset";
+
+afterEach(() => cleanup());
+
+describe("validateMasterPrompt", () => {
+  it("rejects an empty body", () => {
+    expect(validateMasterPrompt("")).toBe("empty");
+  });
+
+  it("rejects a whitespace-only body (trim-then-bound)", () => {
+    expect(validateMasterPrompt("   \n\t  ")).toBe("empty");
+  });
+
+  it("rejects a body over the 8000-char cap (measured trimmed)", () => {
+    expect(validateMasterPrompt("a".repeat(SKILLSET_INSTRUCTIONS_MAX + 1))).toBe("tooLong");
+  });
+
+  it("accepts a body exactly at the cap", () => {
+    expect(validateMasterPrompt("a".repeat(SKILLSET_INSTRUCTIONS_MAX))).toBeNull();
+  });
+
+  it("accepts a normal body", () => {
+    expect(validateMasterPrompt("Run A, then B.")).toBeNull();
+  });
+});
+
+describe("MasterPromptEditor rendering", () => {
+  it("shows a live trimmed character count", () => {
+    render(<MasterPromptEditor value="hello" onChange={() => {}} />);
+    expect(screen.getByText(`5 / ${SKILLSET_INSTRUCTIONS_MAX}`)).toBeInTheDocument();
+  });
+
+  it("surfaces an over-limit warning when past the cap", () => {
+    render(
+      <MasterPromptEditor value={"a".repeat(SKILLSET_INSTRUCTIONS_MAX + 5)} onChange={() => {}} />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(new RegExp(String(SKILLSET_INSTRUCTIONS_MAX)));
+  });
+
+  it("surfaces an external error only when the body is empty", () => {
+    render(<MasterPromptEditor value="   " onChange={() => {}} error="Prompt is required" />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Prompt is required");
+  });
+});

--- a/ornn-web/src/components/skillset/MasterPromptEditor.test.tsx
+++ b/ornn-web/src/components/skillset/MasterPromptEditor.test.tsx
@@ -11,8 +11,8 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { MasterPromptEditor, validateMasterPrompt } from "./MasterPromptEditor";
-import { SKILLSET_INSTRUCTIONS_MAX } from "@/types/skillset";
+import { MasterPromptEditor } from "./MasterPromptEditor";
+import { SKILLSET_INSTRUCTIONS_MAX, validateMasterPrompt } from "@/types/skillset";
 
 afterEach(() => cleanup());
 

--- a/ornn-web/src/components/skillset/MasterPromptEditor.tsx
+++ b/ornn-web/src/components/skillset/MasterPromptEditor.tsx
@@ -22,18 +22,6 @@ export interface MasterPromptEditorProps {
   className?: string | undefined;
 }
 
-/**
- * Validate a master-prompt body against the #978 contract. Returns `null` when
- * valid, else a reason key. Trim-then-bound so whitespace-only never satisfies
- * the non-empty requirement.
- */
-export function validateMasterPrompt(value: string): "empty" | "tooLong" | null {
-  const trimmed = value.trim();
-  if (trimmed.length === 0) return "empty";
-  if (trimmed.length > SKILLSET_INSTRUCTIONS_MAX) return "tooLong";
-  return null;
-}
-
 export function MasterPromptEditor({
   value,
   onChange,

--- a/ornn-web/src/components/skillset/MasterPromptEditor.tsx
+++ b/ornn-web/src/components/skillset/MasterPromptEditor.tsx
@@ -1,0 +1,97 @@
+/**
+ * MasterPromptEditor — the skillset master prompt (#978) editor.
+ *
+ * Composes the shared `MarkdownEditor` and layers the skillset-specific
+ * contract on top: the body is REQUIRED (trimmed 1–8000 chars), with a live
+ * character count and an over-limit / empty warning. Stored opaque on the
+ * backend; this is a long-form operating manual telling an agent HOW to use
+ * the set (orchestration, ordering, when to pick which member).
+ *
+ * @module components/skillset/MasterPromptEditor
+ */
+
+import { useTranslation } from "react-i18next";
+import { MarkdownEditor } from "@/components/form/MarkdownEditor";
+import { SKILLSET_INSTRUCTIONS_MAX } from "@/types/skillset";
+
+export interface MasterPromptEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** External validation error (e.g. surfaced on submit). */
+  error?: string | undefined;
+  className?: string | undefined;
+}
+
+/**
+ * Validate a master-prompt body against the #978 contract. Returns `null` when
+ * valid, else a reason key. Trim-then-bound so whitespace-only never satisfies
+ * the non-empty requirement.
+ */
+export function validateMasterPrompt(value: string): "empty" | "tooLong" | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return "empty";
+  if (trimmed.length > SKILLSET_INSTRUCTIONS_MAX) return "tooLong";
+  return null;
+}
+
+export function MasterPromptEditor({
+  value,
+  onChange,
+  error,
+  className = "",
+}: MasterPromptEditorProps) {
+  const { t } = useTranslation();
+  const trimmedLength = value.trim().length;
+  const over = trimmedLength > SKILLSET_INSTRUCTIONS_MAX;
+  const empty = trimmedLength === 0;
+
+  return (
+    <div className={`space-y-1.5 ${className}`}>
+      <div className="flex items-center justify-between">
+        <label className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
+          {t("skillsetPrompt.label", "Master prompt")}
+          <span className="ml-1 text-danger">*</span>
+        </label>
+        <span
+          className={`font-mono text-[10px] ${over ? "text-danger" : "text-meta"}`}
+          aria-live="polite"
+        >
+          {t("skillsetPrompt.count", "{{count}} / {{max}}", {
+            count: trimmedLength,
+            max: SKILLSET_INSTRUCTIONS_MAX,
+          })}
+        </span>
+      </div>
+
+      <p className="font-text text-xs text-meta">
+        {t(
+          "skillsetPrompt.help",
+          "Required. Tell an agent how to use this set — orchestration, ordering, and when to pick which member.",
+        )}
+      </p>
+
+      <MarkdownEditor
+        value={value}
+        onChange={onChange}
+        placeholder={
+          t("skillsetPrompt.placeholder", "# How to use this set\n\n1. Start with ...") as string
+        }
+        minRows={8}
+        maxRows={24}
+      />
+
+      {over && (
+        <p className="font-mono text-[11px] text-danger" role="alert">
+          {t("skillsetPrompt.errorTooLong", "Master prompt must be at most {{max}} characters.", {
+            max: SKILLSET_INSTRUCTIONS_MAX,
+          })}
+        </p>
+      )}
+      {!over && empty && error && (
+        <p className="font-mono text-[11px] text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ornn-web/src/components/skillset/SkillsetCard.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetCard.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * SkillsetCard — renders identity + kind/visibility, NEVER a member count.
+ *
+ * The load-bearing assertion (#969 / #1059): the browse card must not surface
+ * a member count, because `SkillsetSearchItem.memberCount` is hardcoded `0` in
+ * the backend search service. The test passes a result with `memberCount: 0`
+ * and asserts the card neither shows that count nor a "members" label.
+ *
+ * Owner controls (Edit / Delete) only render for the author when explicitly
+ * enabled, and clicking them does NOT navigate (stopPropagation).
+ *
+ * @module components/skillset/SkillsetCard.test
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const navigateSpy = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+import { SkillsetCard } from "./SkillsetCard";
+import type { SkillsetSearchItem } from "@/types/skillset";
+
+const ITEM: SkillsetSearchItem = {
+  guid: "g-1",
+  name: "research-bundle",
+  description: "A curated comparison set",
+  kind: "consensus-supported",
+  tags: ["research", "rag"],
+  memberCount: 0,
+  latestVersion: "1.2",
+  isPrivate: false,
+  createdBy: "user-1",
+  createdByDisplayName: "Ada",
+  createdOn: "2026-06-01T00:00:00.000Z",
+  updatedOn: "2026-06-02T00:00:00.000Z",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderCard(props: Partial<Parameters<typeof SkillsetCard>[0]> = {}) {
+  return render(
+    <MemoryRouter>
+      <SkillsetCard skillset={ITEM} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("SkillsetCard", () => {
+  it("renders the name, kind, visibility, version, tags, and author", () => {
+    renderCard();
+    expect(screen.getByText("research-bundle")).toBeInTheDocument();
+    expect(screen.getByText("Consensus")).toBeInTheDocument();
+    expect(screen.getByText(/Public/)).toBeInTheDocument();
+    expect(screen.getByText("v1.2")).toBeInTheDocument();
+    expect(screen.getByText("research")).toBeInTheDocument();
+    expect(screen.getByText("Ada")).toBeInTheDocument();
+  });
+
+  it("never surfaces a member count (memberCount is 0 from search)", () => {
+    renderCard();
+    // No "0 members", no "member" label, no bare "0" count chip anywhere.
+    expect(screen.queryByText(/member/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("navigates to the detail page by name on card click", () => {
+    renderCard();
+    fireEvent.click(screen.getByText("research-bundle"));
+    expect(navigateSpy).toHaveBeenCalledWith("/skillsets/research-bundle");
+  });
+
+  it("shows owner Edit/Delete only when enabled for the author, and they don't navigate", () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    renderCard({
+      showOwnerControls: true,
+      currentUserId: "user-1",
+      onEdit,
+      onDelete,
+    });
+    const editBtn = screen.getByRole("button", { name: "Edit" });
+    const deleteBtn = screen.getByRole("button", { name: "Delete" });
+    fireEvent.click(editBtn);
+    fireEvent.click(deleteBtn);
+    expect(onEdit).toHaveBeenCalledWith(ITEM);
+    expect(onDelete).toHaveBeenCalledWith(ITEM);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("hides owner controls for a non-author even when enabled", () => {
+    renderCard({ showOwnerControls: true, currentUserId: "someone-else", onDelete: vi.fn() });
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/components/skillset/SkillsetCard.tsx
+++ b/ornn-web/src/components/skillset/SkillsetCard.tsx
@@ -1,0 +1,142 @@
+/**
+ * SkillsetCard — one browse-grid card for a skillset search result.
+ *
+ * Mirrors `SkillCard`: title row, kind + visibility badges, description,
+ * tags, author + timestamp footer, optional owner Edit/Delete controls.
+ *
+ * NOTE (#969 follow-up): `SkillsetSearchItem.memberCount` is hardcoded `0`
+ * in the backend search service — the identity doc the search reads doesn't
+ * carry the member list. So this card DELIBERATELY does not surface a member
+ * count; the real count lives on the detail page (resolved from the version).
+ *
+ * @module components/skillset/SkillsetCard
+ */
+
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import type { BadgeProps } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { KindBadge } from "@/components/skillset/KindBadge";
+import type { SkillsetSearchItem } from "@/types/skillset";
+import { formatDateSGT } from "@/utils/formatters";
+
+const TAG_COLORS: NonNullable<BadgeProps["color"]>[] = ["cyan", "magenta", "yellow", "green"];
+
+function getTagColor(tag: string): NonNullable<BadgeProps["color"]> {
+  const hash = tag.split("").reduce((a, c) => a + c.charCodeAt(0), 0);
+  return TAG_COLORS[hash % TAG_COLORS.length]!;
+}
+
+export interface SkillsetCardProps {
+  skillset: SkillsetSearchItem;
+  // Optionals widen to `T | undefined` for exactOptionalPropertyTypes (#657).
+  showOwnerControls?: boolean | undefined;
+  currentUserId?: string | undefined;
+  onEdit?: ((skillset: SkillsetSearchItem) => void) | undefined;
+  onDelete?: ((skillset: SkillsetSearchItem) => void) | undefined;
+  className?: string | undefined;
+}
+
+export function SkillsetCard({
+  skillset,
+  showOwnerControls = false,
+  currentUserId,
+  onEdit,
+  onDelete,
+  className = "",
+}: SkillsetCardProps) {
+  const navigate = useNavigate();
+  const { t, i18n } = useTranslation();
+
+  const isOwner = currentUserId && skillset.createdBy === currentUserId;
+  const displayName =
+    skillset.createdByDisplayName || skillset.createdByEmail || skillset.createdBy;
+  const timestamp = skillset.updatedOn || skillset.createdOn;
+
+  return (
+    <Card
+      hoverable
+      onClick={() => navigate(`/skillsets/${skillset.name}`)}
+      className={`flex flex-col h-full ${className}`}
+    >
+      {/* Title — full card width, wrap up to two lines then ellipsis. */}
+      <h3 className="mb-2 font-display text-lg font-semibold text-accent break-words line-clamp-2">
+        {skillset.name}
+      </h3>
+
+      {/* Kind + visibility badges. No member count (sourced 0 from search). */}
+      <div className="mb-3 flex flex-wrap items-center gap-1.5">
+        <KindBadge kind={skillset.kind} />
+        {skillset.isPrivate ? (
+          <Badge color="cyan">🔒 {t("common.private")}</Badge>
+        ) : (
+          <Badge color="green">🌐 {t("common.public")}</Badge>
+        )}
+        <Badge color="muted">v{skillset.latestVersion}</Badge>
+      </div>
+
+      {/* Description — fixed 2 lines, break long words. */}
+      <p className="mb-4 font-text text-sm leading-relaxed text-meta line-clamp-2 break-words">
+        {skillset.description}
+      </p>
+
+      {/* Tags — fixed single row. */}
+      <div className="mb-3 flex flex-wrap gap-1.5 min-h-[24px]">
+        {skillset.tags.slice(0, 5).map((tag) => (
+          <Badge key={tag} color={getTagColor(tag)}>
+            {tag}
+          </Badge>
+        ))}
+      </div>
+
+      {/* Spacer to push footer to bottom. */}
+      <div className="flex-1" />
+
+      {/* Author + timestamp. */}
+      <div className="flex items-center justify-between gap-4 text-xs text-meta">
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="flex h-4 w-4 items-center justify-center rounded-full bg-elevated text-[8px] text-meta shrink-0">
+            {displayName.charAt(0).toUpperCase()}
+          </div>
+          <span className="truncate">{displayName}</span>
+        </div>
+        <span className="shrink-0">
+          {formatDateSGT(timestamp, i18n.language, { withSeconds: true })}
+        </span>
+      </div>
+
+      {showOwnerControls && isOwner && (
+        <div className="mt-4 pt-4 border-t border-accent/10">
+          <div className="flex items-center justify-end gap-2" onClick={(e) => e.stopPropagation()}>
+            {onEdit && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={(e) => {
+                  e?.stopPropagation();
+                  onEdit(skillset);
+                }}
+              >
+                {t("common.edit")}
+              </Button>
+            )}
+            {onDelete && (
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={(e) => {
+                  e?.stopPropagation();
+                  onDelete(skillset);
+                }}
+              >
+                {t("common.delete")}
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/ornn-web/src/components/skillset/SkillsetClosureViewer.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetClosureViewer.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * SkillsetClosureViewer — flat render + depth indent.
+ *
+ * The server pre-flattens the graph; this component just renders the list and
+ * indents by `depth`. We assert: every node renders in the given (deps-first)
+ * order, depth-0 rows are tagged "member" and deeper rows "dep", and the
+ * indent (marginLeft) scales with depth.
+ *
+ * @module components/skillset/SkillsetClosureViewer.test
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { SkillsetClosureViewer } from "./SkillsetClosureViewer";
+import type { SkillsetClosureItem } from "@/types/skillset";
+
+const ITEMS: SkillsetClosureItem[] = [
+  { ref: "a@1.0", name: "a", version: "1.0", depth: 0 },
+  { ref: "b@1.0", name: "b", version: "1.0", depth: 0 },
+  { ref: "a-dep@2.1", name: "a-dep", version: "2.1", depth: 1 },
+  { ref: "deep@0.3", name: "deep", version: "0.3", depth: 2 },
+];
+
+afterEach(() => cleanup());
+
+describe("SkillsetClosureViewer", () => {
+  it("renders an empty hint when there are no items", () => {
+    render(<SkillsetClosureViewer items={[]} />);
+    expect(screen.getByText(/No resolved members/i)).toBeInTheDocument();
+  });
+
+  it("renders every node flat, in the given deps-first order", () => {
+    render(<SkillsetClosureViewer items={ITEMS} />);
+    const rows = within(screen.getByTestId("closure-list")).getAllByRole("listitem");
+    expect(rows).toHaveLength(4);
+    expect(rows[0]).toHaveTextContent("a");
+    expect(rows[1]).toHaveTextContent("b");
+    expect(rows[2]).toHaveTextContent("a-dep");
+    expect(rows[3]).toHaveTextContent("deep");
+  });
+
+  it("tags depth-0 rows as members and deeper rows as deps", () => {
+    render(<SkillsetClosureViewer items={ITEMS} />);
+    const rows = within(screen.getByTestId("closure-list")).getAllByRole("listitem");
+    expect(rows[0]).toHaveTextContent("member");
+    expect(rows[2]).toHaveTextContent("dep");
+    expect(rows[3]).toHaveTextContent("dep");
+  });
+
+  it("indents each row proportional to its depth", () => {
+    render(<SkillsetClosureViewer items={ITEMS} />);
+    const rows = within(screen.getByTestId("closure-list")).getAllByRole("listitem");
+    // depth 0 → 0px, depth 1 → 20px, depth 2 → 40px.
+    expect((rows[0] as HTMLElement).style.marginLeft).toBe("0px");
+    expect((rows[2] as HTMLElement).style.marginLeft).toBe("20px");
+    expect((rows[3] as HTMLElement).style.marginLeft).toBe("40px");
+    // Depth is also reflected on a data attribute for downstream styling.
+    expect(rows[2]?.getAttribute("data-depth")).toBe("1");
+  });
+});

--- a/ornn-web/src/components/skillset/SkillsetClosureViewer.tsx
+++ b/ornn-web/src/components/skillset/SkillsetClosureViewer.tsx
@@ -1,0 +1,63 @@
+/**
+ * SkillsetClosureViewer — renders a resolved skillset closure as a FLAT,
+ * depth-indented list.
+ *
+ * The server PRE-FLATTENS the dependency graph (deps-first topo-sorted) and
+ * stamps each node with a BFS-style `depth` (0 = direct member, deeper =
+ * transitive dependency). We render that flat list and indent by depth — no
+ * client-side tree reconstruction. A depth-0 row reads as a direct member; a
+ * depth-1+ row reads as a pulled-in dependency.
+ *
+ * @module components/skillset/SkillsetClosureViewer
+ */
+
+import { useTranslation } from "react-i18next";
+import type { SkillsetClosureItem } from "@/types/skillset";
+
+export interface SkillsetClosureViewerProps {
+  items: SkillsetClosureItem[];
+  className?: string | undefined;
+}
+
+/** px of indent per depth level. */
+const INDENT_PER_DEPTH = 20;
+
+export function SkillsetClosureViewer({ items, className = "" }: SkillsetClosureViewerProps) {
+  const { t } = useTranslation();
+
+  if (items.length === 0) {
+    return (
+      <p className={`font-text text-sm text-meta italic ${className}`}>
+        {t("skillsetClosure.empty", "No resolved members yet.")}
+      </p>
+    );
+  }
+
+  return (
+    <ul className={`space-y-1 ${className}`} data-testid="closure-list">
+      {items.map((item) => (
+        <li
+          key={`${item.ref}:${item.depth}`}
+          data-depth={item.depth}
+          className="flex items-center gap-2 rounded-sm border border-subtle bg-elevated/40 px-3 py-2"
+          style={{ marginLeft: `${item.depth * INDENT_PER_DEPTH}px` }}
+        >
+          {/* Depth marker — direct member vs. pulled-in dependency. */}
+          <span
+            className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider ${
+              item.depth === 0
+                ? "border border-accent/40 bg-accent/10 text-accent"
+                : "border border-subtle bg-elevated text-meta"
+            }`}
+          >
+            {item.depth === 0
+              ? t("skillsetClosure.member", "member")
+              : t("skillsetClosure.dependency", "dep")}
+          </span>
+          <span className="min-w-0 truncate font-mono text-sm text-strong">{item.name}</span>
+          <span className="shrink-0 font-mono text-xs text-meta">v{item.version}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/ornn-web/src/components/skillset/SkillsetForm.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetForm.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * SkillsetForm — create vs. edit contract.
+ *
+ * create: name is editable; submit requires ≥2 members + a required prompt;
+ *         the create payload carries name / members / instructions / version.
+ * edit:   name is LOCKED (display-only, no name field); the version must be
+ *         BUMPED — submitting with the same loaded version is rejected, a new
+ *         version publishes.
+ *
+ * The member picker's skill-search query is gated on focus + non-empty query
+ * and never runs (we drive raw refs via Enter), so only a QueryClient is
+ * needed — plus the auth-store stub so the api layer import chain stays inert.
+ *
+ * @module components/skillset/SkillsetForm.test
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: {
+    getState: () => ({
+      accessToken: null,
+      isAuthenticated: false,
+      ensureFreshToken: async () => {},
+      refreshToken: async () => {},
+    }),
+  },
+}));
+
+import { SkillsetForm } from "./SkillsetForm";
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{node}</QueryClientProvider>);
+}
+
+/** Add a member ref via the picker's raw-ref Enter path. */
+function addMember(ref: string) {
+  const input = screen.getByPlaceholderText(/search a skill/);
+  fireEvent.change(input, { target: { value: ref } });
+  fireEvent.keyDown(input, { key: "Enter" });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SkillsetForm — create", () => {
+  it("submits a create payload with name, ≥2 members, prompt, and version", async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    wrap(<SkillsetForm mode="create" onCreate={onCreate} />);
+
+    fireEvent.change(screen.getByPlaceholderText("research-bundle"), {
+      target: { value: "research-bundle" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/human-readable summary/), {
+      target: { value: "A bundle" },
+    });
+    addMember("a@1.0");
+    addMember("b@1.0");
+    // The master prompt textarea is the MarkdownEditor's first textbox.
+    const promptBox = screen.getAllByRole("textbox").find((el) => el.tagName === "TEXTAREA")!;
+    fireEvent.change(promptBox, { target: { value: "Run A, then B." } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create skillset" }));
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1));
+    expect(onCreate.mock.calls[0]?.[0]).toMatchObject({
+      name: "research-bundle",
+      members: ["a@1.0", "b@1.0"],
+      instructions: "Run A, then B.",
+      version: "1.0",
+    });
+  });
+
+  it("blocks submit with fewer than 2 members", async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    wrap(<SkillsetForm mode="create" onCreate={onCreate} />);
+
+    fireEvent.change(screen.getByPlaceholderText("research-bundle"), { target: { value: "x" } });
+    fireEvent.change(screen.getByPlaceholderText(/human-readable summary/), {
+      target: { value: "d" },
+    });
+    addMember("a@1.0"); // only one
+    const promptBox = screen.getAllByRole("textbox").find((el) => el.tagName === "TEXTAREA")!;
+    fireEvent.change(promptBox, { target: { value: "do it" } });
+
+    // Submit button is disabled (membersValid false).
+    expect(screen.getByRole("button", { name: "Create skillset" })).toBeDisabled();
+  });
+
+  it("blocks submit when the master prompt is empty", () => {
+    wrap(<SkillsetForm mode="create" onCreate={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("research-bundle"), { target: { value: "x" } });
+    fireEvent.change(screen.getByPlaceholderText(/human-readable summary/), {
+      target: { value: "d" },
+    });
+    addMember("a@1.0");
+    addMember("b@1.0");
+    // No prompt typed → still disabled.
+    expect(screen.getByRole("button", { name: "Create skillset" })).toBeDisabled();
+  });
+});
+
+describe("SkillsetForm — edit", () => {
+  const initial = {
+    name: "research-bundle",
+    description: "A bundle",
+    instructions: "Run A, then B.",
+    kind: "generic" as const,
+    tags: ["research"],
+    members: ["a@1.0", "b@1.0"],
+    version: "1.0",
+  };
+
+  it("locks the name (no editable name field, label shows the locked name)", () => {
+    wrap(<SkillsetForm mode="edit" initial={initial} onPublish={vi.fn()} />);
+    // No editable input for the name (it's render-only).
+    expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
+    expect(screen.getByText("research-bundle")).toBeInTheDocument();
+    expect(screen.getByText("(locked)")).toBeInTheDocument();
+  });
+
+  it("rejects publishing with the same (un-bumped) version", () => {
+    wrap(<SkillsetForm mode="edit" initial={initial} onPublish={vi.fn()} />);
+    // Version field is pre-seeded with the loaded "1.0" → not bumped → disabled.
+    expect(screen.getByRole("button", { name: "Publish version" })).toBeDisabled();
+  });
+
+  it("publishes when the version is bumped", async () => {
+    const onPublish = vi.fn().mockResolvedValue(undefined);
+    wrap(<SkillsetForm mode="edit" initial={initial} onPublish={onPublish} />);
+
+    // The version field is pre-seeded with the loaded "1.0"; bump it.
+    fireEvent.change(screen.getByDisplayValue("1.0"), { target: { value: "1.1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Publish version" }));
+
+    await waitFor(() => expect(onPublish).toHaveBeenCalledTimes(1));
+    expect(onPublish.mock.calls[0]?.[0]).toMatchObject({
+      version: "1.1",
+      members: ["a@1.0", "b@1.0"],
+      instructions: "Run A, then B.",
+    });
+    // The create-only `name` field is never part of the publish payload.
+    expect(onPublish.mock.calls[0]?.[0]).not.toHaveProperty("name");
+  });
+});

--- a/ornn-web/src/components/skillset/SkillsetForm.tsx
+++ b/ornn-web/src/components/skillset/SkillsetForm.tsx
@@ -18,15 +18,16 @@
  * @module components/skillset/SkillsetForm
  */
 
-import { useMemo, useState } from "react";
+import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { SkillsetMemberPicker } from "@/components/skillset/SkillsetMemberPicker";
-import { MasterPromptEditor, validateMasterPrompt } from "@/components/skillset/MasterPromptEditor";
+import { MasterPromptEditor } from "@/components/skillset/MasterPromptEditor";
 import {
   SKILLSET_KINDS,
   SKILLSET_MIN_MEMBERS,
+  validateMasterPrompt,
   type CreateSkillsetInput,
   type PublishSkillsetInput,
   type SkillsetKind,
@@ -91,7 +92,7 @@ export function SkillsetForm({
   const canSubmit =
     nameValid && descriptionValid && membersValid && promptValid && versionValid && !submitting;
 
-  const tagInputId = useMemo(() => `skillset-tag-${Math.random().toString(36).slice(2)}`, []);
+  const tagInputId = useId();
 
   function addTag(raw: string) {
     const tag = raw.trim().toLowerCase();

--- a/ornn-web/src/components/skillset/SkillsetForm.tsx
+++ b/ornn-web/src/components/skillset/SkillsetForm.tsx
@@ -1,0 +1,295 @@
+/**
+ * SkillsetForm — the ONE create/publish form, used by both
+ * `/skillsets/new` (create → POST) and `/skillsets/:id/edit` (publish → PUT).
+ *
+ * Composes the kind selector, tag editor, `SkillsetMemberPicker`, and
+ * `MasterPromptEditor`. The two modes differ in three ways:
+ *
+ *   create  → name is editable + required (kebab-case); version defaults 1.0;
+ *             submits via `onSubmit` with the create payload.
+ *   edit    → name is LOCKED (display-only); version is REQUIRED and must be
+ *             bumped (the publish path validates the bump server-side; the
+ *             form requires a non-empty version distinct from the loaded one).
+ *
+ * Validation is surfaced inline; the submit button is disabled until the form
+ * is structurally valid (name present in create, ≥2 members, required prompt,
+ * version present in edit).
+ *
+ * @module components/skillset/SkillsetForm
+ */
+
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+import { SkillsetMemberPicker } from "@/components/skillset/SkillsetMemberPicker";
+import { MasterPromptEditor, validateMasterPrompt } from "@/components/skillset/MasterPromptEditor";
+import {
+  SKILLSET_KINDS,
+  SKILLSET_MIN_MEMBERS,
+  type CreateSkillsetInput,
+  type PublishSkillsetInput,
+  type SkillsetKind,
+} from "@/types/skillset";
+
+/** Kebab-case skill/skillset name. Mirrors the backend `SKILL_NAME_REGEX`. */
+const NAME_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+/** `<major>.<minor>` version. */
+const VERSION_REGEX = /^\d+\.\d+$/;
+
+export interface SkillsetFormInitial {
+  name?: string | undefined;
+  description?: string | undefined;
+  instructions?: string | undefined;
+  kind?: SkillsetKind | undefined;
+  tags?: string[] | undefined;
+  members?: string[] | undefined;
+  version?: string | undefined;
+}
+
+export interface SkillsetFormProps {
+  mode: "create" | "edit";
+  initial?: SkillsetFormInitial | undefined;
+  /** Submit handler — receives the mode-appropriate payload. */
+  onCreate?: ((input: CreateSkillsetInput) => Promise<void>) | undefined;
+  onPublish?: ((input: PublishSkillsetInput) => Promise<void>) | undefined;
+  submitting?: boolean | undefined;
+  onCancel?: (() => void) | undefined;
+}
+
+export function SkillsetForm({
+  mode,
+  initial,
+  onCreate,
+  onPublish,
+  submitting = false,
+  onCancel,
+}: SkillsetFormProps) {
+  const { t } = useTranslation();
+
+  const lockedName = initial?.name ?? "";
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [instructions, setInstructions] = useState(initial?.instructions ?? "");
+  const [kind, setKind] = useState<SkillsetKind>(initial?.kind ?? "generic");
+  const [tags, setTags] = useState<string[]>(initial?.tags ?? []);
+  const [members, setMembers] = useState<string[]>(initial?.members ?? []);
+  const [version, setVersion] = useState(initial?.version ?? (mode === "create" ? "1.0" : ""));
+  const [submitted, setSubmitted] = useState(false);
+
+  const promptError = validateMasterPrompt(instructions);
+
+  const nameValid = mode === "edit" || NAME_REGEX.test(name.trim());
+  const descriptionValid = description.trim().length > 0 && description.trim().length <= 1024;
+  const membersValid = members.length >= SKILLSET_MIN_MEMBERS;
+  const promptValid = promptError === null;
+  const versionValid =
+    mode === "create"
+      ? VERSION_REGEX.test(version.trim())
+      : VERSION_REGEX.test(version.trim()) && version.trim() !== lockedVersion(initial);
+
+  const canSubmit =
+    nameValid && descriptionValid && membersValid && promptValid && versionValid && !submitting;
+
+  const tagInputId = useMemo(() => `skillset-tag-${Math.random().toString(36).slice(2)}`, []);
+
+  function addTag(raw: string) {
+    const tag = raw.trim().toLowerCase();
+    if (!tag || tags.includes(tag) || !/^[a-z0-9-]+$/.test(tag)) return;
+    setTags([...tags, tag]);
+  }
+
+  function removeTag(tag: string) {
+    setTags(tags.filter((x) => x !== tag));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitted(true);
+    if (!canSubmit) return;
+    if (mode === "create") {
+      await onCreate?.({
+        name: name.trim(),
+        description: description.trim(),
+        instructions,
+        kind,
+        tags,
+        members,
+        version: version.trim(),
+      });
+    } else {
+      await onPublish?.({
+        description: description.trim(),
+        instructions,
+        kind,
+        tags,
+        members,
+        version: version.trim(),
+      });
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+      {/* Name — editable on create, locked on edit. */}
+      {mode === "create" ? (
+        <Input
+          label={t("skillsetForm.name", "Name") as string}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="research-bundle"
+          error={
+            submitted && !nameValid
+              ? (t("skillsetForm.nameError", "Name must be kebab-case (a-z, 0-9, hyphens).") as string)
+              : undefined
+          }
+        />
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
+            {t("skillsetForm.name", "Name")}
+          </span>
+          <div className="rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-mono text-sm text-meta">
+            {lockedName}
+            <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-meta">
+              ({t("skillsetForm.nameLocked", "locked")})
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Description. */}
+      <Input
+        label={t("skillsetForm.description", "Description") as string}
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder={t("skillsetForm.descriptionPlaceholder", "A short, human-readable summary") as string}
+        error={
+          submitted && !descriptionValid
+            ? (t("skillsetForm.descriptionError", "Description is required (1–1024 chars).") as string)
+            : undefined
+        }
+      />
+
+      {/* Kind. */}
+      <div className="flex flex-col gap-1.5">
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
+          {t("skillsetForm.kind", "Kind")}
+        </span>
+        <select
+          value={kind}
+          onChange={(e) => setKind(e.target.value as SkillsetKind)}
+          className="rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-text text-sm text-strong focus:border-accent focus:outline-none cursor-pointer"
+        >
+          {SKILLSET_KINDS.map((k) => (
+            <option key={k} value={k}>
+              {k === "consensus-supported"
+                ? t("skillsetKind.consensusSupportedLong", "Consensus-supported")
+                : t("skillsetKind.genericLong", "Generic bundle")}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Tags. */}
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor={tagInputId}
+          className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta"
+        >
+          {t("skillsetForm.tags", "Tags")}
+        </label>
+        <div className="flex flex-wrap items-center gap-2">
+          {tags.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => removeTag(tag)}
+              className="inline-flex items-center gap-1.5 rounded-full border border-accent/60 bg-accent/15 px-2.5 py-1 font-text text-xs text-accent cursor-pointer"
+            >
+              <span className="max-w-[140px] truncate">{tag}</span>
+              <span aria-hidden>×</span>
+            </button>
+          ))}
+          <input
+            id={tagInputId}
+            type="text"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addTag((e.target as HTMLInputElement).value);
+                (e.target as HTMLInputElement).value = "";
+              }
+            }}
+            placeholder={t("skillsetForm.addTag", "add tag…") as string}
+            className="w-28 rounded-sm border border-subtle bg-elevated/40 px-2 py-1.5 font-text text-xs text-strong placeholder:text-meta/70 focus:border-accent focus:outline-none"
+          />
+        </div>
+      </div>
+
+      {/* Members. */}
+      <SkillsetMemberPicker
+        members={members}
+        onChange={setMembers}
+        selfName={mode === "edit" ? lockedName : undefined}
+        error={
+          submitted && !membersValid
+            ? (t("skillsetForm.membersError", "Add at least {{min}} members.", {
+                min: SKILLSET_MIN_MEMBERS,
+              }) as string)
+            : undefined
+        }
+      />
+
+      {/* Master prompt. */}
+      <MasterPromptEditor
+        value={instructions}
+        onChange={setInstructions}
+        error={
+          submitted && !promptValid
+            ? (t("skillsetForm.promptError", "A master prompt is required.") as string)
+            : undefined
+        }
+      />
+
+      {/* Version — defaulted 1.0 on create; required + bumped on edit. */}
+      <Input
+        label={t("skillsetForm.version", "Version") as string}
+        value={version}
+        onChange={(e) => setVersion(e.target.value)}
+        placeholder={mode === "edit" ? "1.1" : "1.0"}
+        error={
+          submitted && !versionValid
+            ? mode === "edit"
+              ? (t("skillsetForm.versionBumpError", "Publish requires a new, bumped version (e.g. 1.1).") as string)
+              : (t("skillsetForm.versionError", "Version must be <major>.<minor> (e.g. 1.0).") as string)
+            : undefined
+        }
+      />
+
+      {mode === "edit" && (
+        <p className="font-text text-xs text-meta">
+          {t("skillsetForm.editHint", "Publishing creates a new immutable version. The name cannot change.")}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2 border-t border-subtle pt-4">
+        {onCancel && (
+          <Button type="button" variant="secondary" onClick={onCancel}>
+            {t("common.cancel")}
+          </Button>
+        )}
+        <Button type="submit" disabled={!canSubmit} loading={submitting}>
+          {mode === "create"
+            ? t("skillsetForm.createSubmit", "Create skillset")
+            : t("skillsetForm.publishSubmit", "Publish version")}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/** The version the form loaded with — edit must publish a DIFFERENT one. */
+function lockedVersion(initial: SkillsetFormInitial | undefined): string {
+  return initial?.version ?? "";
+}

--- a/ornn-web/src/components/skillset/SkillsetMemberPicker.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberPicker.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * SkillsetMemberPicker — client-side member-ref rejections + count hint.
+ *
+ * Mirrors the backend v1 rules: reject `skillset:`-prefixed refs (no nested
+ * skillsets), reject a ref pointing at the skillset being edited (self), and
+ * reject duplicates. A valid ref is added as a chip and pushed up via
+ * `onChange`. The 2–100 count bound is surfaced as a count hint; the picker
+ * blocks adding past the max.
+ *
+ * The skill-search query is gated on focus + a non-empty debounced query and
+ * never runs here (we drive the raw-ref Enter path), so no network mock is
+ * needed beyond a QueryClient.
+ *
+ * @module components/skillset/SkillsetMemberPicker.test
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+// Stub the auth store so importing the api layer (via searchSkills) doesn't
+// run the persist-middleware localStorage init chain on module load.
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: {
+    getState: () => ({
+      accessToken: null,
+      isAuthenticated: false,
+      ensureFreshToken: async () => {},
+      refreshToken: async () => {},
+    }),
+  },
+}));
+
+import { SkillsetMemberPicker } from "./SkillsetMemberPicker";
+import { SKILLSET_MAX_MEMBERS } from "@/types/skillset";
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+}
+
+function typeAndEnter(value: string) {
+  const input = screen.getByRole("textbox");
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: "Enter" });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillsetMemberPicker", () => {
+  it("adds a valid raw ref as a chip via onChange", () => {
+    const onChange = vi.fn();
+    render(wrap(<SkillsetMemberPicker members={[]} onChange={onChange} />));
+    typeAndEnter("pdf-tools@1.0");
+    expect(onChange).toHaveBeenCalledWith(["pdf-tools@1.0"]);
+  });
+
+  it("rejects a nested skillset: ref without calling onChange", () => {
+    const onChange = vi.fn();
+    render(wrap(<SkillsetMemberPicker members={[]} onChange={onChange} />));
+    typeAndEnter("skillset:other-set@1.0");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/skillset/i);
+  });
+
+  it("rejects a ref pointing at the skillset being edited (self)", () => {
+    const onChange = vi.fn();
+    render(
+      wrap(<SkillsetMemberPicker members={[]} onChange={onChange} selfName="research-bundle" />),
+    );
+    typeAndEnter("research-bundle@1.0");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/itself/i);
+  });
+
+  it("rejects a versionless ref (no @) client-side", () => {
+    const onChange = vi.fn();
+    render(wrap(<SkillsetMemberPicker members={[]} onChange={onChange} />));
+    typeAndEnter("pdf-tools");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/version/i);
+  });
+
+  it("rejects an empty-version ref (name@) client-side", () => {
+    const onChange = vi.fn();
+    render(wrap(<SkillsetMemberPicker members={[]} onChange={onChange} />));
+    typeAndEnter("pdf-tools@");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/version/i);
+  });
+
+  it("rejects a duplicate member", () => {
+    const onChange = vi.fn();
+    render(wrap(<SkillsetMemberPicker members={["a@1.0"]} onChange={onChange} />));
+    typeAndEnter("a@1.0");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/already/i);
+  });
+
+  it("blocks adding past the max member count", () => {
+    const full = Array.from({ length: SKILLSET_MAX_MEMBERS }, (_, i) => `s${i}@1.0`);
+    const onChange = vi.fn();
+    render(wrap(<SkillsetMemberPicker members={full} onChange={onChange} />));
+    typeAndEnter("one-more@1.0");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(new RegExp(String(SKILLSET_MAX_MEMBERS)));
+  });
+
+  it("surfaces a below-minimum count hint with the max bound", () => {
+    render(wrap(<SkillsetMemberPicker members={["a@1.0"]} onChange={vi.fn()} />));
+    // "1 / 100" — below the 2-member minimum.
+    expect(screen.getByText(`1 / ${SKILLSET_MAX_MEMBERS}`)).toBeInTheDocument();
+  });
+
+  it("removes a member via its chip × button", () => {
+    const onChange = vi.fn();
+    render(wrap(<SkillsetMemberPicker members={["a@1.0", "b@1.0"]} onChange={onChange} />));
+    fireEvent.click(screen.getByRole("button", { name: /Remove a@1.0/ }));
+    expect(onChange).toHaveBeenCalledWith(["b@1.0"]);
+  });
+});

--- a/ornn-web/src/components/skillset/SkillsetMemberPicker.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberPicker.tsx
@@ -1,0 +1,228 @@
+/**
+ * SkillsetMemberPicker — add/remove member skill refs for a skillset.
+ *
+ * A skill typeahead (`searchSkills`) feeds a ref builder: pick a skill, the
+ * picker appends a `name@<latest-major.minor>` ref (the version defaults to
+ * the skill's `latestVersion` when known, else `latest`). The author can also
+ * type a raw ref (`name@1.0` / `name@tag`) and press Enter.
+ *
+ * Client-side rejections mirror the backend v1 rules:
+ *   - `skillset:`-prefixed refs (no nested skillsets)
+ *   - a ref pointing at the skillset being edited (a set can't contain itself)
+ *   - empty / duplicate refs
+ *
+ * Members render as removable chips. The 2–100 count bound is enforced at the
+ * form level (publish disabled out of range) and surfaced here as a count hint.
+ *
+ * @module components/skillset/SkillsetMemberPicker
+ */
+
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { searchSkills } from "@/services/searchApi";
+import { useDebounce } from "@/hooks/useDebounce";
+import {
+  SKILLSET_MAX_MEMBERS,
+  SKILLSET_MIN_MEMBERS,
+  parseMemberRef,
+  rejectMemberRef,
+} from "@/types/skillset";
+
+export interface SkillsetMemberPickerProps {
+  /** Current member refs (controlled). */
+  members: string[];
+  onChange: (next: string[]) => void;
+  /** Name of the skillset being edited — refs pointing at it are rejected. */
+  selfName?: string | undefined;
+  error?: string | undefined;
+  className?: string | undefined;
+}
+
+export function SkillsetMemberPicker({
+  members,
+  onChange,
+  selfName,
+  error,
+  className = "",
+}: SkillsetMemberPickerProps) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const debounced = useDebounce(query.trim(), 200);
+  const { data: results } = useQuery({
+    queryKey: ["skillset-member-search", debounced],
+    queryFn: () =>
+      searchSkills({ query: debounced, mode: "keyword", scope: "public", pageSize: 8 }),
+    enabled: focused && debounced.length > 0,
+    staleTime: 10_000,
+  });
+  const suggestions = results?.items ?? [];
+
+  function tryAdd(ref: string) {
+    const trimmed = ref.trim();
+    const rejection = rejectMemberRef(trimmed, selfName);
+    if (rejection === "empty") {
+      setLocalError(t("skillsetMembers.errorEmpty", "Enter a skill ref."));
+      return;
+    }
+    if (rejection === "nested") {
+      setLocalError(
+        t(
+          "skillsetMembers.errorNested",
+          "A skillset cannot reference another skillset. Remove the skillset: prefix.",
+        ),
+      );
+      return;
+    }
+    if (rejection === "self") {
+      setLocalError(
+        t("skillsetMembers.errorSelf", "A skillset cannot include itself as a member."),
+      );
+      return;
+    }
+    if (rejection === "noversion") {
+      setLocalError(
+        t("skillsetMembers.errorNoVersion", "Include a version, e.g. name@1.0."),
+      );
+      return;
+    }
+    if (members.includes(trimmed)) {
+      setLocalError(t("skillsetMembers.errorDuplicate", "That member is already added."));
+      return;
+    }
+    if (members.length >= SKILLSET_MAX_MEMBERS) {
+      setLocalError(
+        t("skillsetMembers.errorMax", "A skillset may have at most {{max}} members.", {
+          max: SKILLSET_MAX_MEMBERS,
+        }),
+      );
+      return;
+    }
+    setLocalError(null);
+    onChange([...members, trimmed]);
+    setQuery("");
+    setFocused(false);
+    inputRef.current?.blur();
+  }
+
+  function addFromSkill(name: string, latestVersion?: string) {
+    const version = latestVersion && latestVersion.length > 0 ? latestVersion : "latest";
+    tryAdd(`${name}@${version}`);
+  }
+
+  function removeMember(ref: string) {
+    onChange(members.filter((m) => m !== ref));
+  }
+
+  const count = members.length;
+  const belowMin = count < SKILLSET_MIN_MEMBERS;
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <div className="flex items-center justify-between">
+        <label className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
+          {t("skillsetMembers.label", "Members")}
+        </label>
+        <span
+          className={`font-mono text-[10px] ${belowMin ? "text-warning" : "text-meta"}`}
+          aria-live="polite"
+        >
+          {t("skillsetMembers.count", "{{count}} / {{max}}", {
+            count,
+            max: SKILLSET_MAX_MEMBERS,
+          })}
+        </span>
+      </div>
+
+      {/* Chips. */}
+      <div className="flex flex-wrap gap-1.5 min-h-[2rem]">
+        {members.length === 0 && (
+          <p className="font-text text-xs text-meta italic w-full">
+            {t("skillsetMembers.empty", "No members yet. Add at least {{min}} skills.", {
+              min: SKILLSET_MIN_MEMBERS,
+            })}
+          </p>
+        )}
+        {members.map((ref) => {
+          const { name, version } = parseMemberRef(ref);
+          return (
+            <span
+              key={ref}
+              className="inline-flex items-center gap-2 rounded-full border border-accent/30 bg-accent/5 px-2 py-1 font-mono text-xs text-strong h-fit"
+            >
+              <span className="truncate max-w-[16rem]">
+                {name}
+                {version && <span className="text-meta">@{version}</span>}
+              </span>
+              <button
+                type="button"
+                onClick={() => removeMember(ref)}
+                className="text-danger hover:text-danger/80 cursor-pointer"
+                aria-label={t("skillsetMembers.remove", "Remove {{ref}}", { ref })}
+              >
+                ×
+              </button>
+            </span>
+          );
+        })}
+      </div>
+
+      {/* Typeahead + raw-ref entry. */}
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            if (localError) setLocalError(null);
+          }}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setTimeout(() => setFocused(false), 150)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              tryAdd(query);
+            }
+          }}
+          placeholder={
+            t("skillsetMembers.placeholder", "search a skill, or type name@1.0 then Enter") as string
+          }
+          className="w-full rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-text text-sm text-strong placeholder:text-meta/70 focus:border-accent focus:bg-card focus:outline-none"
+        />
+        {focused && suggestions.length > 0 && (
+          <div className="absolute left-0 right-0 top-full mt-1 z-10 max-h-52 overflow-y-auto rounded-sm border border-subtle bg-card card-impression">
+            {suggestions.map((s) => (
+              <button
+                key={s.guid}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  addFromSkill(s.name);
+                }}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left font-text text-sm hover:bg-accent/10 cursor-pointer"
+              >
+                <span className="truncate text-strong">{s.name}</span>
+                <span className="ml-auto shrink-0 font-mono text-[10px] text-meta">
+                  {s.isPrivate
+                    ? t("common.private")
+                    : t("common.public")}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {(localError || error) && (
+        <p className="font-mono text-[11px] text-danger" role="alert">
+          {localError ?? error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ornn-web/src/components/skillset/SkillsetPermissionsModal.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetPermissionsModal.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * SkillsetPermissionsModal — save wiring + skills-modal isolation.
+ *
+ * This modal is a DUPLICATE of the skills PermissionsModal, bound to
+ * `SkillsetDetail` + `useUpdateSkillsetPermissions`. We assert:
+ *   - Save calls the SKILLSET permissions mutation with the desired ACL state
+ *     (here: flip a private skillset to public).
+ *   - It uses `useUpdateSkillsetPermissions` (skillset hook), never the skills
+ *     `useUpdateSkillPermissions` — the two surfaces must not cross-wire.
+ *
+ * The user directory + org hooks are stubbed so no network runs.
+ *
+ * @module components/skillset/SkillsetPermissionsModal.test
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const updateSkillsetPermissions = vi.fn().mockResolvedValue(undefined);
+const useUpdateSkillsetPermissions = vi.fn(() => ({
+  mutateAsync: updateSkillsetPermissions,
+  isPending: false,
+}));
+
+vi.mock("@/hooks/useSkillsets", () => ({
+  useUpdateSkillsetPermissions: (...a: unknown[]) => useUpdateSkillsetPermissions(...a),
+}));
+
+// Guard rail: if this module ever imported the skills permissions hook, the
+// mock would record it — we assert it never gets called.
+const useUpdateSkillPermissions = vi.fn();
+vi.mock("@/hooks/useSkills", () => ({
+  useUpdateSkillPermissions: (...a: unknown[]) => useUpdateSkillPermissions(...a),
+}));
+
+vi.mock("@/hooks/useMe", () => ({ useMyOrgs: () => ({ data: [] }) }));
+vi.mock("@/services/usersApi", () => ({
+  searchUsersByEmail: vi.fn().mockResolvedValue([]),
+  resolveUsers: vi.fn().mockResolvedValue([]),
+  fetchOrgSummary: vi.fn().mockResolvedValue(null),
+}));
+
+const addToast = vi.fn();
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: (sel: (s: { addToast: () => void }) => unknown) => sel({ addToast }),
+}));
+
+vi.mock("@/utils/translateError", () => ({ translateError: (e: unknown) => String(e) }));
+
+// Render the Modal children inline.
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { SkillsetPermissionsModal } from "./SkillsetPermissionsModal";
+import type { SkillsetDetail } from "@/types/skillset";
+
+const PRIVATE_SET: SkillsetDetail = {
+  guid: "g-1",
+  name: "research-bundle",
+  description: "d",
+  instructions: "i",
+  kind: "generic",
+  tags: [],
+  members: ["a@1.0", "b@1.0"],
+  version: "1.0",
+  latestVersion: "1.0",
+  isPrivate: true,
+  createdBy: "user-1",
+  sharedWithUsers: [],
+  sharedWithOrgs: [],
+  createdOn: "2026-06-01T00:00:00.000Z",
+  updatedOn: "2026-06-01T00:00:00.000Z",
+};
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{node}</QueryClientProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SkillsetPermissionsModal", () => {
+  it("binds to the SKILLSET permissions hook (guid + name), never the skills hook", () => {
+    wrap(<SkillsetPermissionsModal isOpen onClose={() => {}} skillset={PRIVATE_SET} />);
+    expect(useUpdateSkillsetPermissions).toHaveBeenCalledWith("g-1", "research-bundle");
+    expect(useUpdateSkillPermissions).not.toHaveBeenCalled();
+  });
+
+  it("saves the desired ACL state (flip private → public)", async () => {
+    wrap(<SkillsetPermissionsModal isOpen onClose={() => {}} skillset={PRIVATE_SET} />);
+
+    // Check the Public checkbox (the first checkbox in the tier stack).
+    const publicCheckbox = screen.getAllByRole("checkbox")[0]!;
+    fireEvent.click(publicCheckbox);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(updateSkillsetPermissions).toHaveBeenCalledTimes(1));
+    expect(updateSkillsetPermissions).toHaveBeenCalledWith({
+      isPrivate: false,
+      sharedWithUsers: [],
+      sharedWithOrgs: [],
+    });
+  });
+
+  it("short-circuits with no save when nothing changed", async () => {
+    const onClose = vi.fn();
+    wrap(<SkillsetPermissionsModal isOpen onClose={onClose} skillset={PRIVATE_SET} />);
+
+    // Save without changing anything (still private, no grants).
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(updateSkillsetPermissions).not.toHaveBeenCalled();
+  });
+});

--- a/ornn-web/src/components/skillset/SkillsetPermissionsModal.tsx
+++ b/ornn-web/src/components/skillset/SkillsetPermissionsModal.tsx
@@ -1,0 +1,444 @@
+/**
+ * SkillsetPermissionsModal — per-skillset visibility editor.
+ *
+ * A DUPLICATE of the skills `PermissionsModal`, bound to `SkillsetDetail` +
+ * `useUpdateSkillsetPermissions` (the skills modal is left untouched — it
+ * couples to `SkillDetail` + `useUpdateSkillPermissions`). Same UX: broader at
+ * the top (Public), narrower at the bottom (Private), with org + user grants
+ * in between. Saving is unconditional — `PUT /api/v1/skillsets/:id/permissions`
+ * applies the desired state directly.
+ *
+ * @module components/skillset/SkillsetPermissionsModal
+ */
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { useMyOrgs } from "@/hooks/useMe";
+import { useUpdateSkillsetPermissions } from "@/hooks/useSkillsets";
+import { useToastStore } from "@/stores/toastStore";
+import {
+  searchUsersByEmail,
+  resolveUsers,
+  fetchOrgSummary,
+  type UserDirectoryEntry,
+} from "@/services/usersApi";
+import type { SkillsetDetail } from "@/types/skillset";
+import { translateError } from "@/utils/translateError";
+
+interface SkillsetPermissionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  skillset: SkillsetDetail;
+}
+
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(handle);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+export function SkillsetPermissionsModal({
+  isOpen,
+  onClose,
+  skillset,
+}: SkillsetPermissionsModalProps) {
+  const { t } = useTranslation();
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t("permissions.title", "Permissions") as string}
+      className="!max-w-3xl"
+    >
+      {/* Keyed on the ACL signature (+ open) so form state resets by
+          construction whenever the modal reopens or the ACLs change (#888). */}
+      <PermissionsForm
+        key={`${isOpen ? "open" : "closed"}:${skillset.guid}:${skillset.isPrivate}:${skillset.sharedWithOrgs.join(",")}:${skillset.sharedWithUsers.join(",")}`}
+        skillset={skillset}
+        onClose={onClose}
+        t={t}
+      />
+    </Modal>
+  );
+}
+
+interface PermissionsFormProps {
+  skillset: SkillsetDetail;
+  onClose: () => void;
+  t: ReturnType<typeof useTranslation>["t"];
+}
+
+function PermissionsForm({ skillset, onClose, t }: PermissionsFormProps) {
+  const addToast = useToastStore((s) => s.addToast);
+  const { data: myOrgs = [] } = useMyOrgs();
+  const permissionsMutation = useUpdateSkillsetPermissions(skillset.guid, skillset.name);
+
+  const [isPublic, setIsPublic] = useState<boolean>(!skillset.isPrivate);
+  const [sharedUsers, setSharedUsers] = useState<UserDirectoryEntry[]>(() =>
+    skillset.sharedWithUsers.map((id) => ({ userId: id, email: "", displayName: id })),
+  );
+  const [sharedOrgIds, setSharedOrgIds] = useState<string[]>(skillset.sharedWithOrgs);
+  const [userQuery, setUserQuery] = useState("");
+  const [userInputFocused, setUserInputFocused] = useState(false);
+  const userInputRef = useRef<HTMLInputElement>(null);
+
+  // Resolve saved user_ids into email/displayName once the form mounts.
+  useEffect(() => {
+    const ids = skillset.sharedWithUsers;
+    if (ids.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      const resolved = await resolveUsers(ids).catch(() => []);
+      if (cancelled || resolved.length === 0) return;
+      const byId = new Map(resolved.map((r) => [r.userId, r]));
+      setSharedUsers((prev) => prev.map((existing) => byId.get(existing.userId) ?? existing));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [skillset]);
+
+  const debouncedQuery = useDebouncedValue(userQuery.trim(), 200);
+  const shouldSearch = !isPublic && (userInputFocused || debouncedQuery.length > 0);
+  const { data: suggestions = [] } = useQuery({
+    queryKey: ["users-search", debouncedQuery],
+    queryFn: () => searchUsersByEmail(debouncedQuery, 8),
+    enabled: shouldSearch,
+    staleTime: 10_000,
+  });
+
+  const unknownOrgIds = useMemo(
+    () => sharedOrgIds.filter((id) => !myOrgs.some((o) => o.userId === id)),
+    [sharedOrgIds, myOrgs],
+  );
+  const { data: fetchedUnknownOrgs = [] } = useQuery({
+    queryKey: ["orgs-backfill", unknownOrgIds.sort().join(",")],
+    queryFn: async () => {
+      const resolved = await Promise.all(unknownOrgIds.map((id) => fetchOrgSummary(id)));
+      return resolved.map((entry, i) => {
+        const orgId = unknownOrgIds[i]!;
+        return entry
+          ? { ...entry, isUnresolved: false }
+          : { userId: orgId, displayName: orgId, avatarUrl: null, isUnresolved: true };
+      });
+    },
+    enabled: unknownOrgIds.length > 0,
+    staleTime: 5 * 60_000,
+  });
+
+  const allOrgOptions = useMemo(() => {
+    const map = new Map<
+      string,
+      { userId: string; displayName: string; isMember: boolean; isUnresolved: boolean }
+    >();
+    for (const o of myOrgs) {
+      map.set(o.userId, { userId: o.userId, displayName: o.displayName, isMember: true, isUnresolved: false });
+    }
+    for (const o of fetchedUnknownOrgs) {
+      if (!map.has(o.userId)) {
+        map.set(o.userId, {
+          userId: o.userId,
+          displayName: o.displayName,
+          isMember: false,
+          isUnresolved: o.isUnresolved,
+        });
+      }
+    }
+    return Array.from(map.values());
+  }, [myOrgs, fetchedUnknownOrgs]);
+
+  const toggleOrg = (orgId: string) => {
+    setSharedOrgIds((prev) =>
+      prev.includes(orgId) ? prev.filter((id) => id !== orgId) : [...prev, orgId],
+    );
+  };
+
+  const addUser = (entry: UserDirectoryEntry) => {
+    if (sharedUsers.some((u) => u.userId === entry.userId)) return;
+    setSharedUsers((prev) => [...prev, entry]);
+    setUserQuery("");
+    setUserInputFocused(false);
+    userInputRef.current?.blur();
+  };
+
+  const removeUser = (userId: string) => {
+    setSharedUsers((prev) => prev.filter((u) => u.userId !== userId));
+  };
+
+  const orgsActive = !isPublic && sharedOrgIds.length > 0;
+  const usersActive = !isPublic && sharedUsers.length > 0;
+  const privateActive = !isPublic && !orgsActive && !usersActive;
+
+  const handleSave = async () => {
+    const beforePrivate = skillset.isPrivate;
+    const beforeUsers = new Set(skillset.sharedWithUsers);
+    const beforeOrgs = new Set(skillset.sharedWithOrgs);
+    const afterPrivate = !isPublic;
+
+    const privateChanged = beforePrivate !== afterPrivate;
+    const usersChanged =
+      sharedUsers.length !== beforeUsers.size ||
+      sharedUsers.some((u) => !beforeUsers.has(u.userId));
+    const orgsChanged =
+      sharedOrgIds.length !== beforeOrgs.size ||
+      sharedOrgIds.some((id) => !beforeOrgs.has(id));
+
+    if (!privateChanged && !usersChanged && !orgsChanged) {
+      addToast({ type: "info", message: t("permissions.noChanges", "No changes to save.") });
+      onClose();
+      return;
+    }
+
+    try {
+      await permissionsMutation.mutateAsync({
+        isPrivate: !isPublic,
+        sharedWithUsers: sharedUsers.map((u) => u.userId),
+        sharedWithOrgs: sharedOrgIds,
+      });
+      addToast({ type: "success", message: t("permissions.saveSuccess", "Permissions updated") });
+      onClose();
+    } catch (err) {
+      addToast({ type: "error", message: translateError(err) });
+    }
+  };
+
+  return (
+    <>
+      <div className="flex gap-4">
+        <div className="flex flex-col items-center py-1 shrink-0" aria-hidden>
+          <svg
+            viewBox="0 0 16 16"
+            className="h-4 w-4 text-accent"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="4 10 8 6 12 10" />
+          </svg>
+          <div className="flex-1 w-px my-1 bg-gradient-to-b from-accent/70 via-accent/25 to-accent/5" />
+        </div>
+
+        <div className="flex-1">
+          <SectionHeader label={t("permissions.levelPublic", "Public access") as string} />
+          <TierCard active={isPublic} accent="public" onToggle={() => setIsPublic((v) => !v)}>
+            <label className="flex items-start gap-3 cursor-pointer w-full">
+              <input
+                type="checkbox"
+                checked={isPublic}
+                onChange={(e) => setIsPublic(e.target.checked)}
+                className="mt-1 h-4 w-4 shrink-0 rounded border-accent/40 accent-accent"
+              />
+              <div className="flex-1">
+                <p className="font-display text-base text-strong">
+                  {t("permissions.publicTitle", "Public")}
+                </p>
+                <p className="mt-0.5 font-text text-sm text-meta">
+                  {t(
+                    "skillsetPermissions.publicDesc",
+                    "Anyone on Ornn can find and use this skillset, including unauthenticated visitors.",
+                  )}
+                </p>
+              </div>
+            </label>
+          </TierCard>
+
+          <SectionHeader label={t("permissions.levelLimited", "Limited access") as string} />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <TierCard active={orgsActive} dimmed={isPublic} accent="limited" className="p-4">
+              <p className="font-display text-base text-strong">
+                {t("permissions.orgsTitle", "Shared with organizations")}
+              </p>
+              <p className="mt-0.5 font-text text-sm text-meta">
+                {t(
+                  "skillsetPermissions.orgsDesc",
+                  "Every admin and member of a checked org can see and use this skillset.",
+                )}
+              </p>
+              <div
+                className={`mt-3 max-h-48 overflow-y-auto space-y-1.5 pr-1 ${
+                  isPublic ? "opacity-60 pointer-events-none" : ""
+                }`}
+              >
+                {allOrgOptions.length === 0 && (
+                  <p className="font-text text-xs text-meta italic">
+                    {t("permissions.noOrgs", "No organizations to choose from.")}
+                  </p>
+                )}
+                {allOrgOptions.map((org) => {
+                  const checked = sharedOrgIds.includes(org.userId);
+                  return (
+                    <label
+                      key={org.userId}
+                      className={`flex items-center gap-2 cursor-pointer py-1 px-2 rounded hover:bg-accent/5 ${
+                        org.isUnresolved ? "bg-warning-soft/40" : ""
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleOrg(org.userId)}
+                        className="h-4 w-4 rounded border-accent/40 accent-accent"
+                      />
+                      <span className="font-text text-sm text-strong truncate">{org.displayName}</span>
+                      {org.isUnresolved ? (
+                        <span className="ml-auto font-mono text-[10px] uppercase tracking-wider text-warning">
+                          {t("permissions.orgUnresolved", "unresolved")}
+                        </span>
+                      ) : !org.isMember ? (
+                        <span className="font-mono text-[10px] text-meta ml-auto">
+                          {t("permissions.notMember", "not member")}
+                        </span>
+                      ) : null}
+                    </label>
+                  );
+                })}
+              </div>
+            </TierCard>
+
+            <TierCard active={usersActive} dimmed={isPublic} accent="limited" className="p-4">
+              <p className="font-display text-base text-strong">
+                {t("permissions.usersTitle", "Shared with specific users")}
+              </p>
+              <p className="mt-0.5 font-text text-sm text-meta">
+                {t(
+                  "permissions.usersDesc",
+                  "Search by email. Only users who have signed into Ornn appear here.",
+                )}
+              </p>
+              <div
+                className={`mt-3 flex flex-wrap gap-1.5 min-h-[2rem] ${
+                  isPublic ? "opacity-60 pointer-events-none" : ""
+                }`}
+              >
+                {sharedUsers.map((u) => (
+                  <span
+                    key={u.userId}
+                    className="inline-flex items-center gap-2 px-2 py-1 rounded-full border border-accent/30 bg-accent/5 text-strong font-mono text-xs h-fit"
+                  >
+                    <span>{u.email || u.displayName || u.userId}</span>
+                    <button
+                      type="button"
+                      onClick={() => removeUser(u.userId)}
+                      className="text-danger hover:text-danger/80 cursor-pointer"
+                      aria-label={t("permissions.removeUser", "Remove") as string}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+                {sharedUsers.length === 0 && (
+                  <p className="font-text text-xs text-meta italic w-full">
+                    {t("permissions.noUsersYet", "No users added yet.")}
+                  </p>
+                )}
+              </div>
+              <div className="relative mt-3">
+                <input
+                  ref={userInputRef}
+                  type="text"
+                  value={userQuery}
+                  onChange={(e) => setUserQuery(e.target.value)}
+                  onFocus={() => setUserInputFocused(true)}
+                  onBlur={() => setTimeout(() => setUserInputFocused(false), 150)}
+                  placeholder={
+                    t("permissions.searchPlaceholder", "type an email to find a user...") as string
+                  }
+                  className="w-full rounded border border-accent/20 bg-elevated px-3 py-2 font-text text-sm text-strong focus:outline-none focus:border-accent/60"
+                  disabled={isPublic}
+                />
+                {userInputFocused && suggestions.length > 0 && (
+                  <div className="absolute left-0 right-0 bottom-full mb-1 z-10 rounded border border-accent/20 bg-card card-impression max-h-52 overflow-y-auto">
+                    {suggestions.map((s) => (
+                      <button
+                        key={s.userId}
+                        type="button"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          addUser(s);
+                        }}
+                        className="flex w-full items-center gap-2 px-3 py-2 text-left font-text text-sm hover:bg-accent/10 cursor-pointer"
+                      >
+                        <span className="text-strong truncate">{s.displayName || s.email}</span>
+                        <span className="ml-auto font-mono text-xs text-meta truncate">{s.email}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </TierCard>
+          </div>
+
+          <SectionHeader label={t("permissions.levelPrivate", "Private access") as string} />
+          <TierCard active={privateActive} dimmed={isPublic} accent="private">
+            <p className="font-display text-base text-strong">
+              {t("permissions.privateTitle", "Private")}
+            </p>
+            <p className="mt-0.5 font-text text-sm text-meta">
+              {t(
+                "skillsetPermissions.privateDesc",
+                "Only you and platform admins can see this skillset. Active when nothing above is set.",
+              )}
+            </p>
+          </TierCard>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-4 mt-5 border-t border-accent/10">
+        <Button variant="secondary" onClick={onClose}>
+          {t("common.cancel", "Cancel")}
+        </Button>
+        <Button onClick={handleSave} loading={permissionsMutation.isPending}>
+          {t("common.save", "Save")}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function SectionHeader({ label }: { label: string }) {
+  return (
+    <div className="mt-5 mb-3 first:mt-0 flex items-center gap-3" aria-hidden>
+      <div className="flex-1 h-px bg-accent/15" />
+      <span className="font-mono text-[10px] uppercase tracking-widest text-meta shrink-0">{label}</span>
+      <div className="flex-1 h-px bg-accent/15" />
+    </div>
+  );
+}
+
+interface TierCardProps {
+  active: boolean;
+  dimmed?: boolean;
+  accent: "public" | "limited" | "private";
+  onToggle?: () => void;
+  className?: string;
+  children: ReactNode;
+}
+
+const TIER_ACTIVE_CLASS: Record<TierCardProps["accent"], string> = {
+  public: "border-success/60 bg-success-soft",
+  limited: "border-warning/60 bg-warning-soft",
+  private: "border-info/60 bg-info-soft",
+};
+
+function TierCard({ active, dimmed = false, accent, onToggle, className = "", children }: TierCardProps) {
+  const ringClass = active ? TIER_ACTIVE_CLASS[accent] : "border-subtle bg-elevated/40";
+  const dimmedClass = dimmed ? "opacity-60" : "";
+  return (
+    <div
+      onClick={onToggle}
+      className={`rounded border p-4 transition-colors ${ringClass} ${dimmedClass} ${className} ${
+        onToggle ? "cursor-pointer" : ""
+      }`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/ornn-web/src/hooks/useSkillsets.test.tsx
+++ b/ornn-web/src/hooks/useSkillsets.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * useSkillsets — mutation invalidation + the #940 delete-cache guard.
+ *
+ * The load-bearing case mirrors `useSkills.test.tsx`: when a skillset is
+ * deleted, the still-mounted detail page must NOT refetch it (→ 404). The
+ * delete hook copies the #940 `removeQueries` predicate, removing the
+ * detail + versions + closure cache entries (scoped to guid / idOrName)
+ * BEFORE invalidating the list keys. This test seeds those caches, runs the
+ * delete, and asserts the entries are gone — not merely invalidated.
+ *
+ * The auth store is stubbed so the api layer's module-load chain stays out of
+ * the test and `accessToken` is null (one fetch call per mutation).
+ *
+ * @module hooks/useSkillsets.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: {
+    getState: () => ({
+      accessToken: null,
+      isAuthenticated: false,
+      ensureFreshToken: async () => {},
+      refreshToken: async () => {},
+    }),
+  },
+}));
+
+import {
+  useDeleteSkillset,
+  usePublishSkillset,
+  useUpdateSkillsetPermissions,
+  useCreateSkillset,
+} from "./useSkillsets";
+
+const GUID = "11111111-2222-3333-4444-555555555555";
+const NAME = "research-bundle";
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const removeSpy = vi.spyOn(queryClient, "removeQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, invalidateSpy, removeSpy, queryClient };
+}
+
+/** Did `removeQueries` fire with a predicate that matches this queryKey? */
+function removedKey(
+  spy: ReturnType<typeof vi.spyOn>,
+  key: readonly unknown[],
+): boolean {
+  return spy.mock.calls.some(
+    ([arg]) =>
+      arg != null &&
+      typeof arg === "object" &&
+      "predicate" in arg &&
+      (arg as { predicate: (q: { queryKey: readonly unknown[] }) => boolean }).predicate({
+        queryKey: key,
+      }),
+  );
+}
+
+/** Did `invalidateQueries` fire with exactly this queryKey? */
+function invalidatedKey(
+  spy: ReturnType<typeof vi.spyOn>,
+  key: readonly unknown[],
+): boolean {
+  return spy.mock.calls.some(
+    ([arg]) =>
+      arg != null &&
+      typeof arg === "object" &&
+      "queryKey" in arg &&
+      JSON.stringify((arg as { queryKey?: unknown }).queryKey) === JSON.stringify(key),
+  );
+}
+
+function url(spy: ReturnType<typeof vi.spyOn>): string {
+  const [input] = spy.mock.calls[0] ?? [];
+  return typeof input === "string" ? input : (input as Request).url;
+}
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data, error: null }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useDeleteSkillset (#940 delete-cache guard)", () => {
+  function stubDelete() {
+    return vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+  }
+
+  it("removes the deleted skillset's detail + versions + closure cache (name-keyed) so nothing refetches → 404", async () => {
+    stubDelete();
+    const { wrapper, removeSpy, invalidateSpy, queryClient } = makeWrapper();
+
+    // Seed the still-mounted caches keyed on the NAME (the detail URL id).
+    queryClient.setQueryData(["skillsets", NAME, "latest"], { guid: GUID, name: NAME });
+    queryClient.setQueryData(["skillset-versions", NAME], [{ version: "1.0" }]);
+    queryClient.setQueryData(["skillset-closure", NAME, "latest"], { instructions: "x", items: [] });
+
+    const { result } = renderHook(() => useDeleteSkillset(GUID, NAME), { wrapper });
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // (a) removeQueries fired for the detail + versions + closure keys.
+    expect(removedKey(removeSpy, ["skillsets", NAME, "latest"])).toBe(true);
+    expect(removedKey(removeSpy, ["skillset-versions", NAME])).toBe(true);
+    expect(removedKey(removeSpy, ["skillset-closure", NAME, "latest"])).toBe(true);
+
+    // (b) the entries are actually gone — nothing left to refetch.
+    expect(queryClient.getQueryData(["skillsets", NAME, "latest"])).toBeUndefined();
+    expect(queryClient.getQueryData(["skillset-versions", NAME])).toBeUndefined();
+    expect(queryClient.getQueryData(["skillset-closure", NAME, "latest"])).toBeUndefined();
+
+    // (c) lists still invalidate to drop the deleted card.
+    expect(invalidatedKey(invalidateSpy, ["skillsets"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["my-skillsets"])).toBe(true);
+  });
+
+  it("removes a GUID-keyed detail entry too (predicate covers both keyings)", async () => {
+    stubDelete();
+    const { wrapper, removeSpy, queryClient } = makeWrapper();
+
+    // Browse card passes the card's GUID as the cache-key id.
+    queryClient.setQueryData(["skillsets", GUID, "latest"], { guid: GUID, name: NAME });
+
+    const { result } = renderHook(() => useDeleteSkillset(GUID, GUID), { wrapper });
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(removedKey(removeSpy, ["skillsets", GUID, "latest"])).toBe(true);
+    expect(queryClient.getQueryData(["skillsets", GUID, "latest"])).toBeUndefined();
+  });
+
+  it("sends the GUID on the wire, not the name, when opened by name", async () => {
+    const fetchSpy = stubDelete();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDeleteSkillset(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(url(fetchSpy)).toContain(`/skillsets/${encodeURIComponent(GUID)}`);
+    expect(url(fetchSpy)).not.toContain(`/skillsets/${encodeURIComponent(NAME)}`);
+  });
+});
+
+describe("usePublishSkillset", () => {
+  it("PUTs the GUID, primes the detail cache, and invalidates name-keyed reads", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ guid: GUID, name: NAME, version: "1.1" }));
+    const { wrapper, invalidateSpy, queryClient } = makeWrapper();
+    const setSpy = vi.spyOn(queryClient, "setQueryData");
+    const { result } = renderHook(() => usePublishSkillset(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync({
+      instructions: "Run A then B then C.",
+      members: ["a@1.0", "b@1.0", "c@1.0"],
+      version: "1.1",
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // GUID on the wire (publish is GUID-only).
+    expect(url(fetchSpy)).toContain(`/skillsets/${encodeURIComponent(GUID)}`);
+    // Detail (latest) cache primed with the published payload. Asserted via
+    // the setQueryData call (a subsequent broad invalidate would GC the
+    // inactive entry under gcTime:0, so reading the cache back is flaky).
+    const primed = setSpy.mock.calls.some(
+      ([key, value]) =>
+        JSON.stringify(key) === JSON.stringify(["skillsets", NAME, "latest"]) &&
+        (value as { version?: string })?.version === "1.1",
+    );
+    expect(primed).toBe(true);
+    // Name-keyed reads invalidated.
+    expect(invalidatedKey(invalidateSpy, ["skillset-versions", NAME])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["skillsets", NAME])).toBe(true);
+  });
+});
+
+describe("useUpdateSkillsetPermissions", () => {
+  it("PUTs /permissions on the GUID and invalidates the name-keyed detail", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ skillset: { guid: GUID, name: NAME, isPrivate: true } }));
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useUpdateSkillsetPermissions(GUID, NAME), { wrapper });
+
+    await result.current.mutateAsync({
+      isPrivate: true,
+      sharedWithUsers: [],
+      sharedWithOrgs: [],
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(url(fetchSpy)).toContain(`/skillsets/${encodeURIComponent(GUID)}/permissions`);
+    expect(invalidatedKey(invalidateSpy, ["skillsets", NAME])).toBe(true);
+  });
+});
+
+describe("useCreateSkillset", () => {
+  it("POSTs and invalidates the public + mine list tabs", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ guid: GUID, name: NAME }));
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useCreateSkillset(), { wrapper });
+
+    await result.current.mutateAsync({
+      name: NAME,
+      description: "desc",
+      instructions: "do the thing",
+      kind: "generic",
+      tags: [],
+      members: ["a@1.0", "b@1.0"],
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(url(fetchSpy)).toMatch(/\/api\/v1\/skillsets$/);
+    expect(invalidatedKey(invalidateSpy, ["skillsets"])).toBe(true);
+    expect(invalidatedKey(invalidateSpy, ["my-skillsets"])).toBe(true);
+  });
+});

--- a/ornn-web/src/hooks/useSkillsets.ts
+++ b/ornn-web/src/hooks/useSkillsets.ts
@@ -1,0 +1,232 @@
+/**
+ * TanStack Query hooks for the skillsets domain (#1059).
+ *
+ * Mirrors `useSkills.ts`: per-scope list queries, a detail query keyed on
+ * `idOrName + version`, a versions query, a closure query, and create /
+ * publish / delete / permissions mutations with the same invalidation shape.
+ *
+ * Two-id split (mirrors #750): write routes (publish / delete / permissions)
+ * are GUID-only, so a name-opened detail page must send the GUID on the wire
+ * while keying cache invalidation on the URL `idOrName`.
+ *
+ * @module hooks/useSkillsets
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  searchSkillsets,
+  fetchSkillset,
+  fetchSkillsetVersions,
+  fetchSkillsetClosure,
+  createSkillset,
+  publishSkillset,
+  deleteSkillset,
+  updateSkillsetPermissions,
+} from "@/services/skillsetApi";
+import type {
+  CreateSkillsetInput,
+  PublishSkillsetInput,
+  SkillsetKind,
+  SkillsetPermissionsInput,
+  SkillsetScope,
+  SkillsetSearchParams,
+} from "@/types/skillset";
+
+const SKILLSETS_KEY = "skillsets";
+const MY_SKILLSETS_KEY = "my-skillsets";
+const SHARED_WITH_ME_KEY = "shared-with-me-skillsets";
+const SKILLSET_VERSIONS_KEY = "skillset-versions";
+const SKILLSET_CLOSURE_KEY = "skillset-closure";
+
+/** Common per-scope list params. */
+interface SkillsetListParams {
+  // Optionals widen to `T | undefined` for exactOptionalPropertyTypes (#657).
+  kind?: SkillsetKind | undefined;
+  tags?: string[] | undefined;
+  page?: number | undefined;
+  pageSize?: number | undefined;
+  enabled?: boolean | undefined;
+}
+
+function buildSearchParams(
+  scope: SkillsetScope,
+  params: SkillsetListParams,
+): SkillsetSearchParams {
+  return {
+    scope,
+    kind: params.kind,
+    tags: params.tags,
+    page: params.page,
+    pageSize: params.pageSize,
+  };
+}
+
+/** Search public skillsets. Visible to anonymous + authed callers. */
+export function usePublicSkillsets(params: SkillsetListParams) {
+  const searchParams = buildSearchParams("public", params);
+  return useQuery({
+    queryKey: [SKILLSETS_KEY, searchParams],
+    queryFn: () => searchSkillsets(searchParams),
+    enabled: params.enabled ?? true,
+  });
+}
+
+/** Search skillsets authored by the caller (public + private I created). */
+export function useMySkillsets(params: SkillsetListParams) {
+  const searchParams = buildSearchParams("mine", params);
+  return useQuery({
+    queryKey: [MY_SKILLSETS_KEY, searchParams],
+    queryFn: () => searchSkillsets(searchParams),
+    enabled: params.enabled ?? true,
+  });
+}
+
+/** Search skillsets others (users / orgs) have shared with the caller. */
+export function useSharedWithMeSkillsets(params: SkillsetListParams) {
+  const searchParams = buildSearchParams("shared-with-me", params);
+  return useQuery({
+    queryKey: [SHARED_WITH_ME_KEY, searchParams],
+    queryFn: () => searchSkillsets(searchParams),
+    enabled: params.enabled ?? true,
+  });
+}
+
+/**
+ * Fetch a single skillset by ID or name. When `version` is provided, resolves
+ * to that specific published version; otherwise the latest. The query key
+ * includes `version` so version switching uses the cache correctly.
+ */
+export function useSkillset(idOrName: string, version?: string) {
+  return useQuery({
+    queryKey: [SKILLSETS_KEY, idOrName, version ?? "latest"],
+    queryFn: () => fetchSkillset(idOrName, version),
+    enabled: !!idOrName,
+  });
+}
+
+/** List every published version for a skillset, newest first. */
+export function useSkillsetVersions(idOrName: string) {
+  return useQuery({
+    queryKey: [SKILLSET_VERSIONS_KEY, idOrName],
+    queryFn: () => fetchSkillsetVersions(idOrName),
+    enabled: !!idOrName,
+  });
+}
+
+/**
+ * Resolve the skillset's closure (master prompt + flattened deps-first member
+ * graph). Keyed on `idOrName + version` so it tracks the version picker.
+ */
+export function useSkillsetClosure(idOrName: string, version?: string) {
+  return useQuery({
+    queryKey: [SKILLSET_CLOSURE_KEY, idOrName, version ?? "latest"],
+    queryFn: () => fetchSkillsetClosure(idOrName, version),
+    enabled: !!idOrName,
+  });
+}
+
+/** Create a new skillset. Invalidates the public + mine list tabs. */
+export function useCreateSkillset() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateSkillsetInput) => createSkillset(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MY_SKILLSETS_KEY] });
+    },
+  });
+}
+
+/**
+ * Publish a new immutable version. `guid` is the WIRE id (publish is
+ * GUID-only); `idOrName` is the CACHE-KEY id so the detail + versions read
+ * queries refresh whether the page was opened by name or guid.
+ */
+export function usePublishSkillset(guid: string, idOrName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: PublishSkillsetInput) => publishSkillset(guid, input),
+    onSuccess: (updated) => {
+      // Prime the detail (latest) cache with the published payload so the
+      // page redraws in place without a manual refetch.
+      queryClient.setQueryData([SKILLSETS_KEY, idOrName, "latest"], updated);
+      queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY, idOrName] });
+      queryClient.invalidateQueries({ queryKey: [SKILLSET_VERSIONS_KEY, idOrName] });
+      queryClient.invalidateQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === SKILLSET_CLOSURE_KEY &&
+          q.queryKey[1] === idOrName,
+      });
+      queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MY_SKILLSETS_KEY] });
+    },
+  });
+}
+
+/**
+ * Replace the skillset's visibility config. `guid` is the WIRE id;
+ * `idOrName` is the CACHE-KEY id. Invalidates the detail + list tabs so the
+ * visibility chips + cards redraw.
+ */
+export function useUpdateSkillsetPermissions(guid: string, idOrName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: SkillsetPermissionsInput) =>
+      updateSkillsetPermissions(guid, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MY_SKILLSETS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [SHARED_WITH_ME_KEY] });
+      queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY, idOrName] });
+    },
+  });
+}
+
+/**
+ * Delete an entire skillset (every version).
+ *
+ * Two-id split (#750 shape): `guid` is the WIRE id — the delete route is
+ * GUID-only. `idOrName` is the CACHE-KEY id — the detail / versions / closure
+ * read queries are keyed on it, and callers pass either the GUID (browse card)
+ * or a NAME (detail URL), so cache cleanup must cover BOTH keyings.
+ *
+ * #940 — onSuccess must REMOVE the deleted skillset's detail + versions +
+ * closure entries (not just invalidate). The detail query stays mounted
+ * through the delete (the caller's `navigate(...)` runs AFTER this onSuccess,
+ * and the breadcrumb re-subscribes), so a broad `invalidateQueries`
+ * prefix-matches the still-mounted detail key and triggers a refetch of the
+ * just-deleted skillset → 404. `removeQueries` drops the cache entry outright
+ * so nothing can refetch it; the list keys still invalidate to drop the
+ * deleted card. Removal is id-scoped (predicate on `guid` / `idOrName`) so
+ * only the deleted skillset's caches are touched, never other skillsets'.
+ */
+export function useDeleteSkillset(guid: string, idOrName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deleteSkillset(guid),
+    onSuccess: () => {
+      queryClient.removeQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === SKILLSETS_KEY &&
+          (q.queryKey[1] === guid || q.queryKey[1] === idOrName),
+      });
+      queryClient.removeQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === SKILLSET_VERSIONS_KEY &&
+          (q.queryKey[1] === guid || q.queryKey[1] === idOrName),
+      });
+      queryClient.removeQueries({
+        predicate: (q) =>
+          Array.isArray(q.queryKey) &&
+          q.queryKey[0] === SKILLSET_CLOSURE_KEY &&
+          (q.queryKey[1] === guid || q.queryKey[1] === idOrName),
+      });
+      queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MY_SKILLSETS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [SHARED_WITH_ME_KEY] });
+    },
+  });
+}

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -77,6 +77,7 @@
     "home": "Home",
     "registry": "Registry",
     "build": "Build",
+    "skillsets": "Skillsets",
     "docs": "Docs",
     "news": "News",
     "contact": "Contact",
@@ -90,6 +91,7 @@
     "lightMode": "Light Mode",
     "darkMode": "Dark Mode",
     "myProfile": "My Profile",
+    "mySkillsets": "My Skillsets",
     "myOrgs": "My Organizations",
     "myServices": "My Services",
     "adminServices": "Admin Services",
@@ -1651,6 +1653,115 @@
     "fieldPrivateKey": "App private key (PEM)",
     "confirmTitle": "Confirm: abandon current mirror repo",
     "confirmConfirm": "Yes, change repo"
+  },
+  "skillsetKind": {
+    "generic": "Bundle",
+    "genericLong": "Generic bundle",
+    "consensusSupported": "Consensus",
+    "consensusSupportedLong": "Consensus-supported"
+  },
+  "skillsetExplore": {
+    "publicTab": "Public",
+    "mineTab": "Mine",
+    "sharedTab": "Shared with me",
+    "kindLabel": "Kind",
+    "kindAll": "All kinds",
+    "tagsLabel": "Tags",
+    "addTag": "add tag…",
+    "create": "New skillset",
+    "nonePublic": "No public skillsets match",
+    "noneMine": "You haven't created any skillsets yet",
+    "noneShared": "Nothing has been shared with you yet",
+    "tryAdjusting": "Try adjusting the kind or tag filters.",
+    "createFirst": "Bundle two or more skills into your first skillset.",
+    "sharedIntro": "When someone grants you access to a private skillset, it shows up here."
+  },
+  "skillsetDetail": {
+    "notFoundTitle": "Skillset not found",
+    "notFoundDesc": "It may have been deleted, or you may not have access to it.",
+    "backToRegistry": "Back to skillsets",
+    "consensusNote": "The author asserts these members are an independent, comparable set suitable for agent-side consensus. This is a claim, not a platform guarantee.",
+    "managePermissions": "Permissions",
+    "masterPrompt": "Master prompt",
+    "noPrompt": "No master prompt for this version.",
+    "resolvedClosure": "Resolved closure",
+    "members": "Members",
+    "metadata": "Metadata",
+    "version": "Version",
+    "latest": "latest",
+    "versionsCount": "Versions",
+    "updated": "Updated",
+    "guid": "GUID",
+    "guidCopied": "GUID copied",
+    "visibility": "Visibility",
+    "visPublic": "Public",
+    "visPrivate": "Private",
+    "sharedWith": "Shared with {{users}} users · {{orgs}} orgs",
+    "dangerZone": "Danger zone",
+    "dangerExplain": "Permanently delete this skillset and every version. This cannot be undone.",
+    "deleteSkillset": "Delete skillset",
+    "deleteTitle": "Delete this skillset?",
+    "deleteConfirm": "This permanently deletes {{name}} and all its versions.",
+    "deleteSuccess": "Skillset deleted"
+  },
+  "skillsetForm": {
+    "name": "Name",
+    "nameLocked": "locked",
+    "nameError": "Name must be kebab-case (a-z, 0-9, hyphens).",
+    "description": "Description",
+    "descriptionPlaceholder": "A short, human-readable summary",
+    "descriptionError": "Description is required (1–1024 chars).",
+    "kind": "Kind",
+    "tags": "Tags",
+    "addTag": "add tag…",
+    "membersError": "Add at least {{min}} members.",
+    "promptError": "A master prompt is required.",
+    "version": "Version",
+    "versionError": "Version must be <major>.<minor> (e.g. 1.0).",
+    "versionBumpError": "Publish requires a new, bumped version (e.g. 1.1).",
+    "editHint": "Publishing creates a new immutable version. The name cannot change.",
+    "createSubmit": "Create skillset",
+    "publishSubmit": "Publish version"
+  },
+  "skillsetNew": {
+    "title": "New skillset",
+    "subtitle": "Bundle two or more skills with a master prompt that tells agents how to use them together.",
+    "created": "Skillset created"
+  },
+  "skillsetEdit": {
+    "title": "Edit skillset",
+    "subtitle": "Revise the members, prompt, kind, or tags and publish a new version.",
+    "published": "New version published"
+  },
+  "skillsetMembers": {
+    "label": "Members",
+    "count": "{{count}} / {{max}}",
+    "empty": "No members yet. Add at least {{min}} skills.",
+    "placeholder": "search a skill, or type name@1.0 then Enter",
+    "remove": "Remove {{ref}}",
+    "errorEmpty": "Enter a skill ref.",
+    "errorNested": "A skillset cannot reference another skillset. Remove the skillset: prefix.",
+    "errorSelf": "A skillset cannot include itself as a member.",
+    "errorNoVersion": "Include a version, e.g. name@1.0.",
+    "errorDuplicate": "That member is already added.",
+    "errorMax": "A skillset may have at most {{max}} members."
+  },
+  "skillsetPrompt": {
+    "label": "Master prompt",
+    "count": "{{count}} / {{max}}",
+    "help": "Required. Tell an agent how to use this set — orchestration, ordering, and when to pick which member.",
+    "placeholder": "# How to use this set\n\n1. Start with ...",
+    "errorTooLong": "Master prompt must be at most {{max}} characters."
+  },
+  "skillsetClosure": {
+    "empty": "No resolved members yet.",
+    "member": "member",
+    "dependency": "dep"
+  },
+  "skillsetPermissions": {
+    "publicDesc": "Anyone on Ornn can find and use this skillset, including unauthenticated visitors.",
+    "orgsDesc": "Every admin and member of a checked org can see and use this skillset.",
+    "privateDesc": "Only you and platform admins can see this skillset. Active when nothing above is set."
   },
   "errors": {
     "generic": {

--- a/ornn-web/src/i18n/skillsetParity.test.ts
+++ b/ornn-web/src/i18n/skillsetParity.test.ts
@@ -1,0 +1,87 @@
+/**
+ * i18n key-symmetry guard for the skillset namespaces (#1059).
+ *
+ * Every skillset UI string is keyed under a `skillset*` namespace (plus the
+ * two new `nav.*` entries) and MUST exist in BOTH en.json and zh.json with the
+ * exact same key set. This test recursively flattens both locale files and
+ * asserts: (a) the skillset namespaces are present in both, (b) the flattened
+ * key sets are identical for those namespaces, and (c) no value is left empty.
+ *
+ * Catches the classic drift where a key is added to en.json and forgotten in
+ * zh.json (or vice versa).
+ *
+ * @module i18n/skillsetParity.test
+ */
+
+import { describe, it, expect } from "vitest";
+import en from "./en.json";
+import zh from "./zh.json";
+
+/** The skillset namespaces introduced by #1059. */
+const SKILLSET_NAMESPACES = [
+  "skillsetKind",
+  "skillsetExplore",
+  "skillsetDetail",
+  "skillsetForm",
+  "skillsetNew",
+  "skillsetEdit",
+  "skillsetMembers",
+  "skillsetPrompt",
+  "skillsetClosure",
+  "skillsetPermissions",
+] as const;
+
+/** The new nav entries. */
+const NAV_KEYS = ["skillsets", "mySkillsets"] as const;
+
+type Json = Record<string, unknown>;
+
+/** Recursively flatten a nested object into dot-joined leaf keys. */
+function flatten(obj: Json, prefix = ""): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      Object.assign(out, flatten(v as Json, key));
+    } else {
+      out[key] = String(v);
+    }
+  }
+  return out;
+}
+
+const enFlat = flatten(en as Json);
+const zhFlat = flatten(zh as Json);
+
+function namespaceKeys(flat: Record<string, string>, ns: string): string[] {
+  return Object.keys(flat)
+    .filter((k) => k === ns || k.startsWith(`${ns}.`))
+    .sort();
+}
+
+describe("skillset i18n parity", () => {
+  it.each(SKILLSET_NAMESPACES)("'%s' namespace exists in both locales", (ns) => {
+    expect(namespaceKeys(enFlat, ns).length).toBeGreaterThan(0);
+    expect(namespaceKeys(zhFlat, ns).length).toBeGreaterThan(0);
+  });
+
+  it.each(SKILLSET_NAMESPACES)("'%s' has identical key sets in en + zh", (ns) => {
+    expect(namespaceKeys(zhFlat, ns)).toEqual(namespaceKeys(enFlat, ns));
+  });
+
+  it("the new nav keys exist in both locales", () => {
+    for (const key of NAV_KEYS) {
+      expect(enFlat[`nav.${key}`]).toBeTruthy();
+      expect(zhFlat[`nav.${key}`]).toBeTruthy();
+    }
+  });
+
+  it("no skillset string is empty in either locale", () => {
+    for (const ns of SKILLSET_NAMESPACES) {
+      for (const k of namespaceKeys(enFlat, ns)) {
+        expect(enFlat[k]?.trim().length, `en ${k}`).toBeGreaterThan(0);
+        expect(zhFlat[k]?.trim().length, `zh ${k}`).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -77,6 +77,7 @@
     "home": "首页",
     "registry": "技能库",
     "build": "构建",
+    "skillsets": "技能集",
     "docs": "文档",
     "news": "动态",
     "contact": "联系",
@@ -90,6 +91,7 @@
     "lightMode": "浅色模式",
     "darkMode": "深色模式",
     "myProfile": "个人资料",
+    "mySkillsets": "我的技能集",
     "myOrgs": "我的组织",
     "myServices": "我的服务",
     "adminServices": "平台服务",
@@ -1651,6 +1653,115 @@
     "fieldPrivateKey": "App 私钥 (PEM)",
     "confirmTitle": "确认：放弃当前镜像仓库",
     "confirmConfirm": "是，更换仓库"
+  },
+  "skillsetKind": {
+    "generic": "组合",
+    "genericLong": "通用组合",
+    "consensusSupported": "共识",
+    "consensusSupportedLong": "支持共识"
+  },
+  "skillsetExplore": {
+    "publicTab": "公开",
+    "mineTab": "我的",
+    "sharedTab": "共享给我",
+    "kindLabel": "类型",
+    "kindAll": "全部类型",
+    "tagsLabel": "标签",
+    "addTag": "添加标签…",
+    "create": "新建技能集",
+    "nonePublic": "没有匹配的公开技能集",
+    "noneMine": "你还没有创建任何技能集",
+    "noneShared": "还没有人向你共享任何内容",
+    "tryAdjusting": "尝试调整类型或标签筛选。",
+    "createFirst": "将两个或更多技能组合成你的第一个技能集。",
+    "sharedIntro": "当有人授予你访问某个私有技能集的权限时，它会显示在这里。"
+  },
+  "skillsetDetail": {
+    "notFoundTitle": "未找到技能集",
+    "notFoundDesc": "它可能已被删除，或你没有访问权限。",
+    "backToRegistry": "返回技能集",
+    "consensusNote": "作者声明这些成员是一组独立、可比较、适合代理端共识的技能集。这是作者声明，并非平台保证。",
+    "managePermissions": "权限",
+    "masterPrompt": "主提示词",
+    "noPrompt": "此版本没有主提示词。",
+    "resolvedClosure": "解析闭包",
+    "members": "成员",
+    "metadata": "元数据",
+    "version": "版本",
+    "latest": "最新",
+    "versionsCount": "版本数",
+    "updated": "更新于",
+    "guid": "GUID",
+    "guidCopied": "已复制 GUID",
+    "visibility": "可见性",
+    "visPublic": "公开",
+    "visPrivate": "私有",
+    "sharedWith": "已共享给 {{users}} 位用户 · {{orgs}} 个组织",
+    "dangerZone": "危险区",
+    "dangerExplain": "永久删除此技能集及其所有版本。此操作无法撤销。",
+    "deleteSkillset": "删除技能集",
+    "deleteTitle": "删除此技能集？",
+    "deleteConfirm": "这将永久删除 {{name}} 及其所有版本。",
+    "deleteSuccess": "技能集已删除"
+  },
+  "skillsetForm": {
+    "name": "名称",
+    "nameLocked": "已锁定",
+    "nameError": "名称必须为短横线格式（a-z、0-9、连字符）。",
+    "description": "描述",
+    "descriptionPlaceholder": "简短的可读摘要",
+    "descriptionError": "描述为必填项（1–1024 个字符）。",
+    "kind": "类型",
+    "tags": "标签",
+    "addTag": "添加标签…",
+    "membersError": "至少添加 {{min}} 个成员。",
+    "promptError": "主提示词为必填项。",
+    "version": "版本",
+    "versionError": "版本必须为 <主>.<次>（例如 1.0）。",
+    "versionBumpError": "发布需要一个新的、递增的版本（例如 1.1）。",
+    "editHint": "发布会创建一个新的不可变版本。名称不可更改。",
+    "createSubmit": "创建技能集",
+    "publishSubmit": "发布版本"
+  },
+  "skillsetNew": {
+    "title": "新建技能集",
+    "subtitle": "将两个或更多技能与一段主提示词组合，告诉代理如何协同使用它们。",
+    "created": "技能集已创建"
+  },
+  "skillsetEdit": {
+    "title": "编辑技能集",
+    "subtitle": "修改成员、提示词、类型或标签，并发布新版本。",
+    "published": "新版本已发布"
+  },
+  "skillsetMembers": {
+    "label": "成员",
+    "count": "{{count}} / {{max}}",
+    "empty": "暂无成员。请至少添加 {{min}} 个技能。",
+    "placeholder": "搜索技能，或输入 name@1.0 后回车",
+    "remove": "移除 {{ref}}",
+    "errorEmpty": "请输入技能引用。",
+    "errorNested": "技能集不能引用另一个技能集。请移除 skillset: 前缀。",
+    "errorSelf": "技能集不能将自身作为成员。",
+    "errorNoVersion": "请带上版本号，例如 name@1.0。",
+    "errorDuplicate": "该成员已添加。",
+    "errorMax": "技能集最多可包含 {{max}} 个成员。"
+  },
+  "skillsetPrompt": {
+    "label": "主提示词",
+    "count": "{{count}} / {{max}}",
+    "help": "必填。告诉代理如何使用这组技能——编排、顺序，以及何时选用哪个成员。",
+    "placeholder": "# 如何使用这组技能\n\n1. 首先 ...",
+    "errorTooLong": "主提示词最多 {{max}} 个字符。"
+  },
+  "skillsetClosure": {
+    "empty": "尚无解析成员。",
+    "member": "成员",
+    "dependency": "依赖"
+  },
+  "skillsetPermissions": {
+    "publicDesc": "Ornn 上的任何人（包括未登录访客）都可以发现并使用此技能集。",
+    "orgsDesc": "已勾选组织的每位管理员和成员都可以查看并使用此技能集。",
+    "privateDesc": "仅你和平台管理员可以查看此技能集。当上方均未设置时生效。"
   },
   "errors": {
     "generic": {

--- a/ornn-web/src/lib/userMenu.ts
+++ b/ornn-web/src/lib/userMenu.ts
@@ -91,6 +91,12 @@ export function useUserMenuGroups(user: AuthUser | null): UserMenuGroup[] {
         label: t("nav.myOrgs"),
       },
       {
+        key: "my-skillsets",
+        kind: "internal",
+        to: "/my-skillsets",
+        label: t("nav.mySkillsets"),
+      },
+      {
         key: "redeem",
         kind: "internal",
         to: "/settings",

--- a/ornn-web/src/pages/MySkillsetsPage.tsx
+++ b/ornn-web/src/pages/MySkillsetsPage.tsx
@@ -1,0 +1,14 @@
+/**
+ * MySkillsetsPage — thin wrapper that renders `SkillsetExplorePage` pinned to
+ * the `mine` scope (route `/my-skillsets`). Mirrors how the skills `MySkills`
+ * surface is a focused view of the registry. Owner Edit/Delete controls and
+ * the "New skillset" CTA come from the pinned explore page.
+ *
+ * @module pages/MySkillsetsPage
+ */
+
+import { SkillsetExplorePage } from "@/pages/SkillsetExplorePage";
+
+export function MySkillsetsPage() {
+  return <SkillsetExplorePage pinScope="mine" />;
+}

--- a/ornn-web/src/pages/SkillsetDetailPage.test.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * SkillsetDetailPage — `?version` resolution + all fields render.
+ *
+ * We mock the data hooks and assert: (a) the `?version` query param is passed
+ * to `useSkillset` / `useSkillsetClosure` so a specific version resolves, and
+ * (b) the page surfaces name / description / kind / instructions / members /
+ * closure / version / visibility for the resolved skillset.
+ *
+ * The permissions modal + delete flow are exercised in their own test; here we
+ * stub the modal to keep the tree light.
+ *
+ * @module pages/SkillsetDetailPage.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+const useSkillset = vi.fn();
+const useSkillsetVersions = vi.fn();
+const useSkillsetClosure = vi.fn();
+const useDeleteSkillset = vi.fn();
+
+vi.mock("@/hooks/useSkillsets", () => ({
+  useSkillset: (...a: unknown[]) => useSkillset(...a),
+  useSkillsetVersions: (...a: unknown[]) => useSkillsetVersions(...a),
+  useSkillsetClosure: (...a: unknown[]) => useSkillsetClosure(...a),
+  useDeleteSkillset: (...a: unknown[]) => useDeleteSkillset(...a),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useCurrentUser: () => ({ id: "user-1" }),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: (sel: (s: { addToast: () => void }) => unknown) => sel({ addToast: vi.fn() }),
+}));
+
+// Keep the permissions modal + markdown viewer light.
+vi.mock("@/components/skillset/SkillsetPermissionsModal", () => ({
+  SkillsetPermissionsModal: () => null,
+}));
+vi.mock("@/components/skill/ReadmeViewer", () => ({
+  ReadmeViewer: ({ content }: { content: string }) => <div data-testid="readme">{content}</div>,
+}));
+
+import { SkillsetDetailPage } from "./SkillsetDetailPage";
+import type { SkillsetDetail } from "@/types/skillset";
+
+const DETAIL: SkillsetDetail = {
+  guid: "g-1",
+  name: "research-bundle",
+  description: "A curated comparison set",
+  instructions: "Run A, then B.",
+  kind: "consensus-supported",
+  tags: ["research"],
+  members: ["a@1.0", "b@1.0"],
+  version: "1.1",
+  latestVersion: "1.1",
+  isPrivate: true,
+  createdBy: "user-1",
+  sharedWithUsers: ["u1"],
+  sharedWithOrgs: [],
+  createdOn: "2026-06-01T00:00:00.000Z",
+  updatedOn: "2026-06-02T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  useSkillset.mockReturnValue({ data: DETAIL, isLoading: false, error: null });
+  useSkillsetVersions.mockReturnValue({ data: [{ version: "1.1" }, { version: "1.0" }] });
+  useSkillsetClosure.mockReturnValue({
+    data: {
+      instructions: "Run A, then B.",
+      items: [
+        { ref: "a@1.0", name: "a", version: "1.0", depth: 0 },
+        { ref: "b@1.0", name: "b", version: "1.0", depth: 0 },
+        { ref: "a-dep@2.0", name: "a-dep", version: "2.0", depth: 1 },
+      ],
+    },
+  });
+  useDeleteSkillset.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/skillsets/:idOrName" element={<SkillsetDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("SkillsetDetailPage", () => {
+  it("passes the ?version query param through to the data hooks", () => {
+    renderAt("/skillsets/research-bundle?version=1.0");
+    expect(useSkillset).toHaveBeenCalledWith("research-bundle", "1.0");
+    expect(useSkillsetClosure).toHaveBeenCalledWith("research-bundle", "1.0");
+  });
+
+  it("resolves the latest (no version param) when ?version is absent", () => {
+    renderAt("/skillsets/research-bundle");
+    expect(useSkillset).toHaveBeenCalledWith("research-bundle", undefined);
+  });
+
+  it("renders name, description, kind, prompt, members, closure, and visibility", () => {
+    renderAt("/skillsets/research-bundle");
+
+    // Name + description.
+    expect(screen.getByRole("heading", { name: "research-bundle" })).toBeInTheDocument();
+    expect(screen.getByText("A curated comparison set")).toBeInTheDocument();
+    // Kind badge (consensus).
+    expect(screen.getByText("Consensus")).toBeInTheDocument();
+    // Master prompt (rendered via stubbed ReadmeViewer).
+    expect(screen.getByTestId("readme")).toHaveTextContent("Run A, then B.");
+    // Members — both a@1.0 and b@1.0 render their @version chip.
+    expect(screen.getAllByText("a").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("@1.0").length).toBeGreaterThan(0);
+    // Closure (flat list with a depth-1 dependency).
+    expect(screen.getByTestId("closure-list")).toHaveTextContent("a-dep");
+    // Visibility — private, with the shared-with count.
+    expect(screen.getByText(/Shared with 1 users/)).toBeInTheDocument();
+  });
+
+  it("shows owner actions (Edit + Delete) for the author", () => {
+    renderAt("/skillsets/research-bundle");
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete skillset" })).toBeInTheDocument();
+  });
+
+  it("renders the not-found state when the skillset is missing", () => {
+    useSkillset.mockReturnValue({ data: undefined, isLoading: false, error: new Error("404") });
+    renderAt("/skillsets/missing");
+    expect(screen.getByText("Skillset not found")).toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -1,0 +1,381 @@
+/**
+ * SkillsetDetailPage — Editorial Forge layout (DESIGN.md) for one skillset.
+ *
+ * `?version` resolves which published version is shown (latest by default).
+ * Surfaces: name / description / kind / master prompt (rendered markdown) /
+ * members / resolved closure / version picker / visibility. Owner gets the
+ * Edit, Manage-permissions, and Delete affordances; the actual permissions
+ * modal + delete flow are wired in the next commit (this page exposes the
+ * triggers).
+ *
+ * @module pages/SkillsetDetailPage
+ */
+
+import { useState } from "react";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { BackLink } from "@/components/layout/BackLink";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { ReadmeViewer } from "@/components/skill/ReadmeViewer";
+import { VersionPicker } from "@/components/skill/VersionPicker";
+import { KindBadge } from "@/components/skillset/KindBadge";
+import { SkillsetClosureViewer } from "@/components/skillset/SkillsetClosureViewer";
+import { SkillsetPermissionsModal } from "@/components/skillset/SkillsetPermissionsModal";
+import { useToastStore } from "@/stores/toastStore";
+import { useCurrentUser } from "@/stores/authStore";
+import {
+  useSkillset,
+  useSkillsetVersions,
+  useSkillsetClosure,
+  useDeleteSkillset,
+} from "@/hooks/useSkillsets";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { parseMemberRef } from "@/types/skillset";
+import { formatDateSGT } from "@/utils/formatters";
+import { translateError } from "@/utils/translateError";
+
+export function SkillsetDetailPage() {
+  const { idOrName } = useParams<{ idOrName: string }>();
+  const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
+  const addToast = useToastStore((s) => s.addToast);
+  const user = useCurrentUser();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const versionParam = searchParams.get("version") || undefined;
+  const id = idOrName ?? "";
+
+  const { data: skillset, isLoading, error } = useSkillset(id, versionParam);
+  const { data: versions = [] } = useSkillsetVersions(id);
+  const { data: closure } = useSkillsetClosure(id, versionParam);
+
+  const [showPermissions, setShowPermissions] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+
+  // Two-id split: delete is GUID-only on the wire; cache cleanup keys on the
+  // URL idOrName so the still-mounted detail page doesn't refetch → 404 (#940).
+  const deleteMutation = useDeleteSkillset(skillset?.guid ?? "", id);
+
+  if (isLoading) {
+    return (
+      <PageTransition>
+        <div className="mx-auto max-w-[1280px] px-4 py-8 sm:px-6 lg:px-8">
+          <Skeleton lines={10} />
+        </div>
+      </PageTransition>
+    );
+  }
+
+  if (error || !skillset) {
+    return (
+      <PageTransition>
+        <div className="mx-auto max-w-[1280px] px-4 py-16 sm:px-6 lg:px-8">
+          <EmptyState
+            title={t("skillsetDetail.notFoundTitle", "Skillset not found")}
+            description={t(
+              "skillsetDetail.notFoundDesc",
+              "It may have been deleted, or you may not have access to it.",
+            )}
+            action={
+              <Button onClick={() => navigate("/skillsets")}>
+                {t("skillsetDetail.backToRegistry", "Back to skillsets")}
+              </Button>
+            }
+          />
+        </div>
+      </PageTransition>
+    );
+  }
+
+  const isOwner = !!user && skillset.createdBy === user.id;
+  const latestVersion = versions[0]?.version ?? skillset.latestVersion;
+
+  function handleVersionChange(versionOrLatest: string | null) {
+    const next = new URLSearchParams(searchParams);
+    if (versionOrLatest === null) next.delete("version");
+    else next.set("version", versionOrLatest);
+    setSearchParams(next);
+  }
+
+  async function handleDeleteConfirm() {
+    try {
+      await deleteMutation.mutateAsync();
+      addToast({ type: "success", message: t("skillsetDetail.deleteSuccess", "Skillset deleted") });
+      setShowDelete(false);
+      navigate("/skillsets");
+    } catch (err) {
+      addToast({ type: "error", message: translateError(err) });
+    }
+  }
+
+  return (
+    <PageTransition>
+      <div className="bg-page text-body h-full overflow-y-auto">
+        <div className="mx-auto flex max-w-[1280px] flex-col gap-4 px-4 py-4 pb-16 sm:px-6 lg:px-8">
+          <nav className="shrink-0">
+            <BackLink label={t("common.back", "Back")} />
+          </nav>
+
+          {/* Hero — name, kind, visibility, version picker, owner actions. */}
+          <section className="card-impression rounded border border-subtle bg-card p-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <KindBadge kind={skillset.kind} />
+                  {skillset.isPrivate ? (
+                    <Badge color="cyan">🔒 {t("common.private")}</Badge>
+                  ) : (
+                    <Badge color="green">🌐 {t("common.public")}</Badge>
+                  )}
+                </div>
+                <h1 className="font-display text-2xl font-semibold text-strong break-words">
+                  {skillset.name}
+                </h1>
+                <p className="mt-2 max-w-2xl font-text text-sm leading-relaxed text-meta break-words">
+                  {skillset.description}
+                </p>
+                {skillset.kind === "consensus-supported" && (
+                  <p className="mt-3 rounded-sm border border-info/40 bg-info-soft px-3 py-2 font-text text-xs text-info">
+                    {t(
+                      "skillsetDetail.consensusNote",
+                      "The author asserts these members are an independent, comparable set suitable for agent-side consensus. This is a claim, not a platform guarantee.",
+                    )}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex shrink-0 flex-col items-stretch gap-3 lg:items-end">
+                {versions.length > 0 && (
+                  <VersionPicker
+                    versions={versions}
+                    currentVersion={skillset.version}
+                    onChange={handleVersionChange}
+                  />
+                )}
+                {isOwner && (
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      onClick={() => navigate(`/skillsets/${skillset.guid}/edit`)}
+                    >
+                      {t("common.edit")}
+                    </Button>
+                    <Button variant="secondary" size="sm" onClick={() => setShowPermissions(true)}>
+                      {t("skillsetDetail.managePermissions", "Permissions")}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Tags. */}
+            {skillset.tags.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-1.5">
+                {skillset.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center rounded-sm border border-subtle bg-elevated px-1.5 py-0.5 font-mono text-[10px] tracking-wider text-body"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* Main grid: left = master prompt + closure; right = members + meta. */}
+          <main className="grid gap-4 lg:grid-cols-[1fr_320px]">
+            <div className="flex flex-col gap-4 min-w-0">
+              {/* Master prompt (#978) — rendered markdown. */}
+              <section className="card-impression rounded border border-subtle bg-card p-6 min-w-0">
+                <h2 className="mb-3 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+                  {t("skillsetDetail.masterPrompt", "Master prompt")}
+                </h2>
+                {skillset.instructions ? (
+                  <ReadmeViewer content={skillset.instructions} />
+                ) : (
+                  <p className="font-text text-sm text-meta italic">
+                    {t("skillsetDetail.noPrompt", "No master prompt for this version.")}
+                  </p>
+                )}
+              </section>
+
+              {/* Resolved closure — flat depth-indented list. */}
+              <section className="card-impression rounded border border-subtle bg-card p-6 min-w-0">
+                <h2 className="mb-3 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+                  {t("skillsetDetail.resolvedClosure", "Resolved closure")}
+                </h2>
+                <SkillsetClosureViewer items={closure?.items ?? []} />
+              </section>
+            </div>
+
+            <aside className="flex flex-col gap-4">
+              {/* Members. */}
+              <section className="card-impression rounded border border-subtle bg-card p-5">
+                <h3 className="mb-3 flex items-center justify-between gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+                  <span>{t("skillsetDetail.members", "Members")}</span>
+                  <span className="text-strong">{skillset.members.length}</span>
+                </h3>
+                <ul className="space-y-1.5">
+                  {skillset.members.map((ref) => {
+                    const { name, version } = parseMemberRef(ref);
+                    return (
+                      <li
+                        key={ref}
+                        className="flex items-center justify-between gap-2 rounded-sm border border-subtle bg-elevated/40 px-2.5 py-1.5"
+                      >
+                        <span className="min-w-0 truncate font-mono text-xs text-strong">{name}</span>
+                        {version && (
+                          <span className="shrink-0 font-mono text-[10px] text-meta">@{version}</span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+
+              {/* Metadata. */}
+              <section className="card-impression rounded border border-subtle bg-card p-5">
+                <h3 className="mb-3 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+                  {t("skillsetDetail.metadata", "Metadata")}
+                </h3>
+                <dl className="space-y-2.5 font-text text-sm text-body">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <dt className="font-mono text-[10px] uppercase tracking-widest text-meta">
+                      {t("skillsetDetail.version", "Version")}
+                    </dt>
+                    <dd className="font-mono text-xs text-strong">
+                      {skillset.version}
+                      {skillset.version === latestVersion && (
+                        <span className="ml-1 text-meta">({t("skillsetDetail.latest", "latest")})</span>
+                      )}
+                    </dd>
+                  </div>
+                  <div className="flex items-baseline justify-between gap-2">
+                    <dt className="font-mono text-[10px] uppercase tracking-widest text-meta">
+                      {t("skillsetDetail.versionsCount", "Versions")}
+                    </dt>
+                    <dd className="font-mono text-xs text-strong">{versions.length}</dd>
+                  </div>
+                  <div className="flex items-baseline justify-between gap-2">
+                    <dt className="font-mono text-[10px] uppercase tracking-widest text-meta">
+                      {t("skillsetDetail.updated", "Updated")}
+                    </dt>
+                    <dd className="font-mono text-xs text-strong">
+                      {formatDateSGT(skillset.updatedOn, i18n.language)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="mb-1 font-mono text-[10px] uppercase tracking-widest text-meta">
+                      {t("skillsetDetail.guid", "GUID")}
+                    </dt>
+                    <dd>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (typeof navigator !== "undefined" && navigator.clipboard) {
+                            void navigator.clipboard.writeText(skillset.guid);
+                            addToast({
+                              type: "success",
+                              message: t("skillsetDetail.guidCopied", "GUID copied") as string,
+                            });
+                          }
+                        }}
+                        className="block w-full truncate rounded-sm border border-subtle bg-elevated px-2 py-1 text-left font-mono text-[11px] text-body transition-colors hover:border-strong-edge hover:text-strong"
+                        title={skillset.guid}
+                      >
+                        {skillset.guid}
+                      </button>
+                    </dd>
+                  </div>
+                </dl>
+              </section>
+
+              {/* Visibility — owner sees grant counts + manage. */}
+              <section className="card-impression rounded border border-subtle bg-card p-5">
+                <h3 className="mb-3 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+                  {t("skillsetDetail.visibility", "Visibility")}
+                </h3>
+                <p className="font-text text-sm text-body">
+                  {skillset.isPrivate
+                    ? t("skillsetDetail.visPrivate", "Private")
+                    : t("skillsetDetail.visPublic", "Public")}
+                </p>
+                {skillset.isPrivate && (
+                  <p className="mt-1 font-mono text-[11px] text-meta">
+                    {t("skillsetDetail.sharedWith", "Shared with {{users}} users · {{orgs}} orgs", {
+                      users: skillset.sharedWithUsers.length,
+                      orgs: skillset.sharedWithOrgs.length,
+                    })}
+                  </p>
+                )}
+                {isOwner && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="mt-3 w-full"
+                    onClick={() => setShowPermissions(true)}
+                  >
+                    {t("skillsetDetail.managePermissions", "Permissions")}
+                  </Button>
+                )}
+              </section>
+
+              {/* Danger zone (owner only). */}
+              {isOwner && (
+                <section className="card-impression rounded border border-subtle bg-card p-5">
+                  <h3 className="mb-3 border-b border-dashed border-danger/30 pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-danger">
+                    {t("skillsetDetail.dangerZone", "Danger zone")}
+                  </h3>
+                  <p className="mb-3 font-mono text-[11px] leading-relaxed text-meta">
+                    {t(
+                      "skillsetDetail.dangerExplain",
+                      "Permanently delete this skillset and every version. This cannot be undone.",
+                    )}
+                  </p>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => setShowDelete(true)}
+                  >
+                    {t("skillsetDetail.deleteSkillset", "Delete skillset")}
+                  </Button>
+                </section>
+              )}
+            </aside>
+          </main>
+        </div>
+      </div>
+
+      {/* Permissions editor (owner only). */}
+      {isOwner && (
+        <SkillsetPermissionsModal
+          isOpen={showPermissions}
+          onClose={() => setShowPermissions(false)}
+          skillset={skillset}
+        />
+      )}
+
+      {/* Delete confirmation. */}
+      <ConfirmDialog
+        isOpen={showDelete}
+        onClose={() => setShowDelete(false)}
+        onConfirm={handleDeleteConfirm}
+        variant="danger"
+        title={t("skillsetDetail.deleteTitle", "Delete this skillset?")}
+        description={t(
+          "skillsetDetail.deleteConfirm",
+          "This permanently deletes {{name}} and all its versions.",
+          { name: skillset.name },
+        )}
+        confirmLabel={t("common.delete")}
+        isLoading={deleteMutation.isPending}
+      />
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/pages/SkillsetEditPage.tsx
+++ b/ornn-web/src/pages/SkillsetEditPage.tsx
@@ -1,0 +1,110 @@
+/**
+ * SkillsetEditPage — publish a new immutable version (PUT /skillsets/:id).
+ *
+ * Wraps `SkillsetForm` in edit mode, seeded from the current latest version.
+ * The name is locked; the version field is required and must be bumped. On
+ * success, navigates back to the detail page.
+ *
+ * The URL `:id` is human-readable (name OR guid); reads accept either, but the
+ * publish route is GUID-only, so the form resolves through the GET first and
+ * hands the resulting `guid` to the publish mutation.
+ *
+ * @module pages/SkillsetEditPage
+ */
+
+import { useParams, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { BackLink } from "@/components/layout/BackLink";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Button } from "@/components/ui/Button";
+import { SkillsetForm } from "@/components/skillset/SkillsetForm";
+import { useSkillset, usePublishSkillset } from "@/hooks/useSkillsets";
+import { useToastStore } from "@/stores/toastStore";
+import { translateError } from "@/utils/translateError";
+import type { PublishSkillsetInput } from "@/types/skillset";
+
+export function SkillsetEditPage() {
+  const { id } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const idOrName = id ?? "";
+  const { data: skillset, isLoading, error } = useSkillset(idOrName);
+  // `guid` on the wire (publish is GUID-only); cache keys on the URL idOrName.
+  const publishMutation = usePublishSkillset(skillset?.guid ?? idOrName, idOrName);
+
+  if (isLoading) {
+    return (
+      <PageTransition>
+        <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+          <Skeleton lines={10} />
+        </div>
+      </PageTransition>
+    );
+  }
+
+  if (error || !skillset) {
+    return (
+      <PageTransition>
+        <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+          <EmptyState
+            title={t("skillsetDetail.notFoundTitle", "Skillset not found")}
+            description={t(
+              "skillsetDetail.notFoundDesc",
+              "It may have been deleted, or you may not have access to it.",
+            )}
+            action={
+              <Button onClick={() => navigate("/skillsets")}>
+                {t("skillsetDetail.backToRegistry", "Back to skillsets")}
+              </Button>
+            }
+          />
+        </div>
+      </PageTransition>
+    );
+  }
+
+  async function handlePublish(input: PublishSkillsetInput) {
+    try {
+      await publishMutation.mutateAsync(input);
+      addToast({ type: "success", message: t("skillsetEdit.published", "New version published") });
+      navigate(`/skillsets/${skillset!.name}`);
+    } catch (err) {
+      addToast({ type: "error", message: translateError(err) });
+    }
+  }
+
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-3xl px-4 py-4 pb-16 sm:px-6 lg:px-8">
+        <nav className="mb-4">
+          <BackLink label={t("common.back", "Back")} />
+        </nav>
+        <h1 className="mb-2 font-display text-2xl font-semibold text-strong">
+          {t("skillsetEdit.title", "Edit skillset")}
+        </h1>
+        <p className="mb-6 font-text text-sm text-meta">
+          {t("skillsetEdit.subtitle", "Revise the members, prompt, kind, or tags and publish a new version.")}
+        </p>
+        <SkillsetForm
+          mode="edit"
+          initial={{
+            name: skillset.name,
+            description: skillset.description,
+            instructions: skillset.instructions,
+            kind: skillset.kind,
+            tags: skillset.tags,
+            members: skillset.members,
+            version: skillset.version,
+          }}
+          onPublish={handlePublish}
+          submitting={publishMutation.isPending}
+          onCancel={() => navigate(`/skillsets/${skillset.name}`)}
+        />
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/pages/SkillsetExplorePage.test.tsx
+++ b/ornn-web/src/pages/SkillsetExplorePage.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * SkillsetExplorePage — tab switch + filters drive the per-scope queries.
+ *
+ * No member-count assertion (search returns 0 — see SkillsetCard.test). We
+ * mock the three list hooks and assert: (a) the active scope's hook is the one
+ * whose results render, (b) switching tabs via the tab buttons rewrites the
+ * `?scope` URL param, and (c) the kind filter passes through to the hook.
+ *
+ * @module pages/SkillsetExplorePage.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const publicHook = vi.fn();
+const mineHook = vi.fn();
+const sharedHook = vi.fn();
+
+vi.mock("@/hooks/useSkillsets", () => ({
+  usePublicSkillsets: (p: unknown) => publicHook(p),
+  useMySkillsets: (p: unknown) => mineHook(p),
+  useSharedWithMeSkillsets: (p: unknown) => sharedHook(p),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useIsAuthenticated: () => true,
+  useCurrentUser: () => ({ id: "user-1" }),
+}));
+
+import { SkillsetExplorePage } from "./SkillsetExplorePage";
+import type { SkillsetSearchItem } from "@/types/skillset";
+
+function makeItem(name: string): SkillsetSearchItem {
+  return {
+    guid: `g-${name}`,
+    name,
+    description: "d",
+    kind: "generic",
+    tags: [],
+    memberCount: 0,
+    latestVersion: "1.0",
+    isPrivate: false,
+    createdBy: "user-1",
+    createdOn: "2026-06-01T00:00:00.000Z",
+    updatedOn: "2026-06-01T00:00:00.000Z",
+  };
+}
+
+function result(items: SkillsetSearchItem[]) {
+  return {
+    data: { items, total: items.length, page: 1, pageSize: 20, totalPages: 1 },
+    isLoading: false,
+  };
+}
+
+beforeEach(() => {
+  publicHook.mockReturnValue(result([makeItem("public-set")]));
+  mineHook.mockReturnValue(result([makeItem("mine-set")]));
+  sharedHook.mockReturnValue(result([makeItem("shared-set")]));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <SkillsetExplorePage />
+    </MemoryRouter>,
+  );
+}
+
+describe("SkillsetExplorePage tabs + filters", () => {
+  it("defaults to the public scope and renders public results", () => {
+    renderAt("/skillsets");
+    expect(screen.getByText("public-set")).toBeInTheDocument();
+    expect(screen.queryByText("mine-set")).not.toBeInTheDocument();
+    // The active scope's hook is enabled; the inactive ones are disabled.
+    expect(publicHook).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
+    expect(mineHook).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it("reads the mine scope from ?scope=mine and renders mine results", () => {
+    renderAt("/skillsets?scope=mine");
+    expect(screen.getByText("mine-set")).toBeInTheDocument();
+    expect(mineHook).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
+  });
+
+  it("switches scope when a tab button is clicked", () => {
+    renderAt("/skillsets");
+    fireEvent.click(screen.getByRole("button", { name: "Shared with me" }));
+    // After the click, the shared hook becomes the enabled one.
+    expect(sharedHook).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: true }));
+    expect(screen.getByText("shared-set")).toBeInTheDocument();
+  });
+
+  it("passes the kind filter from ?kind through to the active hook", () => {
+    renderAt("/skillsets?kind=consensus-supported");
+    expect(publicHook).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "consensus-supported" }),
+    );
+  });
+
+  it("passes tag filters from ?tags through to the active hook", () => {
+    renderAt("/skillsets?tags=research,rag");
+    expect(publicHook).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: ["research", "rag"] }),
+    );
+  });
+
+  it("respects a pinned scope and hides the tab strip (My Skillsets wrapper)", () => {
+    render(
+      <MemoryRouter initialEntries={["/my-skillsets"]}>
+        <SkillsetExplorePage pinScope="mine" />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("mine-set")).toBeInTheDocument();
+    // No "Public" tab button when pinned.
+    expect(screen.queryByRole("button", { name: "Public" })).not.toBeInTheDocument();
+    expect(mineHook).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
+  });
+});

--- a/ornn-web/src/pages/SkillsetExplorePage.tsx
+++ b/ornn-web/src/pages/SkillsetExplorePage.tsx
@@ -1,0 +1,376 @@
+/**
+ * SkillsetExplorePage — the skillset registry (ONE browse page, #1059).
+ *
+ * Three tabs via `?scope`: Public · Mine · Shared with me. Filters are a
+ * simple kind dropdown + tag chips (typed inline) — NO facet sidebars (the
+ * backend search surface is intentionally minimal: kind / tags / scope only).
+ * Everything is URL-encoded so a filtered view is copy-pasteable.
+ *
+ *   Public         → anyone (anon + authed)
+ *   Mine           → authed only
+ *   Shared with me → authed only
+ *
+ * When `pinScope` is set (the /my-skillsets wrapper passes "mine"), the tab
+ * strip is hidden and the page renders that single scope.
+ *
+ * @module pages/SkillsetExplorePage
+ */
+
+import { useMemo } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { motion, type Variants } from "framer-motion";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { SkillsetCard } from "@/components/skillset/SkillsetCard";
+import { SkeletonCard } from "@/components/ui/Skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Button } from "@/components/ui/Button";
+import { Pagination } from "@/components/ui/Pagination";
+import {
+  usePublicSkillsets,
+  useMySkillsets,
+  useSharedWithMeSkillsets,
+} from "@/hooks/useSkillsets";
+import { useCurrentUser, useIsAuthenticated } from "@/stores/authStore";
+import { SKILLSET_KINDS, type SkillsetKind } from "@/types/skillset";
+
+type ExploreTab = "public" | "mine" | "shared-with-me";
+
+const DEFAULT_PAGE_SIZE = 20;
+
+const containerVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.05 } },
+};
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 10 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.15, ease: "easeOut" } },
+};
+
+function parseTab(raw: string | null, authed: boolean): ExploreTab {
+  if (raw === "mine" || raw === "shared-with-me") return authed ? raw : "public";
+  return "public";
+}
+
+function parseKind(raw: string | null): SkillsetKind | undefined {
+  return SKILLSET_KINDS.includes(raw as SkillsetKind) ? (raw as SkillsetKind) : undefined;
+}
+
+function parseCsvParam(raw: string | null): string[] {
+  if (!raw) return [];
+  return [...new Set(raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0))];
+}
+
+export interface SkillsetExplorePageProps {
+  /** Pin the page to a single scope and hide the tab strip (My Skillsets). */
+  pinScope?: ExploreTab | undefined;
+}
+
+export function SkillsetExplorePage({ pinScope }: SkillsetExplorePageProps = {}) {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const isAuthenticated = useIsAuthenticated();
+  const user = useCurrentUser();
+
+  const activeTab = pinScope ?? parseTab(searchParams.get("scope"), isAuthenticated);
+  const pageParam = Number.parseInt(searchParams.get("page") ?? "1", 10);
+  const activePage = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
+
+  const selectedKind = parseKind(searchParams.get("kind"));
+  const selectedTags = useMemo(
+    () => parseCsvParam(searchParams.get("tags")),
+    [searchParams],
+  );
+
+  const listParams = {
+    kind: selectedKind,
+    tags: selectedTags,
+    page: activePage,
+    pageSize: DEFAULT_PAGE_SIZE,
+  };
+
+  const { data: publicData, isLoading: publicLoading } = usePublicSkillsets({
+    ...listParams,
+    enabled: activeTab === "public",
+  });
+  const { data: mineData, isLoading: mineLoading } = useMySkillsets({
+    ...listParams,
+    enabled: activeTab === "mine" && isAuthenticated,
+  });
+  const { data: sharedData, isLoading: sharedLoading } = useSharedWithMeSkillsets({
+    ...listParams,
+    enabled: activeTab === "shared-with-me" && isAuthenticated,
+  });
+
+  const activeData =
+    activeTab === "public" ? publicData : activeTab === "mine" ? mineData : sharedData;
+  const activeLoading =
+    activeTab === "public" ? publicLoading : activeTab === "mine" ? mineLoading : sharedLoading;
+
+  const totalPages = activeData?.totalPages ?? 0;
+  const items = useMemo(() => activeData?.items ?? [], [activeData]);
+
+  function handleTabChange(tab: ExploreTab) {
+    const next = new URLSearchParams();
+    if (tab !== "public") next.set("scope", tab);
+    setSearchParams(next);
+  }
+
+  function handlePageChange(p: number) {
+    const next = new URLSearchParams(searchParams);
+    if (p <= 1) next.delete("page");
+    else next.set("page", String(p));
+    setSearchParams(next);
+  }
+
+  function setKind(kind: SkillsetKind | undefined) {
+    const next = new URLSearchParams(searchParams);
+    if (!kind) next.delete("kind");
+    else next.set("kind", kind);
+    next.delete("page");
+    setSearchParams(next);
+  }
+
+  function toggleTag(tag: string) {
+    const next = new URLSearchParams(searchParams);
+    const current = parseCsvParam(next.get("tags"));
+    const updated = current.includes(tag)
+      ? current.filter((v) => v !== tag)
+      : [...current, tag];
+    if (updated.length === 0) next.delete("tags");
+    else next.set("tags", updated.join(","));
+    next.delete("page");
+    setSearchParams(next);
+  }
+
+  function addTagFromInput(raw: string) {
+    const tag = raw.trim().toLowerCase();
+    if (!tag || selectedTags.includes(tag)) return;
+    toggleTag(tag);
+  }
+
+  function emptyTitle(tab: ExploreTab): string {
+    if (tab === "mine")
+      return t("skillsetExplore.noneMine", "You haven't created any skillsets yet");
+    if (tab === "shared-with-me")
+      return t("skillsetExplore.noneShared", "Nothing has been shared with you yet");
+    return t("skillsetExplore.nonePublic", "No public skillsets match");
+  }
+
+  function emptyDescription(tab: ExploreTab): string {
+    if (tab === "mine")
+      return t("skillsetExplore.createFirst", "Bundle two or more skills into your first skillset.");
+    if (tab === "shared-with-me")
+      return t(
+        "skillsetExplore.sharedIntro",
+        "When someone grants you access to a private skillset, it shows up here.",
+      );
+    return t("skillsetExplore.tryAdjusting", "Try adjusting the kind or tag filters.");
+  }
+
+  return (
+    <PageTransition>
+      <div className="flex flex-col h-full py-2 gap-3">
+        {/* Tabs (hidden when pinned). */}
+        {!pinScope && (
+          <div className="shrink-0 flex justify-center">
+            <div
+              className={`grid rounded border border-accent/20 bg-elevated p-1 gap-1 w-full max-w-xl ${
+                isAuthenticated ? "grid-cols-3" : "grid-cols-1"
+              }`}
+            >
+              <TabButton
+                label={t("skillsetExplore.publicTab", "Public")}
+                active={activeTab === "public"}
+                onClick={() => handleTabChange("public")}
+              />
+              {isAuthenticated && (
+                <>
+                  <TabButton
+                    label={t("skillsetExplore.mineTab", "Mine")}
+                    active={activeTab === "mine"}
+                    onClick={() => handleTabChange("mine")}
+                  />
+                  <TabButton
+                    label={t("skillsetExplore.sharedTab", "Shared with me")}
+                    active={activeTab === "shared-with-me"}
+                    onClick={() => handleTabChange("shared-with-me")}
+                  />
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Filters: kind dropdown + tag chips. */}
+        <div className="shrink-0 flex flex-wrap items-center gap-3">
+          <KindFilter selected={selectedKind} onChange={setKind} />
+          <TagFilter
+            tags={selectedTags}
+            onAdd={addTagFromInput}
+            onRemove={toggleTag}
+          />
+          {activeTab === "mine" && isAuthenticated && (
+            <Button size="sm" className="ml-auto" onClick={() => navigate("/skillsets/new")}>
+              {t("skillsetExplore.create", "New skillset")}
+            </Button>
+          )}
+        </div>
+
+        {/* Cards. */}
+        <main className="flex-1 min-h-0 overflow-y-auto px-2 py-1 -mx-2 -my-1">
+          {activeLoading ? (
+            <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3 pb-4">
+              {Array.from({ length: 6 }).map((_, i) => (
+                // Positional list — never reorders, key={i} is intentional (#451).
+                <SkeletonCard key={i} />
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <EmptyState
+              title={emptyTitle(activeTab)}
+              description={emptyDescription(activeTab)}
+              action={
+                activeTab === "mine" && isAuthenticated ? (
+                  <Button onClick={() => navigate("/skillsets/new")}>
+                    {t("skillsetExplore.create", "New skillset")}
+                  </Button>
+                ) : undefined
+              }
+            />
+          ) : (
+            <motion.div
+              variants={containerVariants}
+              initial="hidden"
+              animate="visible"
+              className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3 pb-4"
+            >
+              {items.map((skillset) => (
+                <motion.div key={skillset.guid} variants={itemVariants}>
+                  <SkillsetCard
+                    skillset={skillset}
+                    showOwnerControls={activeTab === "mine"}
+                    currentUserId={user?.id}
+                    onEdit={
+                      activeTab === "mine"
+                        ? (s) => navigate(`/skillsets/${s.guid}/edit`)
+                        : undefined
+                    }
+                  />
+                </motion.div>
+              ))}
+            </motion.div>
+          )}
+
+          <Pagination page={activePage} totalPages={totalPages} onPageChange={handlePageChange} />
+        </main>
+      </div>
+    </PageTransition>
+  );
+}
+
+interface TabButtonProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+function TabButton({ label, active, onClick }: TabButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full px-3 py-2 rounded-md font-text text-sm transition-all cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap ${
+        active
+          ? "bg-accent/20 text-accent border border-accent/50"
+          : "text-meta hover:text-strong"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function KindFilter({
+  selected,
+  onChange,
+}: {
+  selected: SkillsetKind | undefined;
+  onChange: (kind: SkillsetKind | undefined) => void;
+}) {
+  const { t } = useTranslation();
+  const options: { value: SkillsetKind | "all"; label: string }[] = [
+    { value: "all", label: t("skillsetExplore.kindAll", "All kinds") },
+    { value: "generic", label: t("skillsetKind.generic", "Bundle") },
+    {
+      value: "consensus-supported",
+      label: t("skillsetKind.consensusSupported", "Consensus"),
+    },
+  ];
+  return (
+    <label className="inline-flex items-center gap-2">
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+        {t("skillsetExplore.kindLabel", "Kind")}
+      </span>
+      <select
+        value={selected ?? "all"}
+        onChange={(e) => {
+          const v = e.target.value;
+          onChange(v === "all" ? undefined : (v as SkillsetKind));
+        }}
+        className="rounded-sm border border-subtle bg-elevated/40 px-2 py-1.5 font-text text-sm text-strong focus:border-accent focus:outline-none cursor-pointer"
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function TagFilter({
+  tags,
+  onAdd,
+  onRemove,
+}: {
+  tags: string[];
+  onAdd: (tag: string) => void;
+  onRemove: (tag: string) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="inline-flex flex-wrap items-center gap-2">
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+        {t("skillsetExplore.tagsLabel", "Tags")}
+      </span>
+      {tags.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          onClick={() => onRemove(tag)}
+          className="inline-flex items-center gap-1.5 rounded-full border border-accent/60 bg-accent/15 px-2.5 py-1 font-text text-xs text-accent cursor-pointer"
+        >
+          <span className="max-w-[140px] truncate">{tag}</span>
+          <span aria-hidden>×</span>
+        </button>
+      ))}
+      <input
+        type="text"
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            onAdd((e.target as HTMLInputElement).value);
+            (e.target as HTMLInputElement).value = "";
+          }
+        }}
+        placeholder={t("skillsetExplore.addTag", "add tag…") as string}
+        className="w-28 rounded-sm border border-subtle bg-elevated/40 px-2 py-1.5 font-text text-xs text-strong placeholder:text-meta/70 focus:border-accent focus:outline-none"
+        aria-label={t("skillsetExplore.addTag", "add tag…") as string}
+      />
+    </div>
+  );
+}

--- a/ornn-web/src/pages/SkillsetNewPage.tsx
+++ b/ornn-web/src/pages/SkillsetNewPage.tsx
@@ -1,0 +1,61 @@
+/**
+ * SkillsetNewPage — create a new skillset (POST /skillsets).
+ *
+ * Wraps `SkillsetForm` in create mode. On success, navigates to the new
+ * skillset's detail page. New skillsets are private by default — visibility is
+ * managed afterward via the permissions modal on the detail page.
+ *
+ * @module pages/SkillsetNewPage
+ */
+
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { BackLink } from "@/components/layout/BackLink";
+import { SkillsetForm } from "@/components/skillset/SkillsetForm";
+import { useCreateSkillset } from "@/hooks/useSkillsets";
+import { useToastStore } from "@/stores/toastStore";
+import { translateError } from "@/utils/translateError";
+import type { CreateSkillsetInput } from "@/types/skillset";
+
+export function SkillsetNewPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const addToast = useToastStore((s) => s.addToast);
+  const createMutation = useCreateSkillset();
+
+  async function handleCreate(input: CreateSkillsetInput) {
+    try {
+      const created = await createMutation.mutateAsync(input);
+      addToast({ type: "success", message: t("skillsetNew.created", "Skillset created") });
+      navigate(`/skillsets/${created.name}`);
+    } catch (err) {
+      addToast({ type: "error", message: translateError(err) });
+    }
+  }
+
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-3xl px-4 py-4 pb-16 sm:px-6 lg:px-8">
+        <nav className="mb-4">
+          <BackLink label={t("common.back", "Back")} />
+        </nav>
+        <h1 className="mb-2 font-display text-2xl font-semibold text-strong">
+          {t("skillsetNew.title", "New skillset")}
+        </h1>
+        <p className="mb-6 font-text text-sm text-meta">
+          {t(
+            "skillsetNew.subtitle",
+            "Bundle two or more skills with a master prompt that tells agents how to use them together.",
+          )}
+        </p>
+        <SkillsetForm
+          mode="create"
+          onCreate={handleCreate}
+          submitting={createMutation.isPending}
+          onCancel={() => navigate("/skillsets")}
+        />
+      </div>
+    </PageTransition>
+  );
+}

--- a/ornn-web/src/services/skillsetApi.test.ts
+++ b/ornn-web/src/services/skillsetApi.test.ts
@@ -1,0 +1,220 @@
+/**
+ * skillsetApi — verb / path / body per function.
+ *
+ * The 8 functions bottom out in the local `apiClient` wrappers (apiGet /
+ * apiPost / apiPut / apiDelete), which all bottom out in `globalThis.fetch`.
+ * Spying there lets us assert the wire shape without a server: the HTTP verb,
+ * the URL (GUID-only write routes, `?version` on reads), and the JSON body.
+ *
+ * The auth store is stubbed so importing the api layer doesn't drag in the
+ * persist-middleware localStorage chain on module load, and so `accessToken`
+ * is null (no proactive refresh → exactly one fetch call per function).
+ *
+ * @module services/skillsetApi.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: {
+    getState: () => ({
+      accessToken: null,
+      isAuthenticated: false,
+      ensureFreshToken: async () => {},
+      refreshToken: async () => {},
+    }),
+  },
+}));
+
+import {
+  searchSkillsets,
+  fetchSkillset,
+  fetchSkillsetVersions,
+  fetchSkillsetClosure,
+  createSkillset,
+  publishSkillset,
+  deleteSkillset,
+  updateSkillsetPermissions,
+} from "./skillsetApi";
+import type {
+  CreateSkillsetInput,
+  PublishSkillsetInput,
+} from "@/types/skillset";
+
+const GUID = "11111111-2222-3333-4444-555555555555";
+const NAME = "research-bundle";
+
+/** A 200 JSON `{ data }` envelope. */
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data, error: null }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function url(spy: ReturnType<typeof vi.spyOn>): string {
+  const [input] = spy.mock.calls[0] ?? [];
+  return typeof input === "string" ? input : (input as Request).url;
+}
+
+function init(spy: ReturnType<typeof vi.spyOn>): RequestInit {
+  return (spy.mock.calls[0]?.[1] ?? {}) as RequestInit;
+}
+
+function body(spy: ReturnType<typeof vi.spyOn>): unknown {
+  const raw = init(spy).body;
+  return typeof raw === "string" ? JSON.parse(raw) : raw;
+}
+
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("searchSkillsets", () => {
+  it("GETs /skillset-search with kind + scope + joined tags", async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ items: [], total: 0, page: 1, pageSize: 20, totalPages: 0 }),
+    );
+    await searchSkillsets({
+      kind: "consensus-supported",
+      scope: "mine",
+      page: 2,
+      pageSize: 20,
+      tags: ["research", "rag"],
+    });
+    const u = url(fetchSpy);
+    expect(init(fetchSpy).method).toBe("GET");
+    expect(u).toContain("/api/v1/skillset-search");
+    expect(u).toContain("kind=consensus-supported");
+    expect(u).toContain("scope=mine");
+    expect(u).toContain("page=2");
+    expect(u).toContain("tags=research%2Crag");
+  });
+
+  it("omits empty tag lists from the query", async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ items: [], total: 0, page: 1, pageSize: 20, totalPages: 0 }),
+    );
+    await searchSkillsets({ scope: "public", tags: [] });
+    expect(url(fetchSpy)).not.toContain("tags=");
+  });
+});
+
+describe("fetchSkillset", () => {
+  it("GETs /skillsets/:idOrName with no version suffix by default", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ guid: GUID, name: NAME }));
+    await fetchSkillset(NAME);
+    expect(init(fetchSpy).method).toBe("GET");
+    expect(url(fetchSpy)).toContain(`/api/v1/skillsets/${NAME}`);
+    expect(url(fetchSpy)).not.toContain("version=");
+  });
+
+  it("appends ?version when a specific version is requested", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ guid: GUID, name: NAME }));
+    await fetchSkillset(NAME, "1.2");
+    expect(url(fetchSpy)).toContain("version=1.2");
+  });
+});
+
+describe("fetchSkillsetVersions", () => {
+  it("GETs /versions and unwraps the items array", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ items: [{ version: "1.0" }] }));
+    const out = await fetchSkillsetVersions(NAME);
+    expect(url(fetchSpy)).toContain(`/api/v1/skillsets/${NAME}/versions`);
+    expect(out).toEqual([{ version: "1.0" }]);
+  });
+
+  it("returns [] when the envelope has no items", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({}));
+    expect(await fetchSkillsetVersions(NAME)).toEqual([]);
+  });
+});
+
+describe("fetchSkillsetClosure", () => {
+  it("GETs /closure and returns { instructions, items }", async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ instructions: "use A then B", items: [] }),
+    );
+    const out = await fetchSkillsetClosure(NAME, "1.0");
+    expect(url(fetchSpy)).toContain(`/api/v1/skillsets/${NAME}/closure`);
+    expect(url(fetchSpy)).toContain("version=1.0");
+    expect(out.instructions).toBe("use A then B");
+  });
+});
+
+describe("createSkillset", () => {
+  it("POSTs /skillsets with the full create body", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ guid: GUID, name: NAME }));
+    const input: CreateSkillsetInput = {
+      name: NAME,
+      description: "A research bundle",
+      instructions: "Run A, then B.",
+      kind: "generic",
+      tags: ["research"],
+      members: ["a@1.0", "b@1.0"],
+    };
+    await createSkillset(input);
+    expect(init(fetchSpy).method).toBe("POST");
+    expect(url(fetchSpy)).toMatch(/\/api\/v1\/skillsets$/);
+    expect(body(fetchSpy)).toMatchObject({
+      name: NAME,
+      members: ["a@1.0", "b@1.0"],
+      instructions: "Run A, then B.",
+    });
+  });
+});
+
+describe("publishSkillset", () => {
+  it("PUTs /skillsets/:guid (GUID-only) with the publish body", async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ guid: GUID, name: NAME }));
+    const input: PublishSkillsetInput = {
+      description: "Updated",
+      instructions: "Run A, then B, then C.",
+      kind: "consensus-supported",
+      tags: ["research"],
+      members: ["a@1.0", "b@1.0", "c@1.0"],
+      version: "1.1",
+    };
+    await publishSkillset(GUID, input);
+    expect(init(fetchSpy).method).toBe("PUT");
+    expect(url(fetchSpy)).toContain(`/api/v1/skillsets/${GUID}`);
+    expect(url(fetchSpy)).not.toContain("/permissions");
+    expect(body(fetchSpy)).toMatchObject({ version: "1.1", members: ["a@1.0", "b@1.0", "c@1.0"] });
+  });
+});
+
+describe("deleteSkillset", () => {
+  it("DELETEs /skillsets/:guid (GUID-only)", async () => {
+    fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
+    await deleteSkillset(GUID);
+    expect(init(fetchSpy).method).toBe("DELETE");
+    expect(url(fetchSpy)).toContain(`/api/v1/skillsets/${GUID}`);
+  });
+});
+
+describe("updateSkillsetPermissions", () => {
+  it("PUTs /permissions and unwraps the { skillset } envelope", async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ skillset: { guid: GUID, name: NAME, isPrivate: true } }),
+    );
+    const out = await updateSkillsetPermissions(GUID, {
+      isPrivate: true,
+      sharedWithUsers: ["u1"],
+      sharedWithOrgs: ["o1"],
+    });
+    expect(init(fetchSpy).method).toBe("PUT");
+    expect(url(fetchSpy)).toContain(`/api/v1/skillsets/${GUID}/permissions`);
+    expect(body(fetchSpy)).toMatchObject({
+      isPrivate: true,
+      sharedWithUsers: ["u1"],
+      sharedWithOrgs: ["o1"],
+    });
+    expect(out).toMatchObject({ guid: GUID, name: NAME });
+  });
+});

--- a/ornn-web/src/services/skillsetApi.ts
+++ b/ornn-web/src/services/skillsetApi.ts
@@ -1,0 +1,144 @@
+/**
+ * Client for the skillsets domain (#1059 web UI for #969 backend).
+ *
+ * Eight functions over the local `apiClient` (JSON bodies — NO SDK). URL
+ * layout follows CONVENTIONS.md (plural noun). Read endpoints accept GUID or
+ * name; write endpoints (publish / permissions / delete) are GUID-only per
+ * CONVENTIONS §2.2 — callers must pass the GUID on the wire.
+ *
+ *   searchSkillsets            → GET    /skillset-search
+ *   fetchSkillset              → GET    /skillsets/:idOrName[?version]
+ *   fetchSkillsetVersions      → GET    /skillsets/:idOrName/versions
+ *   fetchSkillsetClosure       → GET    /skillsets/:idOrName/closure[?version]
+ *   createSkillset             → POST   /skillsets
+ *   publishSkillset            → PUT    /skillsets/:id
+ *   deleteSkillset             → DELETE /skillsets/:id
+ *   updateSkillsetPermissions  → PUT    /skillsets/:id/permissions
+ *
+ * @module services/skillsetApi
+ */
+
+import { apiGet, apiPost, apiPut, apiDelete } from "./apiClient";
+import type {
+  CreateSkillsetInput,
+  PublishSkillsetInput,
+  SkillsetClosureResult,
+  SkillsetDetail,
+  SkillsetPermissionsInput,
+  SkillsetSearchParams,
+  SkillsetSearchResponse,
+  SkillsetVersionEntry,
+} from "@/types/skillset";
+
+/**
+ * Discover skillsets by kind / tags / scope. Mirrors the backend
+ * `searchQuerySchema` knobs — tags are comma-joined (skillsets must have ALL
+ * listed tags). Empty filters are dropped so URLs stay clean.
+ */
+export async function searchSkillsets(
+  params: SkillsetSearchParams,
+): Promise<SkillsetSearchResponse> {
+  const queryParams: Record<string, string | number | undefined> = {
+    kind: params.kind,
+    scope: params.scope,
+    page: params.page,
+    pageSize: params.pageSize,
+    tags: params.tags?.length ? params.tags.join(",") : undefined,
+  };
+  const res = await apiGet<SkillsetSearchResponse>(
+    "/api/v1/skillset-search",
+    queryParams,
+  );
+  return res.data!;
+}
+
+/**
+ * Fetch a single skillset by GUID or name.
+ * Without `version` → latest. With `version` → that specific version's payload.
+ */
+export async function fetchSkillset(
+  idOrName: string,
+  version?: string,
+): Promise<SkillsetDetail> {
+  const suffix = version ? `?version=${encodeURIComponent(version)}` : "";
+  const res = await apiGet<SkillsetDetail>(
+    `/api/v1/skillsets/${encodeURIComponent(idOrName)}${suffix}`,
+  );
+  return res.data!;
+}
+
+/** List every published version for a skillset, newest first. */
+export async function fetchSkillsetVersions(
+  idOrName: string,
+): Promise<SkillsetVersionEntry[]> {
+  const res = await apiGet<{ items: SkillsetVersionEntry[] }>(
+    `/api/v1/skillsets/${encodeURIComponent(idOrName)}/versions`,
+  );
+  return res.data?.items ?? [];
+}
+
+/**
+ * Resolve the skillset's closure — the master prompt (`instructions`) plus the
+ * server-flattened, deps-first topo-sorted union of all members + their
+ * dependency closures. `instructions` is a ROOT sibling of `items`.
+ */
+export async function fetchSkillsetClosure(
+  idOrName: string,
+  version?: string,
+): Promise<SkillsetClosureResult> {
+  const suffix = version ? `?version=${encodeURIComponent(version)}` : "";
+  const res = await apiGet<SkillsetClosureResult>(
+    `/api/v1/skillsets/${encodeURIComponent(idOrName)}/closure${suffix}`,
+  );
+  return res.data!;
+}
+
+/**
+ * Create a skillset (private by default — visibility is managed afterward via
+ * the permissions modal on the detail page). Seeds version 1.0.
+ */
+export async function createSkillset(
+  input: CreateSkillsetInput,
+): Promise<SkillsetDetail> {
+  const res = await apiPost<SkillsetDetail>("/api/v1/skillsets", input);
+  return res.data!;
+}
+
+/**
+ * Publish a new immutable version. First arg MUST be the skillset GUID —
+ * publish is GUID-only (CONVENTIONS §2.2). `name` is fixed after create.
+ */
+export async function publishSkillset(
+  guid: string,
+  input: PublishSkillsetInput,
+): Promise<SkillsetDetail> {
+  const res = await apiPut<SkillsetDetail>(
+    `/api/v1/skillsets/${encodeURIComponent(guid)}`,
+    input,
+  );
+  return res.data!;
+}
+
+/**
+ * Delete a skillset + all its versions. First arg MUST be the GUID — delete is
+ * GUID-only (CONVENTIONS §2.2).
+ */
+export async function deleteSkillset(guid: string): Promise<void> {
+  await apiDelete(`/api/v1/skillsets/${encodeURIComponent(guid)}`);
+}
+
+/**
+ * Replace the skillset's visibility config in one atomic call. First arg MUST
+ * be the GUID. Returns the refreshed skillset detail (unwrapped from the
+ * `{ skillset }` envelope the route emits).
+ */
+export async function updateSkillsetPermissions(
+  guid: string,
+  body: SkillsetPermissionsInput,
+): Promise<SkillsetDetail> {
+  const res = await apiPut<{ skillset: SkillsetDetail }>(
+    `/api/v1/skillsets/${encodeURIComponent(guid)}/permissions`,
+    body,
+  );
+  return res.data!.skillset;
+}

--- a/ornn-web/src/types/skillset.ts
+++ b/ornn-web/src/types/skillset.ts
@@ -1,0 +1,246 @@
+/**
+ * Frontend types for the skillsets domain (#1059 web UI for #969 backend).
+ *
+ * A **skillset** is a named, versioned, owned, visibility-scoped meta-package
+ * that references N member skills and carries a `kind`. These types mirror the
+ * serialized API shapes from `ornn-api/src/domains/skillsets/types.ts` — the
+ * frontend reads them over the local `apiClient`, NOT the SDK.
+ *
+ * Deliberately NOT aliased to the skill types: a `SkillsetDetail` is a distinct
+ * resource (member refs + master prompt, no blob/hash/storage key), and
+ * `SkillsetSearchParams` is a much smaller surface than `SkillSearchParams`
+ * (kind / tags / scope / page / pageSize only — no semantic mode, no system
+ * filter, no author facets).
+ *
+ * @module types/skillset
+ */
+
+/**
+ * Skillset kind (#969 v1). `generic` is the DEFAULT — a plain curated bundle.
+ * `consensus-supported` is an author CLAIM that the members are an
+ * independent, comparable set suitable for agent-side consensus (not a
+ * guarantee). Extensible: future kinds append here.
+ */
+export const SKILLSET_KINDS = ["generic", "consensus-supported"] as const;
+export type SkillsetKind = (typeof SKILLSET_KINDS)[number];
+
+/** Lower bound on members — a one-member "set" is just a skill. */
+export const SKILLSET_MIN_MEMBERS = 2;
+/** Upper bound on members — guards against a pathological publish. */
+export const SKILLSET_MAX_MEMBERS = 100;
+
+/** Upper bound on the master-prompt body (the per-version usage instructions). */
+export const SKILLSET_INSTRUCTIONS_MAX = 8000;
+
+/**
+ * The one explicit way an author might try to nest a skillset — a
+ * `skillset:`-prefixed member ref. Rejected client-side with a clear message
+ * before the request leaves the browser (the backend rejects it too).
+ */
+export const SKILLSET_REF_PREFIX = "skillset:";
+
+/**
+ * Serialized skillset detail — GET /api/v1/skillsets/:idOrName.
+ * Mirrors `SkillsetDetailResponse`. Carries the resolved version's master
+ * prompt (`instructions`) + member refs + the full ACL state.
+ */
+export interface SkillsetDetail {
+  guid: string;
+  name: string;
+  description: string;
+  /** Master prompt (#978) — the per-version usage instructions for agents. */
+  instructions: string;
+  kind: SkillsetKind;
+  tags: string[];
+  /** Member skill refs (`<name-or-guid>@<major.minor>` or `<name>@<dist-tag>`). */
+  members: string[];
+  /** Version of the currently-returned payload (latest by default). */
+  version: string;
+  latestVersion: string;
+  isPrivate: boolean;
+  createdBy: string;
+  // Optionals widen to `T | undefined` for exactOptionalPropertyTypes (#657).
+  createdByEmail?: string | undefined;
+  createdByDisplayName?: string | undefined;
+  sharedWithUsers: string[];
+  sharedWithOrgs: string[];
+  createdOn: string;
+  updatedOn: string;
+}
+
+/**
+ * Search-result item — GET /api/v1/skillset-search.
+ * Mirrors `SkillsetSearchItem`. NOTE: `memberCount` is hardcoded `0` in the
+ * backend search service (a #969 follow-up — search reads the identity doc,
+ * which doesn't carry the member list). Do NOT surface a member count sourced
+ * from search; use the detail/closure endpoints for the real count.
+ */
+export interface SkillsetSearchItem {
+  guid: string;
+  name: string;
+  description: string;
+  kind: SkillsetKind;
+  tags: string[];
+  /** Always `0` from search (see note above). */
+  memberCount: number;
+  latestVersion: string;
+  isPrivate: boolean;
+  createdBy: string;
+  createdByEmail?: string | undefined;
+  createdByDisplayName?: string | undefined;
+  createdOn: string;
+  updatedOn: string;
+}
+
+/**
+ * Search-response cursor metadata appended by the search route
+ * (`{ ...response, meta }`). Mirrors CONVENTIONS §4.3.
+ */
+export interface SkillsetSearchMeta {
+  limit: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export interface SkillsetSearchResponse {
+  items: SkillsetSearchItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  meta?: SkillsetSearchMeta | undefined;
+}
+
+/** Skillset browse scope. Mirrors the backend `scope` enum. */
+export type SkillsetScope =
+  | "public"
+  | "private"
+  | "mixed"
+  | "shared-with-me"
+  | "mine";
+
+/**
+ * Search params — DELIBERATELY MINIMAL. Only `kind` / `tags` / `scope` /
+ * `page` / `pageSize` (no semantic mode, no author facets). Mirrors the
+ * backend `searchQuerySchema` knobs the web UI drives.
+ */
+export interface SkillsetSearchParams {
+  // Optionals widen to `T | undefined` for exactOptionalPropertyTypes (#657).
+  kind?: SkillsetKind | undefined;
+  tags?: string[] | undefined;
+  scope?: SkillsetScope | undefined;
+  page?: number | undefined;
+  pageSize?: number | undefined;
+}
+
+/**
+ * One node in a resolved skillset closure — GET
+ * /api/v1/skillsets/:idOrName/closure. The server PRE-FLATTENS the dependency
+ * graph into a deps-first topo-sorted list; each node carries its BFS-style
+ * `depth` (0 for roots / direct members, deeper for transitive deps). Mirrors
+ * the shared `ClosureNode` shape (#968).
+ */
+export interface SkillsetClosureItem {
+  ref: string;
+  name: string;
+  version: string;
+  guid?: string | undefined;
+  skillHash?: string | undefined;
+  /** 0 for roots; max distance from any root for deeper deps. */
+  depth: number;
+}
+
+/**
+ * Closure result — the master prompt (`instructions`) is a ROOT sibling of
+ * the flattened `items`, sourced from the same loaded version.
+ */
+export interface SkillsetClosureResult {
+  instructions: string;
+  items: SkillsetClosureItem[];
+}
+
+/** One published version row — GET /api/v1/skillsets/:idOrName/versions. */
+export interface SkillsetVersionEntry {
+  version: string;
+  kind: SkillsetKind;
+  description: string;
+  instructions: string;
+  tags: string[];
+  members: string[];
+  createdBy: string;
+  createdByEmail?: string | undefined;
+  createdByDisplayName?: string | undefined;
+  createdOn: string;
+}
+
+/** Body for POST /api/v1/skillsets (create — seeds version 1.0). */
+export interface CreateSkillsetInput {
+  name: string;
+  description: string;
+  instructions: string;
+  kind: SkillsetKind;
+  tags: string[];
+  members: string[];
+  version?: string | undefined;
+}
+
+/** Body for PUT /api/v1/skillsets/:id (publish a new immutable version). */
+export interface PublishSkillsetInput {
+  description?: string | undefined;
+  instructions: string;
+  kind?: SkillsetKind | undefined;
+  tags?: string[] | undefined;
+  members: string[];
+  version: string;
+}
+
+/** Body for PUT /api/v1/skillsets/:id/permissions. Mirrors skills. */
+export interface SkillsetPermissionsInput {
+  isPrivate: boolean;
+  sharedWithUsers: string[];
+  sharedWithOrgs: string[];
+}
+
+/**
+ * Parse a member ref into its `name@version` (or `name@tag`) parts for chip
+ * display. Returns the raw ref as `name` and an empty `version` when the ref
+ * carries no `@` (defensive — the backend grammar always includes one).
+ */
+export function parseMemberRef(ref: string): { name: string; version: string } {
+  const at = ref.lastIndexOf("@");
+  if (at <= 0) return { name: ref, version: "" };
+  return { name: ref.slice(0, at), version: ref.slice(at + 1) };
+}
+
+/**
+ * Reasons a candidate member ref is invalid in the picker. `null` = valid.
+ * `nested` — `skillset:`-prefixed (no nested skillsets in v1).
+ * `self` — references the skillset being edited (a set can't contain itself).
+ * `empty` — blank ref.
+ * `noversion` — the ref carries no version part (`name` or `name@`); the v1
+ *   grammar requires `name@<version>` (or `name@<dist-tag>`).
+ */
+export type MemberRefRejection = "nested" | "self" | "empty" | "noversion" | null;
+
+/**
+ * Validate a candidate member ref against the v1 rules the picker enforces
+ * client-side. `selfName` is the name of the skillset being edited (omit on
+ * create). Returns a rejection reason or `null` when acceptable.
+ */
+export function rejectMemberRef(
+  ref: string,
+  selfName?: string,
+): MemberRefRejection {
+  const trimmed = ref.trim();
+  if (trimmed.length === 0) return "empty";
+  if (trimmed.startsWith(SKILLSET_REF_PREFIX)) return "nested";
+  if (selfName) {
+    const { name } = parseMemberRef(trimmed);
+    if (name === selfName) return "self";
+  }
+  // Version is required: catches both a bare `name` (no `@`) and `name@`
+  // (empty/whitespace version). The backend rejects these too.
+  const { version } = parseMemberRef(trimmed);
+  if (version.trim().length === 0) return "noversion";
+  return null;
+}

--- a/ornn-web/src/types/skillset.ts
+++ b/ornn-web/src/types/skillset.ts
@@ -32,6 +32,21 @@ export const SKILLSET_MAX_MEMBERS = 100;
 /** Upper bound on the master-prompt body (the per-version usage instructions). */
 export const SKILLSET_INSTRUCTIONS_MAX = 8000;
 
+/** Why a master-prompt body is invalid. `null` = valid. */
+export type MasterPromptRejection = "empty" | "tooLong" | null;
+
+/**
+ * Validate a master-prompt body against the #978 contract. Returns `null` when
+ * valid, else a reason key. Trim-then-bound so whitespace-only never satisfies
+ * the non-empty requirement.
+ */
+export function validateMasterPrompt(value: string): MasterPromptRejection {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return "empty";
+  if (trimmed.length > SKILLSET_INSTRUCTIONS_MAX) return "tooLong";
+  return null;
+}
+
 /**
  * The one explicit way an author might try to nest a skillset — a
  * `skillset:`-prefixed member ref. Rejected client-side with a clear message


### PR DESCRIPTION
Closes #1059

Automated change by `/auto` (run `20260609T061849Z-71017`, runner `auto-runner-20260609T061849Z-71017-32688-13181-1059`).
Base is hard-locked to `develop-auto`; squash-merged when CI is 100% green.
