### PR TITLE
Smoother skillset dependency-graph canvas: drag-sticks, no-teleport, react-flow polish

### DIFF
--- a/.changeset/smooth-skillset-depgraph-canvas.md
+++ b/.changeset/smooth-skillset-depgraph-canvas.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Smoother skillset dependency-graph canvas (#1072): dragging a node now sticks (was snapping home), drawing a dependency no longer teleports the layout, and the editor gains directed arrowheaded edges, grabbable handles, zoom Controls, a Tidy re-layout button, a taller canvas, and tweened motion — while node positions stay presentation-only (never persisted) and the dependency edges still live solely in the skillset master prompt.

--- a/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.test.tsx
@@ -53,6 +53,15 @@ vi.mock("@xyflow/react", () => {
     ReactFlow,
     Background: () => null,
     BackgroundVariant: { Dots: "dots" },
+    Controls: () => null,
+    Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+    MarkerType: { ArrowClosed: "arrowclosed" },
+    ConnectionLineType: { SmoothStep: "smoothstep", Bezier: "default" },
+    ConnectionMode: { Loose: "loose", Strict: "strict" },
+    // Faithful [state, setState, onChange] 3-tuple — destructuring it in the
+    // component must not throw. State is the initial nodes; setState/onChange
+    // are inert no-ops (jsdom can't measure layout, so positions are untested).
+    useNodesState: (init: unknown) => [init ?? [], vi.fn(), vi.fn()],
   };
 });
 
@@ -125,6 +134,45 @@ describe("SkillsetDependencyGraphCanvas — react-flow wiring", () => {
     fireEvent.click(screen.getByTestId("rf-delete-a-b"));
     expect(onEdgesChange).toHaveBeenCalledTimes(1);
     expect(onEdgesChange.mock.calls[0]?.[0]).toEqual([{ from: "b@1.0", to: "c@1.0" }]);
+  });
+});
+
+describe("SkillsetDependencyGraphCanvas — smoothness pass (#1071)", () => {
+  it("a node connection emits ONLY {from,to} — node positions never leak upward", () => {
+    // Positions live in session-local useNodesState and are presentation-only;
+    // the sole upward emit is onEdgesChange(Edge[]). An exact-shape assertion
+    // guards that no x/y ever rides along to the backend.
+    const onEdgesChange = vi.fn();
+    render(
+      <SkillsetDependencyGraphCanvas members={MEMBERS} edges={[]} onEdgesChange={onEdgesChange} />,
+    );
+    fireEvent.click(screen.getByTestId("rf-connect-a-b"));
+    const emitted = onEdgesChange.mock.calls[0]?.[0] as Edge[];
+    expect(emitted).toEqual([{ from: "a@1.0", to: "b@1.0" }]);
+    for (const e of emitted) {
+      expect(Object.keys(e).sort()).toEqual(["from", "to"]);
+    }
+  });
+
+  it("Tidy re-layouts node positions WITHOUT touching edges (no upward emit)", () => {
+    // Tidy is the only path that repositions existing nodes; positions are
+    // local, so it must never call onEdgesChange.
+    const onEdgesChange = vi.fn();
+    const edges: Edge[] = [{ from: "a@1.0", to: "b@1.0" }];
+    render(
+      <SkillsetDependencyGraphCanvas members={MEMBERS} edges={edges} onEdgesChange={onEdgesChange} />,
+    );
+    const tidy = screen.getByTestId("graph-tidy");
+    expect(tidy).toBeInTheDocument();
+    fireEvent.click(tidy);
+    expect(onEdgesChange).not.toHaveBeenCalled();
+  });
+
+  it("the canvas reserves a generous editing height (#1071)", () => {
+    render(
+      <SkillsetDependencyGraphCanvas members={MEMBERS} edges={[]} onEdgesChange={vi.fn()} />,
+    );
+    expect(screen.getByTestId("graph-canvas")).toHaveClass("h-[460px]");
   });
 });
 

--- a/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
+++ b/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
@@ -1,15 +1,18 @@
 /**
  * SkillsetDependencyGraphCanvas — the EDITOR surface for the member-dependency
- * graph (#1064, #1067). Lazy-loaded by `SkillsetDependencyGraph` so the
- * ~150 KB `@xyflow/react` chunk is fetched ONLY when the create/edit form
- * mounts — never on the read-only detail page (which keeps Mermaid).
+ * graph (#1064, #1067; smoothness pass #1071). Lazy-loaded by
+ * `SkillsetDependencyGraph` so the ~150 KB `@xyflow/react` chunk is fetched
+ * ONLY when the create/edit form mounts — never on the read-only detail page
+ * (which keeps Mermaid).
  *
  * Two coupled editing surfaces, one controlled `edges` projection:
- *   1. A drag-on-canvas `<ReactFlow>` graph. Node x/y are SEEDED from the
- *      existing deterministic `topoColumns` layout (positions are NOT persisted
- *      — they're presentation only). Dragging a connection (`onConnect`) adds
- *      `{ from, to }`; deleting an edge on the canvas (`onEdgesDelete`) removes
- *      it. Self-loops are dropped.
+ *   1. A drag-on-canvas `<ReactFlow>` graph. Node x/y live in SESSION-LOCAL
+ *      `useNodesState` so a drag STICKS (the prior controlled-without-handler
+ *      memo snapped every node home on the next render). Positions are seeded
+ *      once from the deterministic `topoColumns` layout and preserved across
+ *      edge edits — drawing a dependency never teleports a node. Positions are
+ *      presentation only and are NEVER emitted upward (only `onEdgesChange` is).
+ *      A manual "Tidy" button is the ONLY path that re-arranges existing nodes.
  *   2. A click-to-connect node grid + removable edge chips. This is the
  *      keyboard-accessible, jsdom-testable mirror of the same wiring — click a
  *      source member, then a target, to declare "runs before".
@@ -20,22 +23,32 @@
  * CONTRACT (AC-enforced, #1064 / #1067):
  *   - This component edits NOTHING but its own `edges` projection. Its only
  *     output is `onEdgesChange`. It imports NO skill-mutation hook and NO
- *     closure hook — the grep-guard test asserts the source has no such import.
+ *     dependency-resolution hook — the grep-guard test asserts the source has
+ *     no such import. `useNodesState`/`onNodesChange` is react-flow's OWN node
+ *     reducer and is unrelated to the upward `onEdgesChange` prop.
  *   - Edges are owned by the parent (`SkillsetForm`), persisted inside the
  *     skillset's `instructions` master prompt. This is a pure controlled view.
  *
- * CUT (deliberately, per #1067 scope): minimap, react-flow Controls, custom
- * node theming beyond DESIGN tokens, edge-label editing, and multi-select.
+ * CUT (deliberately, per #1067 scope): minimap, custom node theming beyond
+ * DESIGN tokens, edge-label editing, and multi-select. (react-flow `Controls`
+ * is reinstated in #1071 as the camera-recovery affordance that replaces
+ * auto-refit-on-edit.)
  *
  * @module components/skillset/SkillsetDependencyGraphCanvas
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ReactFlow,
   Background,
   BackgroundVariant,
+  Controls,
+  useNodesState,
+  Position,
+  MarkerType,
+  ConnectionLineType,
+  ConnectionMode,
   type Node,
   type Edge as FlowEdge,
   type Connection,
@@ -152,6 +165,67 @@ function refLabel(ref: string): { name: string; version: string } {
 const COL_GAP = 220;
 const ROW_GAP = 80;
 
+// Stable module-level react-flow config — referenced by identity so react-flow
+// never sees a "new object" on re-render (no churn, no v12 re-init warning).
+const FIT_VIEW_OPTIONS = { padding: 0.2, maxZoom: 1, duration: 200 } as const;
+const DEFAULT_EDGE_OPTIONS = {
+  type: "smoothstep",
+  // `color` is load-bearing: v12 paints the arrowhead with an INLINE fill that
+  // overrides any CSS rule, falling back to stock grey (#b1b1b7) when absent.
+  // Pin it to the arc-blue edge token so the marker matches the edge stroke and
+  // no stock palette leaks back (same silent-fallback trap as the #1067 vars).
+  markerEnd: {
+    type: MarkerType.ArrowClosed,
+    width: 16,
+    height: 16,
+    color: "var(--color-accent-secondary)",
+  },
+} as const;
+const CONNECTION_LINE_STYLE = { strokeWidth: 2 } as const;
+const PRO_OPTIONS = { hideAttribution: true } as const;
+const DELETE_KEYS = ["Backspace", "Delete"];
+
+/**
+ * Build react-flow nodes for `members` at their topo-column slots, oriented for
+ * a left→right flow (source handle right, target handle left). Used for the
+ * mount seed, for placing newly-added members, and for the Tidy re-layout.
+ */
+function buildNodes(members: string[], columns: Map<string, number>): Node[] {
+  const rowInCol = new Map<number, number>();
+  return members.map((ref) => {
+    const col = columns.get(ref) ?? 0;
+    const row = rowInCol.get(col) ?? 0;
+    rowInCol.set(col, row + 1);
+    const { name, version } = refLabel(ref);
+    return {
+      id: ref,
+      position: { x: col * COL_GAP, y: row * ROW_GAP },
+      data: { label: version ? `${name}@${version}` : name },
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+    } satisfies Node;
+  });
+}
+
+/**
+ * Reconcile the live node set against the current members: keep every existing
+ * node's position VERBATIM (including user drags), seed newly-added members at
+ * their topo slot, and drop removed members. Returns the previous array
+ * unchanged when the id set already matches so the members-keyed effect is
+ * idempotent (StrictMode-safe) and edge edits never move a node.
+ */
+function reconcileNodes(prev: Node[], members: string[], columns: Map<string, number>): Node[] {
+  const memberSet = new Set(members);
+  if (prev.length === members.length && prev.every((n) => memberSet.has(n.id))) {
+    return prev;
+  }
+  const prevById = new Map(prev.map((n) => [n.id, n] as const));
+  // A node's id IS its member ref, so an existing node's label + orientation are
+  // already correct — keep it wholesale (preserving its user-dragged position).
+  // Only brand-new members take a freshly seeded node.
+  return buildNodes(members, columns).map((seed) => prevById.get(seed.id) ?? seed);
+}
+
 export function SkillsetDependencyGraphCanvas({
   members,
   edges,
@@ -163,23 +237,22 @@ export function SkillsetDependencyGraphCanvas({
   const cyclic = useMemo(() => hasCycle(members, edges), [members, edges]);
   const columns = useMemo(() => topoColumns(members, edges), [members, edges]);
 
-  // Seed react-flow node positions from the deterministic topo columns. We
-  // track per-column row index so members in the same column stack vertically.
-  // Positions are NOT persisted — they exist only to lay out the canvas.
-  const flowNodes: Node[] = useMemo(() => {
-    const rowInCol = new Map<number, number>();
-    return members.map((ref) => {
-      const col = columns.get(ref) ?? 0;
-      const row = rowInCol.get(col) ?? 0;
-      rowInCol.set(col, row + 1);
-      const { name, version } = refLabel(ref);
-      return {
-        id: ref,
-        position: { x: col * COL_GAP, y: row * ROW_GAP },
-        data: { label: version ? `${name}@${version}` : name },
-      } satisfies Node;
-    });
-  }, [members, columns]);
+  // Seed react-flow node positions ONCE from the deterministic topo columns.
+  // After mount, positions are owned by the user's drags (and the Tidy button),
+  // NOT by re-solving topology — so drawing an edge never teleports a node.
+  // Positions are presentation only and never reach the backend.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- mount seed only; later positions come from drags/Tidy.
+  const initialNodes = useMemo<Node[]>(() => buildNodes(members, topoColumns(members, edges)), []);
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>(initialNodes);
+
+  // Reconcile positions only when MEMBERS change (add/remove). `edges` is read
+  // for a new member's initial column but is deliberately NOT a dependency —
+  // re-seeding on edge edits is exactly the teleport bug we removed.
+  const membersKey = members.join("|");
+  useEffect(() => {
+    setNodes((prev) => reconcileNodes(prev, members, topoColumns(members, edges)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed from members only; edges feed a new node's slot but must not re-seed.
+  }, [membersKey]);
 
   const flowEdges: FlowEdge[] = useMemo(
     () =>
@@ -213,6 +286,26 @@ export function SkillsetDependencyGraphCanvas({
     [edges, onEdgesChange],
   );
 
+  // ── Tidy: the ONLY path that re-arranges EXISTING nodes — re-run the topo
+  // layout and snap every node to its column slot. Node ids persist, so the
+  // scoped `transform` transition tweens them into place. Never fires
+  // automatically; touches no edges (positions stay local, never emitted).
+  const tidy = useCallback(() => {
+    const cols = topoColumns(members, edges);
+    setNodes((prev) => {
+      const rowInCol = new Map<number, number>();
+      const byId = new Map(prev.map((n) => [n.id, n] as const));
+      return members.map((ref) => {
+        const col = cols.get(ref) ?? 0;
+        const row = rowInCol.get(col) ?? 0;
+        rowInCol.set(col, row + 1);
+        const existing = byId.get(ref);
+        const base = existing ?? buildNodes([ref], cols)[0]!;
+        return { ...base, position: { x: col * COL_GAP, y: row * ROW_GAP } };
+      });
+    });
+  }, [members, edges, setNodes]);
+
   // ── click-to-connect mirror (keyboard-accessible + jsdom-testable).
   function clickNode(ref: string) {
     if (source === null) {
@@ -243,21 +336,46 @@ export function SkillsetDependencyGraphCanvas({
 
   return (
     <div className="space-y-3">
+      {/* Canvas header: opt-in Tidy re-layout (the only non-drag reposition). */}
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          data-testid="graph-tidy"
+          onClick={tidy}
+          className="inline-flex items-center gap-1.5 rounded-sm border border-subtle bg-card px-2 py-1 font-mono text-[10px] text-meta transition-colors cursor-pointer hover:border-accent hover:text-strong"
+        >
+          {t("skillsetGraph.tidy", "Tidy")}
+        </button>
+      </div>
+
       {/* Drag-on-canvas react-flow surface. */}
       <div
-        className="skillset-depgraph-canvas h-[280px] overflow-hidden rounded-sm border border-subtle bg-elevated/30"
+        className="skillset-depgraph-canvas h-[460px] overflow-hidden rounded-sm border border-subtle bg-elevated/30"
         data-testid="graph-canvas"
       >
         <ReactFlow
-          nodes={flowNodes}
+          nodes={nodes}
           edges={flowEdges}
+          onNodesChange={onNodesChange}
           onConnect={onConnect}
           onEdgesDelete={onEdgesDelete}
           fitView
+          fitViewOptions={FIT_VIEW_OPTIONS}
+          minZoom={0.4}
+          maxZoom={1.5}
           nodesConnectable
-          proOptions={{ hideAttribution: true }}
+          defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
+          connectionLineType={ConnectionLineType.SmoothStep}
+          connectionLineStyle={CONNECTION_LINE_STYLE}
+          connectionRadius={30}
+          connectionMode={ConnectionMode.Loose}
+          deleteKeyCode={DELETE_KEYS}
+          proOptions={PRO_OPTIONS}
         >
           <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
+          {/* bottom-LEFT so the cluster never overlaps a node's right-edge
+              (source) handle — the primary drag-to-connect grab target. */}
+          <Controls showInteractive={false} position="bottom-left" />
         </ReactFlow>
       </div>
 

--- a/ornn-web/src/components/skillset/skillset-depgraph-canvas.css
+++ b/ornn-web/src/components/skillset/skillset-depgraph-canvas.css
@@ -33,3 +33,64 @@
   --xy-node-border: 1px solid var(--color-border-subtle);
   --xy-node-color: var(--color-strong);
 }
+
+/*
+ * Smoothness pass (#1071). Everything below is sizing / motion / on-brand
+ * chrome — no off-brand react-flow stock palette is reintroduced. Every
+ * var() is a token defined in styles/neon.css (both themes); the token-guard
+ * test enforces this.
+ */
+
+/* Silky motion: programmatic moves (Tidy / member reconcile) tween, but the
+   node being dragged tracks the pointer 1:1 (no transition while dragging).
+   Couples to react-flow v12 applying the inline `transform` to the
+   `.react-flow__node` wrapper (not the viewport) and adding `.dragging` to that
+   same element during a drag — re-verify the drag feel on any @xyflow upgrade. */
+.skillset-depgraph-canvas .react-flow__node {
+  transition: transform 180ms ease;
+}
+.skillset-depgraph-canvas .react-flow__node.dragging {
+  transition: none;
+}
+
+/* Enlarged handles — a bigger visible dot plus a transparent hit pad (~23px)
+   so drag-to-connect lands first try instead of missing the default ~6px dot. */
+.skillset-depgraph-canvas .react-flow__handle {
+  width: 11px;
+  height: 11px;
+}
+.skillset-depgraph-canvas .react-flow__handle::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 9999px;
+}
+
+/* Directed-edge arrowhead color is set via markerEnd.color in the component
+   (v12 paints it as an inline fill that beats CSS), so no rule is needed here. */
+
+/* Subtle node hover — ember outline, no layout shift. */
+.skillset-depgraph-canvas .react-flow__node:hover {
+  box-shadow: 0 0 0 1px var(--color-accent);
+}
+
+/* Edge hover thickening — the only edge motion (no animated dashes). */
+.skillset-depgraph-canvas .react-flow__edge:hover .react-flow__edge-path {
+  stroke-width: 2.5px;
+}
+
+/* Controls skin — on-brand, zero stock blue. */
+.skillset-depgraph-canvas .react-flow__controls {
+  background: var(--color-card);
+  border: 1px solid var(--color-border-subtle);
+}
+.skillset-depgraph-canvas .react-flow__controls-button {
+  background: var(--color-card);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.skillset-depgraph-canvas .react-flow__controls-button:hover {
+  background: var(--color-elevated);
+}
+.skillset-depgraph-canvas .react-flow__controls-button svg {
+  fill: var(--color-strong);
+}

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -1776,6 +1776,7 @@
     "loadingCanvas": "Loading graph editor…",
     "pickTarget": "Pick a target for {{ref}}…",
     "removeEdge": "Remove edge {{from}} → {{to}}",
+    "tidy": "Tidy",
     "cycleWarning": "Members form a cycle — order is advisory.",
     "emptyReadonly": "No members to graph.",
     "emptyDeps": "No dependencies declared between members."

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -1776,6 +1776,7 @@
     "loadingCanvas": "正在加载依赖关系图编辑器…",
     "pickTarget": "为 {{ref}} 选择目标…",
     "removeEdge": "移除依赖边 {{from}} → {{to}}",
+    "tidy": "整理",
     "cycleWarning": "成员之间形成了环——执行顺序仅供参考。",
     "emptyReadonly": "没有可绘制的成员。",
     "emptyDeps": "成员之间未声明依赖关系。"


### PR DESCRIPTION
Closes #1072

Makes the #1067 react-flow drag-on-canvas dependency editor feel silky — the user reported it as "不丝滑" (not smooth).

## Two real defects fixed
1. **Dragging a node didn't stick.** Nodes were a controlled `useMemo` with no `onNodesChange`, so in react-flow v12 a released drag was overwritten on the next render (snapped home). → session-local `useNodesState` + `onNodesChange` (react-flow's own reducer; node x/y **never** emitted upward).
2. **Layout teleported on every edge edit.** `flowNodes` re-seeded from the edge-derived topo solve. → seed once; a members-keyed reconcile effect **preserves** existing/dragged positions and only seeds new members. Drawing an edge moves nothing.

## Polish
Left→right node orientation, directed `smoothstep`+arrowhead edges (arrowhead color pinned to the arc-blue token — v12 paints an inline marker fill that otherwise falls back to stock grey), enlarged grabbable handles (+hit pad), forgiving connect (`connectionRadius` + `ConnectionMode.Loose`), bounded zoom, eased mount-only `fitView`, react-flow `Controls` (bottom-left, clear of source handles), a manual **Tidy** re-layout, a scoped `transform` transition (Tidy/reconcile tween; live drag stays 1:1), and a taller 460px canvas. `snapToGrid` deliberately omitted (steppy ≠ silky).

## Constraints held (unchanged from #1064/#1067)
- Node positions presentation-only, never persisted; only upward emit is `onEdgesChange(Edge[])` ({from,to}). Edges remain a pure projection of the master prompt via `lib/skillsetDeps.ts` (untouched); no backend change. Click-to-connect a11y mirror + cycle advisory intact. All @xyflow imports stay in the lazy child.

## Process
Designed via a 3-approach panel; reviewed by a 3-lens adversarial pass (react-flow-v12 correctness / AC-safety / did-it-actually-fix-it) — all approved against verified v12.11 internals; the one MED finding (off-brand arrowhead) is fixed here.

## Verification
ROOT `bun run lint` 0 · `bun run test` 547 pass (77 files) · `bun run typecheck` 0 · `bun run build:web` 0 · all canvas-CSS `--color-*` tokens real. Smoothness itself (drag-sticks / no-teleport / camera-calm) is a runtime feel jsdom can't assert — verified by manual browser pass post-deploy.