### PR TITLE
Fix skillset create/edit scroll + compact the metadata fields

### DIFF
--- a/.changeset/skillset-form-compact-scroll.md
+++ b/.changeset/skillset-form-compact-scroll.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Fix the skillset create/edit page so it scrolls (its content was clipped by the overflow-hidden app shell — each page needs its own scroll container), and reorganize the metadata fields into a compact 2-column grid (name + version, description, kind + tags) so the member picker, dependency-graph canvas, and master prompt get the vertical room (#1074).

--- a/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
+++ b/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
@@ -370,6 +370,10 @@ export function SkillsetDependencyGraphCanvas({
           connectionRadius={30}
           connectionMode={ConnectionMode.Loose}
           deleteKeyCode={DELETE_KEYS}
+          // The canvas is embedded in a scrolling form — let a plain wheel
+          // scroll the PAGE (don't trap it as graph zoom). Zoom stays available
+          // via the Controls buttons, pinch, and ⌘/ctrl+wheel (#1074).
+          preventScrolling={false}
           proOptions={PRO_OPTIONS}
         >
           <Background variant={BackgroundVariant.Dots} gap={20} size={1} />

--- a/ornn-web/src/components/skillset/SkillsetForm.tsx
+++ b/ornn-web/src/components/skillset/SkillsetForm.tsx
@@ -159,99 +159,122 @@ export function SkillsetForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-      {/* Name — editable on create, locked on edit. */}
-      {mode === "create" ? (
+      {/* Identity + metadata — a compact 2-col grid so the editor surfaces below
+          (members, dependency graph, master prompt) get the vertical room.
+          Name + version share the top row; description spans full width; kind +
+          tags share the bottom row. */}
+      <div className="grid grid-cols-1 items-start gap-x-4 gap-y-4 sm:grid-cols-2">
+        {/* Name — editable on create, locked on edit. */}
+        {mode === "create" ? (
+          <Input
+            label={t("skillsetForm.name", "Name") as string}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="research-bundle"
+            error={
+              submitted && !nameValid
+                ? (t("skillsetForm.nameError", "Name must be kebab-case (a-z, 0-9, hyphens).") as string)
+                : undefined
+            }
+          />
+        ) : (
+          <div className="flex flex-col gap-1.5">
+            <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
+              {t("skillsetForm.name", "Name")}
+            </span>
+            <div className="rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-mono text-sm text-meta">
+              {lockedName}
+              <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-meta">
+                ({t("skillsetForm.nameLocked", "locked")})
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Version — defaulted 1.0 on create; required + bumped on edit. */}
         <Input
-          label={t("skillsetForm.name", "Name") as string}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="research-bundle"
+          label={t("skillsetForm.version", "Version") as string}
+          value={version}
+          onChange={(e) => setVersion(e.target.value)}
+          placeholder={mode === "edit" ? "1.1" : "1.0"}
           error={
-            submitted && !nameValid
-              ? (t("skillsetForm.nameError", "Name must be kebab-case (a-z, 0-9, hyphens).") as string)
+            submitted && !versionValid
+              ? mode === "edit"
+                ? (t("skillsetForm.versionBumpError", "Publish requires a new, bumped version (e.g. 1.1).") as string)
+                : (t("skillsetForm.versionError", "Version must be <major>.<minor> (e.g. 1.0).") as string)
               : undefined
           }
         />
-      ) : (
+
+        {/* Description — full width. */}
+        <div className="sm:col-span-2">
+          <Input
+            label={t("skillsetForm.description", "Description") as string}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder={t("skillsetForm.descriptionPlaceholder", "A short, human-readable summary") as string}
+            error={
+              submitted && !descriptionValid
+                ? (t("skillsetForm.descriptionError", "Description is required (1–1024 chars).") as string)
+                : undefined
+            }
+          />
+        </div>
+
+        {/* Kind. */}
         <div className="flex flex-col gap-1.5">
           <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
-            {t("skillsetForm.name", "Name")}
+            {t("skillsetForm.kind", "Kind")}
           </span>
-          <div className="rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-mono text-sm text-meta">
-            {lockedName}
-            <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-meta">
-              ({t("skillsetForm.nameLocked", "locked")})
-            </span>
-          </div>
+          <select
+            value={kind}
+            onChange={(e) => setKind(e.target.value as SkillsetKind)}
+            className="rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-text text-sm text-strong focus:border-accent focus:outline-none cursor-pointer"
+          >
+            {SKILLSET_KINDS.map((k) => (
+              <option key={k} value={k}>
+                {k === "consensus-supported"
+                  ? t("skillsetKind.consensusSupportedLong", "Consensus-supported")
+                  : t("skillsetKind.genericLong", "Generic bundle")}
+              </option>
+            ))}
+          </select>
         </div>
-      )}
 
-      {/* Description. */}
-      <Input
-        label={t("skillsetForm.description", "Description") as string}
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        placeholder={t("skillsetForm.descriptionPlaceholder", "A short, human-readable summary") as string}
-        error={
-          submitted && !descriptionValid
-            ? (t("skillsetForm.descriptionError", "Description is required (1–1024 chars).") as string)
-            : undefined
-        }
-      />
-
-      {/* Kind. */}
-      <div className="flex flex-col gap-1.5">
-        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta">
-          {t("skillsetForm.kind", "Kind")}
-        </span>
-        <select
-          value={kind}
-          onChange={(e) => setKind(e.target.value as SkillsetKind)}
-          className="rounded-sm border border-subtle bg-elevated/40 px-3 py-2 font-text text-sm text-strong focus:border-accent focus:outline-none cursor-pointer"
-        >
-          {SKILLSET_KINDS.map((k) => (
-            <option key={k} value={k}>
-              {k === "consensus-supported"
-                ? t("skillsetKind.consensusSupportedLong", "Consensus-supported")
-                : t("skillsetKind.genericLong", "Generic bundle")}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* Tags. */}
-      <div className="flex flex-col gap-1.5">
-        <label
-          htmlFor={tagInputId}
-          className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta"
-        >
-          {t("skillsetForm.tags", "Tags")}
-        </label>
-        <div className="flex flex-wrap items-center gap-2">
-          {tags.map((tag) => (
-            <button
-              key={tag}
-              type="button"
-              onClick={() => removeTag(tag)}
-              className="inline-flex items-center gap-1.5 rounded-full border border-accent/60 bg-accent/15 px-2.5 py-1 font-text text-xs text-accent cursor-pointer"
-            >
-              <span className="max-w-[140px] truncate">{tag}</span>
-              <span aria-hidden>×</span>
-            </button>
-          ))}
-          <input
-            id={tagInputId}
-            type="text"
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                addTag((e.target as HTMLInputElement).value);
-                (e.target as HTMLInputElement).value = "";
-              }
-            }}
-            placeholder={t("skillsetForm.addTag", "add tag…") as string}
-            className="w-28 rounded-sm border border-subtle bg-elevated/40 px-2 py-1.5 font-text text-xs text-strong placeholder:text-meta/70 focus:border-accent focus:outline-none"
-          />
+        {/* Tags. */}
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor={tagInputId}
+            className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-meta"
+          >
+            {t("skillsetForm.tags", "Tags")}
+          </label>
+          <div className="flex flex-wrap items-center gap-2">
+            {tags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="inline-flex items-center gap-1.5 rounded-full border border-accent/60 bg-accent/15 px-2.5 py-1 font-text text-xs text-accent cursor-pointer"
+              >
+                <span className="max-w-[140px] truncate">{tag}</span>
+                <span aria-hidden>×</span>
+              </button>
+            ))}
+            <input
+              id={tagInputId}
+              type="text"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addTag((e.target as HTMLInputElement).value);
+                  (e.target as HTMLInputElement).value = "";
+                }
+              }}
+              placeholder={t("skillsetForm.addTag", "add tag…") as string}
+              className="w-28 rounded-sm border border-subtle bg-elevated/40 px-2 py-1.5 font-text text-xs text-strong placeholder:text-meta/70 focus:border-accent focus:outline-none"
+            />
+          </div>
         </div>
       </div>
 
@@ -285,21 +308,6 @@ export function SkillsetForm({
         error={
           submitted && !promptValid
             ? (t("skillsetForm.promptError", "A master prompt is required.") as string)
-            : undefined
-        }
-      />
-
-      {/* Version — defaulted 1.0 on create; required + bumped on edit. */}
-      <Input
-        label={t("skillsetForm.version", "Version") as string}
-        value={version}
-        onChange={(e) => setVersion(e.target.value)}
-        placeholder={mode === "edit" ? "1.1" : "1.0"}
-        error={
-          submitted && !versionValid
-            ? mode === "edit"
-              ? (t("skillsetForm.versionBumpError", "Publish requires a new, bumped version (e.g. 1.1).") as string)
-              : (t("skillsetForm.versionError", "Version must be <major>.<minor> (e.g. 1.0).") as string)
             : undefined
         }
       />

--- a/ornn-web/src/pages/SkillsetEditPage.tsx
+++ b/ornn-web/src/pages/SkillsetEditPage.tsx
@@ -79,31 +79,35 @@ export function SkillsetEditPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-3xl px-4 py-4 pb-16 sm:px-6 lg:px-8">
-        <nav className="mb-4">
-          <BackLink label={t("common.back", "Back")} />
-        </nav>
-        <h1 className="mb-2 font-display text-2xl font-semibold text-strong">
-          {t("skillsetEdit.title", "Edit skillset")}
-        </h1>
-        <p className="mb-6 font-text text-sm text-meta">
-          {t("skillsetEdit.subtitle", "Revise the members, prompt, kind, or tags and publish a new version.")}
-        </p>
-        <SkillsetForm
-          mode="edit"
-          initial={{
-            name: skillset.name,
-            description: skillset.description,
-            instructions: skillset.instructions,
-            kind: skillset.kind,
-            tags: skillset.tags,
-            members: skillset.members,
-            version: skillset.version,
-          }}
-          onPublish={handlePublish}
-          submitting={publishMutation.isPending}
-          onCancel={() => navigate(`/skillsets/${skillset.name}`)}
-        />
+      {/* RootLayout's <main> is overflow-hidden — each page owns its own scroll
+          container (mirrors SkillsetDetailPage), else a tall form is clipped. */}
+      <div className="h-full overflow-y-auto">
+        <div className="mx-auto max-w-3xl px-4 py-4 pb-16 sm:px-6 lg:px-8">
+          <nav className="mb-4">
+            <BackLink label={t("common.back", "Back")} />
+          </nav>
+          <h1 className="mb-2 font-display text-2xl font-semibold text-strong">
+            {t("skillsetEdit.title", "Edit skillset")}
+          </h1>
+          <p className="mb-6 font-text text-sm text-meta">
+            {t("skillsetEdit.subtitle", "Revise the members, prompt, kind, or tags and publish a new version.")}
+          </p>
+          <SkillsetForm
+            mode="edit"
+            initial={{
+              name: skillset.name,
+              description: skillset.description,
+              instructions: skillset.instructions,
+              kind: skillset.kind,
+              tags: skillset.tags,
+              members: skillset.members,
+              version: skillset.version,
+            }}
+            onPublish={handlePublish}
+            submitting={publishMutation.isPending}
+            onCancel={() => navigate(`/skillsets/${skillset.name}`)}
+          />
+        </div>
       </div>
     </PageTransition>
   );

--- a/ornn-web/src/pages/SkillsetNewPage.tsx
+++ b/ornn-web/src/pages/SkillsetNewPage.tsx
@@ -36,25 +36,29 @@ export function SkillsetNewPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-3xl px-4 py-4 pb-16 sm:px-6 lg:px-8">
-        <nav className="mb-4">
-          <BackLink label={t("common.back", "Back")} />
-        </nav>
-        <h1 className="mb-2 font-display text-2xl font-semibold text-strong">
-          {t("skillsetNew.title", "New skillset")}
-        </h1>
-        <p className="mb-6 font-text text-sm text-meta">
-          {t(
-            "skillsetNew.subtitle",
-            "Bundle two or more skills with a master prompt that tells agents how to use them together.",
-          )}
-        </p>
-        <SkillsetForm
-          mode="create"
-          onCreate={handleCreate}
-          submitting={createMutation.isPending}
-          onCancel={() => navigate("/skillsets")}
-        />
+      {/* RootLayout's <main> is overflow-hidden — each page owns its own scroll
+          container (mirrors SkillsetDetailPage), else a tall form is clipped. */}
+      <div className="h-full overflow-y-auto">
+        <div className="mx-auto max-w-3xl px-4 py-4 pb-16 sm:px-6 lg:px-8">
+          <nav className="mb-4">
+            <BackLink label={t("common.back", "Back")} />
+          </nav>
+          <h1 className="mb-2 font-display text-2xl font-semibold text-strong">
+            {t("skillsetNew.title", "New skillset")}
+          </h1>
+          <p className="mb-6 font-text text-sm text-meta">
+            {t(
+              "skillsetNew.subtitle",
+              "Bundle two or more skills with a master prompt that tells agents how to use them together.",
+            )}
+          </p>
+          <SkillsetForm
+            mode="create"
+            onCreate={handleCreate}
+            submitting={createMutation.isPending}
+            onCancel={() => navigate("/skillsets")}
+          />
+        </div>
       </div>
     </PageTransition>
   );


### PR DESCRIPTION
Closes #1074

Fixes two issues on `/skillsets/new` and `/skillsets/:id/edit`.

## 1. Page couldn't scroll
`RootLayout`'s `<main>` is `overflow-hidden` — each page must supply its own scroll container (as `SkillsetDetailPage` does with `h-full overflow-y-auto`). The New/Edit pages wrapped content in a plain `mx-auto` div with none, so a tall form was clipped and the submit button was unreachable. Both pages now wrap in `h-full overflow-y-auto` (verified by review as a byte-for-byte mirror of the working detail-page pattern).

Also: the 460px dependency canvas captured wheel events over itself as graph-zoom (react-flow's default `preventScrolling`), so resting the cursor on it felt stuck. Set `preventScrolling={false}` — plain wheel scrolls the page; zoom stays on the Controls buttons, pinch, and ⌘/ctrl+wheel.

## 2. Metadata fields wasted vertical space
Name, description, kind, tags, and version were five full-width stacked rows pushing the member picker / dependency canvas / master prompt far down. Now a compact **2-column grid**: name + version (row 1), description (full width), kind + tags (row 3). Version moved up from the bottom into the grid.

**No behavior change** — same fields, same validators (`versionValid` create-vs-edit branch preserved), same submit payload. Collapses gracefully to one column below `sm`.

## Process
2-lens adversarial review (scroll-correctness/layout-tree + grid-responsive/regression) — both approved, 0 blocking; the canvas `preventScrolling` was the reviewer's one suggestion, folded in here since the user's goal is page-scroll.

## Verification
ROOT lint 0 · test 547 pass (77 files) · typecheck 0 · build 0.

Follow-up to #1072.