### PR TITLE
Skillset detail page → visual parity with the skill detail page

### DIFF
--- a/.changeset/skillset-detail-parity.md
+++ b/.changeset/skillset-detail-parity.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Bring the skillset detail page to visual parity with the skill detail page (#1076): the two-pane layout is now viewport-locked with independently scrolling columns, the master-prompt / member-dependencies / resolved-closure sections use the shared RailCard chrome instead of bespoke cards, and the hero gains the owner + published/updated footer with a varied pill trio (kind · visibility · version).

--- a/ornn-web/src/components/skillset/SkillsetHeroStrip.tsx
+++ b/ornn-web/src/components/skillset/SkillsetHeroStrip.tsx
@@ -29,6 +29,15 @@ export interface SkillsetHeroStripProps {
   onManagePermissions?: (() => void) | undefined;
 }
 
+/** Format a date in the user's locale, abbreviated. Returns ISO on parse
+ * failure. Mirrors SkillHeroStrip so both hero footers read identically. */
+function formatShortDate(iso: string | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
 export function SkillsetHeroStrip({
   skillset,
   isOwner,
@@ -46,6 +55,9 @@ export function SkillsetHeroStrip({
   const visibilityLabel = skillset.isPrivate
     ? t("common.private", "Private")
     : t("common.public", "Public");
+
+  const ownerName =
+    skillset.createdByDisplayName || skillset.createdByEmail || skillset.createdBy;
 
   return (
     <DetailHeroStrip
@@ -71,8 +83,10 @@ export function SkillsetHeroStrip({
       }
       pills={
         <>
-          {/* Kind */}
-          <span className="inline-flex items-center gap-1.5 rounded-sm border border-info/40 bg-info-soft px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider text-info">
+          {/* Kind — neutral metal pill so the trio reads kind·visibility·version
+              instead of two identical info-soft pills (the skill hero varies its
+              pills the same way). */}
+          <span className="inline-flex items-center gap-1.5 rounded-sm border border-strong-edge px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider text-strong">
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
               <rect x="3" y="3" width="7" height="7" rx="1" />
               <rect x="14" y="14" width="7" height="7" rx="1" />
@@ -94,6 +108,24 @@ export function SkillsetHeroStrip({
           <span className="inline-flex items-center gap-1.5 rounded-sm border border-strong-edge px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider text-strong">
             v{skillset.version}
           </span>
+        </>
+      }
+      footer={
+        <>
+          <span className="inline-flex h-[18px] w-[18px] items-center justify-center rounded-full bg-accent text-page text-[10px] font-bold font-text">
+            {ownerName.charAt(0).toUpperCase()}
+          </span>
+          <span className="text-body">
+            <strong className="font-medium">{ownerName}</strong>
+          </span>
+          <span className="opacity-50">·</span>
+          <span>{t("skillDetail.heroPublishedOn", "Published {{date}}", { date: formatShortDate(skillset.createdOn) })}</span>
+          {skillset.updatedOn && skillset.updatedOn !== skillset.createdOn && (
+            <>
+              <span className="opacity-50">·</span>
+              <span>{t("skillDetail.heroUpdatedOn", "Updated {{date}}", { date: formatShortDate(skillset.updatedOn) })}</span>
+            </>
+          )}
         </>
       }
       actions={

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -153,14 +153,28 @@ export function SkillsetDetailPage() {
             </p>
           )}
 
-          {/* Main grid: left = master prompt + closure; right = members + meta. */}
-          <main className="grid gap-4 lg:grid-cols-[1fr_320px]">
-            <div className="flex flex-col gap-4 min-w-0">
-              {/* Master prompt (#978) — rendered markdown. */}
-              <section className="card-impression rounded border border-subtle bg-card p-6 min-w-0">
-                <h2 className="mb-3 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
-                  {t("skillsetDetail.masterPrompt", "Master prompt")}
-                </h2>
+          {/* Main grid: left = master prompt + deps + closure; right = members +
+              meta. Mirrors SkillDetailPage — on lg+ the grid is locked to a
+              viewport-relative height so each column scrolls its own long
+              content (master prompt / closure can grow) instead of growing the
+              page; on mobile it falls back to natural page flow. */}
+          <main className="flex flex-col gap-4 lg:flex-row lg:items-stretch lg:h-[calc(100vh-280px)] lg:min-h-[480px]">
+            <div className="flex flex-col gap-4 min-w-0 lg:flex-1 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
+              {/* Master prompt (#978) — rendered markdown. Shared RailCard
+                  chrome so the left column reads identically to the skill
+                  detail's section cards (#1067 reuse mandate). */}
+              <RailCard
+                className="min-w-0"
+                title={t("skillsetDetail.masterPrompt", "Master prompt")}
+                icon={
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="8" y1="13" x2="16" y2="13" />
+                    <line x1="8" y1="17" x2="13" y2="17" />
+                  </svg>
+                }
+              >
                 {skillset.instructions ? (
                   <ReadmeViewer content={skillset.instructions} />
                 ) : (
@@ -168,27 +182,45 @@ export function SkillsetDetailPage() {
                     {t("skillsetDetail.noPrompt", "No master prompt for this version.")}
                   </p>
                 )}
-              </section>
+              </RailCard>
 
               {/* Member-dependency graph (#1064) — read-only projection of the
                   master prompt's managed deps block. No write path. */}
-              <section className="card-impression rounded border border-subtle bg-card p-6 min-w-0">
-                <h2 className="mb-3 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
-                  {t("skillsetGraph.sectionTitle", "Member dependencies")}
-                </h2>
+              <RailCard
+                className="min-w-0"
+                title={t("skillsetGraph.sectionTitle", "Member dependencies")}
+                icon={
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                    <circle cx="6" cy="6" r="2.5" />
+                    <circle cx="18" cy="6" r="2.5" />
+                    <circle cx="12" cy="18" r="2.5" />
+                    <path d="M7.7 7.7 10.6 16M16.3 7.7 13.4 16" />
+                  </svg>
+                }
+              >
                 <SkillsetDependencyGraph readOnly members={skillset.members} edges={depEdges} />
-              </section>
+              </RailCard>
 
               {/* Resolved closure — flat depth-indented list. */}
-              <section className="card-impression rounded border border-subtle bg-card p-6 min-w-0">
-                <h2 className="mb-3 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
-                  {t("skillsetDetail.resolvedClosure", "Resolved closure")}
-                </h2>
+              <RailCard
+                className="min-w-0"
+                title={t("skillsetDetail.resolvedClosure", "Resolved closure")}
+                icon={
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                    <line x1="8" y1="6" x2="21" y2="6" />
+                    <line x1="8" y1="12" x2="21" y2="12" />
+                    <line x1="8" y1="18" x2="21" y2="18" />
+                    <line x1="3" y1="6" x2="3.01" y2="6" />
+                    <line x1="3" y1="12" x2="3.01" y2="12" />
+                    <line x1="3" y1="18" x2="3.01" y2="18" />
+                  </svg>
+                }
+              >
                 <SkillsetClosureViewer items={closure?.items ?? []} />
-              </section>
+              </RailCard>
             </div>
 
-            <aside className="flex flex-col gap-4">
+            <aside className="flex flex-col gap-4 lg:w-[320px] lg:shrink-0 lg:min-h-0 lg:overflow-y-auto">
               {/* Members. */}
               <RailCard
                 title={t("skillsetDetail.members", "Members")}


### PR DESCRIPTION
Closes #1076

A parity audit (skillset pages vs registry/skill pages) found the real divergences concentrated on the **detail page**. This brings it to parity, reusing the shared shells (#1067 mandate).

## Changes
1. **Viewport-locked two-pane layout** — `<main>` swaps the plain `grid` for the skill page's `flex lg:flex-row lg:items-stretch lg:h-[calc(100vh-280px)] lg:min-h-[480px]`; the left column and right rail each become independent scroll containers (`lg:min-h-0 lg:overflow-y-auto`) instead of growing the page.
2. **Shared RailCard sections** — master prompt / member dependencies / resolved closure now use the shared `RailCard` (dashed-mono eyebrow + icon, `p-5`) instead of hand-rolled `<section>` cards with bare `<h2>` and `p-6`.
3. **Hero footer + pills** — `SkillsetHeroStrip` gains the owner + `Published`/`Updated` footer (mirrors `SkillHeroStrip`, reuses existing i18n keys); the kind pill becomes a neutral metal pill so the trio reads kind · visibility · version.

## Deliberately NOT changed
- **Card badges** (GitHub, multi-chip permissions, access-reason, owner avatar) — blocked on `SkillsetSearchItem` backend fields; faking them would be dishonest UI.
- **Card version pill** — the audit suggested a metal pill, but `SkillCard` has no version pill and the skillset card already mirrors the `Badge` vocabulary, so a lone metal pill would break the card's internal consistency. Left as-is.
- **Browse page** — found already at parity (no framed page-title to add; SearchBar correctly omitted — no `q` param backend-side).

## Process
5-dimension parallel parity audit → synthesized fix plan (which also corrected a false 'missing page-title' finding).

## Verification
ROOT lint 0 · test 547 pass (77 files, incl. SkillsetDetailPage + SkillsetHeroStrip) · typecheck 0 · build 0.

Follow-up to #1067.