### PR TITLE
Restore breadcrumb + quota chip on skillset pages; trim card to SkillCard parity

### DIFF
--- a/.changeset/skillset-breadcrumb-quota.md
+++ b/.changeset/skillset-breadcrumb-quota.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Restore the breadcrumb row + quota chip (playground + skill-gen pills) on the skillset pages (#1078): `useBreadcrumbs()` had no cases for `/skillsets*` routes, so `RootLayout` hid the whole breadcrumb bar — and with it the auth-only `QuotaChip` — on every skillset page. Adds breadcrumb trails for the skillset browse / detail / new / edit / mine routes (resolving GUID→name like the skill route). Also drops the version badge from the skillset browse card so its badge row matches `SkillCard` (which surfaces version only on the detail page).

--- a/ornn-web/src/components/layout/RootLayout.tsx
+++ b/ornn-web/src/components/layout/RootLayout.tsx
@@ -5,6 +5,7 @@ import { ToastContainer } from "@/components/ui/Toast";
 import { QuotaChip } from "@/components/quota/QuotaChip";
 import { useIsAuthenticated } from "@/stores/authStore";
 import { useSkill } from "@/hooks/useSkills";
+import { useSkillset } from "@/hooks/useSkillsets";
 
 /** Build breadcrumb segments from current route — every crumb is clickable */
 function useBreadcrumbs() {
@@ -21,6 +22,12 @@ function useBreadcrumbs() {
   // hits without a second round-trip.
   const isSkillRoute = path.startsWith("/skills/") && Boolean(params.idOrName);
   const { data: skillForCrumb } = useSkill(isSkillRoute ? params.idOrName! : "");
+
+  // Same idOrName → name resolution for the skillset detail route, so the
+  // skillset breadcrumb reads the human label instead of a raw GUID. Gated on
+  // path; the detail page already has this query in flight (cache hit).
+  const isSkillsetRoute = path.startsWith("/skillsets/") && Boolean(params.idOrName);
+  const { data: skillsetForCrumb } = useSkillset(isSkillsetRoute ? params.idOrName! : "");
 
   const crumbs: Array<{ label: string; to: string }> = [
     { label: t("breadcrumb.ornn"), to: "/" },
@@ -55,6 +62,22 @@ function useBreadcrumbs() {
     }
   } else if (path.startsWith("/skills/") && params.id) {
     crumbs.push({ label: t("breadcrumb.editSkill"), to: path });
+  } else if (path === "/skillsets") {
+    crumbs.push({ label: t("breadcrumb.skillsets", "Skillsets"), to: "/skillsets" });
+  } else if (path === "/my-skillsets") {
+    crumbs.push({ label: t("breadcrumb.mySkillsets", "My skillsets"), to: "/my-skillsets" });
+  } else if (path === "/skillsets/new") {
+    crumbs.push({ label: t("breadcrumb.skillsets", "Skillsets"), to: "/skillsets" });
+    crumbs.push({ label: t("breadcrumb.newSkillset", "New skillset"), to: "/skillsets/new" });
+  } else if (path.startsWith("/skillsets/") && path.endsWith("/edit") && params.id) {
+    crumbs.push({ label: t("breadcrumb.skillsets", "Skillsets"), to: "/skillsets" });
+    crumbs.push({ label: t("breadcrumb.editSkillset", "Edit skillset"), to: path });
+  } else if (path.startsWith("/skillsets/") && params.idOrName) {
+    // Resolve GUID → skillset name so the trail reads the human label even on
+    // a deep link; falls back to the raw idOrName until the query lands.
+    const skillsetName = skillsetForCrumb?.name || params.idOrName;
+    crumbs.push({ label: t("breadcrumb.skillsets", "Skillsets"), to: "/skillsets" });
+    crumbs.push({ label: skillsetName, to: `/skillsets/${params.idOrName}` });
   } else if (path === "/playground") {
     const skillName = new URLSearchParams(location.search).get("skill");
     if (skillName) {

--- a/ornn-web/src/components/skillset/SkillsetCard.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetCard.test.tsx
@@ -54,14 +54,20 @@ function renderCard(props: Partial<Parameters<typeof SkillsetCard>[0]> = {}) {
 }
 
 describe("SkillsetCard", () => {
-  it("renders the name, kind, visibility, version, tags, and author", () => {
+  it("renders the name, kind, visibility, tags, and author", () => {
     renderCard();
     expect(screen.getByText("research-bundle")).toBeInTheDocument();
     expect(screen.getByText("Consensus")).toBeInTheDocument();
     expect(screen.getByText(/Public/)).toBeInTheDocument();
-    expect(screen.getByText("v1.2")).toBeInTheDocument();
     expect(screen.getByText("research")).toBeInTheDocument();
     expect(screen.getByText("Ada")).toBeInTheDocument();
+  });
+
+  it("does not surface a version badge in the grid (parity with SkillCard)", () => {
+    // SkillCard shows version only on the detail page, not the browse grid;
+    // the skillset card matches that badge-row weight.
+    renderCard();
+    expect(screen.queryByText("v1.2")).not.toBeInTheDocument();
   });
 
   it("never surfaces a member count (memberCount is 0 from search)", () => {

--- a/ornn-web/src/components/skillset/SkillsetCard.tsx
+++ b/ornn-web/src/components/skillset/SkillsetCard.tsx
@@ -66,7 +66,9 @@ export function SkillsetCard({
         {skillset.name}
       </h3>
 
-      {/* Kind + visibility badges. No member count (sourced 0 from search). */}
+      {/* Kind + visibility badges — mirrors SkillCard's badge row weight (no
+          version badge: SkillCard surfaces version only on the detail page, not
+          in the grid). No member count (sourced 0 from search). */}
       <div className="mb-3 flex flex-wrap items-center gap-1.5">
         <KindBadge kind={skillset.kind} />
         {skillset.isPrivate ? (
@@ -74,7 +76,6 @@ export function SkillsetCard({
         ) : (
           <Badge color="green">🌐 {t("common.public")}</Badge>
         )}
-        <Badge color="muted">v{skillset.latestVersion}</Badge>
       </div>
 
       {/* Description — fixed 2 lines, break long words. */}

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -114,7 +114,11 @@
     "admin": "admin",
     "categories": "categories",
     "tags": "tags",
-    "auditHistory": "Audit history"
+    "auditHistory": "Audit history",
+    "skillsets": "skillsets",
+    "mySkillsets": "my skillsets",
+    "newSkillset": "new skillset",
+    "editSkillset": "edit skillset"
   },
   "explore": {
     "semanticQueryRequiredTitle": "Enter a search description",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -114,7 +114,11 @@
     "admin": "管理",
     "categories": "分类",
     "tags": "标签",
-    "auditHistory": "审计历史"
+    "auditHistory": "审计历史",
+    "skillsets": "技能集",
+    "mySkillsets": "我的技能集",
+    "newSkillset": "新建技能集",
+    "editSkillset": "编辑技能集"
   },
   "explore": {
     "semanticQueryRequiredTitle": "请输入搜索描述",


### PR DESCRIPTION
Closes #1078

Browser-screenshot QA of the skillset pages vs the registry/skill pages found the reported gaps. Three of the four symptoms share **one root cause**.

## Breadcrumb + playground + skill-gen quota (one fix)
`RootLayout` renders the breadcrumb bar only when `crumbs.length > 1`, and `useBreadcrumbs()` had **no cases for `/skillsets*` routes** — so on every skillset page `crumbs` was just `[Ornn]` and the whole bar was hidden. That bar is also where the auth-only `QuotaChip` lives, which the code comment describes as the **paired playground + skill-gen pills**. So the missing breadcrumb, missing playground pill, and missing skill-gen quota were all the same thing.

Added breadcrumb trails for `/skillsets`, `/my-skillsets`, `/skillsets/new`, `/skillsets/:id/edit`, and `/skillsets/:idOrName` (detail resolves GUID→name via `useSkillset`, mirroring the skill route), plus en/zh keys. Restores the breadcrumb **and** the playground + skill-gen quota pills.

## Card parity
The skillset browse card showed a version badge `SkillCard` doesn't (skills surface version only on the detail page). Dropped it so the badge rows match (kind + visibility). The cards are otherwise structurally identical; GitHub/permission/avatar badges stay backend-blocked (no `SkillsetSearchItem` fields — not faked).

## Verification
ROOT lint 0 · test 548 pass (77 files, +1 card parity test) · typecheck 0 · build 0. Breadcrumb absence confirmed via before screenshots; the quota pills are auth-gated so they're verified logged-in post-deploy.

Follow-up to #1076 / #1067.