### PR TITLE
Restructure skillset detail: master-prompt top card, graph above a slimmer viewer, vertical skills selector

### DIFF
--- a/.changeset/skillset-detail-relayout.md
+++ b/.changeset/skillset-detail-relayout.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Restructure the skillset detail page (#1082): the master prompt becomes the topmost full-width card (right under the hero, out of the right rail); the member-dependency graph moves into the left column above a slimmer fixed-height package viewer; and the package viewer's skill selector becomes a vertical list on the far left of the file tree (skills | files | content) instead of tabs on top. The right rail keeps metadata + resolved closure + visibility + danger; the fragile viewport-height lock is dropped in favor of natural page scroll.

--- a/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
@@ -1,10 +1,10 @@
 /**
  * SkillsetMemberViewer — the skillset detail page's left pane (#1080).
  *
- * A member selector (a row of clickable skill chips) + a READ-ONLY
- * `SkillPackagePreview` of the selected member skill's files — mirroring the
- * skill detail page's package pane so a skillset reads like "a workshop of its
- * member skills". The user clicks a member to view its content.
+ * A vertical skills selector (far-left column) + a READ-ONLY
+ * `SkillPackagePreview` of the selected member skill's files — so the viewer
+ * reads skills | file tree | content. The user clicks a skill in the set to
+ * view its content, mirroring the skill detail page's package pane.
  *
  * Data path (all read-only — NO skill mutation, NO closure write):
  *   member ref `name@version`
@@ -56,15 +56,17 @@ export function SkillsetMemberViewer({ members }: SkillsetMemberViewerProps) {
 
   return (
     <section
-      className="card-impression flex min-h-[420px] flex-col overflow-hidden rounded border border-subtle bg-card lg:flex-1 lg:min-h-0 lg:min-w-0"
+      className="card-impression flex h-[520px] flex-row overflow-hidden rounded border border-subtle bg-card"
       data-testid="skillset-member-viewer"
     >
-      {/* Member selector — click a skill in the set to view its package. */}
+      {/* Skills selector — a vertical list on the far LEFT (#1082), so the
+          viewer reads skills | file tree | content. Click a skill in the set to
+          view its package. */}
       <div
-        className="flex shrink-0 items-center gap-2 overflow-x-auto border-b border-subtle bg-elevated px-3 py-2"
+        className="flex w-[168px] shrink-0 flex-col gap-1 overflow-y-auto border-r border-subtle bg-elevated p-2"
         data-testid="member-tabs"
       >
-        <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
+        <span className="px-1 pb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-meta">
           {t("skillsetDetail.membersLabel", "Members")}
         </span>
         {members.map((ref) => {
@@ -76,21 +78,21 @@ export function SkillsetMemberViewer({ members }: SkillsetMemberViewerProps) {
               type="button"
               onClick={() => setSelectedRef(ref)}
               aria-pressed={isActive}
-              className={`shrink-0 rounded-sm border px-2.5 py-1 font-mono text-xs transition-colors cursor-pointer ${
+              className={`w-full rounded-sm border px-2 py-1.5 text-left font-mono text-xs transition-colors cursor-pointer ${
                 isActive
                   ? "border-accent bg-accent/15 text-strong"
-                  : "border-subtle bg-card text-meta hover:border-accent hover:text-strong"
+                  : "border-transparent text-meta hover:border-subtle hover:text-strong"
               }`}
             >
-              <span className="max-w-[12rem] truncate align-middle">{name}</span>
-              {version && <span className="text-meta">@{version}</span>}
+              <span className="block truncate">{name}</span>
+              {version && <span className="text-[10px] text-meta">@{version}</span>}
             </button>
           );
         })}
       </div>
 
-      {/* Selected member's package — read-only file tree + viewer. */}
-      <div className="flex-1 min-h-0">
+      {/* Selected member's package — read-only file tree + content. */}
+      <div className="min-w-0 flex-1">
         {!activeRef ? (
           <p className="py-12 text-center font-text text-sm text-meta">
             {t("skillsetDetail.noMembers", "This skillset has no members.")}

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -153,48 +153,61 @@ export function SkillsetDetailPage() {
             </p>
           )}
 
-          {/* Two-pane workshop (#1080): left = member skill-package viewer
-              (click a member to view its files); right rail = metadata (leading
-              with the master prompt) + member dependencies + resolved closure +
-              visibility + danger. Mirrors SkillDetailPage — on lg+ the grid is
-              locked to a viewport-relative height so each pane scrolls its own
-              content; on mobile it falls back to natural page flow. */}
-          <main className="flex flex-col gap-4 lg:flex-row lg:items-stretch lg:h-[calc(100vh-280px)] lg:min-h-[480px]">
-            {/* Left pane: member skill-package viewer (#1080) — click a member
-                to view its files, like the skill detail page. The master prompt
-                + dependency graph + resolved closure now live in the right rail. */}
-            <SkillsetMemberViewer members={skillset.members} />
+          {/* Master prompt (#1082) — the skillset's "how to use" entry point,
+              as the TOPMOST full-width card right under the hero. */}
+          <RailCard
+            title={t("skillsetDetail.masterPrompt", "Master prompt")}
+            icon={
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                <polyline points="14 2 14 8 20 8" />
+                <line x1="8" y1="13" x2="16" y2="13" />
+                <line x1="8" y1="17" x2="13" y2="17" />
+              </svg>
+            }
+          >
+            {skillset.instructions ? (
+              <div className="max-h-64 overflow-y-auto">
+                <ReadmeViewer content={skillset.instructions} />
+              </div>
+            ) : (
+              <p className="font-text text-sm text-meta italic">
+                {t("skillsetDetail.noPrompt", "No master prompt for this version.")}
+              </p>
+            )}
+          </RailCard>
 
-            <aside className="flex flex-col gap-4 lg:w-[320px] lg:shrink-0 lg:min-h-0 lg:overflow-y-auto">
-              {/* Metadata — now leads with the master prompt (#1080), the
-                  skillset's "how to use" entry point, then the typed fields. */}
+          {/* Workshop (#1082): left column = member-dependency graph (top) + a
+              slimmer package viewer (below); right rail = metadata + resolved
+              closure + visibility + danger. Natural page scroll (no viewport
+              lock) — the viewer has its own fixed height. */}
+          <main className="flex flex-col gap-4 lg:flex-row lg:items-start">
+            <div className="flex min-w-0 flex-col gap-4 lg:flex-1">
+              {/* Member-dependency graph (#1064) — read-only projection of the
+                  master prompt's managed deps block. Now above the package
+                  viewer in the left column (#1082); gets full width here. */}
               <RailCard
-                title={t("skillsetDetail.metadata", "Metadata")}
+                title={t("skillsetGraph.sectionTitle", "Member dependencies")}
                 icon={
                   <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                    <polyline points="14 2 14 8 20 8" />
-                    <line x1="8" y1="13" x2="16" y2="13" />
-                    <line x1="8" y1="17" x2="13" y2="17" />
+                    <circle cx="6" cy="6" r="2.5" />
+                    <circle cx="18" cy="6" r="2.5" />
+                    <circle cx="12" cy="18" r="2.5" />
+                    <path d="M7.7 7.7 10.6 16M16.3 7.7 13.4 16" />
                   </svg>
                 }
               >
-                {/* Master prompt — rendered markdown, capped + scrollable so a
-                    long prompt doesn't dominate the rail. */}
-                <div className="mb-4">
-                  <p className="mb-1.5 font-mono text-[10px] uppercase tracking-widest text-meta">
-                    {t("skillsetDetail.masterPrompt", "Master prompt")}
-                  </p>
-                  {skillset.instructions ? (
-                    <div className="max-h-72 overflow-y-auto rounded-sm border border-subtle bg-elevated/30 px-3 py-2">
-                      <ReadmeViewer content={skillset.instructions} />
-                    </div>
-                  ) : (
-                    <p className="font-text text-sm text-meta italic">
-                      {t("skillsetDetail.noPrompt", "No master prompt for this version.")}
-                    </p>
-                  )}
-                </div>
+                <SkillsetDependencyGraph readOnly members={skillset.members} edges={depEdges} />
+              </RailCard>
+
+              {/* Package viewer — pick a member skill (left column), view its
+                  files. Slimmer than before (fixed height inside the viewer). */}
+              <SkillsetMemberViewer members={skillset.members} />
+            </div>
+
+            <aside className="flex flex-col gap-4 lg:w-[320px] lg:shrink-0">
+              {/* Metadata. */}
+              <RailCard title={t("skillsetDetail.metadata", "Metadata")}>
                 <dl className="space-y-2.5 font-text text-sm text-body">
                   <div className="flex items-baseline justify-between gap-2">
                     <dt className="font-mono text-[10px] uppercase tracking-widest text-meta">
@@ -251,22 +264,6 @@ export function SkillsetDetailPage() {
                     </dd>
                   </div>
                 </dl>
-              </RailCard>
-
-              {/* Member-dependency graph (#1064) — read-only projection of the
-                  master prompt's managed deps block. No write path. */}
-              <RailCard
-                title={t("skillsetGraph.sectionTitle", "Member dependencies")}
-                icon={
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-                    <circle cx="6" cy="6" r="2.5" />
-                    <circle cx="18" cy="6" r="2.5" />
-                    <circle cx="12" cy="18" r="2.5" />
-                    <path d="M7.7 7.7 10.6 16M16.3 7.7 13.4 16" />
-                  </svg>
-                }
-              >
-                <SkillsetDependencyGraph readOnly members={skillset.members} edges={depEdges} />
               </RailCard>
 
               {/* Resolved closure — flat depth-indented list. */}


### PR DESCRIPTION
Closes #1082

Layout feedback on the skillset detail page (follow-up to #1080). Frontend-only.

## Changes
1. **Master prompt → topmost full-width card** right under the hero (moved out of the right-rail metadata card).
2. **Member-dependency graph → left column, above the package viewer** (it now gets full width instead of the cramped 320px rail).
3. **Package viewer slimmed** to a fixed-height section (no longer the whole left pane).
4. **Skills selector → vertical column on the far left of the file tree** (skills | files | content), replacing the horizontal tabs on top.
5. Dropped the viewport-height lock — the page scrolls naturally; the viewer owns its own fixed height.

Right rail keeps metadata + resolved closure + visibility + danger.

## Verification
ROOT lint 0 · typecheck 0 · build 0 · web vitest 553 (78 files). Tests assert by text/testid so the relocation kept them green; visual layout best confirmed in-browser.

Follow-up to #1080.