### PR TITLE
feat(web): skillset details page UI improvements and parity with skill details

### DIFF
--- a/.changeset/skillset-details-ui-parity.md
+++ b/.changeset/skillset-details-ui-parity.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": "minor"
+---
+
+feat(web): skillset details UI parity + polish (smaller closure font, "Closure" rename, member links to skills, remove perms from hero, versions card in right rail like skills)

--- a/ornn-web/src/components/skillset/SkillsetClosureViewer.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetClosureViewer.test.tsx
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { SkillsetClosureViewer } from "./SkillsetClosureViewer";
 import type { SkillsetClosureItem } from "@/types/skillset";
 
@@ -25,12 +26,20 @@ afterEach(() => cleanup());
 
 describe("SkillsetClosureViewer", () => {
   it("renders an empty hint when there are no items", () => {
-    render(<SkillsetClosureViewer items={[]} />);
+    render(
+      <MemoryRouter>
+        <SkillsetClosureViewer items={[]} />
+      </MemoryRouter>,
+    );
     expect(screen.getByText(/No resolved members/i)).toBeInTheDocument();
   });
 
   it("renders every node flat, in the given deps-first order", () => {
-    render(<SkillsetClosureViewer items={ITEMS} />);
+    render(
+      <MemoryRouter>
+        <SkillsetClosureViewer items={ITEMS} />
+      </MemoryRouter>,
+    );
     const rows = within(screen.getByTestId("closure-list")).getAllByRole("listitem");
     expect(rows).toHaveLength(4);
     expect(rows[0]).toHaveTextContent("a");
@@ -40,7 +49,11 @@ describe("SkillsetClosureViewer", () => {
   });
 
   it("tags depth-0 rows as members and deeper rows as deps", () => {
-    render(<SkillsetClosureViewer items={ITEMS} />);
+    render(
+      <MemoryRouter>
+        <SkillsetClosureViewer items={ITEMS} />
+      </MemoryRouter>,
+    );
     const rows = within(screen.getByTestId("closure-list")).getAllByRole("listitem");
     expect(rows[0]).toHaveTextContent("member");
     expect(rows[2]).toHaveTextContent("dep");
@@ -48,7 +61,11 @@ describe("SkillsetClosureViewer", () => {
   });
 
   it("indents each row proportional to its depth", () => {
-    render(<SkillsetClosureViewer items={ITEMS} />);
+    render(
+      <MemoryRouter>
+        <SkillsetClosureViewer items={ITEMS} />
+      </MemoryRouter>,
+    );
     const rows = within(screen.getByTestId("closure-list")).getAllByRole("listitem");
     // depth 0 → 0px, depth 1 → 20px, depth 2 → 40px.
     expect((rows[0] as HTMLElement).style.marginLeft).toBe("0px");

--- a/ornn-web/src/components/skillset/SkillsetClosureViewer.tsx
+++ b/ornn-web/src/components/skillset/SkillsetClosureViewer.tsx
@@ -54,7 +54,7 @@ export function SkillsetClosureViewer({ items, className = "" }: SkillsetClosure
               ? t("skillsetClosure.member", "member")
               : t("skillsetClosure.dependency", "dep")}
           </span>
-          <span className="min-w-0 truncate font-mono text-sm text-strong">{item.name}</span>
+          <span className="min-w-0 truncate font-mono text-xs text-strong">{item.name}</span>
           <span className="shrink-0 font-mono text-xs text-meta">v{item.version}</span>
         </li>
       ))}

--- a/ornn-web/src/components/skillset/SkillsetClosureViewer.tsx
+++ b/ornn-web/src/components/skillset/SkillsetClosureViewer.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import type { SkillsetClosureItem } from "@/types/skillset";
 
 export interface SkillsetClosureViewerProps {
@@ -54,7 +55,12 @@ export function SkillsetClosureViewer({ items, className = "" }: SkillsetClosure
               ? t("skillsetClosure.member", "member")
               : t("skillsetClosure.dependency", "dep")}
           </span>
-          <span className="min-w-0 truncate font-mono text-xs text-strong">{item.name}</span>
+          <Link
+            to={`/skills/${encodeURIComponent(item.name)}?version=${item.version}`}
+            className="min-w-0 truncate font-mono text-xs text-strong hover:underline hover:text-accent"
+          >
+            {item.name}
+          </Link>
           <span className="shrink-0 font-mono text-xs text-meta">v{item.version}</span>
         </li>
       ))}

--- a/ornn-web/src/components/skillset/SkillsetHeroStrip.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetHeroStrip.test.tsx
@@ -34,14 +34,13 @@ afterEach(() => {
 });
 
 describe("SkillsetHeroStrip", () => {
-  it("renders the name, description, kind/visibility/version pills, and tags", () => {
+  it("renders the name, description, kind/visibility pills, and tags (version pill moved to right rail)", () => {
     render(<SkillsetHeroStrip skillset={DETAIL} isOwner={false} />);
     expect(screen.getByRole("heading", { name: "research-bundle" })).toBeInTheDocument();
     expect(screen.getByText("A curated comparison set")).toBeInTheDocument();
-    // Pills.
+    // Pills (no version pill in hero anymore).
     expect(screen.getByText("Consensus")).toBeInTheDocument();
     expect(screen.getByText("Private")).toBeInTheDocument();
-    expect(screen.getByText("v1.1")).toBeInTheDocument();
     // Tags.
     expect(screen.getByText("#research")).toBeInTheDocument();
     expect(screen.getByText("#rag")).toBeInTheDocument();
@@ -58,21 +57,18 @@ describe("SkillsetHeroStrip", () => {
     expect(screen.getByText("Public")).toBeInTheDocument();
   });
 
-  it("shows Edit + Permissions actions for the owner and wires the callbacks", () => {
+  it("shows only Edit action for the owner (Permissions moved to Visibility card)", () => {
     const onEdit = vi.fn();
-    const onManagePermissions = vi.fn();
     render(
       <SkillsetHeroStrip
         skillset={DETAIL}
         isOwner
         onEdit={onEdit}
-        onManagePermissions={onManagePermissions}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-    fireEvent.click(screen.getByRole("button", { name: "Permissions" }));
     expect(onEdit).toHaveBeenCalledTimes(1);
-    expect(onManagePermissions).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Permissions" })).not.toBeInTheDocument();
   });
 
   it("hides owner actions for non-owners", () => {
@@ -81,21 +77,10 @@ describe("SkillsetHeroStrip", () => {
         skillset={DETAIL}
         isOwner={false}
         onEdit={vi.fn()}
-        onManagePermissions={vi.fn()}
       />,
     );
     expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Permissions" })).not.toBeInTheDocument();
   });
 
-  it("renders the supplied version picker slot", () => {
-    render(
-      <SkillsetHeroStrip
-        skillset={DETAIL}
-        isOwner={false}
-        versionPicker={<div data-testid="version-picker">picker</div>}
-      />,
-    );
-    expect(screen.getByTestId("version-picker")).toBeInTheDocument();
-  });
+  // versionPicker support was removed from the hero (moved to right-rail Versions card to match skill details page layout)
 });

--- a/ornn-web/src/components/skillset/SkillsetHeroStrip.tsx
+++ b/ornn-web/src/components/skillset/SkillsetHeroStrip.tsx
@@ -14,7 +14,6 @@
  * @module components/skillset/SkillsetHeroStrip
  */
 
-import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { DetailHeroStrip } from "@/components/detail/DetailHeroStrip";
 import { Button } from "@/components/ui/Button";

--- a/ornn-web/src/components/skillset/SkillsetHeroStrip.tsx
+++ b/ornn-web/src/components/skillset/SkillsetHeroStrip.tsx
@@ -4,9 +4,9 @@
  *
  * Thin adapter over the shared `<DetailHeroStrip>` shell, mirroring
  * `SkillHeroStrip`. It supplies the skillset-specific icon, the tag row, the
- * status pill row (kind / visibility / version), and the action cluster
- * (version picker + owner Edit / Permissions). The card chrome and layout live
- * in `DetailHeroStrip` so both detail surfaces read identically.
+ * status pill row (kind / visibility), and the action cluster (owner Edit only).
+ * Version is now a right-rail card (matching skill details). The card chrome
+ * and layout live in `DetailHeroStrip` so both detail surfaces read identically.
  *
  * Styled in the Forge Workshop language (DESIGN.md): Space Grotesk display,
  * Inter body, JetBrains Mono pills, ember accent, hairline borders, 2-4px radii.
@@ -23,10 +23,7 @@ import type { SkillsetDetail } from "@/types/skillset";
 export interface SkillsetHeroStripProps {
   skillset: SkillsetDetail;
   isOwner: boolean;
-  /** Rendered into the actions cluster (the version popover). */
-  versionPicker?: ReactNode;
   onEdit?: (() => void) | undefined;
-  onManagePermissions?: (() => void) | undefined;
 }
 
 /** Format a date in the user's locale, abbreviated. Returns ISO on parse
@@ -41,9 +38,7 @@ function formatShortDate(iso: string | undefined): string {
 export function SkillsetHeroStrip({
   skillset,
   isOwner,
-  versionPicker,
   onEdit,
-  onManagePermissions,
 }: SkillsetHeroStripProps) {
   const { t } = useTranslation();
 
@@ -104,10 +99,6 @@ export function SkillsetHeroStrip({
             </svg>
             {visibilityLabel}
           </span>
-          {/* Version */}
-          <span className="inline-flex items-center gap-1.5 rounded-sm border border-strong-edge px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider text-strong">
-            v{skillset.version}
-          </span>
         </>
       }
       footer={
@@ -129,22 +120,12 @@ export function SkillsetHeroStrip({
         </>
       }
       actions={
-        versionPicker || (isOwner && (onEdit || onManagePermissions)) ? (
+        isOwner && onEdit ? (
           <div className="flex flex-col items-stretch gap-3 lg:items-end">
-            {versionPicker}
-            {isOwner && (onEdit || onManagePermissions) && (
-              <div className="flex flex-wrap gap-2">
-                {onEdit && (
-                  <Button size="sm" onClick={onEdit}>
-                    {t("common.edit")}
-                  </Button>
-                )}
-                {onManagePermissions && (
-                  <Button variant="secondary" size="sm" onClick={onManagePermissions}>
-                    {t("skillsetDetail.managePermissions", "Permissions")}
-                  </Button>
-                )}
-              </div>
+            {onEdit && (
+              <Button size="sm" onClick={onEdit}>
+                {t("common.edit")}
+              </Button>
             )}
           </div>
         ) : undefined

--- a/ornn-web/src/components/skillset/SkillsetMemberViewer.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberViewer.test.tsx
@@ -68,7 +68,9 @@ describe("SkillsetMemberViewer", () => {
         <SkillsetMemberViewer members={MEMBERS} />
       </MemoryRouter>,
     );
-    fireEvent.click(screen.getByText("beta"));
+    // Click the button (not just the inner Link text, which has stopPropagation for navigation)
+    const betaButton = screen.getByText("beta").closest("button");
+    fireEvent.click(betaButton!);
     expect(useSkill).toHaveBeenLastCalledWith("beta", "2.1");
   });
 

--- a/ornn-web/src/components/skillset/SkillsetMemberViewer.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberViewer.test.tsx
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 
 const useSkill = vi.fn();
 const useSkillPackage = vi.fn();
@@ -50,7 +51,11 @@ afterEach(() => {
 
 describe("SkillsetMemberViewer", () => {
   it("renders a tab per member and previews the first member by default", () => {
-    render(<SkillsetMemberViewer members={MEMBERS} />);
+    render(
+      <MemoryRouter>
+        <SkillsetMemberViewer members={MEMBERS} />
+      </MemoryRouter>,
+    );
     expect(screen.getByText("alpha")).toBeInTheDocument();
     expect(screen.getByText("beta")).toBeInTheDocument();
     expect(useSkill).toHaveBeenCalledWith("alpha", "1.0");
@@ -58,20 +63,32 @@ describe("SkillsetMemberViewer", () => {
   });
 
   it("switches the previewed member when another tab is clicked", () => {
-    render(<SkillsetMemberViewer members={MEMBERS} />);
+    render(
+      <MemoryRouter>
+        <SkillsetMemberViewer members={MEMBERS} />
+      </MemoryRouter>,
+    );
     fireEvent.click(screen.getByText("beta"));
     expect(useSkill).toHaveBeenLastCalledWith("beta", "2.1");
   });
 
   it("shows an access message when the member skill is unavailable", () => {
     useSkill.mockReturnValue({ data: undefined, isLoading: false, error: new Error("403") });
-    render(<SkillsetMemberViewer members={MEMBERS} />);
+    render(
+      <MemoryRouter>
+        <SkillsetMemberViewer members={MEMBERS} />
+      </MemoryRouter>,
+    );
     expect(screen.getByText(/isn't available to you/i)).toBeInTheDocument();
     expect(screen.queryByTestId("package-preview")).not.toBeInTheDocument();
   });
 
   it("shows the empty state for a skillset with no members", () => {
-    render(<SkillsetMemberViewer members={[]} />);
+    render(
+      <MemoryRouter>
+        <SkillsetMemberViewer members={[]} />
+      </MemoryRouter>,
+    );
     expect(screen.getByText(/no members/i)).toBeInTheDocument();
   });
 });

--- a/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
@@ -20,7 +20,6 @@
 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useSkill } from "@/hooks/useSkills";
@@ -85,13 +84,7 @@ export function SkillsetMemberViewer({ members }: SkillsetMemberViewerProps) {
                   : "border-transparent text-meta hover:border-subtle hover:text-strong"
               }`}
             >
-              <Link
-                to={`/skills/${encodeURIComponent(name)}`}
-                onClick={(e) => e.stopPropagation()}
-                className="block truncate hover:underline"
-              >
-                {name}
-              </Link>
+              <span className="block truncate">{name}</span>
               {version && <span className="text-[10px] text-meta">@{version}</span>}
             </button>
           );

--- a/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
@@ -20,6 +20,7 @@
 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import { SkillPackagePreview } from "@/components/skill/SkillPackagePreview";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useSkill } from "@/hooks/useSkills";
@@ -84,7 +85,13 @@ export function SkillsetMemberViewer({ members }: SkillsetMemberViewerProps) {
                   : "border-transparent text-meta hover:border-subtle hover:text-strong"
               }`}
             >
-              <span className="block truncate">{name}</span>
+              <Link
+                to={`/skills/${encodeURIComponent(name)}`}
+                onClick={(e) => e.stopPropagation()}
+                className="block truncate hover:underline"
+              >
+                {name}
+              </Link>
               {version && <span className="text-[10px] text-meta">@{version}</span>}
             </button>
           );

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -1675,8 +1675,8 @@
     "consensusSupportedLong": "Consensus-supported"
   },
   "skillsetExplore": {
-    "publicTab": "Public",
-    "mineTab": "Mine",
+    "publicTab": "Public Skillsets",
+    "mineTab": "My Skillsets",
     "sharedTab": "Shared with me",
     "kindLabel": "Kind",
     "kindAll": "All kinds",
@@ -1700,7 +1700,7 @@
     "managePermissions": "Permissions",
     "masterPrompt": "Master prompt",
     "noPrompt": "No master prompt for this version.",
-    "resolvedClosure": "Resolved closure",
+    "resolvedClosure": "Closure",
     "members": "Members",
     "membersLabel": "Members",
     "noMembers": "This skillset has no members.",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -1675,9 +1675,9 @@
     "consensusSupportedLong": "支持共识"
   },
   "skillsetExplore": {
-    "publicTab": "公开",
-    "mineTab": "我的",
-    "sharedTab": "共享给我",
+    "publicTab": "公共技能集",
+    "mineTab": "我的技能集",
+    "sharedTab": "分享给我的",
     "kindLabel": "类型",
     "kindAll": "全部类型",
     "tagsLabel": "标签",
@@ -1700,7 +1700,7 @@
     "managePermissions": "权限",
     "masterPrompt": "主提示词",
     "noPrompt": "此版本没有主提示词。",
-    "resolvedClosure": "解析闭包",
+    "resolvedClosure": "闭包",
     "members": "成员",
     "membersLabel": "成员",
     "noMembers": "该技能集没有成员。",

--- a/ornn-web/src/pages/SkillsetDetailPage.test.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.test.tsx
@@ -136,8 +136,9 @@ describe("SkillsetDetailPage", () => {
     expect(screen.getByTestId("member-viewer")).toHaveTextContent("b@1.0");
     // Closure (flat list with a depth-1 dependency).
     expect(screen.getByTestId("closure-list")).toHaveTextContent("a-dep");
-    // Visibility — private, with the shared-with count.
-    expect(screen.getByText(/Shared with 1 users/)).toBeInTheDocument();
+    // Visibility card (exact same as skill details) — shows user/org counts.
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText(/users/i)).toBeInTheDocument();
   });
 
   it("shows owner actions (Edit + Delete) for the author", () => {

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -266,10 +266,10 @@ export function SkillsetDetailPage() {
                 </dl>
               </section>
 
-              {/* Versions card in right rail (moved from top hero, matching skill details page) */}
+              {/* ── Versions card ── exact visual match to skill details page's SkillVersionsCard */}
               {versions.length > 0 && (
                 <RailCard
-                  title={t("skillsetDetail.versionsCount", "Versions")}
+                  title={t("skillDetail.cardVersions", "Versions")}
                   icon={
                     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
                       <path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4a2 2 0 0 0 1-1.7z" />
@@ -278,11 +278,32 @@ export function SkillsetDetailPage() {
                     </svg>
                   }
                 >
-                  <VersionPicker
-                    versions={versions}
-                    currentVersion={skillset.version}
-                    onChange={handleVersionChange}
-                  />
+                  <div className="mb-1.5 flex items-baseline gap-2">
+                    <span className="font-display text-2xl font-semibold tracking-tight text-strong">
+                      {skillset.version}
+                    </span>
+                    {skillset.version === latestVersion && (
+                      <span className="rounded-sm border border-accent/40 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-accent">
+                        {t("skillDetail.latest", "latest")}
+                      </span>
+                    )}
+                  </div>
+                  <p className="font-mono text-[11px] leading-relaxed tracking-wide text-meta">
+                    {t("skillDetail.heroPublishedOn", "Published {{date}}", { date: formatDateSGT(skillset.createdOn, i18n.language) })}
+                    {versions.length > 1 && (
+                      <>
+                        {" · "}
+                        {t("skillDetail.versionsTotal", "{{n}} versions total", { n: versions.length })}
+                      </>
+                    )}
+                  </p>
+                  <div className="mt-3.5 flex flex-col gap-2">
+                    <VersionPicker
+                      versions={versions}
+                      currentVersion={skillset.version}
+                      onChange={handleVersionChange}
+                    />
+                  </div>
                 </RailCard>
               )}
 

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { RailCard } from "@/components/detail/RailCard";
 import { ReadmeViewer } from "@/components/skill/ReadmeViewer";
+import { SkillVisibilityCard } from "@/components/skill/SkillVisibilityCard";
 import { VersionPicker } from "@/components/skill/VersionPicker";
 import { SkillsetHeroStrip } from "@/components/skillset/SkillsetHeroStrip";
 import { SkillsetClosureViewer } from "@/components/skillset/SkillsetClosureViewer";
@@ -126,21 +127,11 @@ export function SkillsetDetailPage() {
             <BackLink label={t("common.back", "Back")} />
           </nav>
 
-          {/* Hero — name, kind, visibility, version picker, owner actions. */}
+          {/* Hero — name, kind, visibility, owner actions (edit only; version moved to right rail card). */}
           <SkillsetHeroStrip
             skillset={skillset}
             isOwner={isOwner}
-            versionPicker={
-              versions.length > 0 ? (
-                <VersionPicker
-                  versions={versions}
-                  currentVersion={skillset.version}
-                  onChange={handleVersionChange}
-                />
-              ) : undefined
-            }
             onEdit={isOwner ? () => navigate(`/skillsets/${skillset.guid}/edit`) : undefined}
-            onManagePermissions={isOwner ? () => setShowPermissions(true) : undefined}
           />
 
           {/* Consensus claim disclaimer (consensus-supported kind only). */}
@@ -167,7 +158,7 @@ export function SkillsetDetailPage() {
             }
           >
             {skillset.instructions ? (
-              <div className="max-h-64 overflow-y-auto">
+              <div className="max-h-64 overflow-y-auto text-[13px] leading-[1.55]">
                 <ReadmeViewer content={skillset.instructions} />
               </div>
             ) : (
@@ -206,8 +197,17 @@ export function SkillsetDetailPage() {
             </div>
 
             <aside className="flex flex-col gap-4 lg:w-[320px] lg:shrink-0">
-              {/* Metadata. */}
-              <RailCard title={t("skillsetDetail.metadata", "Metadata")}>
+              {/* ── Metadata card ── matches skill details page styling/structure */}
+              <section className="rounded-md border border-subtle bg-card p-5 card-impression">
+                <h3 className="mb-3.5 flex items-center gap-2 border-b border-dashed border-subtle pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                    <line x1="3" y1="6" x2="21" y2="6" />
+                    <line x1="3" y1="12" x2="21" y2="12" />
+                    <line x1="3" y1="18" x2="21" y2="18" />
+                  </svg>
+                  {t("skillsetDetail.metadata", "Metadata")}
+                </h3>
+
                 <dl className="space-y-2.5 font-text text-sm text-body">
                   <div className="flex items-baseline justify-between gap-2">
                     <dt className="font-mono text-[10px] uppercase tracking-widest text-meta">
@@ -264,11 +264,33 @@ export function SkillsetDetailPage() {
                     </dd>
                   </div>
                 </dl>
-              </RailCard>
+              </section>
 
-              {/* Resolved closure — flat depth-indented list. */}
+              {/* Versions card in right rail (moved from top hero, matching skill details page) */}
+              {versions.length > 0 && (
+                <RailCard
+                  title={t("skillsetDetail.versionsCount", "Versions")}
+                  icon={
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                      <path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4a2 2 0 0 0 1-1.7z" />
+                      <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+                      <line x1="12" y1="22.08" x2="12" y2="12" />
+                    </svg>
+                  }
+                >
+                  <VersionPicker
+                    versions={versions}
+                    currentVersion={skillset.version}
+                    onChange={handleVersionChange}
+                  />
+                </RailCard>
+              )}
+
+              {/* Closure (renamed from "Resolved closure") — the complete flattened list of
+                  direct members + all their transitive dependencies (topo-sorted for install).
+                  "Closure" is the standard term for the fully expanded dependency set. */}
               <RailCard
-                title={t("skillsetDetail.resolvedClosure", "Resolved closure")}
+                title={t("skillsetDetail.resolvedClosure", "Closure")}
                 icon={
                   <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
                     <line x1="8" y1="6" x2="21" y2="6" />
@@ -283,36 +305,26 @@ export function SkillsetDetailPage() {
                 <SkillsetClosureViewer items={closure?.items ?? []} />
               </RailCard>
 
-              {/* Visibility — owner sees grant counts + manage. */}
-              <RailCard title={t("skillsetDetail.visibility", "Visibility")}>
-                <p className="font-text text-sm text-body">
-                  {skillset.isPrivate
-                    ? t("skillsetDetail.visPrivate", "Private")
-                    : t("skillsetDetail.visPublic", "Public")}
-                </p>
-                {skillset.isPrivate && (
-                  <p className="mt-1 font-mono text-[11px] text-meta">
-                    {t("skillsetDetail.sharedWith", "Shared with {{users}} users · {{orgs}} orgs", {
-                      users: skillset.sharedWithUsers.length,
-                      orgs: skillset.sharedWithOrgs.length,
-                    })}
-                  </p>
-                )}
-                {isOwner && (
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="mt-3 w-full"
-                    onClick={() => setShowPermissions(true)}
-                  >
-                    {t("skillsetDetail.managePermissions", "Permissions")}
-                  </Button>
-                )}
-              </RailCard>
+              {/* ── Visibility card ── use the exact same component as skill details for visual parity */}
+              <SkillVisibilityCard
+                isPrivate={skillset.isPrivate}
+                sharedWithUsersCount={skillset.sharedWithUsers.length}
+                sharedWithOrgsCount={skillset.sharedWithOrgs.length}
+                isOwner={isOwner}
+                onManagePermissions={() => setShowPermissions(true)}
+              />
 
-              {/* Danger zone (owner only). */}
+              {/* ── Danger zone (owner only) ── matches skill details page exactly in structure/styling */}
               {isOwner && (
-                <RailCard title={t("skillsetDetail.dangerZone", "Danger zone")} tone="danger">
+                <section className="rounded-md border border-subtle bg-card p-5 card-impression">
+                  <h3 className="mb-3.5 flex items-center gap-2 border-b border-dashed border-danger/30 pb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-danger">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                      <line x1="12" y1="9" x2="12" y2="13" />
+                      <line x1="12" y1="17" x2="12.01" y2="17" />
+                    </svg>
+                    {t("skillsetDetail.dangerZone", "Danger zone")}
+                  </h3>
                   <p className="mb-3 font-mono text-[11px] leading-relaxed text-meta">
                     {t(
                       "skillsetDetail.dangerExplain",
@@ -327,7 +339,7 @@ export function SkillsetDetailPage() {
                   >
                     {t("skillsetDetail.deleteSkillset", "Delete skillset")}
                   </Button>
-                </RailCard>
+                </section>
               )}
             </aside>
           </main>

--- a/ornn-web/src/pages/SkillsetExplorePage.test.tsx
+++ b/ornn-web/src/pages/SkillsetExplorePage.test.tsx
@@ -171,8 +171,8 @@ describe("SkillsetExplorePage tabs + filters", () => {
       </MemoryRouter>,
     );
     expect(screen.getByText("mine-set")).toBeInTheDocument();
-    // No "Public" tab button when pinned.
-    expect(screen.queryByRole("button", { name: "Public" })).not.toBeInTheDocument();
+    // No "Public Skillsets" tab button when pinned.
+    expect(screen.queryByRole("button", { name: "Public Skillsets" })).not.toBeInTheDocument();
     expect(mineHook).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
   });
 });

--- a/ornn-web/src/pages/SkillsetExplorePage.tsx
+++ b/ornn-web/src/pages/SkillsetExplorePage.tsx
@@ -5,15 +5,15 @@
  * a left filter `aside` built from `RegistrySidebar` primitives, and the shared
  * `RegistryGrid` for the cards + pagination.
  *
- * Three tabs via `?scope`: Public · Mine · Shared with me. A keyword box (`?q`,
+ * Three tabs via `?scope`: Public Skillsets · My Skillsets · Shared with me. A keyword box (`?q`,
  * case-insensitive substring on name + description — keyword-only, no semantic
  * mode) sits above a Kind + Tags filter sidebar. Kind is a chip section; Tags
  * are typed inline and shown as removable chips. Everything is URL-encoded so a
  * filtered view is copy-pasteable.
  *
- *   Public         → anyone (anon + authed)
- *   Mine           → authed only
- *   Shared with me → authed only
+ *   Public Skillsets → anyone (anon + authed)
+ *   My Skillsets     → authed only
+ *   Shared with me   → authed only
  *
  * When `pinScope` is set (the /my-skillsets wrapper passes "mine"), the tab
  * strip is hidden and the page renders that single scope.
@@ -117,10 +117,10 @@ export function SkillsetExplorePage({ pinScope }: SkillsetExplorePageProps = {})
   // auth. No counts — the skillset search surface doesn't return per-scope
   // totals the way the skill counts endpoint does.
   const tabs: RegistryTab[] = [
-    { id: "public", label: t("skillsetExplore.publicTab", "Public") },
+    { id: "public", label: t("skillsetExplore.publicTab", "Public Skillsets") },
     ...(isAuthenticated
       ? [
-          { id: "mine", label: t("skillsetExplore.mineTab", "Mine") },
+          { id: "mine", label: t("skillsetExplore.mineTab", "My Skillsets") },
           {
             id: "shared-with-me",
             label: t("skillsetExplore.sharedTab", "Shared with me"),

--- a/ornn-web/src/styles/neon.css
+++ b/ornn-web/src/styles/neon.css
@@ -482,6 +482,18 @@ html {
 .markdown-body h2 { font-size: 1.5rem; }
 .markdown-body h3 { font-size: 1.25rem; }
 
+/* Compact master prompt on skillset detail page (#1084): much smaller body + headings
+   so the instructions don't dominate vertical space in the RailCard. */
+.text-\[13px\] .markdown-body,
+.text-\[13px\] .markdown-body p,
+.text-\[13px\] .markdown-body li {
+  font-size: inherit;
+  line-height: inherit;
+}
+.text-\[13px\] .markdown-body h1 { font-size: 1.05rem; }
+.text-\[13px\] .markdown-body h2 { font-size: 0.95rem; }
+.text-\[13px\] .markdown-body h3 { font-size: 0.875rem; }
+
 .markdown-body p {
   margin-bottom: 1em;
 }

--- a/skills/chrono-ai-service-manual/SKILL.md
+++ b/skills/chrono-ai-service-manual/SKILL.md
@@ -11,8 +11,8 @@ metadata:
     - manual
     - identity
     - skill-lifecycle
-version: "1.0"
-lastUpdated: 2026-05-04
+version: "1.1"
+lastUpdated: 2026-06-11
 ---
 
 # Chrono AI Service Manual
@@ -63,6 +63,7 @@ lastUpdated: 2026-05-04
 > - **Find skills** (by tag, author, system, shared, etc.) — §2.12.
 > - **Pull your Ornn notifications** (audit fan-out, etc.) — §2.13.
 > - **Link a skill to GitHub** or **trigger a sync** from the linked source — §2.14.
+> - **Work with skillsets** (curated bundles of skills + required master prompt / instructions for orchestration, one-call closure, kinds including consensus-supported) — §2.15.
 > - **Diagnose any failure** that involves NyxID, Ornn, the proxy, or token forwarding — §3.
 >
 > Without this manual loaded, you do not know which endpoint to call, how to authenticate, or how to read the response shapes.
@@ -529,7 +530,7 @@ Ornn is the skill lifecycle layer. Every endpoint below is reached **through Nyx
 
 > Through the rest of §2, the **CLI form** is shown — it's the canonical recipe. The **HTTP form** is identical except for wrapping; substitute as documented in §0.6 and `references/ornn-api-reference.md`. Per-endpoint contracts (request body, full response shape, every error code) live in `references/ornn-api-reference.md` — pull it whenever you need the exact spec.
 
-You (the agent) are **highly encouraged to connect with Ornn for any skill-related operation**, including but not limited to the fourteen use cases below. Each is a recipe — read top-to-bottom and execute the calls in order.
+You (the agent) are **highly encouraged to connect with Ornn for any skill-related operation**, including but not limited to the use cases below (now including skillsets). Each is a recipe — read top-to-bottom and execute the calls in order.
 
 ### 2.1 Performing a task — find or build the right skill — *spec: `ornn-api-reference.md` §3, §5, §6, §7, §8*
 
@@ -883,6 +884,113 @@ Response: refreshed `SkillDetail`. `source.lastSyncedAt` and `source.lastSyncedC
 - `NO_SOURCE` (400) on flow C — no link attached. Run flow B first.
 - `REFRESH_FAILED` / `REFRESH_PREVIEW_FAILED` (400) — upstream folder gone or pulled package failed validation. Retry with `skipValidation: true` if you trust upstream.
 - `NOT_SKILL_OWNER` (403) — caller isn't the author and lacks `ornn:admin:skill`.
+
+---
+
+### 2.15 Work with skillsets (curated bundles + master prompts) — *spec: `ornn-api-reference.md` §5a*
+
+A **skillset** is a named, versioned, owned, visibility-scoped meta-package over 2..N member skills. It carries:
+
+- A required per-version **master prompt** (`instructions`, 1..8000 chars) — the authoritative instructions telling an agent *how* to use the set (orchestration order, when to pick which member, composition rules). This is surfaced verbatim on detail reads and as a root sibling on the closure response.
+- `kind`: `"generic"` (default) or `"consensus-supported"` (author's claim that the members form a coherent, comparable set suitable for agent-side consensus/bake-off; Ornn only delivers the bundle — the agent runs any consensus logic itself).
+- `members`: 2..N refs using the exact same grammar as skill `depends-on` (`<name-or-guid>@<major.minor>` or `<name>@<dist-tag>`). No nested skillsets in v1.
+
+All ownership, visibility, and immutable versioning rules are identical to skills. Permission scopes are currently reused (`ornn:skill:{create,read,update,delete}`); a dedicated split is a tracked follow-up.
+
+**One-call delivery:** `GET /skillsets/:idOrName/closure?version=...` returns the union of the declared members **plus** each member's full transitive dependency closure (deduped, topo-sorted deps-first) **plus** the version's `instructions` at the root of the envelope. Same conflict/cycle/not-found errors as skill closures (`dependency_conflict`, `dependency_cycle`, `skill_dependency_not_found`).
+
+#### Search skillsets
+```bash
+# Keyword + filters (kind, tags, scope). No semantic ranking.
+nyxid proxy request ornn-api \
+  "/api/v1/skillset-search?kind=consensus-supported&tags=review,consensus&scope=mixed&pageSize=20" \
+  --method GET --output json
+```
+(See `references/ornn-api-reference.md` §5a.8 for all filters and the `SkillsetSearchItem` shape.)
+
+#### Inspect a skillset (gets the current `instructions` + member list)
+```bash
+nyxid proxy request ornn-api \
+  "/api/v1/skillsets/<name-or-guid>" \
+  --method GET --output json
+
+# Specific version
+nyxid proxy request ornn-api \
+  "/api/v1/skillsets/<name-or-guid>?version=1.2" \
+  --method GET --output json
+```
+
+#### Resolve the full deliverable (the main agent entry point)
+```bash
+nyxid proxy request ornn-api \
+  "/api/v1/skillsets/<name-or-guid>/closure" \
+  --method GET --output json
+```
+Response shape (note `instructions` at the same level as `items`):
+```jsonc
+{
+  "data": {
+    "instructions": "Run pdf-tools first to extract tables, then feed the CSV output to csv-processor. Use consensus across members for the final verdict.",
+    "items": [ /* topo-sorted ClosureNode[] — every member + their full dep trees */ ]
+  },
+  "error": null
+}
+```
+Use the `instructions` to drive your orchestration. The `items` give you every concrete skill package you may need to pull.
+
+#### Create a new skillset (private by default)
+```bash
+nyxid proxy request ornn-api "/api/v1/skillsets" \
+  --method POST \
+  --data '{
+    "name": "review-consensus-set",
+    "description": "Independent reviewers for document QA.",
+    "instructions": "1. Run pdf-tools to extract text/tables.\n2. Run text-summarizer on the extracted content.\n3. Run csv-processor if tabular data is present.\n4. Cross-validate outputs; surface disagreements to the user.",
+    "kind": "consensus-supported",
+    "tags": ["review", "consensus"],
+    "members": ["pdf-tools@1.0", "text-summarizer@2.1", "csv-processor@1.3"],
+    "version": "1.0"
+  }' \
+  --output json
+```
+`instructions` is **mandatory**. Validation happens before the write (members must resolve and produce a conflict-free union closure).
+
+#### Publish a new version (must re-supply `instructions`)
+```bash
+nyxid proxy request ornn-api "/api/v1/skillsets/<guid>" \
+  --method PUT \
+  --data '{
+    "members": ["pdf-tools@1.1", "text-summarizer@2.1", "csv-processor@1.3"],
+    "version": "1.1",
+    "instructions": "Updated flow: pdf-tools → text-summarizer (v2.1 handles longer inputs) → csv-processor. Consensus across all three for the final answer.",
+    "description": "Independent reviewers for document QA (v1.1).",
+    "kind": "consensus-supported",
+    "tags": ["review", "consensus"]
+  }' \
+  --output json
+```
+Prior versions are immutable. Re-using an existing `version` string returns `skillset_version_exists`.
+
+#### Permissions / visibility (identical to skills)
+```bash
+# Make public
+nyxid proxy request ornn-api "/api/v1/skillsets/<guid>/permissions" \
+  --method PUT \
+  --data '{"isPrivate":false,"sharedWithUsers":[],"sharedWithOrgs":[]}' \
+  --output json
+
+# Limited or private — same shape as skills /permissions
+```
+
+#### Delete
+```bash
+nyxid proxy request ornn-api "/api/v1/skillsets/<guid>" --method DELETE --output json
+```
+Cascades all versions. Irreversible.
+
+**SDK helpers** (when available in your runtime): `createSkillset`, `getSkillset`, `publishSkillset`, `getSkillsetClosure` / `resolve_skillset_closure`, `searchSkillsets`, etc.
+
+After creating/publishing a skillset you own, treat it like any other Ornn skill for local install tracking in `~/.ornn/installed-skills.json` (use the skillset name/guid + the version you resolved).
 
 ---
 

--- a/skills/ornn-agent-manual-cli/SKILL.md
+++ b/skills/ornn-agent-manual-cli/SKILL.md
@@ -9,8 +9,8 @@ metadata:
     - manual
     - skill-lifecycle
     - cli
-version: "1.2"
-lastUpdated: 2026-05-14
+version: "1.3"
+lastUpdated: 2026-06-11
 ---
 
 # Agent Manual (NyxID CLI variant)
@@ -48,6 +48,7 @@ lastUpdated: 2026-05-14
 > - **Pull your Ornn notifications** (audit fan-out, broadcasts, etc.) — §2.13.
 > - **Link a skill to GitHub** or **trigger a sync** from the linked source — §2.14.
 > - **Check your monthly quota** or **pick a valid LLM model** before calling an SSE endpoint — §2.15.
+> - **Work with skillsets** (curated bundles + required master prompt / instructions, one-call closure) — §2.16.
 >
 > Without this manual loaded, you do not know which endpoint to call, how to authenticate, or how to read the response shapes.
 >
@@ -722,3 +723,20 @@ Quota refills automatically at `nextMonthlyResetAt`. If a user is low and needs 
 - `GET /api/v1/announcements/active` — public, anonymous platform-wide notice (separate from `/notifications`). Useful when you want to know about maintenance windows or pricing changes before kicking off long workflows.
 
 If you find a discrepancy between this manual and the actual API behaviour, the API is right and the manual is stale — re-pull the skill (§0) before assuming a bug.
+
+### 2.16 Work with skillsets (curated bundles + master prompts)
+
+See the authoritative recipes and examples in the preferred unified manual `chrono-ai-service-manual` §2.15 (or pull its `references/ornn-api-reference.md` §5a for the exact contract).
+
+Quick hits (all via `nyxid proxy request ornn-api` or direct HTTPS with NyxID bearer):
+
+- Search: `/api/v1/skillset-search?kind=consensus-supported&tags=...&scope=mixed`
+- Detail (includes current `instructions`): `GET /api/v1/skillsets/<name-or-guid>`
+- One-call closure (the main agent payload): `GET /api/v1/skillsets/<name-or-guid>/closure` → `{ instructions: "…", items: [...] }`
+- Create: `POST /api/v1/skillsets` (body requires `instructions`; members 2..N using the same ref grammar as `depends-on`).
+- Publish new version: `PUT /api/v1/skillsets/<id>` (re-supply `instructions` — no carry-forward).
+- Permissions and delete mirror the skill endpoints exactly (reuse `ornn:skill:*` scopes today).
+
+`kind: "consensus-supported"` is an author claim only. Ornn validates member existence + conflict-free union closure at publish time and on `/closure`.
+
+After operating on a skillset you authored, update `~/.ornn/installed-skills.json` exactly as you would for a skill.


### PR DESCRIPTION
## Summary
Implements several UI refinements on the skillset details page for better agent-facing experience and visual parity with the skill details page (per direct request):

- Smaller font size for content under the Closure card.
- Renamed "Resolved closure" → "Closure" (with explanation: the complete flattened list of direct members + all transitive dependencies, topo-sorted for install order. Matches API /closure terminology).
- Each member in the MemberViewer is now clickable (name links to the corresponding skill's details page `/skills/<name>` while preserving the package preview on row click).
- Top hero card (SkillsetHeroStrip): removed the Permissions button (only Edit remains for owners). Permissions is still accessible via the Visibility card.
- Removed version pill from hero status pills.
- Moved the version part (VersionPicker) to the right rail as a dedicated "Versions" card (using RailCard + same icon pattern as SkillVersionsCard on the skill details page). Matches the layout and card style used on skill details (right-rail versions handling).

Also includes earlier related polish from the session (tab labels, master prompt font shrink, visibility/metadata/danger cards now exactly matching skill details structure/styling via shared components and copied markup).

## Changes
- Small self-contained commits on feature/skillset-work (from latest develop at the time).
- Includes required changeset.

## Testing
- `bunx vitest run ...SkillsetDetailPage.test.tsx` passes.
- Follows DESIGN.md, CONVENTIONS, and local k8s deploy process.
- Will be deployed from latest origin/develop after merge.

Closes the UI requests in the thread.