### PR TITLE
Modern Forge card nodes + arc edges + blueprint grid for the dependency graph

### DIFF
--- a/.changeset/skillset-graph-modern.md
+++ b/.changeset/skillset-graph-modern.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Modernize the member-dependency graph (#1092): replace react-flow's plain box nodes with a custom Forge card node — a code-glyph icon (arc-blue) + skill name + version, hairline border, letterpress hard-offset shadow, ember border on hover/selected. The read-only detail-page graph now also gets directed arc-blue edges with arrowheads (previously unstyled), and both the editor and read-only canvases gain a faint blueprint grid + vignette. Tokens-only per DESIGN.md (arc-blue diagrammatic accent, ember action accent, letterpress — no soft glow or gradient).

--- a/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
+++ b/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
@@ -37,19 +37,21 @@
  * @module components/skillset/SkillsetDependencyGraphCanvas
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ReactFlow,
   Background,
   BackgroundVariant,
   Controls,
+  Handle,
   useNodesState,
   Position,
   MarkerType,
   ConnectionLineType,
   ConnectionMode,
   type Node,
+  type NodeProps,
   type Edge as FlowEdge,
   type Connection,
 } from "@xyflow/react";
@@ -190,6 +192,45 @@ const CONNECTION_LINE_STYLE = { strokeWidth: 2 } as const;
 const PRO_OPTIONS = { hideAttribution: true } as const;
 const DELETE_KEYS = ["Backspace", "Delete"];
 
+/** Code-glyph icon for a member skill card (arc-blue, set in CSS). */
+const MEMBER_NODE_ICON = (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <polyline points="16 18 22 12 16 6" />
+    <polyline points="8 6 2 12 8 18" />
+  </svg>
+);
+
+/**
+ * Custom Forge "card" node (#1092): a code-glyph icon + the skill name + its
+ * version, with left(target)/right(source) connection handles. The card chrome
+ * (letterpress hard-offset shadow, hover/selected ember border) lives in
+ * skillset-depgraph-canvas.css — this just lays out the content. Replaces
+ * react-flow's plain default box node on both the editor + read-only canvas.
+ */
+const MemberSkillNode = memo(function MemberSkillNode({ data }: NodeProps) {
+  const { name, version } = data as { name: string; version?: string };
+  return (
+    <div className="depgraph-node flex w-[186px] items-center gap-2.5 rounded-lg border border-subtle bg-card px-3 py-2">
+      <Handle type="target" position={Position.Left} />
+      <span className="depgraph-node-icon flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-md border border-strong-edge bg-elevated">
+        {MEMBER_NODE_ICON}
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate font-mono text-[12.5px] font-semibold leading-tight text-strong">
+          {name}
+        </span>
+        {version && (
+          <span className="mt-0.5 block font-mono text-[10px] leading-none text-meta">v{version}</span>
+        )}
+      </span>
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+});
+
+/** Stable nodeTypes map (module-level so react-flow doesn't re-init per render). */
+const NODE_TYPES = { memberSkill: MemberSkillNode };
+
 /**
  * Build react-flow nodes for `members` at their topo-column slots, oriented for
  * a left→right flow (source handle right, target handle left). Used for the
@@ -204,8 +245,9 @@ function buildNodes(members: string[], columns: Map<string, number>): Node[] {
     const { name, version } = refLabel(ref);
     return {
       id: ref,
+      type: "memberSkill",
       position: { x: col * COL_GAP, y: row * ROW_GAP },
-      data: { label: version ? `${name}@${version}` : name },
+      data: { name, version, label: version ? `${name}@${version}` : name },
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
     } satisfies Node;
@@ -329,10 +371,12 @@ export function SkillsetDependencyGraphCanvas({
         <ReactFlow
           nodes={staticNodes}
           edges={readOnlyFlowEdges}
+          nodeTypes={NODE_TYPES}
+          defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
           onNodeMouseEnter={(event, node) => {
             if (onHoverMember && node?.id) {
-              const pos = event && typeof event.clientX === 'number' 
-                ? { clientX: event.clientX, clientY: event.clientY } 
+              const pos = event && typeof event.clientX === 'number'
+                ? { clientX: event.clientX, clientY: event.clientY }
                 : undefined;
               onHoverMember(node.id, pos);
             }
@@ -348,7 +392,7 @@ export function SkillsetDependencyGraphCanvas({
           zoomOnScroll
           preventScrolling={false}
         >
-          <Background variant={BackgroundVariant.Dots} />
+          <Background variant={BackgroundVariant.Lines} gap={26} color="var(--color-border-subtle)" />
         </ReactFlow>
       </div>
     );
@@ -405,6 +449,7 @@ export function SkillsetDependencyGraphCanvas({
         <ReactFlow
           nodes={nodes}
           edges={flowEdges}
+          nodeTypes={NODE_TYPES}
           onNodesChange={onNodesChange}
           onConnect={onConnect}
           onEdgesDelete={onEdgesDelete}
@@ -425,7 +470,7 @@ export function SkillsetDependencyGraphCanvas({
           preventScrolling={false}
           proOptions={PRO_OPTIONS}
         >
-          <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
+          <Background variant={BackgroundVariant.Lines} gap={26} color="var(--color-border-subtle)" />
           {/* bottom-LEFT so the cluster never overlaps a node's right-edge
               (source) handle — the primary drag-to-connect grab target. */}
           <Controls showInteractive={false} position="bottom-left" />

--- a/ornn-web/src/components/skillset/skillset-depgraph-canvas.css
+++ b/ornn-web/src/components/skillset/skillset-depgraph-canvas.css
@@ -69,21 +69,50 @@
 /* Directed-edge arrowhead color is set via markerEnd.color in the component
    (v12 paints it as an inline fill that beats CSS), so no rule is needed here. */
 
-/* Modern nodes: rounded card with letterpress impression (per DESIGN.md),
-   smooth hover without blink/shift. Use hard offset shadow for "pressed" feel.
-   Larger effective size via padding on inner content. */
+/* ── Custom Forge card node (#1092) ───────────────────────────────────────
+   The node's whole visual is the inner `.depgraph-node` card (Tailwind:
+   bg-card + border + rounded). Strip react-flow's wrapper frame so there's no
+   double border/shadow; the transform transition above stays for the tween. */
 .skillset-depgraph-canvas .react-flow__node {
-  border-radius: 6px;
-  box-shadow: 2px 2px 0 0 var(--color-shadow-press);
-  transition: box-shadow 120ms ease, border-color 120ms ease;
-  font-size: 12px;
-  line-height: 1.3;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+  padding: 0;
 }
 
-/* Stronger, attractive hover: ember glow ring + slight lift, no layout shift. */
-.skillset-depgraph-canvas .react-flow__node:hover {
-  box-shadow: 0 0 0 2px var(--color-accent), 3px 3px 0 0 var(--color-shadow-press);
+/* The member-skill card — letterpress hard-offset impression (DESIGN.md: never
+   a soft glow), smooth hover/selected to an ember border with no layout shift. */
+.skillset-depgraph-canvas .depgraph-node {
+  box-shadow: 3px 3px 0 0 var(--color-shadow-press);
+  transition: box-shadow 120ms ease, border-color 120ms ease;
+}
+.skillset-depgraph-canvas .react-flow__node:hover .depgraph-node,
+.skillset-depgraph-canvas .react-flow__node.selected .depgraph-node {
   border-color: var(--color-accent);
+  box-shadow: 0 0 0 1.5px var(--color-accent), 4px 4px 0 0 var(--color-shadow-press);
+}
+
+/* Code-glyph icon — arc-blue diagrammatic accent (restricted role per DESIGN). */
+.skillset-depgraph-canvas .depgraph-node-icon {
+  color: var(--color-accent-secondary);
+}
+
+/* Blueprint canvas: dark drafting base + a subtle center→edge vignette so the
+   faint react-flow Lines grid reads as a drafting surface and the diagram
+   stays the focus. */
+.skillset-depgraph-canvas {
+  position: relative;
+}
+.skillset-depgraph-canvas .react-flow {
+  background-color: var(--color-page);
+}
+.skillset-depgraph-canvas::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(ellipse at center, transparent 45%, var(--color-page) 100%);
 }
 
 /* Edges: thicker base for presence, arc color, smooth hover thicken.


### PR DESCRIPTION
Closes #1092

Makes the member-dependency graph (react-flow canvas) more modern + attractive, in the Editorial Forge language. Frontend-only.

## Changes
- **Custom `MemberSkillNode`** (`nodeTypes`): a Forge card — code-glyph icon (arc-blue) + skill name (mono, strong) + version (meta), hairline border, **letterpress** hard-offset shadow, **ember** border on hover/selected. Replaces react-flow's plain default box on both the editor + read-only canvas.
- **Directed arc edges on the read-only detail graph**: it previously rendered *unstyled default edges* (no arrowheads) — now uses the same `defaultEdgeOptions` as the editor (smoothstep + arc-blue `ArrowClosed`), arc-blue handles.
- **Blueprint grid**: faint react-flow `Lines` grid + a center→edge vignette on a dark page base, replacing the plain dots.
- Tokens-only per DESIGN.md (arc-blue = diagrammatic accent, ember = action, letterpress — no soft glow / gradient).

## Verification
ROOT lint 0 · typecheck 0 · build 0 · web vitest 552 (78 files; grep-guard + token-guard green). The visual was validated against an offline HTML mock (the live react-flow graph is behind auth, so confirm in-browser after deploy).

Follow-up to #1091.