### PR TITLE
Graph: animated edges, 'runs before' labels, read-only zoom, hover-popup fix

### DIFF
--- a/.changeset/skillset-graph-edges.md
+++ b/.changeset/skillset-graph-edges.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Dependency graph polish (#1094): the arc-blue edges now animate with a gentle flowing dash and carry a "runs before" label pill so the relationship direction is legible at a glance; the read-only detail-page graph gains zoom in/out/fit controls; and the on-hover package-preview dialog is bigger and no longer vanishes when you move the cursor toward it (a grace timer bridges the node→dialog gap and the dialog stays open while hovered).

--- a/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
+++ b/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
@@ -177,6 +177,8 @@ const ROW_GAP = 80;
 const FIT_VIEW_OPTIONS = { padding: 0.2, maxZoom: 1, duration: 200 } as const;
 const DEFAULT_EDGE_OPTIONS = {
   type: "smoothstep",
+  // Subtle flowing dash so the "runs before" direction reads as motion (#1094).
+  animated: true,
   // `color` is load-bearing: v12 paints the arrowhead with an INLINE fill that
   // overrides any CSS rule, falling back to stock grey (#b1b1b7) when absent.
   // Pin it to the arc-blue edge token so the marker matches the edge stroke and
@@ -187,6 +189,8 @@ const DEFAULT_EDGE_OPTIONS = {
     height: 16,
     color: "var(--color-accent-secondary)",
   },
+  // The "runs before" label pill is styled via CSS (.react-flow__edge-text /
+  // -textbg) with Forge tokens — see skillset-depgraph-canvas.css (#1094).
 } as const;
 const CONNECTION_LINE_STYLE = { strokeWidth: 2 } as const;
 const PRO_OPTIONS = { hideAttribution: true } as const;
@@ -282,6 +286,9 @@ export function SkillsetDependencyGraphCanvas({
 }: SkillsetDependencyGraphCanvasProps) {
   const { t } = useTranslation();
   const [source, setSource] = useState<string | null>(null);
+  // Relationship label rendered on every arrow: source "runs before" target (the
+  // canonical skillset-deps semantic). i18n; pill-styled via DEFAULT_EDGE_OPTIONS.
+  const edgeLabel = t("skillsetGraph.edgeLabel", "runs before");
 
   const cyclic = useMemo(() => hasCycle(members, edges), [members, edges]);
   const columns = useMemo(() => topoColumns(members, edges), [members, edges]);
@@ -302,8 +309,9 @@ export function SkillsetDependencyGraphCanvas({
         id: `${e.from}->${e.to}`,
         source: e.from,
         target: e.to,
+        label: edgeLabel,
       })),
-    [edges],
+    [edges, edgeLabel],
   );
 
   const onConnect = useCallback(
@@ -359,8 +367,9 @@ export function SkillsetDependencyGraphCanvas({
         id: `${e.from}->${e.to}`,
         source: e.from,
         target: e.to,
+        label: edgeLabel,
       })),
-    [edges]
+    [edges, edgeLabel]
   );
 
   if (readOnly) {
@@ -390,9 +399,13 @@ export function SkillsetDependencyGraphCanvas({
           elementsSelectable={false}
           panOnDrag
           zoomOnScroll
+          minZoom={0.4}
+          maxZoom={2}
           preventScrolling={false}
         >
           <Background variant={BackgroundVariant.Lines} gap={26} color="var(--color-border-subtle)" />
+          {/* Zoom in / out / fit on the read-only detail graph (#1094). */}
+          <Controls showInteractive={false} position="bottom-right" />
         </ReactFlow>
       </div>
     );

--- a/ornn-web/src/components/skillset/skillset-depgraph-canvas.css
+++ b/ornn-web/src/components/skillset/skillset-depgraph-canvas.css
@@ -127,6 +127,34 @@
   stroke-width: 3;
 }
 
+/* Animated edge flow (#1094): a slower, refined dash than react-flow's stock
+   0.5s/dash-5 so the "runs before" direction reads as gentle motion, not a
+   marketplace-y strobe. */
+.skillset-depgraph-canvas .react-flow__edge.animated .react-flow__edge-path {
+  stroke-dasharray: 7 5;
+  animation: depgraph-edge-flow 0.9s linear infinite;
+}
+@keyframes depgraph-edge-flow {
+  to {
+    stroke-dashoffset: -12;
+  }
+}
+
+/* "runs before" edge label (#1094) — arc-blue mono text on a card-chip pill so
+   the relationship is legible without opening the master prompt. */
+.skillset-depgraph-canvas .react-flow__edge-text {
+  fill: var(--color-accent-secondary);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+.skillset-depgraph-canvas .react-flow__edge-textbg {
+  fill: var(--color-card);
+  stroke: var(--color-border-subtle);
+  stroke-width: 1px;
+}
+
 /* Controls skin — on-brand, zero stock blue. */
 .skillset-depgraph-canvas .react-flow__controls {
   background: var(--color-card);

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -1788,6 +1788,7 @@
     "pickTarget": "Pick a target for {{ref}}…",
     "removeEdge": "Remove edge {{from}} → {{to}}",
     "tidy": "Tidy",
+    "edgeLabel": "runs before",
     "cycleWarning": "Members form a cycle — order is advisory.",
     "emptyReadonly": "No members to graph.",
     "emptyDeps": "No dependencies declared between members."

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -1788,6 +1788,7 @@
     "pickTarget": "为 {{ref}} 选择目标…",
     "removeEdge": "移除依赖边 {{from}} → {{to}}",
     "tidy": "整理",
+    "edgeLabel": "先于",
     "cycleWarning": "成员之间形成了环——执行顺序仅供参考。",
     "emptyReadonly": "没有可绘制的成员。",
     "emptyDeps": "成员之间未声明依赖关系。"

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -11,7 +11,7 @@
  * @module pages/SkillsetDetailPage
  */
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { PageTransition } from "@/components/layout/PageTransition";
@@ -69,11 +69,40 @@ export function SkillsetDetailPage() {
   const [hoveredMemberRef, setHoveredMemberRef] = useState<string | null>(null);
   const [hoveredPos, setHoveredPos] = useState<{ clientX: number; clientY: number } | null>(null);
 
-  // Stable callback so memoized graph doesn't re-render on every hover (prevents node blinking/flash).
-  const handleHoverMember = useCallback((ref: string | null, pos?: { clientX: number; clientY: number }) => {
-    setHoveredMemberRef(ref);
-    setHoveredPos(pos || null);
+  // Grace timer so the popup survives the gap between the node and the dialog:
+  // leaving a node SCHEDULES a close, but entering the popup cancels it (#1094 —
+  // previously the popup was "gone already" before the cursor reached it).
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelClose = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
   }, []);
+  const closePreview = useCallback(() => {
+    cancelClose();
+    setHoveredMemberRef(null);
+    setHoveredPos(null);
+  }, [cancelClose]);
+
+  // Stable callback so the memoized graph doesn't re-render on every hover.
+  const handleHoverMember = useCallback(
+    (ref: string | null, pos?: { clientX: number; clientY: number }) => {
+      if (ref) {
+        cancelClose();
+        setHoveredMemberRef(ref);
+        if (pos) setHoveredPos(pos);
+      } else {
+        // Left the node — let the cursor reach the dialog (~250ms) before close.
+        cancelClose();
+        closeTimer.current = setTimeout(() => {
+          setHoveredMemberRef(null);
+          setHoveredPos(null);
+        }, 250);
+      }
+    },
+    [cancelClose],
+  );
 
   // Two-id split: delete is GUID-only on the wire; cache cleanup keys on the
   // URL idOrName so the still-mounted detail page doesn't refetch → 404 (#940).
@@ -218,34 +247,31 @@ export function SkillsetDetailPage() {
                     SVG/Mermaid). Dismiss on mouseleave of the popup. */}
                 {hoveredMemberRef && hoveredPos && (
                   <div
-                    className="fixed z-[100] w-[460px] max-h-[420px] overflow-auto rounded-md border border-subtle bg-card card-impression p-3 text-sm shadow-xl"
+                    className="fixed z-[100] flex w-[600px] max-w-[calc(100vw-2rem)] max-h-[70vh] flex-col overflow-hidden rounded-md border border-subtle bg-card card-impression text-sm shadow-xl"
                     style={{
-                      left: (hoveredPos.clientX ?? 0) + 18,
-                      top: (hoveredPos.clientY ?? 0) + 8,
+                      left: Math.min((hoveredPos.clientX ?? 0) + 18, window.innerWidth - 616),
+                      top: Math.min((hoveredPos.clientY ?? 0) + 8, window.innerHeight - 120),
                     }}
-                    onMouseLeave={() => {
-                      setHoveredMemberRef(null);
-                      setHoveredPos(null);
-                    }}
+                    onMouseEnter={cancelClose}
+                    onMouseLeave={closePreview}
                   >
-                    <div className="mb-1.5 flex items-center justify-between font-mono text-[10px] text-meta">
-                      <span className="truncate font-medium">{hoveredMemberRef}</span>
+                    <div className="flex shrink-0 items-center justify-between border-b border-subtle px-3 py-2 font-mono text-[11px] text-meta">
+                      <span className="truncate font-medium text-strong">{hoveredMemberRef}</span>
                       <button
                         type="button"
-                        onClick={() => {
-                          setHoveredMemberRef(null);
-                          setHoveredPos(null);
-                        }}
-                        className="text-meta hover:text-danger"
+                        onClick={closePreview}
+                        className="ml-2 shrink-0 text-meta hover:text-danger"
                         aria-label="Close preview"
                       >
                         ×
                       </button>
                     </div>
-                    <SkillsetMemberViewer
-                      members={skillset.members}
-                      previewRef={hoveredMemberRef}
-                    />
+                    <div className="min-h-0 flex-1 overflow-auto p-2">
+                      <SkillsetMemberViewer
+                        members={skillset.members}
+                        previewRef={hoveredMemberRef}
+                      />
+                    </div>
                   </div>
                 )}
               </RailCard>


### PR DESCRIPTION
Closes #1094

Four graph-polish asks (follow-up to #1092/#1093). Frontend-only.

- **Animated edges** — arc-blue edges flow a gentle dash (`defaultEdgeOptions.animated` + a slower 0.9s/dash-7 CSS override so it's motion, not a strobe).
- **'runs before' edge labels** — every arrow shows the relationship (the canonical *source runs before target* semantic; i18n en/zh) as a Forge card-chip pill styled in CSS.
- **Read-only zoom controls** — the detail-page graph gains react-flow `Controls` (zoom in/out/fit) + bounded zoom; the editor already had them.
- **Hover popup fix** — the package-preview dialog is bigger (600px / 70vh, viewport-clamped) and no longer vanishes when you move the cursor toward it: a 250ms grace timer on node-leave is cancelled when the cursor enters the dialog (which stays open while hovered).

## Verification
ROOT lint 0 · typecheck 0 · build 0 · web vitest 552 (78 files; grep-guard + token-guard + i18n parity green). Edge label + animation validated against an offline HTML mock; the live react-flow render + the hover-popup behavior confirm in-browser after deploy.

Follow-up to #1093.