### PR TITLE
feat(web): skillset detail graph — fixed popup, node drag, independent pane scroll (#1100)

### DIFF
--- a/.changeset/warm-actors-call.md
+++ b/.changeset/warm-actors-call.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Fix skillset detail graph hover popup to 800×40vh with independent pane scroll; enable node drag for repositioning

--- a/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
+++ b/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
@@ -350,37 +350,16 @@ export function SkillsetDependencyGraphCanvas({
     });
   }, [members, edges, setNodes]);
 
-  // Read-only specific memos (also unconditional hooks for consistent hook order).
-  const staticNodes = useMemo(
-    () =>
-      buildNodes(members, columns).map((n) => ({
-        ...n,
-        draggable: false,
-        connectable: false,
-        selectable: false,
-      })),
-    [members, columns]
-  );
-  const readOnlyFlowEdges: FlowEdge[] = useMemo(
-    () =>
-      edges.map((e) => ({
-        id: `${e.from}->${e.to}`,
-        source: e.from,
-        target: e.to,
-        label: edgeLabel,
-      })),
-    [edges, edgeLabel]
-  );
-
   if (readOnly) {
-    // Read-only display for detail page: static topo layout, no editing, hover support
-    // for the package preview dialog.
+    // Read-only display for detail page: nodes are draggable for repositioning
+    // but no connect/edit. Hover support for the package preview dialog.
     return (
       <div className="skillset-depgraph-canvas h-full min-h-[200px] overflow-hidden rounded-sm border border-subtle bg-elevated/30">
         <ReactFlow
-          nodes={staticNodes}
-          edges={readOnlyFlowEdges}
+          nodes={nodes}
+          edges={flowEdges}
           nodeTypes={NODE_TYPES}
+          onNodesChange={onNodesChange}
           defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
           onNodeMouseEnter={(event, node) => {
             if (onHoverMember && node?.id) {
@@ -394,7 +373,6 @@ export function SkillsetDependencyGraphCanvas({
           fitView
           fitViewOptions={FIT_VIEW_OPTIONS}
           proOptions={PRO_OPTIONS}
-          nodesDraggable={false}
           nodesConnectable={false}
           elementsSelectable={false}
           panOnDrag

--- a/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
@@ -58,7 +58,7 @@ export function SkillsetMemberViewer({ members, previewRef }: SkillsetMemberView
 
   return (
     <section
-      className={`card-impression flex ${previewRef ? '' : 'h-[280px]'} flex-row overflow-hidden rounded border border-subtle bg-card`}
+      className={`card-impression flex ${previewRef ? 'h-full' : 'h-[280px]'} flex-row overflow-hidden rounded border border-subtle bg-card`}
       data-testid="skillset-member-viewer"
     >
       {/* Skills selector — a vertical list on the far LEFT (#1082), so the

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -247,9 +247,9 @@ export function SkillsetDetailPage() {
                     SVG/Mermaid). Dismiss on mouseleave of the popup. */}
                 {hoveredMemberRef && hoveredPos && (
                   <div
-                    className="fixed z-[100] flex w-[600px] max-w-[calc(100vw-2rem)] max-h-[70vh] flex-col overflow-hidden rounded-md border border-subtle bg-card card-impression text-sm shadow-xl"
+                    className="fixed z-[100] flex w-[800px] max-w-[calc(100vw-2rem)] h-[40vh] flex-col overflow-hidden rounded-md border border-subtle bg-card card-impression text-sm shadow-xl"
                     style={{
-                      left: Math.min((hoveredPos.clientX ?? 0) + 18, window.innerWidth - 616),
+                      left: Math.min((hoveredPos.clientX ?? 0) + 18, window.innerWidth - 816),
                       top: Math.min((hoveredPos.clientY ?? 0) + 8, window.innerHeight - 120),
                     }}
                     onMouseEnter={cancelClose}
@@ -266,7 +266,7 @@ export function SkillsetDetailPage() {
                         ×
                       </button>
                     </div>
-                    <div className="min-h-0 flex-1 overflow-auto p-2">
+                    <div className="min-h-0 flex-1 p-2">
                       <SkillsetMemberViewer
                         members={skillset.members}
                         previewRef={hoveredMemberRef}


### PR DESCRIPTION
## Changes

Three UX improvements to the skillset detail page dependency graph:

1. **Fixed popup dialog** — pinned to 800×40vh (wider + shorter than the previous 600×70vh). Content overflow scrolls within each pane independently instead of scrolling the whole dialog as one block.
2. **Node drag in read-only graph** — nodes on the detail page can now be dragged to rearrange. Positions persist for the session. Connect/edit remain disabled (still read-only).
3. **Independent pane scroll** — file tree and content viewer each scroll independently within the fixed popup.

## Commits

| Commit | Scope |
|--------|-------|
| `feat(web): fix graph hover popup to 800×40vh with independent pane scroll` | Popup sizing + scroll fix |
| `feat(web): enable node drag on skillset detail graph` | Node drag + member viewer height |
| `chore: add changeset for #1100` | Changeset |

Closes #1100