### PR TITLE
feat(web): landing popups, graph popup click-to-open, assistant position (#1100)

### DIFF
--- a/.changeset/nice-wolves-trade.md
+++ b/.changeset/nice-wolves-trade.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Restore landing announcement popups with glassmorphic style; skillset graph popup click-to-open with blurred backdrop; assistant mascot default position right-edge centered

--- a/ornn-web/src/App.tsx
+++ b/ornn-web/src/App.tsx
@@ -29,7 +29,6 @@ import { AdminLayout } from "@/components/layout/AdminLayout";
 import { AuthGuard } from "@/components/auth/AuthGuard";
 import { AdminGuard } from "@/components/auth/AdminGuard";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { AnnouncementBanner } from "@/components/announcements/AnnouncementBanner";
 import { HighlighterMarkFilter } from "@/pages/landing/HighlighterMark";
 import { VersionUpdateBanner } from "@/components/layout/VersionUpdateBanner";
 import { PostHogProvider } from "@/components/analytics/PostHogProvider";
@@ -55,8 +54,6 @@ function AnalyticsRoot() {
       <PostHogProvider />
       <Outlet />
       <CookieConsentBanner />
-      {/* Global announcement surface — top-right headline pill on every page. */}
-      <AnnouncementBanner />
       {!hideAssistant && <AssistantWidget />}
     </>
   );

--- a/ornn-web/src/components/assistant/AssistantWidget.tsx
+++ b/ornn-web/src/components/assistant/AssistantWidget.tsx
@@ -91,12 +91,12 @@ function clampLauncherPos(pos: Point, w = LAUNCHER_W, h = LAUNCHER_H): Point {
   };
 }
 
-/** Default resting position — bottom-right corner. */
+/** Default resting position — right edge, vertically centered. */
 function defaultLauncherPos(): Point {
   if (typeof window === "undefined") return { x: 0, y: 0 };
   return clampLauncherPos({
     x: window.innerWidth - LAUNCHER_W - EDGE_MARGIN,
-    y: window.innerHeight - LAUNCHER_H - EDGE_MARGIN,
+    y: (window.innerHeight - LAUNCHER_H) / 2,
   });
 }
 

--- a/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
+++ b/ornn-web/src/components/skillset/SkillsetDependencyGraphCanvas.tsx
@@ -71,8 +71,7 @@ export interface SkillsetDependencyGraphCanvasProps {
   onEdgesChange: (edges: Edge[]) => void;
   /** Display-only mode for detail page (no drag/connect/edit). */
   readOnly?: boolean | undefined;
-  /** Hover callback for nodes (used by detail page for package preview dialog).
-   *  Second arg is mouse position for cursor-follow popup. */
+  /** Click callback for nodes (used by detail page for package preview dialog). */
   onHoverMember?: ((ref: string | null, pos?: { clientX: number; clientY: number }) => void) | undefined;
 }
 
@@ -361,15 +360,11 @@ export function SkillsetDependencyGraphCanvas({
           nodeTypes={NODE_TYPES}
           onNodesChange={onNodesChange}
           defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
-          onNodeMouseEnter={(event, node) => {
+          onNodeClick={(_event, node) => {
             if (onHoverMember && node?.id) {
-              const pos = event && typeof event.clientX === 'number'
-                ? { clientX: event.clientX, clientY: event.clientY }
-                : undefined;
-              onHoverMember(node.id, pos);
+              onHoverMember(node.id);
             }
           }}
-          onNodeMouseLeave={() => onHoverMember?.(null)}
           fitView
           fitViewOptions={FIT_VIEW_OPTIONS}
           proOptions={PRO_OPTIONS}

--- a/ornn-web/src/pages/LandingPage.tsx
+++ b/ornn-web/src/pages/LandingPage.tsx
@@ -22,6 +22,8 @@ import { Navbar } from "@/components/layout/Navbar";
 import { HeroVideo } from "@/pages/landing/HeroVideo";
 import { LandingFooter } from "@/pages/landing/LandingFooter";
 import { LandingChrome } from "@/pages/landing/LandingChrome";
+import { AnnouncementPopup } from "@/pages/landing/AnnouncementPopup";
+import { LaunchCelebrationPopup } from "@/pages/landing/LaunchCelebrationPopup";
 
 export function LandingPage() {
   return (
@@ -37,6 +39,8 @@ export function LandingPage() {
         <HeroVideo />
       </main>
       <LandingFooter />
+      <AnnouncementPopup />
+      <LaunchCelebrationPopup />
     </div>
   );
 }

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -11,7 +11,7 @@
  * @module pages/SkillsetDetailPage
  */
 
-import { useState, useCallback, useMemo, useRef } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { PageTransition } from "@/components/layout/PageTransition";
@@ -64,44 +64,21 @@ export function SkillsetDetailPage() {
   const [showPermissions, setShowPermissions] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
 
-  // Hover state for graph nodes (now canvas-based). Shows floating preview dialog.
-  // Position tracks cursor for "beside my cursor" placement.
-  const [hoveredMemberRef, setHoveredMemberRef] = useState<string | null>(null);
-  const [hoveredPos, setHoveredPos] = useState<{ clientX: number; clientY: number } | null>(null);
+  // Click-to-open state for graph node package preview dialog.
+  const [previewMemberRef, setPreviewMemberRef] = useState<string | null>(null);
 
-  // Grace timer so the popup survives the gap between the node and the dialog:
-  // leaving a node SCHEDULES a close, but entering the popup cancels it (#1094 —
-  // previously the popup was "gone already" before the cursor reached it).
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cancelClose = useCallback(() => {
-    if (closeTimer.current) {
-      clearTimeout(closeTimer.current);
-      closeTimer.current = null;
-    }
-  }, []);
   const closePreview = useCallback(() => {
-    cancelClose();
-    setHoveredMemberRef(null);
-    setHoveredPos(null);
-  }, [cancelClose]);
+    setPreviewMemberRef(null);
+  }, []);
 
-  // Stable callback so the memoized graph doesn't re-render on every hover.
-  const handleHoverMember = useCallback(
-    (ref: string | null, pos?: { clientX: number; clientY: number }) => {
+  // Stable callback so the memoized graph doesn't re-render on every click.
+  const handleClickMember = useCallback(
+    (ref: string | null, _pos?: { clientX: number; clientY: number }) => {
       if (ref) {
-        cancelClose();
-        setHoveredMemberRef(ref);
-        if (pos) setHoveredPos(pos);
-      } else {
-        // Left the node — let the cursor reach the dialog (~250ms) before close.
-        cancelClose();
-        closeTimer.current = setTimeout(() => {
-          setHoveredMemberRef(null);
-          setHoveredPos(null);
-        }, 250);
+        setPreviewMemberRef(ref);
       }
     },
-    [cancelClose],
+    [],
   );
 
   // Two-id split: delete is GUID-only on the wire; cache cleanup keys on the
@@ -237,40 +214,38 @@ export function SkillsetDetailPage() {
                   members={graphMembers}
                   edges={depEdges}
                   className="h-full"
-                  onHoverMember={handleHoverMember}
+                  onHoverMember={handleClickMember}
                 />
 
-                {/* Floating package preview dialog for the hovered graph node.
-                    Positioned fixed beside the cursor (offset right+down) so it appears
-                    "right beside my cursor". Larger size for better readability of the
-                    package tree + content. Uses canvas node hover (no more blinking from
-                    SVG/Mermaid). Dismiss on mouseleave of the popup. */}
-                {hoveredMemberRef && hoveredPos && (
+                {/* Click-to-open package preview dialog — fixed size, centered. */}
+                {previewMemberRef && (
                   <div
-                    className="fixed z-[100] flex w-[800px] max-w-[calc(100vw-2rem)] h-[40vh] flex-col overflow-hidden rounded-md border border-subtle bg-card card-impression text-sm shadow-xl"
-                    style={{
-                      left: Math.min((hoveredPos.clientX ?? 0) + 18, window.innerWidth - 816),
-                      top: Math.min((hoveredPos.clientY ?? 0) + 8, window.innerHeight - 120),
-                    }}
-                    onMouseEnter={cancelClose}
-                    onMouseLeave={closePreview}
+                    className="fixed inset-0 z-[100] flex items-center justify-center"
+                    onClick={closePreview}
                   >
-                    <div className="flex shrink-0 items-center justify-between border-b border-subtle px-3 py-2 font-mono text-[11px] text-meta">
-                      <span className="truncate font-medium text-strong">{hoveredMemberRef}</span>
-                      <button
-                        type="button"
-                        onClick={closePreview}
-                        className="ml-2 shrink-0 text-meta hover:text-danger"
-                        aria-label="Close preview"
-                      >
-                        ×
-                      </button>
-                    </div>
-                    <div className="min-h-0 flex-1 p-2">
-                      <SkillsetMemberViewer
-                        members={skillset.members}
-                        previewRef={hoveredMemberRef}
-                      />
+                    <div className="absolute inset-0 bg-black/30 backdrop-blur-sm" />
+                    <div
+                      className="relative flex flex-col overflow-hidden rounded-md border border-subtle bg-card card-impression text-sm shadow-xl"
+                      style={{ top: '15vh', bottom: '15vh', left: '15vw', right: '15vw', position: 'fixed' }}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex shrink-0 items-center justify-between border-b border-subtle px-3 py-2 font-mono text-[11px] text-meta">
+                        <span className="truncate font-medium text-strong">{previewMemberRef}</span>
+                        <button
+                          type="button"
+                          onClick={closePreview}
+                          className="ml-2 shrink-0 text-meta hover:text-danger"
+                          aria-label="Close preview"
+                        >
+                          ×
+                        </button>
+                      </div>
+                      <div className="min-h-0 flex-1 p-2">
+                        <SkillsetMemberViewer
+                          members={skillset.members}
+                          previewRef={previewMemberRef}
+                        />
+                      </div>
                     </div>
                   </div>
                 )}

--- a/ornn-web/src/pages/landing/AnnouncementPopup.test.tsx
+++ b/ornn-web/src/pages/landing/AnnouncementPopup.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * AnnouncementPopup tests.
+ *
+ * Covers:
+ *   - Renders the modal when an active announcement exists and the
+ *     user hasn't dismissed that id.
+ *   - Does NOT render when the active id has already been dismissed
+ *     (localStorage flag from a prior visit).
+ *   - Dismiss writes the per-id flag so a re-mount stays closed.
+ *   - Returns null when there is no active announcement.
+ *
+ * Mocks `useActiveAnnouncement` directly so the test never pulls in
+ * the api client / auth store auto-init chain.
+ *
+ * @module pages/landing/AnnouncementPopup.test
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import type { PublicAnnouncement } from "@/services/announcementsApi";
+
+// jsdom in this project does not ship a working localStorage. Inject
+// a minimal in-memory replacement before any test code touches it.
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  const fake: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: fake,
+    configurable: true,
+  });
+}
+installFakeLocalStorage();
+
+const mockActive = vi.fn<() => { data: PublicAnnouncement | null }>();
+
+vi.mock("@/hooks/useAnnouncements", () => ({
+  useActiveAnnouncement: () => mockActive(),
+}));
+
+import { AnnouncementPopup } from "./AnnouncementPopup";
+
+describe("AnnouncementPopup", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockActive.mockReset();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when there is no active announcement", () => {
+    mockActive.mockReturnValue({ data: null });
+    render(<AnnouncementPopup />);
+    expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
+  });
+
+  it("renders the announcement modal when active and not dismissed", async () => {
+    mockActive.mockReturnValue({
+      data: {
+        id: "a-1",
+        titleEn: "Ornn 1.2 is live",
+        titleZh: "",
+        bodyMarkdownEn: "**Now with** chained skills.",
+        bodyMarkdownZh: "",
+        ctaLabelEn: "See changelog",
+        ctaLabelZh: "",
+        ctaUrl: "https://ornn.dev/changelog",
+      },
+    });
+    render(<AnnouncementPopup />);
+    expect(
+      await screen.findByRole("heading", { name: /Ornn 1\.2 is live/i }),
+    ).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: /See changelog/i });
+    expect(cta).toHaveAttribute("href", "https://ornn.dev/changelog");
+    expect(cta).toHaveAttribute("target", "_blank");
+  });
+
+  it("does not render when the active id has been dismissed", () => {
+    localStorage.setItem("ornn:announcement:dismissed:a-1", "1");
+    mockActive.mockReturnValue({
+      data: {
+        id: "a-1",
+        titleEn: "Already-seen news",
+        titleZh: "",
+        bodyMarkdownEn: "Body",
+        bodyMarkdownZh: "",
+        ctaLabelEn: null,
+        ctaLabelZh: null,
+        ctaUrl: null,
+      },
+    });
+    render(<AnnouncementPopup />);
+    expect(screen.queryByRole("heading", { name: /Already-seen news/i })).toBeNull();
+  });
+
+  it("dismiss button closes and persists the flag", async () => {
+    mockActive.mockReturnValue({
+      data: {
+        id: "a-2",
+        titleEn: "Hello there",
+        titleZh: "",
+        bodyMarkdownEn: "Body",
+        bodyMarkdownZh: "",
+        ctaLabelEn: null,
+        ctaLabelZh: null,
+        ctaUrl: null,
+      },
+    });
+    render(<AnnouncementPopup />);
+    expect(
+      await screen.findByRole("heading", { name: /Hello there/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(localStorage.getItem("ornn:announcement:dismissed:a-2")).toBe("1");
+  });
+});

--- a/ornn-web/src/pages/landing/AnnouncementPopup.tsx
+++ b/ornn-web/src/pages/landing/AnnouncementPopup.tsx
@@ -1,0 +1,294 @@
+/**
+ * AnnouncementPopup — landing-page modal that surfaces the currently
+ * active announcement to every visitor (anonymous + signed-in).
+ *
+ * Industry-standard "what's new" pattern (Linear / Vercel / GitHub),
+ * dressed in Forge Workshop vocabulary per DESIGN.md:
+ *   - Ember surface (the brand action color, here promoted to a
+ *     full-card stamp). Obsidian ink throughout. The card reads as a
+ *     hot-pressed ember plate against the page.
+ *   - Space Grotesk Bold UPPERCASE title — the landing display voice.
+ *   - JetBrains Mono bracketed micro-label (`[§ NEWS — ORNN]`) for
+ *     editorial / industrial-publication signal.
+ *   - Hard-offset letterpress shadow in ember-deep, no soft drop shadow.
+ *   - Press-down hover on CTA + dismiss buttons (translate INTO the
+ *     impression). No hover-lift.
+ *
+ * Dismissal stays as before: localStorage-keyed (`ornn:announcement:
+ * dismissed:<id>`), one-shot per id, no server write — anonymous-safe.
+ *
+ * @module pages/landing/AnnouncementPopup
+ */
+
+import { useEffect, useState, type CSSProperties } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
+import { useActiveAnnouncement } from "@/hooks/useAnnouncements";
+import {
+  pickLocalized,
+  pickLocalizedCtaLabel,
+} from "@/lib/announcementLocale";
+
+const DISMISS_KEY_PREFIX = "ornn:announcement:dismissed:";
+
+function isDismissed(id: string): boolean {
+  try {
+    return localStorage.getItem(DISMISS_KEY_PREFIX + id) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markDismissed(id: string): void {
+  try {
+    localStorage.setItem(DISMISS_KEY_PREFIX + id, "1");
+  } catch {
+    // No-op: private mode / disabled storage. Better to nag than to break.
+  }
+}
+
+/**
+ * Glassmorphic surface overrides — re-pin semantic tokens AND the
+ * obsidian/ember-deep colours used in explicit var() references so
+ * all text renders light over the transparent backdrop-blur glass
+ * on the dark hero video background.
+ */
+const GLASS_OVERRIDES: CSSProperties = {
+  "--color-obsidian": "#fff",
+  "--color-ember-deep": "rgba(255, 255, 255, 0.5)",
+  "--color-strong": "#fff",
+  "--color-body": "rgba(255, 255, 255, 0.88)",
+  "--color-meta": "rgba(255, 255, 255, 0.6)",
+  "--color-accent-muted": "rgba(255, 255, 255, 0.25)",
+  "--color-subtle": "rgba(255, 255, 255, 0.15)",
+  "--color-elevated": "rgba(255, 255, 255, 0.1)",
+  "--color-strong-edge": "rgba(255, 255, 255, 0.2)",
+} as CSSProperties;
+
+export function AnnouncementPopup() {
+  const { t, i18n } = useTranslation();
+  const { data: announcement } = useActiveAnnouncement();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!announcement) {
+      setOpen(false);
+      return;
+    }
+    if (!isDismissed(announcement.id)) {
+      setOpen(true);
+    }
+  }, [announcement]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const close = () => {
+    if (announcement) markDismissed(announcement.id);
+    setOpen(false);
+  };
+
+  if (!announcement) return null;
+
+  // Resolve bilingual fields against the active i18n language. EN is the
+  // canonical / required content; ZH falls back to EN when empty so the
+  // popup still renders cleanly for ZH users on a half-translated record.
+  const lang = i18n.language;
+  const displayTitle = pickLocalized(
+    announcement.titleEn,
+    announcement.titleZh,
+    lang,
+  );
+  const displayBody = pickLocalized(
+    announcement.bodyMarkdownEn,
+    announcement.bodyMarkdownZh,
+    lang,
+  );
+  const ctaHref = announcement.ctaUrl ?? null;
+  const ctaLabel = pickLocalizedCtaLabel(
+    announcement.ctaLabelEn,
+    announcement.ctaLabelZh,
+    lang,
+  );
+  const isExternalCta = ctaHref ? /^https?:\/\//i.test(ctaHref) : false;
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        // Anchored to the top-right corner (below the 64px navbar) as a
+        // non-blocking notification card — no page-dimming backdrop, so the
+        // hero + lifecycle ring stay visible and interactive. Dismiss via the
+        // X / Dismiss buttons or Escape.
+        <div className="pointer-events-none fixed z-50" style={{ top: '10vh', bottom: '10vh', left: '15vw', right: '15vw' }}>
+          <motion.div
+            initial={{ opacity: 0, x: 28, scale: 0.98 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: 28, scale: 0.98 }}
+            transition={{ type: "spring", stiffness: 240, damping: 24, mass: 0.9 }}
+            role="dialog"
+            aria-labelledby="announcement-title"
+            // exactOptionalPropertyTypes (#657): framer-motion's
+            // `MotionStyle` rejects React.CSSProperties under the
+            // stricter flag (incompatible optionals on transform/etc.).
+            // Cast to `never` to bridge — runtime shape is unchanged.
+            style={GLASS_OVERRIDES as unknown as never}
+            className="
+              pointer-events-auto relative h-full w-full overflow-y-auto
+              rounded-[3px] border border-white/15 bg-black/40 backdrop-blur-2xl
+              p-8 sm:p-10
+            "
+          >
+
+            {/* Bracketed mono micro-label — Forge Workshop section signature. */}
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--color-obsidian)]/85">
+                [§ NEWS — ORNN]
+              </p>
+              <button
+                type="button"
+                onClick={close}
+                aria-label={t("aria.dismissAnnouncement")}
+                className="
+                  -mr-2 -mt-1 inline-flex h-8 w-8 items-center justify-center rounded-[2px]
+                  text-[var(--color-obsidian)]/85
+                  transition-colors duration-150
+                  hover:bg-white/10 hover:text-[var(--color-obsidian)]
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)]
+                "
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.75}
+                  className="h-5 w-5"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Display title — Space Grotesk Bold UPPERCASE, the landing
+                display voice. Tight letter-spacing per DESIGN.md type rules. */}
+            <h2
+              id="announcement-title"
+              className="
+                font-display font-bold uppercase
+                text-[var(--color-obsidian)]
+                text-[28px] sm:text-[32px] leading-[1.02] tracking-[-0.025em]
+              "
+            >
+              {displayTitle}
+            </h2>
+
+            {/* Welded-seam divider — hairline + rivet pair pattern in
+                ember-deep. Matches the landing's section-divider language. */}
+            <div className="relative mt-5 mb-5 h-px w-full bg-white/25">
+              <span
+                aria-hidden
+                className="absolute -top-[2.5px] left-[25%] h-[5px] w-[5px] rounded-full bg-white/50"
+              />
+              <span
+                aria-hidden
+                className="absolute -top-[2.5px] left-[75%] h-[5px] w-[5px] rounded-full bg-white/50"
+              />
+            </div>
+
+            {/* Body — markdown over the ember surface. The INK_OVERRIDES
+                style above re-pins markdown-body tokens to dark ink so
+                paragraphs / headings / links read against ember. */}
+            <div className="markdown-body text-[15px] leading-[1.65]">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeSanitize]}
+              >
+                {displayBody}
+              </ReactMarkdown>
+            </div>
+
+            {/* Footer — CTA + dismiss. Both press DOWN on hover per
+                DESIGN.md hover behavior rule (no lift). The CTA carries
+                a hard-offset shadow at rest that shrinks on hover. */}
+            <div className="mt-7 flex flex-wrap items-center justify-end gap-3">
+              <button
+                type="button"
+                onClick={close}
+                className="
+                  group inline-flex items-center justify-center
+                  rounded-[2px] border border-[var(--color-obsidian)]/55
+                  bg-transparent
+                  px-4 py-2
+                  font-mono text-[11px] font-semibold uppercase tracking-[0.18em]
+                  text-[var(--color-obsidian)]
+                  transition-[transform,background-color,border-color] duration-150
+                  hover:bg-white/10 hover:border-[var(--color-obsidian)]
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)]
+                  motion-reduce:transition-none
+                "
+              >
+                Dismiss
+              </button>
+              {ctaHref && ctaLabel && (
+                <a
+                  href={ctaHref}
+                  target={isExternalCta ? "_blank" : undefined}
+                  rel={isExternalCta ? "noopener noreferrer" : undefined}
+                  onClick={() => {
+                    // Mark dismissed on CTA click so a returning user who
+                    // followed the link isn't asked again on next visit.
+                    if (announcement) markDismissed(announcement.id);
+                  }}
+                  style={{
+                    boxShadow: "4px 4px 0 0 var(--color-ember-deep)",
+                  }}
+                  className="
+                    relative inline-flex items-center justify-center gap-2
+                    rounded-[2px] border border-[var(--color-obsidian)]
+                    bg-[var(--color-obsidian)]
+                    px-5 py-2
+                    font-mono text-[11px] font-semibold uppercase tracking-[0.16em]
+                    text-[var(--color-accent)]
+                    transition-[transform,box-shadow,background-color] duration-150
+                    hover:translate-x-[2px] hover:translate-y-[2px]
+                    hover:shadow-[2px_2px_0_0_var(--color-ember-deep)]
+                    active:translate-x-[4px] active:translate-y-[4px]
+                    active:shadow-none
+                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-obsidian)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-accent)]
+                    motion-reduce:hover:translate-x-0 motion-reduce:hover:translate-y-0
+                    motion-reduce:active:translate-x-0 motion-reduce:active:translate-y-0
+                  "
+                >
+                  {ctaLabel}
+                  {isExternalCta && (
+                    <svg
+                      aria-hidden
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      className="h-3.5 w-3.5"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M14 5h5v5M19 5L9 15M5 11v8h8" />
+                    </svg>
+                  )}
+                </a>
+              )}
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/ornn-web/src/pages/landing/HeroVideo.tsx
+++ b/ornn-web/src/pages/landing/HeroVideo.tsx
@@ -98,7 +98,7 @@ export function HeroVideo() {
           overlay) keeps the labels above WCAG AA regardless of the decorative
           video frame behind them — the top scrim alone can't guarantee
           contrast once the CTA outgrows it. */}
-      <div className="absolute left-8 top-24 z-10 flex gap-3 rounded-[4px] border border-[color:var(--color-border-strong)] [background-color:var(--surface-overlay)] p-3 backdrop-blur-[14px] sm:left-12 sm:top-28">
+      <div className="absolute left-8 top-24 z-10 flex gap-3 sm:left-12 sm:top-28">
         <EmberLink to="/registry">{t("landing.browseSkills")}</EmberLink>
         <EmberLink to="/skills/new" variant="ghost">
           {t("landing.publishYours")}

--- a/ornn-web/src/pages/landing/LaunchCelebrationPopup.test.tsx
+++ b/ornn-web/src/pages/landing/LaunchCelebrationPopup.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * LaunchCelebrationPopup tests.
+ *
+ * Locks in the load-bearing contract: the popup is hardcoded (no DB
+ * dependency) and shows on every landing-page mount, even after the
+ * user dismissed it on a prior visit. Closing only sets local state;
+ * a re-mount must reopen it.
+ *
+ * @module pages/landing/LaunchCelebrationPopup.test
+ */
+
+import { describe, expect, it, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+
+import { LaunchCelebrationPopup } from "./LaunchCelebrationPopup";
+
+const DISMISS_BUTTON_NAME = "Dismiss";
+
+describe("LaunchCelebrationPopup", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders open on mount", () => {
+    render(<LaunchCelebrationPopup />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+  });
+
+  it("close button hides the modal", async () => {
+    render(<LaunchCelebrationPopup />);
+    fireEvent.click(screen.getByRole("button", { name: DISMISS_BUTTON_NAME }));
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
+  });
+
+  it("re-opens on remount (no persistence between visits)", async () => {
+    const { unmount } = render(<LaunchCelebrationPopup />);
+    fireEvent.click(screen.getByRole("button", { name: DISMISS_BUTTON_NAME }));
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
+    unmount();
+
+    render(<LaunchCelebrationPopup />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
+++ b/ornn-web/src/pages/landing/LaunchCelebrationPopup.tsx
@@ -1,0 +1,407 @@
+/**
+ * LaunchCelebrationPopup — hardcoded launch-day modal on the landing
+ * page (`/`). Independent of the dynamic announcements collection: the
+ * content is baked into the frontend bundle so the public-launch notice
+ * cannot be edited away, expire from the admin panel, or depend on
+ * `/announcements/active` uptime during launch traffic.
+ *
+ * Behavior:
+ *   - Opens on every mount of LandingPage (anonymous + signed-in).
+ *   - Closing only sets local state — no localStorage write. Navigating
+ *     away and back to `/` reopens the popup. Intentional for the
+ *     launch window; remove the component from LandingPage when the
+ *     offer ends.
+ *
+ * Visual structure:
+ *   1. Bracketed mono eyebrow + ISO date (publication-cite signal).
+ *   2. Space Grotesk display title (the celebration sentence).
+ *   3. Welded-seam divider with rivet dots in ember.
+ *   4. Two-up offer tiles — "200" numerals as the visual anchor, mono
+ *      uppercase labels, model-name meta caption.
+ *   5. Numbered redemption steps (01 / 02) with ember-mono numerals.
+ *   6. Click-to-copy NyxID invite code chip in molten gold mono.
+ *   7. Limited-slots warning row.
+ *   8. Right-aligned CTAs — ghost Dismiss + primary STAR ON GITHUB,
+ *      both letterpress press-down via `.cta-letterpress`.
+ *
+ * Surface uses semantic theme-aware tokens throughout (`bg-card`,
+ * `text-strong`, `border-accent`, etc.) so dark + light themes both
+ * read with full contrast. The card sits on a hard-offset letterpress
+ * plate in `ember-deep` (DESIGN.md card-shadow color). All press-down
+ * behavior is centralized via the `.cta-letterpress` utility so the
+ * popup carries the same hover semantics as the rest of the landing.
+ *
+ * @module pages/landing/LaunchCelebrationPopup
+ */
+
+import { useEffect, useState, type CSSProperties } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+const GITHUB_URL = "https://github.com/ChronoAIProject/Ornn";
+const GITHUB_LINK_LABEL = "github.com/ChronoAIProject/Ornn";
+const DISCUSSIONS_URL = "https://github.com/ChronoAIProject/Ornn/discussions/521";
+const INVITE_CODE = "NYX-2XXJI08A";
+const COPY_FEEDBACK_MS = 1800;
+
+/** Glassmorphic surface overrides — re-pin semantic tokens to light colours
+ *  so all text/readability tokens render correctly over the transparent
+ *  backdrop-blur glass on the dark hero video background. */
+const GLASS_OVERRIDES: CSSProperties = {
+  "--color-strong": "#fff",
+  "--color-body": "rgba(255, 255, 255, 0.88)",
+  "--color-meta": "rgba(255, 255, 255, 0.6)",
+  "--color-accent-muted": "rgba(255, 255, 255, 0.25)",
+  "--color-subtle": "rgba(255, 255, 255, 0.15)",
+  "--color-elevated": "rgba(255, 255, 255, 0.1)",
+  "--color-strong-edge": "rgba(255, 255, 255, 0.2)",
+} as CSSProperties;
+
+export function LaunchCelebrationPopup() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const close = () => setOpen(false);
+
+  const copyInvite = async () => {
+    try {
+      await navigator.clipboard.writeText(INVITE_CODE);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    } catch {
+      // Older Safari / non-secure context — silently no-op. Code is
+      // already visible inline; copy is a convenience, not the contract.
+    }
+  };
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        // Anchored to the top-right corner (below the 64px navbar) as a
+        // non-blocking notification card — no page-dimming backdrop, so the
+        // hero + lifecycle ring stay visible and interactive. Dismiss via the
+        // X / Dismiss buttons or Escape.
+        <div className="pointer-events-none fixed z-50" style={{ top: '10vh', bottom: '10vh', left: '15vw', right: '15vw' }}>
+          <motion.div
+            initial={{ opacity: 0, x: 28, scale: 0.98 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: 28, scale: 0.98 }}
+            transition={{ type: "spring", stiffness: 240, damping: 24, mass: 0.9 }}
+            className="pointer-events-auto relative h-full w-full"
+          >
+          <div
+            role="dialog"
+            aria-labelledby="launch-popup-title"
+            style={GLASS_OVERRIDES as React.CSSProperties}
+            className="
+              relative h-full overflow-y-auto
+              rounded-[3px] border border-white/15 bg-black/40 backdrop-blur-2xl
+              p-8 sm:p-10
+            "
+          >
+
+            {/* Header row — bracketed mono section-cite + date stacked
+                top-left, close affordance top-right. */}
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex flex-col gap-1">
+                <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-accent">
+                  {t("landing.launchPopup.eyebrow")}
+                </p>
+                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-meta">
+                  {t("landing.launchPopup.date")}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={close}
+                aria-label={t("landing.launchPopup.dismissAria")}
+                className="
+                  -mr-2 -mt-1 inline-flex h-8 w-8 items-center justify-center rounded-[2px]
+                  text-meta transition-colors duration-150
+                  hover:bg-elevated hover:text-strong
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+                "
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.75}
+                  className="h-5 w-5"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Title — the celebration sentence. Space Grotesk Bold,
+                anchored to text-strong so it reads near-maximum contrast
+                in both themes. */}
+            <h2
+              id="launch-popup-title"
+              className="
+                mt-4 font-display font-bold text-strong
+                text-[19px] sm:text-[22px] leading-[1.2] tracking-[-0.015em]
+              "
+            >
+              {t("landing.launchPopup.title")}
+            </h2>
+
+            {/* Welded-seam divider — hairline in strong-edge tone +
+                rivet pair in ember accent. */}
+            <div className="relative mt-4 mb-4 h-px w-full bg-strong-edge">
+              <span
+                aria-hidden
+                className="absolute -top-[2.5px] left-[25%] h-[5px] w-[5px] rounded-full bg-accent"
+              />
+              <span
+                aria-hidden
+                className="absolute -top-[2.5px] left-[75%] h-[5px] w-[5px] rounded-full bg-accent"
+              />
+            </div>
+
+            {/* Offer lineup: small mono header followed by two-up tiles.
+                Each tile leads with a big "200" numeral in accent for
+                immediate parsing, then the brand label and the model
+                caption. */}
+            <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-meta">
+              {t("landing.launchPopup.creditsLead")}
+            </p>
+            <div className="mt-2.5 grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+              <OfferTile
+                count={t("landing.launchPopup.credit1Number")}
+                label={t("landing.launchPopup.credit1Title")}
+                caption={t("landing.launchPopup.credit1Caption")}
+              />
+              <OfferTile
+                count={t("landing.launchPopup.credit2Number")}
+                label={t("landing.launchPopup.credit2Title")}
+                caption={t("landing.launchPopup.credit2Caption")}
+                animationOffsetSeconds={-2.5}
+              />
+            </div>
+
+            {/* Redemption block — section heading + numbered steps. */}
+            <h3 className="mt-5 font-display text-[15px] font-bold uppercase tracking-[-0.005em] text-strong">
+              {t("landing.launchPopup.conditionsHeading")}
+            </h3>
+            <ol className="mt-3 space-y-2.5">
+              <li className="grid grid-cols-[auto_1fr] items-start gap-x-4">
+                <span className="font-mono text-[13px] font-semibold tabular-nums text-accent pt-[1px]">
+                  01
+                </span>
+                <p className="text-[14px] leading-[1.55] text-body">
+                  {t("landing.launchPopup.step1Before")}{" "}
+                  <a
+                    href={GITHUB_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="
+                      font-mono font-semibold text-accent
+                      underline decoration-2 underline-offset-[3px] decoration-accent-muted
+                      transition-colors duration-150
+                      hover:text-accent-support hover:decoration-accent-support
+                      focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+                    "
+                  >
+                    {GITHUB_LINK_LABEL}
+                  </a>{" "}
+                  {t("landing.launchPopup.step1After")}
+                </p>
+              </li>
+              <li className="grid grid-cols-[auto_1fr] items-start gap-x-4">
+                <span className="font-mono text-[13px] font-semibold tabular-nums text-accent pt-[1px]">
+                  02
+                </span>
+                <p className="text-[14px] leading-[1.55] text-body">
+                  {t("landing.launchPopup.step2")}
+                </p>
+              </li>
+            </ol>
+
+            {/* Invite-code chip — click-to-copy with mono molten-gold
+                code. Treated as a button (not a div) for keyboard
+                affordance + screen-reader semantics. */}
+            <div className="mt-5">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-meta">
+                {t("landing.launchPopup.inviteLabel")}
+              </p>
+              <button
+                type="button"
+                onClick={copyInvite}
+                aria-label={t("landing.launchPopup.inviteAria")}
+                className="
+                  mt-2 group flex w-full items-center justify-between gap-3
+                  rounded-[2px] border border-accent-support/55 bg-white/10
+                  px-4 py-3
+                  transition-[border-color,background-color] duration-150
+                  hover:border-accent-support hover:bg-accent-support/10
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-support
+                "
+              >
+                <code className="font-mono text-[17px] font-semibold tracking-[0.06em] text-accent-support">
+                  {INVITE_CODE}
+                </code>
+                <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-meta group-hover:text-accent-support">
+                  {copied
+                    ? `${t("landing.launchPopup.copied")} ✓`
+                    : `${t("landing.launchPopup.copy")} ⧉`}
+                </span>
+              </button>
+              {/* Helper prose — explains the actual sign-in flow:
+                  clicking Sign In in Ornn redirects to NyxID (our IdP),
+                  where the invite code is required on first visit before
+                  the user can continue with GitHub. Without this, the
+                  code chip reads as "magic value, purpose unknown". */}
+              <p className="mt-2 text-[12px] leading-[1.5] text-body">
+                {t("landing.launchPopup.inviteHelp")}
+              </p>
+            </div>
+
+            {/* Fulfillment note — body prose covering what happens
+                after redemption: code delivered to in-app notification
+                inbox within 24h, where to find it (bell top-right +
+                profile dropdown → Redeem code), plus a discussions-thread
+                link for support. Sibling block (not inside the invite-
+                code section) so the post-redemption flow doesn't read
+                as just another caption under the code chip. */}
+            <p className="mt-4 text-[12px] leading-[1.5] text-body">
+              {t("landing.launchPopup.fulfillmentBefore")}{" "}
+              <a
+                href={DISCUSSIONS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="
+                  font-mono font-semibold text-accent
+                  underline decoration-2 underline-offset-[3px] decoration-accent-muted
+                  transition-colors duration-150
+                  hover:text-accent-support hover:decoration-accent-support
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent
+                "
+              >
+                {t("landing.launchPopup.fulfillmentLinkLabel")}
+              </a>{" "}
+              {t("landing.launchPopup.fulfillmentAfter")}
+            </p>
+
+            {/* Limited-slots warning — mono caption, italic, ember
+                triangle as a visual cue without saturating the row. */}
+            <p className="mt-4 flex items-start gap-2 font-mono text-[11px] italic uppercase tracking-[0.14em] text-meta">
+              <span aria-hidden className="text-accent not-italic">
+                ▲
+              </span>
+              <span>{t("landing.launchPopup.limitedSlots")}</span>
+            </p>
+
+            {/* CTAs — ghost Dismiss + primary STAR ON GITHUB. Both
+                ride `.cta-letterpress` for the canonical press-down +
+                shadow behavior, reduced-motion safe. */}
+            <div className="mt-5 flex flex-wrap items-center justify-end gap-3">
+              <button
+                type="button"
+                onClick={close}
+                className="
+                  cta-letterpress cta-letterpress--ghost
+                  inline-flex items-center justify-center
+                  rounded-sm border border-white/25 bg-white/10
+                  px-4 py-2
+                  font-mono text-[11px] font-semibold uppercase tracking-[0.18em]
+                  text-body
+                  hover:border-accent hover:text-strong
+                "
+              >
+                {t("landing.launchPopup.dismiss")}
+              </button>
+              <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={close}
+                className="
+                  cta-letterpress
+                  inline-flex items-center justify-center gap-2
+                  rounded-sm border border-accent-muted bg-accent
+                  px-5 py-2
+                  font-mono text-[11px] font-semibold uppercase tracking-[0.16em]
+                  text-page
+                  hover:bg-accent-muted
+                "
+              >
+                <span aria-hidden>★</span>
+                {t("landing.launchPopup.cta")}
+                <svg
+                  aria-hidden
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  className="h-3.5 w-3.5"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M14 5h5v5M19 5L9 15M5 11v8h8" />
+                </svg>
+              </a>
+            </div>
+          </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}
+
+function OfferTile({
+  count,
+  label,
+  caption,
+  animationOffsetSeconds,
+}: {
+  count: string;
+  label: string;
+  caption: string;
+  /**
+   * Negative-valued seconds passed as `animation-delay` on the glow
+   * pseudo-element. Stagger the two tiles by ~50% of the 5s cycle
+   * (-2.5s on the second tile) so the molten "comets" travel out of
+   * phase — feels like two independent objects, not CSS clones. The
+   * delay only takes effect on the `::before`, which we can't target
+   * directly inline; we expose it as a CSS custom property and have
+   * the stylesheet pick it up. CSS reference: see `.offer-tile-glow`
+   * in styles/neon.css.
+   */
+  animationOffsetSeconds?: number;
+}) {
+  const styleVars =
+    animationOffsetSeconds !== undefined
+      ? ({
+          ["--offer-tile-anim-delay" as never]: `${animationOffsetSeconds}s`,
+        } as React.CSSProperties)
+      : undefined;
+  return (
+    <div className="offer-tile-glow" style={styleVars}>
+      <div className="rounded-[2px] border border-white/15 bg-white/10 p-3.5 sm:p-4">
+        <p className="font-display text-[30px] sm:text-[34px] font-bold leading-none tracking-[-0.02em] text-accent">
+          {count}
+        </p>
+        <div className="mt-2 h-px w-8 bg-accent-muted" aria-hidden />
+        <p className="mt-2 font-mono text-[12px] font-semibold uppercase tracking-[0.16em] text-strong">
+          {label}
+        </p>
+        <p className="mt-1 font-mono text-[11px] uppercase tracking-[0.12em] text-meta">
+          {caption}
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes

### Landing page
- **Restore announcement popups** — retire the global top-right AnnouncementBanner and bring back the original landing-only `AnnouncementPopup` + `LaunchCelebrationPopup`, now centered with proportional viewport margins (10vh/15vw) and glassmorphic styling (bg-black/40 + backdrop-blur-2xl, light text for contrast).
- **Remove CTA background plate** — the "Browse skills / Publish yours" buttons no longer have the overlay background/border/blur, just the bare buttons.

### Skillset detail graph
- **Click-to-open popup** — replace hover-triggered cursor-following popup with click-to-open centered dialog. Dialog fills viewport minus 15% margins on all sides with full-screen backdrop blur.
- **Node drag** — graph nodes are draggable on the detail page (session-local positions).
- **Fixed dialog sizing** — independent scroll per pane (file tree / content viewer).

### Assistant widget
- **Default position** — Ornn mascot now defaults to right edge, vertically centered (was bottom-right).

## Commits

| Commit | Scope |
|--------|-------|
| `feat(web): fix graph hover popup to 800×40vh with independent pane scroll` | Popup sizing + scroll |
| `feat(web): enable node drag on skillset detail graph` | Node drag |
| `chore: add changeset for #1100` | Changeset |
| `feat(web): restore landing page announcement popups with glassmorphic style` | Landing popups |
| `chore(web): remove background plate from landing hero CTA buttons` | Hero CTA |
| `feat(web): skillset graph popup — click-to-open, centered, blurred backdrop` | Graph popup |
| `chore(web): default Ornn assistant mascot to right-edge vertically centered` | Assistant |

Closes #1100