### PR TITLE
[CI/CD] Sync develop-auto CI workflows to develop for CI parity

### DIFF
--- a/.changeset/sync-develop-auto-ci-parity.md
+++ b/.changeset/sync-develop-auto-ci-parity.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: sync develop-auto workflow files to develop for CI parity. No version bump.

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Mint app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,21 +75,21 @@ jobs:
       # because a single codecov-action invocation applies one flag set to
       # every file it uploads.
       - name: Upload ornn-api coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         if: ${{ !cancelled() }}
         with:
           flags: api
           fail_ci_if_error: false
           files: ./ornn-api/coverage/lcov.info
       - name: Upload ornn-web coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         if: ${{ !cancelled() }}
         with:
           flags: web
           fail_ci_if_error: false
           files: ./ornn-web/coverage/lcov.info
       - name: Upload TS SDK coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         if: ${{ !cancelled() }}
         with:
           flags: sdk-ts
@@ -123,7 +123,7 @@ jobs:
       # Codecov upload (#471) — same as the bun job but for the
       # Python SDK's coverage.xml.
       - name: Upload Python coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         if: ${{ !cancelled() }}
         with:
           flags: python


### PR DESCRIPTION
## Summary

Restores CI parity between `develop` and `develop-auto` so the `/sa-implement` daemon preflight (code 64 ci-parity gate) passes.

`develop-auto` lagged `develop` by a single Dependabot GitHub-Actions bump (#620) that never propagated:

- `.github/workflows/ci.yml` — `codecov/codecov-action@v4 → v7` (×4)
- `.github/workflows/changeset-release.yml` — `actions/create-github-app-token@v2 → v3` (×1)

This copies `develop`'s exact versions of the two files. No logic, job, or gate changes — pure action version bumps. An empty changeset is included since this is CI-only.

## Verification

- `git diff origin/develop -- .github/workflows/ci.yml .github/workflows/changeset-release.yml` → empty (byte-match).
- All `develop-auto` required checks expected green.

Closes #1110