### PR TITLE
[Misc] Engage /auto kill-switch (.auto/STOP on develop-auto)

### DIFF
--- a/.auto/STOP
+++ b/.auto/STOP
@@ -1,0 +1,3 @@
+/auto kill-switch engaged via .auto/STOP fallback.
+Engaged by chronoai-shining on 2026-06-15 (UTC) at the maintainer's request.
+Delete this file on develop-auto to allow /auto runs to resume (remove before any develop-auto->develop promotion).

--- a/.changeset/engage-auto-killswitch.md
+++ b/.changeset/engage-auto-killswitch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Ops: engage the /auto kill-switch by landing .auto/STOP on develop-auto. No package change. (#1119)


### PR DESCRIPTION
## Summary

Lands the `/auto` kill-switch FALLBACK: `.auto/STOP` on `develop-auto`. The maintainer asked to halt the autonomous `/sa-implement` run; the local daemon was stopped immediately, and this makes the stop durable — `bin/auto-kill.sh` reads `.auto/STOP` on `develop-auto` remotely (Contents API), so every future `/auto` run aborts at preflight until the file is removed.

It had to go through a PR (not a direct write) because the `develop-auto` ruleset requires a PR + 11 checks. The marker is force-added past the root `.gitignore`; an empty changeset accompanies it (ops change, no package bump).

## To resume `/auto` later

Delete `.auto/STOP` from `develop-auto` (and ensure it's removed before any `develop-auto → develop` promotion so the marker doesn't leak downstream).

Closes #1119