### PR TITLE
feat: separate read/write access (drop read_write) + edit UI for write-grantees (#1127)

### DIFF
--- a/.changeset/read-write-split.md
+++ b/.changeset/read-write-split.md
@@ -1,0 +1,10 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+Separate read and write access (drop the `read_write` level) and show edit UI to write-grantees.
+
+The combined `read_write` grant level is renamed to `write`: each grant is now `read` or `write` (a `write` grant implies read), with no combined label. Existing `read_write` grants migrate to `write` automatically at boot — non-disruptive and rollback-safe.
+
+This also fixes a bug where a user with **write** access saw no edit controls: the skill detail page (Edit button, inline file editor, Save) and the edit page now reveal content-editing to write-grantees, not just the owner, while admin actions (permissions, transfer, delete, visibility) remain owner/admin-only.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ so dashboards can disambiguate from frontend events of the same name):
 | `api.skill.published` | skill create + version publish | `skillId`, `skillVersion`, `isNewSkill` |
 | `user.login` / `user.logout` | session open / close | — |
 | `skill.created` / `.updated` / `.deleted` / `.version_deleted` | mutation routes | `skillId`, `skillName`, `version`, `adminAction?` |
-| `skill.visibility_changed` / `.permissions_changed` | visibility + sharing flips | `skillId`, `isPrivate`, `sharedWithUsers`, `sharedWithOrgs`, `readWriteGrants` (count of `read_write` grants, #1123) |
+| `skill.visibility_changed` / `.permissions_changed` | visibility + sharing flips | `skillId`, `isPrivate`, `sharedWithUsers`, `sharedWithOrgs`, `writeGrants` (count of `write` grants, #1123) |
 | `skill.ownership_transferred` | ownership handed to another user (#1123) | `skillId`, `skillName`, `priorOwnerId`, `newOwnerId` |
 | `skill.refresh` / `.source_linked` / `.source_unlinked` | source-pointer ops | `skillId`, `repo`, `ref`, `commit` |
 | `skill.nyxid_service_tied` / `.agentseal_rescanned` | tie + admin-rescan | `skillId`, `isSystemSkill`, `score` |

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -346,7 +346,7 @@ Endpoint-specific. Rules:
 Format: `ornn:<resource>:<action>`. These are the **request scopes** NyxID
 mints onto an access token — `requirePermission(...)` middleware checks them
 per route. They gate *who may call an endpoint at all*; they are **distinct
-from** the per-object READ / READ_WRITE / ADMIN tier (§5.4), which decides
+from** the per-object READ / WRITE / ADMIN tier (§5.4), which decides
 *what the caller may do to a specific skill/skillset*. A caller needs both:
 the route scope to reach the handler, and the object tier to act on the
 target.
@@ -355,7 +355,7 @@ target.
 |---|---|
 | `ornn:skill:read` | Read skills (respects visibility) |
 | `ornn:skill:create` | Create skills (upload, pull from GitHub) |
-| `ornn:skill:update` | Update / publish / refresh / change permissions / transfer ownership / toggle deprecation / bind NyxID service (+ object ADMIN/READ_WRITE per §5.4) |
+| `ornn:skill:update` | Update / publish / refresh / change permissions / transfer ownership / toggle deprecation / bind NyxID service (+ object ADMIN/WRITE per §5.4) |
 | `ornn:skill:delete` | Delete a skill or a single version (+ object ADMIN per §5.4) |
 | `ornn:skill:build` | Invoke skill generation endpoints (high LLM cost) |
 | `ornn:playground:use` | Invoke playground chat (runs user code) |
@@ -396,11 +396,11 @@ tier decides whether they may act on *this specific* skill/skillset.
 
 | Tier | Gate | Who qualifies | What it grants |
 |---|---|---|---|
-| **READ** | `canReadSkill` | Public skill → anyone. Private → author, platform admin, or any grantee (`read` **or** `read_write`), directly or via a granted org. | View / pull / execute / list versions. |
-| **READ_WRITE** | `canWriteSkill` | Author **OR** platform admin **OR** a `read_write` grantee (direct or via a granted org). | READ, plus update the skill's **content + metadata only** (publish a new version). |
+| **READ** | `canReadSkill` | Public skill → anyone. Private → author, platform admin, or any grantee (`read` **or** `write`), directly or via a granted org. | View / pull / execute / list versions. |
+| **WRITE** | `canWriteSkill` | Author **OR** platform admin **OR** a `write` grantee (direct or via a granted org). | READ, plus update the skill's **content + metadata only** (publish a new version). |
 | **ADMIN** | `canManageSkill` | Author **OR** platform admin **only**. | Change permissions, transfer ownership, delete skill/version, toggle deprecation, manage dist-tags, bind a NyxID service. |
 
-A `read_write` grantee is **never** an admin — the danger-zone operations stay
+A `write` grantee is **never** an admin — the danger-zone operations stay
 with the author (`createdBy`) and platform admins (`ornn:admin:skill`). Org
 grants resolve uniformly: every admin/member of a granted org inherits the
 grant's level. The org-membership gates fail soft on an unresolved NyxID
@@ -416,15 +416,16 @@ skill/skillset detail responses and accepted by the permissions endpoints
 {
   "grants": [
     { "type": "user", "id": "<nyxid-person-user-id>", "level": "read" },
-    { "type": "org",  "id": "<nyxid-org-user-id>",    "level": "read_write" }
+    { "type": "org",  "id": "<nyxid-org-user-id>",    "level": "write" }
   ]
 }
 ```
 
 - `type` — `"user"` (a NyxID person user_id) or `"org"` (a NyxID org user_id).
 - `id` — the principal's NyxID id (1..128 chars).
-- `level` — `"read"` or `"read_write"`. An invalid value is rejected with
-  `invalid_permission_level` (a `validation_error` subcode — see `docs/ERRORS.md`).
+- `level` — `"read"` or `"write"` (a `write` grant implies read). An invalid
+  value is rejected with `invalid_permission_level` (a `validation_error`
+  subcode — see `docs/ERRORS.md`).
 
 The author (`createdBy`) is never represented in `grants` — they hold implicit
 ADMIN. The legacy read-only `sharedWithUsers` / `sharedWithOrgs` arrays are
@@ -440,7 +441,7 @@ POST /v1/skillsets/:id/transfer-ownership    { "newOwnerUserId": "<id>" }
 ```
 
 - **Auth:** ADMIN tier (`canManageSkill`) — author or platform admin only. A
-  `read_write` grantee can never transfer. Rides on the existing
+  `write` grantee can never transfer. Rides on the existing
   `ornn:skill:update` request scope; **no new scope** was added.
 - **Behavior:** immediate, synchronous transfer. The target becomes the new
   owner (`createdBy`); the prior owner is kept as a **READ** grantee (retains
@@ -627,7 +628,7 @@ Per-test teardown is the test's responsibility; shared fixtures live in `tests/f
 - [ ] `X-Request-ID` on every response; `requestId` in every error body
 - [ ] Query params camelCase; arrays as repeated keys; `q` for search
 - [ ] Required request scopes from the catalog declared in OpenAPI `security` (§5.2)
-- [ ] Object-level authz, where the target is an owned resource, gates on the READ / READ_WRITE / ADMIN tier (§5.4) — distinct from the route scope
+- [ ] Object-level authz, where the target is an owned resource, gates on the READ / WRITE / ADMIN tier (§5.4) — distinct from the route scope
 - [ ] Content negotiation for multi-representation resources
 - [ ] SSE events named `<resource>_<event>` snake_case
 - [ ] Deprecation uses RFC 8594 headers

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -67,9 +67,9 @@ The uploaded payload is not a parseable ZIP — a malformed or unreadable archiv
 
 ### invalid_permission_level
 
-A typed `grants` entry on a permissions request (#1123) carried a `level` outside the allowed set. The only accepted values are `read` and `read_write` (see [`docs/CONVENTIONS.md`](CONVENTIONS.md) §5.4). Surfaced from `PUT /api/v1/skills/{id}/permissions` and `PUT /api/v1/skillsets/{id}/permissions`.
+A typed `grants` entry on a permissions request (#1123) carried a `level` outside the allowed set. The only accepted values are `read` and `write` (see [`docs/CONVENTIONS.md`](CONVENTIONS.md) §5.4). Surfaced from `PUT /api/v1/skills/{id}/permissions` and `PUT /api/v1/skillsets/{id}/permissions`.
 
-**Client action:** set every grant's `level` to `read` or `read_write` and retry.
+**Client action:** set every grant's `level` to `read` or `write` and retry.
 
 ### invalid_transfer_target
 

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -146,7 +146,7 @@ import { wireAdmin } from "./domains/admin/bootstrap";
 // per-provider arrays). One-time, idempotent, runs before any
 // LlmProvidersService consumer reads from disk.
 import { migrateModelCatalogIntoProviders } from "./domains/settings/llmProviders/migration";
-import { backfillTypedGrants } from "./domains/skills/crud/grants.migration";
+import { backfillTypedGrants, renameReadWriteGrantsToWrite } from "./domains/skills/crud/grants.migration";
 import { createLlmPickerRoutes } from "./domains/settings/llmProviders/routes";
 
 // OpenAPI spec
@@ -687,6 +687,18 @@ export async function bootstrap(
     logger.error(
       { err: err instanceof Error ? err.message : String(err) },
       "typed-grants backfill failed — gates fall back to legacy read lists via effectiveGrants, no data loss",
+    ),
+  );
+
+  // ---- read_write → write grant-level rename (#1127) ----
+  // The combined `read_write` level was renamed to `write`. Rewrite any
+  // existing grant carrying the legacy value. Idempotent + non-disruptive
+  // (write confers what read_write did); `coerceStoredGrants` covers any doc
+  // not yet rewritten, so failure is non-fatal.
+  await renameReadWriteGrantsToWrite(db).catch((err) =>
+    logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "read_write→write rename failed — coerceStoredGrants maps legacy values at read time, no data loss",
     ),
   );
 

--- a/ornn-api/src/domains/skills/crud/authorize.test.ts
+++ b/ornn-api/src/domains/skills/crud/authorize.test.ts
@@ -161,10 +161,10 @@ describe("canReadSkill (#1123 tiers)", () => {
     expect(canReadSkill(s, actor("stranger"))).toBe(false);
   });
 
-  it("any grant level confers read — read AND read_write grantees can read", () => {
+  it("any grant level confers read — read AND write grantees can read", () => {
     const s = skill("owner", [
       { type: "user", id: "reader", level: "read" },
-      { type: "user", id: "editor", level: "read_write" },
+      { type: "user", id: "editor", level: "write" },
     ]);
     expect(canReadSkill(s, actor("reader"))).toBe(true);
     expect(canReadSkill(s, actor("editor"))).toBe(true);
@@ -189,24 +189,24 @@ describe("canReadSkill (#1123 tiers)", () => {
   });
 });
 
-describe("canWriteSkill (#1123 READ_WRITE tier)", () => {
+describe("canWriteSkill (#1123 WRITE tier)", () => {
   it("author + platform admin may write", () => {
     const s = skill("owner", []);
     expect(canWriteSkill(s, actor("owner"))).toBe(true);
     expect(canWriteSkill(s, actor("x", { admin: true }))).toBe(true);
   });
 
-  it("a read grantee may NOT write; a read_write grantee may", () => {
+  it("a read grantee may NOT write; a write grantee may", () => {
     const s = skill("owner", [
       { type: "user", id: "reader", level: "read" },
-      { type: "user", id: "editor", level: "read_write" },
+      { type: "user", id: "editor", level: "write" },
     ]);
     expect(canWriteSkill(s, actor("reader"))).toBe(false);
     expect(canWriteSkill(s, actor("editor"))).toBe(true);
   });
 
-  it("a read_write org grant lets every member write", () => {
-    const s = skill("owner", [{ type: "org", id: "org-a", level: "read_write" }]);
+  it("a write org grant lets every member write", () => {
+    const s = skill("owner", [{ type: "org", id: "org-a", level: "write" }]);
     expect(canWriteSkill(s, actor("u", { orgs: ["org-a"] }))).toBe(true);
     expect(canWriteSkill(s, actor("u", { orgs: ["org-b"] }))).toBe(false);
   });
@@ -225,8 +225,8 @@ describe("canWriteSkill (#1123 READ_WRITE tier)", () => {
 });
 
 describe("canManageSkill (#1123 ADMIN tier)", () => {
-  it("only author + platform admin administer — a read_write grantee never does", () => {
-    const s = skill("owner", [{ type: "user", id: "editor", level: "read_write" }]);
+  it("only author + platform admin administer — a write grantee never does", () => {
+    const s = skill("owner", [{ type: "user", id: "editor", level: "write" }]);
     expect(canManageSkill(s, actor("owner"))).toBe(true);
     expect(canManageSkill(s, actor("x", { admin: true }))).toBe(true);
     expect(canManageSkill(s, actor("editor"))).toBe(false);

--- a/ornn-api/src/domains/skills/crud/authorize.ts
+++ b/ornn-api/src/domains/skills/crud/authorize.ts
@@ -14,21 +14,21 @@
  *   - PRIVATE skill:
  *     - author (`createdBy === actor.userId`) → yes
  *     - platform admin (`ornn:admin:skill`) → yes
- *     - actor holds ANY grant (read or read_write), directly or via
+ *     - actor holds ANY grant (read or write), directly or via
  *       membership of a granted org → yes
  *     - else → no
  *
- * READ_WRITE — `canWriteSkill` (update content + metadata only):
+ * WRITE — `canWriteSkill` (update content + metadata only):
  *   - author → yes
  *   - platform admin → yes
- *   - actor holds a `read_write` grant, directly or via a granted org → yes
+ *   - actor holds a `write` grant, directly or via a granted org → yes
  *   - else → no
  *
  * ADMIN — `canManageSkill` (change permissions, transfer ownership, delete
  * skill/version, toggle deprecation, manage dist-tags, bind NyxID service):
  *   - author → yes
  *   - platform admin → yes
- *   - else → 403. A `read_write` grantee is deliberately NOT an admin.
+ *   - else → 403. A `write` grantee is deliberately NOT an admin.
  *
  * Org grants resolve uniformly: every admin/member of a granted org inherits
  * the grant's level. The org-membership-based gates fail soft on an
@@ -117,7 +117,7 @@ export async function buildActorContext(
 
 /**
  * Returns true when `actor` is allowed to READ the skill. Any grant level
- * (read or read_write) confers read — a read_write grantee is always also a
+ * (read or write) confers read — a write grantee is always also a
  * reader. Public skills are readable by everyone.
  */
 export function canReadSkill(skill: SkillOwnership, actor: ActorContext): boolean {
@@ -129,22 +129,22 @@ export function canReadSkill(skill: SkillOwnership, actor: ActorContext): boolea
 
 /**
  * Returns true when `actor` may UPDATE the skill's content + metadata — the
- * READ_WRITE tier (#1123). Author + platform admin always qualify; otherwise
- * a `read_write` grant (direct, or via membership of a granted org) is
+ * WRITE tier (#1123). Author + platform admin always qualify; otherwise
+ * a `write` grant (direct, or via membership of a granted org) is
  * required. Deliberately NOT sufficient for admin/danger-zone ops — those
  * gate on `canManageSkill`.
  */
 export function canWriteSkill(skill: SkillOwnership, actor: ActorContext): boolean {
   if (actor.isPlatformAdmin) return true;
   if (skill.createdBy === actor.userId) return true;
-  return actorMatchesGrant(skill, actor, (g) => g.level === "read_write");
+  return actorMatchesGrant(skill, actor, (g) => g.level === "write");
 }
 
 /**
  * Returns true when `actor` may ADMINISTER the skill — change permissions,
  * transfer ownership, delete skill/version, toggle deprecation, manage
  * dist-tags, bind a NyxID service. Author + platform admin only; a
- * read_write grantee can never administer.
+ * write grantee can never administer.
  */
 export function canManageSkill(skill: SkillOwnership, actor: ActorContext): boolean {
   if (actor.isPlatformAdmin) return true;

--- a/ornn-api/src/domains/skills/crud/grants.migration.test.ts
+++ b/ornn-api/src/domains/skills/crud/grants.migration.test.ts
@@ -12,7 +12,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { MongoClient, type Db } from "mongodb";
-import { backfillTypedGrants } from "./grants.migration";
+import { backfillTypedGrants, renameReadWriteGrantsToWrite } from "./grants.migration";
 
 let mongo: MongoMemoryServer;
 let client: MongoClient;
@@ -92,15 +92,15 @@ describe("backfillTypedGrants", () => {
       isPrivate: true,
       sharedWithUsers: ["u1"],
       sharedWithOrgs: [],
-      grants: [{ type: "user", id: "u1", level: "read_write" }],
+      grants: [{ type: "user", id: "u1", level: "write" }],
     });
 
     const res = await backfillTypedGrants(db);
     expect(res.skillsBackfilled).toBe(0);
 
     const doc = await db.collection("skills").findOne({ _id: "s4" as never });
-    // read_write grant preserved — migration must not clobber a richer ACL.
-    expect(doc?.grants).toEqual([{ type: "user", id: "u1", level: "read_write" }]);
+    // write grant preserved — migration must not clobber a richer ACL.
+    expect(doc?.grants).toEqual([{ type: "user", id: "u1", level: "write" }]);
   });
 
   it("is a no-op on a second run", async () => {
@@ -129,5 +129,59 @@ describe("backfillTypedGrants", () => {
     expect(res.skillsetsBackfilled).toBe(1);
     const doc = await db.collection("skillsets").findOne({ _id: "ss1" as never });
     expect(doc?.grants).toEqual([{ type: "org", id: "o9", level: "read" }]);
+  });
+});
+
+describe("renameReadWriteGrantsToWrite (#1127)", () => {
+  it("renames legacy read_write grants to write, leaving read grants + other fields intact", async () => {
+    await db.collection("skills").insertOne({
+      _id: "r1" as never,
+      name: "legacy-rw",
+      isPrivate: true,
+      sharedWithUsers: ["u1", "u2"],
+      sharedWithOrgs: ["o1"],
+      grants: [
+        { type: "user", id: "u1", level: "read_write" },
+        { type: "user", id: "u2", level: "read" },
+        { type: "org", id: "o1", level: "read_write" },
+      ],
+    });
+
+    const res = await renameReadWriteGrantsToWrite(db);
+    expect(res.skillsRenamed).toBe(1);
+
+    const doc = await db.collection("skills").findOne({ _id: "r1" as never });
+    expect(doc?.grants).toEqual([
+      { type: "user", id: "u1", level: "write" },
+      { type: "user", id: "u2", level: "read" },
+      { type: "org", id: "o1", level: "write" },
+    ]);
+    // Non-destructive: legacy lists + privacy untouched.
+    expect(doc?.sharedWithUsers).toEqual(["u1", "u2"]);
+    expect(doc?.isPrivate).toBe(true);
+  });
+
+  it("is idempotent — a second run renames nothing", async () => {
+    await db.collection("skills").insertOne({
+      _id: "r2" as never,
+      name: "rw-once",
+      grants: [{ type: "user", id: "u1", level: "read_write" }],
+    });
+    const first = await renameReadWriteGrantsToWrite(db);
+    expect(first.skillsRenamed).toBe(1);
+    const second = await renameReadWriteGrantsToWrite(db);
+    expect(second.skillsRenamed).toBe(0);
+  });
+
+  it("renames skillsets too", async () => {
+    await db.collection("skillsets").insertOne({
+      _id: "rs1" as never,
+      name: "set-rw",
+      grants: [{ type: "org", id: "o9", level: "read_write" }],
+    });
+    const res = await renameReadWriteGrantsToWrite(db);
+    expect(res.skillsetsRenamed).toBe(1);
+    const doc = await db.collection("skillsets").findOne({ _id: "rs1" as never });
+    expect(doc?.grants).toEqual([{ type: "org", id: "o9", level: "write" }]);
   });
 });

--- a/ornn-api/src/domains/skills/crud/grants.migration.ts
+++ b/ornn-api/src/domains/skills/crud/grants.migration.ts
@@ -81,3 +81,57 @@ export async function backfillTypedGrants(db: Db): Promise<GrantsMigrationResult
   }
   return result;
 }
+
+/**
+ * Aggregation `$set` stage that renames any grant with the legacy
+ * `read_write` level to `write` (#1127), leaving `read` grants untouched.
+ */
+const RENAME_LEVEL_STAGE = {
+  $set: {
+    grants: {
+      $map: {
+        input: { $ifNull: ["$grants", []] },
+        as: "g",
+        in: {
+          $cond: [
+            { $eq: ["$$g.level", "read_write"] },
+            { $mergeObjects: ["$$g", { level: "write" }] },
+            "$$g",
+          ],
+        },
+      },
+    },
+  },
+} as const;
+
+export interface LevelRenameResult {
+  skillsRenamed: number;
+  skillsetsRenamed: number;
+}
+
+/**
+ * Rename the legacy `read_write` grant level to `write` (#1127) on every
+ * skill / skillset that still carries one. Idempotent — only docs with a
+ * `read_write` grant are matched, so reruns are no-ops. Non-destructive:
+ * `read` grants and all other fields are untouched, and a `write` grant
+ * confers exactly what `read_write` did (write implies read). Runs at boot
+ * after the typed-grants backfill; `coerceStoredGrants` covers any doc not
+ * yet rewritten.
+ */
+export async function renameReadWriteGrantsToWrite(db: Db): Promise<LevelRenameResult> {
+  const counts: Record<string, number> = {};
+  for (const coll of GRANTED_COLLECTIONS) {
+    const res = await db
+      .collection(coll)
+      .updateMany({ "grants.level": "read_write" }, [RENAME_LEVEL_STAGE]);
+    counts[coll] = res.modifiedCount;
+  }
+  const result: LevelRenameResult = {
+    skillsRenamed: counts.skills ?? 0,
+    skillsetsRenamed: counts.skillsets ?? 0,
+  };
+  if (result.skillsRenamed > 0 || result.skillsetsRenamed > 0) {
+    logger.info({ ...result }, "read_write → write grant-level rename complete (#1127)");
+  }
+  return result;
+}

--- a/ornn-api/src/domains/skills/crud/grants.test.ts
+++ b/ornn-api/src/domains/skills/crud/grants.test.ts
@@ -22,7 +22,7 @@ import {
 
 describe("effectiveGrants", () => {
   it("returns the explicit grants array when present", () => {
-    const grants: SkillGrant[] = [{ type: "user", id: "u1", level: "read_write" }];
+    const grants: SkillGrant[] = [{ type: "user", id: "u1", level: "write" }];
     expect(effectiveGrants({ grants })).toBe(grants);
   });
 
@@ -45,7 +45,7 @@ describe("effectiveGrants", () => {
 });
 
 describe("deriveGrantsFromLegacy", () => {
-  it("maps users + orgs to READ grants, never read_write", () => {
+  it("maps users + orgs to READ grants, never write", () => {
     const out = deriveGrantsFromLegacy(["u1", "u2"], ["o1"]);
     expect(out).toEqual([
       { type: "user", id: "u1", level: "read" },
@@ -66,8 +66,8 @@ describe("legacyListsFromGrants (dual-write projection)", () => {
   it("places every grant id in its legacy list regardless of level (read visibility, no escalation)", () => {
     const grants: SkillGrant[] = [
       { type: "user", id: "u1", level: "read" },
-      { type: "user", id: "u2", level: "read_write" },
-      { type: "org", id: "o1", level: "read_write" },
+      { type: "user", id: "u2", level: "write" },
+      { type: "org", id: "o1", level: "write" },
     ];
     expect(legacyListsFromGrants(grants)).toEqual({
       sharedWithUsers: ["u1", "u2"],
@@ -83,29 +83,29 @@ describe("legacyListsFromGrants (dual-write projection)", () => {
 });
 
 describe("normalizeGrants", () => {
-  it("collapses duplicate (type,id) keeping the highest level (read_write wins)", () => {
+  it("collapses duplicate (type,id) keeping the highest level (write wins)", () => {
     expect(
       normalizeGrants([
         { type: "user", id: "u1", level: "read" },
-        { type: "user", id: "u1", level: "read_write" },
+        { type: "user", id: "u1", level: "write" },
       ]),
-    ).toEqual([{ type: "user", id: "u1", level: "read_write" }]);
+    ).toEqual([{ type: "user", id: "u1", level: "write" }]);
   });
 
-  it("does not let a later read downgrade an earlier read_write", () => {
+  it("does not let a later read downgrade an earlier write", () => {
     expect(
       normalizeGrants([
-        { type: "org", id: "o1", level: "read_write" },
+        { type: "org", id: "o1", level: "write" },
         { type: "org", id: "o1", level: "read" },
       ]),
-    ).toEqual([{ type: "org", id: "o1", level: "read_write" }]);
+    ).toEqual([{ type: "org", id: "o1", level: "write" }]);
   });
 
   it("trims ids and drops empties, preserving first-appearance order", () => {
     expect(
       normalizeGrants([
         { type: "user", id: " u2 ", level: "read" },
-        { type: "user", id: "", level: "read_write" },
+        { type: "user", id: "", level: "write" },
         { type: "user", id: "u1", level: "read" },
       ]),
     ).toEqual([
@@ -118,18 +118,18 @@ describe("normalizeGrants", () => {
     expect(
       normalizeGrants([
         { type: "user", id: "x", level: "read" },
-        { type: "org", id: "x", level: "read_write" },
+        { type: "org", id: "x", level: "write" },
       ]),
     ).toEqual([
       { type: "user", id: "x", level: "read" },
-      { type: "org", id: "x", level: "read_write" },
+      { type: "org", id: "x", level: "write" },
     ]);
   });
 });
 
 describe("levelAllowsWrite", () => {
-  it("only read_write permits writing", () => {
-    expect(levelAllowsWrite("read_write")).toBe(true);
+  it("only write permits writing", () => {
+    expect(levelAllowsWrite("write")).toBe(true);
     expect(levelAllowsWrite("read")).toBe(false);
   });
 });
@@ -145,11 +145,11 @@ describe("coerceStoredGrants", () => {
     expect(
       coerceStoredGrants([
         { type: "user", id: " u1 ", level: "read" },
-        { type: "org", id: "o1", level: "read_write" },
+        { type: "org", id: "o1", level: "write" },
       ]),
     ).toEqual([
       { type: "user", id: "u1", level: "read" },
-      { type: "org", id: "o1", level: "read_write" },
+      { type: "org", id: "o1", level: "write" },
     ]);
   });
 
@@ -161,12 +161,24 @@ describe("coerceStoredGrants", () => {
         { type: "user", id: "u1", level: "admin" },
         42,
         null,
-        { type: "user", id: "u2", level: "read_write" },
+        { type: "user", id: "u2", level: "write" },
       ]),
-    ).toEqual([{ type: "user", id: "u2", level: "read_write" }]);
+    ).toEqual([{ type: "user", id: "u2", level: "write" }]);
   });
 
   it("returns an empty array for an empty stored array (explicit no-grants)", () => {
     expect(coerceStoredGrants([])).toEqual([]);
+  });
+
+  it("coerces a stored legacy read_write level → write (#1127, no drop)", () => {
+    expect(
+      coerceStoredGrants([
+        { type: "user", id: "u1", level: "read_write" },
+        { type: "org", id: "o1", level: "read" },
+      ]),
+    ).toEqual([
+      { type: "user", id: "u1", level: "write" },
+      { type: "org", id: "o1", level: "read" },
+    ]);
   });
 });

--- a/ornn-api/src/domains/skills/crud/grants.ts
+++ b/ornn-api/src/domains/skills/crud/grants.ts
@@ -31,7 +31,7 @@ import type {
 export const skillGrantSchema = z.object({
   type: z.enum(["user", "org"]),
   id: z.string().min(1).max(128),
-  level: z.enum(["read", "read_write"]),
+  level: z.enum(["read", "write"]),
 });
 
 /**
@@ -88,7 +88,7 @@ export function effectiveGrants(src: GrantSource): SkillGrant[] {
 /**
  * Map the legacy read-only allow-lists onto READ-level typed grants. Used by
  * the boot migration and by the read-time fallback. Never produces a
- * `read_write` grant — legacy sharing was read-only, so migrating it must
+ * `write` grant — legacy sharing was read-only, so migrating it must
  * not escalate anyone.
  */
 export function deriveGrantsFromLegacy(
@@ -106,7 +106,7 @@ export function deriveGrantsFromLegacy(
  * dual-write (#1123). EVERY grant id — regardless of level — lands in the
  * matching legacy list so code that only understands the read lists (an
  * older pod mid-rolling-deploy) still resolves correct READ visibility for
- * read_write grantees, and never escalates anyone to write (old code has no
+ * write grantees, and never escalates anyone to write (old code has no
  * write concept). Dropped by the post-rollout cleanup once all pods read
  * `grants`.
  */
@@ -122,7 +122,7 @@ export function legacyListsFromGrants(grants: readonly SkillGrant[]): LegacyShar
 
 /**
  * Normalize an incoming grants list: trim ids, drop empties, and collapse
- * duplicate `(type, id)` pairs keeping the HIGHEST level (`read_write` wins
+ * duplicate `(type, id)` pairs keeping the HIGHEST level (`write` wins
  * over `read`) so a principal can never hold two conflicting grants on the
  * same skill. Order is preserved by first appearance.
  */
@@ -136,7 +136,7 @@ export function normalizeGrants(grants: readonly SkillGrant[]): SkillGrant[] {
     const prev = byKey.get(key);
     if (!prev) order.push(key);
     const level: SkillPermissionLevel =
-      prev?.level === "read_write" || g.level === "read_write" ? "read_write" : "read";
+      prev?.level === "write" || g.level === "write" ? "write" : "read";
     byKey.set(key, { type: g.type, id, level });
   }
   return order.map((k) => byKey.get(k)!);
@@ -144,7 +144,7 @@ export function normalizeGrants(grants: readonly SkillGrant[]): SkillGrant[] {
 
 /** True when `level` permits writing (updating content / metadata). */
 export function levelAllowsWrite(level: SkillPermissionLevel): boolean {
-  return level === "read_write";
+  return level === "write";
 }
 
 /**
@@ -162,9 +162,13 @@ export function coerceStoredGrants(raw: unknown): SkillGrant[] | undefined {
     const e = entry as Record<string, unknown>;
     const type = e.type;
     const id = typeof e.id === "string" ? e.id.trim() : "";
-    const level = e.level;
+    // #1127 renamed the level `read_write` → `write`. Defensively coerce a
+    // stored legacy `read_write` here so a doc the boot migration hasn't
+    // rewritten yet (or one written by an older pod mid-rolling-deploy) still
+    // resolves to write — never dropped, never silently downgraded.
+    const level = e.level === "read_write" ? "write" : e.level;
     if ((type !== "user" && type !== "org") || !id) continue;
-    if (level !== "read" && level !== "read_write") continue;
+    if (level !== "read" && level !== "write") continue;
     out.push({ type, id, level });
   }
   return out;

--- a/ornn-api/src/domains/skills/crud/routes.test.ts
+++ b/ornn-api/src/domains/skills/crud/routes.test.ts
@@ -916,7 +916,7 @@ describe("PUT /skills/:id", () => {
     expect(calls).toEqual(["updateSkill"]);
   });
 
-  test("200 ZIP republish for a read_write grantee — content edit is the write tier (#1123)", async () => {
+  test("200 ZIP republish for a write grantee — content edit is the write tier (#1123)", async () => {
     const calls: string[] = [];
     const app = buildApp({
       userId: "editor",
@@ -926,7 +926,7 @@ describe("PUT /skills/:id", () => {
           skillDoc({
             createdBy: OWNER,
             isPrivate: true,
-            grants: [{ type: "user", id: "editor", level: "read_write" }],
+            grants: [{ type: "user", id: "editor", level: "write" }],
           }),
       },
       service: {
@@ -945,7 +945,7 @@ describe("PUT /skills/:id", () => {
     expect(calls).toEqual(["updateSkill"]);
   });
 
-  test("403 when a read_write grantee tries to flip visibility — that is admin-only (#1123)", async () => {
+  test("403 when a write grantee tries to flip visibility — that is admin-only (#1123)", async () => {
     const app = buildApp({
       userId: "editor",
       permissions: [UPDATE],
@@ -954,7 +954,7 @@ describe("PUT /skills/:id", () => {
           skillDoc({
             createdBy: OWNER,
             isPrivate: true,
-            grants: [{ type: "user", id: "editor", level: "read_write" }],
+            grants: [{ type: "user", id: "editor", level: "write" }],
           }),
       },
     });

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -999,8 +999,8 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
       }
       const actor = await buildActorContext(c);
-      // Updating content + metadata is the READ_WRITE tier (#1123): author,
-      // platform admin, or a read_write grantee. Changing `isPrivate` is a
+      // Updating content + metadata is the WRITE tier (#1123): author,
+      // platform admin, or a write grantee. Changing `isPrivate` is a
       // permission change (ADMIN tier) — gated separately below once parsed.
       if (!canWriteSkill(existing, actor)) {
         throw AppError.forbidden(
@@ -1065,7 +1065,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         throw AppError.badRequest("no_update", "No update data provided. Send a ZIP file and/or isPrivate field.");
       }
 
-      // Visibility is an ADMIN-tier change (#1123): a read_write grantee may
+      // Visibility is an ADMIN-tier change (#1123): a write grantee may
       // replace content but must not flip public/private. Enforce only when
       // `isPrivate` is actually being changed so a no-op resend by an editor
       // doesn't 403.
@@ -1160,7 +1160,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const updated = await skillService.getSkill(guid);
 
-      const readWriteGrants = (updated.grants ?? []).filter((g) => g.level === "read_write").length;
+      const writeGrants = (updated.grants ?? []).filter((g) => g.level === "write").length;
       trackActivity(authCtx.userId, authCtx.email, authCtx.displayName, "skill.permissions_changed", {
         skillId: guid,
         skillName: updated.name,
@@ -1168,7 +1168,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         sharedWithUsers: updated.sharedWithUsers.length,
         sharedWithOrgs: updated.sharedWithOrgs.length,
         // #1123 — richer payload: how many grants confer write.
-        readWriteGrants,
+        writeGrants,
       });
 
       // Permissions change can flip eligibility — sync handles both
@@ -1204,7 +1204,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         throw AppError.notFound("skill_not_found", `Skill '${guid}' not found`);
       }
       const actor = await buildActorContext(c);
-      // ADMIN tier — transfer is a danger-zone op, never a read_write grant.
+      // ADMIN tier — transfer is a danger-zone op, never a write grant.
       if (!canManageSkill(existing, actor)) {
         throw AppError.forbidden(
           "forbidden",

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -478,7 +478,7 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
     expect(state.updateCalled).toBe(false);
   });
 
-  it("(e) accepts typed grants directly, including read_write (#1123)", async () => {
+  it("(e) accepts typed grants directly, including write (#1123)", async () => {
     const { service, state } = makePermissionsService(
       makeSkillDoc({ guid: "guid-1", createdBy: "owner-1", isPrivate: true }),
     );
@@ -494,18 +494,18 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
       {
         isPrivate: true,
         grants: [
-          { type: "user", id: "editor", level: "read_write" },
-          { type: "org", id: "org-A", level: "read_write" },
+          { type: "user", id: "editor", level: "write" },
+          { type: "org", id: "org-A", level: "write" },
         ],
       },
       actor,
     );
     expect(state.updateCalled).toBe(true);
-    expect(result.grants).toContainEqual({ type: "user", id: "editor", level: "read_write" });
-    expect(result.grants).toContainEqual({ type: "org", id: "org-A", level: "read_write" });
+    expect(result.grants).toContainEqual({ type: "user", id: "editor", level: "write" });
+    expect(result.grants).toContainEqual({ type: "org", id: "org-A", level: "write" });
   });
 
-  it("(f) a read_write org grant still honours the #815 non-member gate (#1123)", async () => {
+  it("(f) a write org grant still honours the #815 non-member gate (#1123)", async () => {
     const { service, state } = makePermissionsService(
       makeSkillDoc({ guid: "guid-1", createdBy: "owner-1", isPrivate: true }),
     );
@@ -520,7 +520,7 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
       await service.setSkillPermissions(
         "guid-1",
         "owner-1",
-        { isPrivate: true, grants: [{ type: "org", id: "org-Z", level: "read_write" }] },
+        { isPrivate: true, grants: [{ type: "org", id: "org-Z", level: "write" }] },
         actor,
       );
     } catch (err) {
@@ -543,7 +543,7 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
     const result = await service.setSkillPermissions(
       "guid-1",
       "owner-1",
-      { isPrivate: true, grants: [{ type: "user", id: "owner-1", level: "read_write" }] },
+      { isPrivate: true, grants: [{ type: "user", id: "owner-1", level: "write" }] },
       actor,
     );
     // The author holds implicit ADMIN — a self-grant is redundant and dropped.
@@ -604,7 +604,7 @@ describe("SkillService.transferSkillOwnership (#1123)", () => {
         guid: "guid-1",
         createdBy: "owner-1",
         isPrivate: true,
-        grants: [{ type: "org", id: "org-A", level: "read_write" }],
+        grants: [{ type: "org", id: "org-A", level: "write" }],
       }),
     );
     const result = await service.transferSkillOwnership(
@@ -616,7 +616,7 @@ describe("SkillService.transferSkillOwnership (#1123)", () => {
     expect(result.createdBy).toBe("newbie");
     expect(result.createdByEmail).toBe("new@x.io");
     // Existing org grant preserved; prior owner added as read.
-    expect(result.grants).toContainEqual({ type: "org", id: "org-A", level: "read_write" });
+    expect(result.grants).toContainEqual({ type: "org", id: "org-A", level: "write" });
     expect(result.grants).toContainEqual({ type: "user", id: "owner-1", level: "read" });
   });
 
@@ -626,7 +626,7 @@ describe("SkillService.transferSkillOwnership (#1123)", () => {
         guid: "guid-1",
         createdBy: "owner-1",
         isPrivate: true,
-        grants: [{ type: "user", id: "newbie", level: "read_write" }],
+        grants: [{ type: "user", id: "newbie", level: "write" }],
       }),
     );
     const result = await service.transferSkillOwnership(

--- a/ornn-api/src/domains/skillsets/authorize.ts
+++ b/ornn-api/src/domains/skillsets/authorize.ts
@@ -38,7 +38,7 @@ export function canReadSkillset(
 
 /**
  * True when `actor` may UPDATE the skillset's content/metadata (publish a new
- * version) — the READ_WRITE tier (#1123). Delegates to the skill gate.
+ * version) — the WRITE tier (#1123). Delegates to the skill gate.
  */
 export function canWriteSkillset(
   skillset: SkillsetOwnership,

--- a/ornn-api/src/domains/skillsets/service.ts
+++ b/ornn-api/src/domains/skillsets/service.ts
@@ -177,7 +177,7 @@ export class SkillsetService {
     if (!existing) {
       throw AppError.notFound("skillset_not_found", `Skillset '${guid}' not found`);
     }
-    // Publishing a new version is a content/metadata edit — the READ_WRITE
+    // Publishing a new version is a content/metadata edit — the WRITE
     // tier (#1123). Permissions/transfer/delete remain ADMIN-only below.
     if (!canWriteSkill(existing, actor)) {
       throw AppError.forbidden("forbidden", "You do not have permission to update this skillset");

--- a/ornn-api/src/domains/skillsets/types.ts
+++ b/ornn-api/src/domains/skillsets/types.ts
@@ -211,7 +211,7 @@ export interface SkillsetDocument {
   /** Explicit per-org grants (NyxID org user_ids). */
   sharedWithOrgs: string[];
   /**
-   * Typed access grants (#1123) — canonical read/read-write ACL, mirroring
+   * Typed access grants (#1123) — canonical read/write ACL, mirroring
    * `SkillDocument.grants`. Optional for back-compat; readers fall back to
    * deriving read grants from the legacy lists via `effectiveGrants`.
    */

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -74,13 +74,13 @@ export class AppError extends Error {
 /**
  * Permission level a grant confers on a skill / skillset (#1123).
  * - `read`       → view / pull / execute / read versions.
- * - `read_write` → READ plus update the skill's content & metadata. Does
+ * - `write` → READ plus update the skill's content & metadata. Does
  *   NOT include any admin / danger-zone operation (change permissions,
  *   transfer ownership, delete skill/version, toggle deprecation, manage
  *   dist-tags, bind NyxID service) — those stay with the owner (`createdBy`)
  *   and platform admins only.
  */
-export type SkillPermissionLevel = "read" | "read_write";
+export type SkillPermissionLevel = "read" | "write";
 
 /** The kind of principal a grant targets. */
 export type SkillGrantPrincipalType = "user" | "org";
@@ -92,11 +92,11 @@ export type SkillGrantPrincipalType = "user" | "org";
  *
  * - `type` — `user` (NyxID person user_id) or `org` (NyxID org user_id).
  * - `id`   — the principal's NyxID id.
- * - `level`— `read` or `read_write`.
+ * - `level`— `read` or `write`.
  *
  * The author (`createdBy`) is never represented here — they hold implicit
  * ADMIN. Public skills (`isPrivate === false`) are readable by everyone
- * regardless of grants; `read_write` only ever applies to explicit grants.
+ * regardless of grants; `write` only ever applies to explicit grants.
  */
 export interface SkillGrant {
   type: SkillGrantPrincipalType;
@@ -148,7 +148,7 @@ export interface SkillDocument {
   sharedWithOrgs: string[];
   /**
    * Typed access grants (#1123) — the canonical source of truth for who can
-   * read vs. read-write the skill, beyond the author + platform admin.
+   * read vs. write the skill, beyond the author + platform admin.
    *
    * Optional for back-compat: skills created before #1123 carry only the
    * legacy `sharedWithUsers` / `sharedWithOrgs` read lists. Readers MUST fall
@@ -373,7 +373,7 @@ export interface SkillDetailResponse {
   /** Org user_ids granted access — every admin/member of these orgs can read the skill. */
   sharedWithOrgs: string[];
   /**
-   * Typed access grants (#1123) — the canonical read/read-write ACL. Always
+   * Typed access grants (#1123) — the canonical read/write ACL. Always
    * present in responses (the service emits `effectiveGrants(skill)` so even
    * an un-migrated skill surfaces its legacy lists as read grants here).
    */

--- a/ornn-web/src/components/permissions/PermissionsEditor.tsx
+++ b/ornn-web/src/components/permissions/PermissionsEditor.tsx
@@ -44,14 +44,14 @@ const key = (p: { type: string; id: string }) => `${p.type}:${p.id}`;
 /**
  * Compose the canonical grants from the two audiences. When public, read
  * grants are redundant (everyone reads) so only write grants are emitted.
- * A principal in both audiences resolves to read_write (write wins).
+ * A principal in both audiences resolves to write (write wins).
  */
 function buildGrants(read: Principal[], write: Principal[], isPublic: boolean): SkillGrant[] {
   const map = new Map<string, SkillGrant>();
   if (!isPublic) {
     for (const p of read) map.set(key(p), { type: p.type, id: p.id, level: "read" });
   }
-  for (const p of write) map.set(key(p), { type: p.type, id: p.id, level: "read_write" });
+  for (const p of write) map.set(key(p), { type: p.type, id: p.id, level: "write" });
   return [...map.values()];
 }
 
@@ -78,7 +78,7 @@ export function PermissionsEditor({
   const [isPublic, setIsPublic] = useState<boolean>(!initialIsPrivate);
   const [readGrantees, setReadGrantees] = useState<Principal[]>(() => toPrincipals(initialGrants, "read"));
   const [writeGrantees, setWriteGrantees] = useState<Principal[]>(() =>
-    toPrincipals(initialGrants, "read_write"),
+    toPrincipals(initialGrants, "write"),
   );
 
   // Resolve user-grant labels once on mount (the typeahead supplies labels
@@ -150,7 +150,7 @@ export function PermissionsEditor({
     const grants = buildGrants(readGrantees, writeGrantees, isPublic);
     const initialBuilt = buildGrants(
       toPrincipals(initialGrants, "read"),
-      toPrincipals(initialGrants, "read_write"),
+      toPrincipals(initialGrants, "write"),
       !initialIsPrivate,
     );
     if (isPrivate === initialIsPrivate && signature(grants) === signature(initialBuilt)) {

--- a/ornn-web/src/components/skill/PermissionsModal.test.tsx
+++ b/ornn-web/src/components/skill/PermissionsModal.test.tsx
@@ -107,17 +107,17 @@ describe("PermissionsModal — two-tab Read/Write editor (#1125)", () => {
     fireEvent.click(screen.getByRole("button", { name: /write access/i }));
     fireEvent.click(screen.getByRole("checkbox", { name: "Org One" }));
 
-    // Save → public (isPrivate:false) + a read_write org grant; no read grant
+    // Save → public (isPrivate:false) + a write org grant; no read grant
     // (public makes read grants redundant, so they're dropped).
     fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
     expect(mutateAsync).toHaveBeenCalledWith({
       isPrivate: false,
-      grants: [{ type: "org", id: "org-1", level: "read_write" }],
+      grants: [{ type: "org", id: "org-1", level: "write" }],
     });
   });
 
-  it("seeds the Write tab from an existing read_write grant", () => {
-    renderModal(skill({ grants: [{ type: "org", id: "org-1", level: "read_write" }] }));
+  it("seeds the Write tab from an existing write grant", () => {
+    renderModal(skill({ grants: [{ type: "org", id: "org-1", level: "write" }] }));
     // The Write tab shows a count badge of 1.
     const writeTab = screen.getByRole("button", { name: /write access/i });
     expect(writeTab.textContent).toContain("1");

--- a/ornn-web/src/components/skill/SkillHeroStrip.tsx
+++ b/ornn-web/src/components/skill/SkillHeroStrip.tsx
@@ -25,7 +25,6 @@ interface SkillHeroStripProps {
   pullCount7d?: number | undefined;
   versionAudit?: AuditRecord | undefined;
   isAuthenticated: boolean;
-  isOwner: boolean;
   ownerDisplayName: string;
   ownerAvatarUrl?: string | null | undefined;
   onTryPlayground: () => void;
@@ -87,7 +86,6 @@ export function SkillHeroStrip({
   pullCount7d,
   versionAudit,
   isAuthenticated,
-  isOwner,
   ownerDisplayName,
   ownerAvatarUrl,
   onTryPlayground,
@@ -203,7 +201,7 @@ export function SkillHeroStrip({
                 replaced the older three-dots menu (#411). Each renders
                 independently when its handler is provided, so the row
                 degrades gracefully (e.g. no edit icon for non-owners). */}
-            {isOwner && onEditSkill && (
+            {onEditSkill && (
               <button
                 type="button"
                 onClick={onEditSkill}

--- a/ornn-web/src/components/skill/SkillVisibilityCard.tsx
+++ b/ornn-web/src/components/skill/SkillVisibilityCard.tsx
@@ -24,8 +24,8 @@ export interface SkillVisibilityCardProps {
   isPrivate: boolean;
   sharedWithUsersCount: number;
   sharedWithOrgsCount: number;
-  /** How many grants confer read-write (#1123). Shown as a "can edit" line. */
-  readWriteCount?: number;
+  /** How many grants confer write (#1123). Shown as a "can edit" line. */
+  writeCount?: number;
   isOwner: boolean;
   onManagePermissions: () => void;
 }
@@ -34,7 +34,7 @@ export function SkillVisibilityCard({
   isPrivate,
   sharedWithUsersCount,
   sharedWithOrgsCount,
-  readWriteCount = 0,
+  writeCount = 0,
   isOwner,
   onManagePermissions,
 }: SkillVisibilityCardProps) {
@@ -100,10 +100,10 @@ export function SkillVisibilityCard({
             {t("skillDetail.shareOrgs", "organizations")}
           </span>
         </li>
-        {readWriteCount > 0 && (
+        {writeCount > 0 && (
           <li className="flex items-baseline gap-2.5">
             <span className="min-w-[18px] text-right font-mono text-sm font-semibold text-accent">
-              {readWriteCount}
+              {writeCount}
             </span>
             <span className="text-xs text-meta">{t("skillDetail.shareCanEdit", "can edit")}</span>
           </li>

--- a/ornn-web/src/components/skillset/SkillsetPermissionsModal.tsx
+++ b/ornn-web/src/components/skillset/SkillsetPermissionsModal.tsx
@@ -4,7 +4,7 @@
  * Thin wrapper: the Modal shell + the skillset permissions mutation, around
  * the shared two-tab `PermissionsEditor`. Kept in lock-step with the skill
  * `PermissionsModal` (they now share the editor + selector). This also brings
- * skillsets the read/read-write level support they never had under the old
+ * skillsets the read/write level support they never had under the old
  * single-ladder UI.
  *
  * @module components/skillset/SkillsetPermissionsModal

--- a/ornn-web/src/hooks/useSkillAccess.ts
+++ b/ornn-web/src/hooks/useSkillAccess.ts
@@ -1,0 +1,61 @@
+/**
+ * useSkillAccess — the frontend mirror of the backend's three access tiers
+ * (#1127). One place computes who-can-do-what for a skill/skillset so the
+ * detail page, edit page, and any future surface agree (and match
+ * `authorize.ts` server-side).
+ *
+ * - READ is implicit in being able to load the resource.
+ * - `canWrite` (READ_WRITE tier): owner OR platform admin OR a `write` grant
+ *   that matches the caller directly (user grant) or via membership of a
+ *   granted org. Best-effort — the backend is the real gate; this only
+ *   decides whether to SHOW the edit affordances.
+ * - `canManage` (ADMIN tier): owner OR platform admin only. Gates the
+ *   danger-zone / permissions / visibility actions.
+ *
+ * @module hooks/useSkillAccess
+ */
+
+import { useMemo } from "react";
+import { useCurrentUser, useIsAuthenticated, isAdmin } from "@/stores/authStore";
+import { useMyOrgs } from "@/hooks/useMe";
+import type { SkillGrant } from "@/types/domain";
+
+export interface SkillAccess {
+  isOwner: boolean;
+  isAdmin: boolean;
+  /** May update content/metadata — owner, admin, or a write-grantee. */
+  canWrite: boolean;
+  /** May administer (permissions, transfer, delete, visibility) — owner/admin. */
+  canManage: boolean;
+}
+
+/** Minimal shape needed to evaluate access. Both detail types satisfy it. */
+interface AccessSource {
+  createdBy: string;
+  grants?: SkillGrant[];
+}
+
+export function useSkillAccess(skill?: AccessSource | null): SkillAccess {
+  const user = useCurrentUser();
+  const isAuthenticated = useIsAuthenticated();
+  const adminFlag = isAdmin(user);
+  const { data: myOrgs = [] } = useMyOrgs();
+
+  return useMemo(() => {
+    const isOwner = !!(isAuthenticated && user?.id && skill?.createdBy === user.id);
+    const canManage = isOwner || adminFlag;
+
+    let canWrite = canManage;
+    if (!canWrite && isAuthenticated && user?.id && skill?.grants?.length) {
+      const myOrgIds = new Set(myOrgs.map((o) => o.userId));
+      canWrite = skill.grants.some(
+        (g) =>
+          g.level === "write" &&
+          ((g.type === "user" && g.id === user.id) ||
+            (g.type === "org" && myOrgIds.has(g.id))),
+      );
+    }
+
+    return { isOwner, isAdmin: adminFlag, canWrite, canManage };
+  }, [isAuthenticated, user, adminFlag, skill, myOrgs]);
+}

--- a/ornn-web/src/hooks/useSkillDetail.ts
+++ b/ornn-web/src/hooks/useSkillDetail.ts
@@ -48,7 +48,8 @@ import {
   useSkillAuditHistory,
 } from "@/hooks/useAudit";
 import { useSkillPulls } from "@/hooks/useAnalytics";
-import { useCurrentUser, useIsAuthenticated, isAdmin } from "@/stores/authStore";
+import { useCurrentUser, useIsAuthenticated } from "@/stores/authStore";
+import { useSkillAccess } from "@/hooks/useSkillAccess";
 import { useToastStore } from "@/stores/toastStore";
 import { buildFileTreeFromEntries, type FileTreeEntry } from "@/utils/fileTreeBuilder";
 import { translateError } from "@/utils/translateError";
@@ -114,9 +115,10 @@ export function useSkillDetail(idOrName: string | undefined) {
     error: packageError,
   } = useSkillPackage(skill?.presignedPackageUrl);
 
-  const isOwner = !!(isAuthenticated && user?.id && skill?.createdBy === user.id);
-  const isAdminUser = isAdmin(user);
-  const canManageVersions = isOwner || isAdminUser;
+  // Three access tiers (#1127) from the shared hook — `canWrite` is what
+  // lets a write-grantee (not just the owner) see the content-edit UI.
+  const { isOwner, isAdmin: isAdminUser, canWrite, canManage } = useSkillAccess(skill);
+  const canManageVersions = canManage;
 
   const latestVersion = versionList[0]?.version;
   const viewingLatest = !versionParam || (latestVersion && versionParam === latestVersion);
@@ -405,6 +407,7 @@ export function useSkillDetail(idOrName: string | undefined) {
     isAuthenticated,
     isOwner,
     isAdminUser,
+    canWrite,
     canManageVersions,
     auditSummaryByVersion,
     versionAudit,

--- a/ornn-web/src/pages/skill/EditSkillPage.test.tsx
+++ b/ornn-web/src/pages/skill/EditSkillPage.test.tsx
@@ -74,6 +74,14 @@ vi.mock("@/hooks/useSkills", () => ({
   },
 }));
 
+// Access tier (#1127). Mutable so tests exercise owner / write-grantee /
+// reader. Mocked here so the page doesn't pull in the real authStore (whose
+// persist middleware needs a storage shim this focused test doesn't set up).
+let accessState = { isOwner: true, isAdmin: false, canWrite: true, canManage: true };
+vi.mock("@/hooks/useSkillAccess", () => ({
+  useSkillAccess: () => accessState,
+}));
+
 const addToast = vi.fn();
 vi.mock("@/stores/toastStore", () => ({
   useToastStore: <T,>(selector: (s: { addToast: typeof addToast }) => T) =>
@@ -117,6 +125,7 @@ function resetState() {
   updateMutateAsync.mockResolvedValue(undefined);
   updatePkgMutateAsync.mockResolvedValue(undefined);
   skillState = { data: { ...PUBLIC_SKILL }, isLoading: false };
+  accessState = { isOwner: true, isAdmin: false, canWrite: true, canManage: true };
 }
 
 /** Build a fake .zip File for the upload-flow tests. */
@@ -299,6 +308,31 @@ describe("EditSkillPage — package upload", () => {
     expect(screen.queryByText("skill.zip")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /Upload Package/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("EditSkillPage — access tiers (#1127)", () => {
+  beforeEach(resetState);
+  afterEach(() => cleanup());
+
+  it("a write-grantee sees Update Package but NOT the Visibility (admin) toggle", () => {
+    accessState = { isOwner: false, isAdmin: false, canWrite: true, canManage: false };
+    render(<EditSkillPage />);
+    expect(screen.getByText(/Update Package/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Visibility$/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Make (Public|Private)/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("a read-only viewer sees a read-only notice and no edit controls", () => {
+    accessState = { isOwner: false, isAdmin: false, canWrite: false, canManage: false };
+    render(<EditSkillPage />);
+    expect(screen.getByText(/read-only access/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Update Package/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Make (Public|Private)/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/ornn-web/src/pages/skill/EditSkillPage.tsx
+++ b/ornn-web/src/pages/skill/EditSkillPage.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Badge } from "@/components/ui/Badge";
 import { useSkill, useUpdateSkill, useUpdateSkillPackage } from "@/hooks/useSkills";
+import { useSkillAccess } from "@/hooks/useSkillAccess";
 import { useToastStore } from "@/stores/toastStore";
 import { formatFileSize } from "@/utils/formatters";
 import { translateError } from "@/utils/translateError";
@@ -32,6 +33,9 @@ export function EditSkillPage() {
   const updatePackageMutation = useUpdateSkillPackage(writeId);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [zipFile, setZipFile] = useState<File | null>(null);
+  // Access tiers (#1127): content/package edits need `canWrite` (owner /
+  // admin / write-grantee); visibility is an ADMIN action (`canManage`).
+  const { canWrite, canManage } = useSkillAccess(skill);
 
   const handleToggleVisibility = async () => {
     if (!skill) return;
@@ -113,7 +117,20 @@ export function EditSkillPage() {
         </h1>
 
         <div className="mx-auto max-w-2xl space-y-6">
-          {/* Visibility toggle */}
+          {/* Read-only notice when the caller can't edit at all (#1127). */}
+          {!canWrite && (
+            <Card>
+              <p className="font-text text-sm text-meta">
+                {t(
+                  "editSkill.readOnly",
+                  "You have read-only access to this skill, so there's nothing to edit here.",
+                )}
+              </p>
+            </Card>
+          )}
+
+          {/* Visibility toggle — ADMIN tier (owner / platform admin). */}
+          {canManage && (
           <Card>
             <h3 className="mb-4 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-meta border-b border-dashed border-subtle pb-3">
               {t("editSkill.visibilityHeading", "Visibility")}
@@ -152,8 +169,10 @@ export function EditSkillPage() {
               </Button>
             </div>
           </Card>
+          )}
 
-          {/* Upload new package */}
+          {/* Update Package — WRITE tier (owner / admin / write-grantee). */}
+          {canWrite && (
           <Card>
             <h3 className="mb-4 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-meta border-b border-dashed border-subtle pb-3">
               {t("editSkill.updatePackageHeading", "Update Package")}
@@ -220,6 +239,7 @@ export function EditSkillPage() {
               )}
             </div>
           </Card>
+          )}
         </div>
       </div>
     </PageTransition>

--- a/ornn-web/src/pages/skill/SkillDetailPage.tsx
+++ b/ornn-web/src/pages/skill/SkillDetailPage.tsx
@@ -75,6 +75,7 @@ export function SkillDetailPage() {
     isAuthenticated,
     isOwner,
     isAdminUser,
+    canWrite,
     canManageVersions,
     auditSummaryByVersion,
     versionAudit,
@@ -167,12 +168,12 @@ export function SkillDetailPage() {
           pullCount7d={pullCount7d}
           versionAudit={versionAudit}
           isAuthenticated={isAuthenticated}
-          isOwner={isOwner}
           ownerDisplayName={ownerDisplayName}
           ownerAvatarUrl={ownerAvatarUrl}
           onTryPlayground={() => navigate(`/playground?skill=${encodeURIComponent(skill.name)}`)}
           onDownloadPackage={rawZip ? handleDownloadPackage : undefined}
-          onEditSkill={isOwner ? () => navigate(`/skills/${skill.guid}/edit`) : undefined}
+          // Content edit is the write tier (#1127): owner, admin, or write-grantee.
+          onEditSkill={canWrite ? () => navigate(`/skills/${skill.guid}/edit`) : undefined}
         />
 
         {/* ── Audit-version banner (yellow/red/missing only; green is silent) ── */}
@@ -249,7 +250,7 @@ export function SkillDetailPage() {
                   />
                 )}
               </div>
-              {isOwner && (
+              {canWrite && (
                 <Button
                   size="sm"
                   onClick={() => setShowSaveConfirm(true)}
@@ -273,11 +274,11 @@ export function SkillDetailPage() {
                   files={mergedFiles}
                   fileContents={mergedContents}
                   metadata={null}
-                  editable={isOwner}
+                  editable={canWrite}
                   onContentChange={handleContentChange}
-                  onCreateFile={isOwner ? handleCreateFile : undefined}
-                  onCreateFolder={isOwner ? handleCreateFolder : undefined}
-                  onFileDelete={isOwner ? handleDeleteFile : undefined}
+                  onCreateFile={canWrite ? handleCreateFile : undefined}
+                  onCreateFolder={canWrite ? handleCreateFolder : undefined}
+                  onFileDelete={canWrite ? handleDeleteFile : undefined}
                   className="h-full"
                 />
               ) : (
@@ -367,7 +368,7 @@ export function SkillDetailPage() {
               isPrivate={skill.isPrivate}
               sharedWithUsersCount={skill.sharedWithUsers.length}
               sharedWithOrgsCount={skill.sharedWithOrgs.length}
-              readWriteCount={(skill.grants ?? []).filter((g) => g.level === "read_write").length}
+              writeCount={(skill.grants ?? []).filter((g) => g.level === "write").length}
               isOwner={isOwner}
               onManagePermissions={() => setShowPermissionsModal(true)}
             />

--- a/ornn-web/src/types/domain.ts
+++ b/ornn-web/src/types/domain.ts
@@ -42,10 +42,10 @@ export type SkillSource =
 
 /**
  * Permission level a grant confers (#1123). `read` = view/pull/execute;
- * `read_write` = also update the skill's content & metadata (no admin —
+ * `write` = also update the skill's content & metadata (no admin —
  * permission management, transfer, and delete stay with the owner + admins).
  */
-export type SkillPermissionLevel = "read" | "read_write";
+export type SkillPermissionLevel = "read" | "write";
 
 /** One typed access grant on a skill / skillset (#1123). */
 export interface SkillGrant {
@@ -69,7 +69,7 @@ export interface SkillDetail extends SkillSummary {
   /** Org user_ids this skill has been explicitly shared with. */
   sharedWithOrgs: string[];
   /**
-   * Typed access grants (#1123) — the canonical read/read-write ACL. Always
+   * Typed access grants (#1123) — the canonical read/write ACL. Always
    * present in API responses; the legacy `sharedWith*` arrays above mirror
    * the read-visibility of these for back-compat.
    */

--- a/sdk/python/src/ornn_sdk/client.py
+++ b/sdk/python/src/ornn_sdk/client.py
@@ -252,7 +252,7 @@ class OrnnClient:
         """Apply a new ACL state to a skill (#1123).
 
         ``grants`` is the canonical typed ACL — each entry confers ``read``
-        or ``read_write`` to one user or org. The legacy ``shared_with_*``
+        or ``write`` to one user or org. The legacy ``shared_with_*``
         lists are still accepted (the server maps each entry to a
         ``read``-level grant) but are superseded by ``grants``; pass one or
         the other, not both. ``is_private=False`` makes the skill fully
@@ -372,7 +372,7 @@ class OrnnClient:
         """Update a skillset's visibility / ACL (#1123).
 
         ``grants`` is the canonical typed ACL — each entry confers ``read``
-        or ``read_write`` to one user or org. The legacy ``shared_with_*``
+        or ``write`` to one user or org. The legacy ``shared_with_*``
         lists are still accepted (the server maps each entry to a
         ``read``-level grant) but are superseded by ``grants``; pass one or
         the other, not both.

--- a/sdk/python/src/ornn_sdk/types.py
+++ b/sdk/python/src/ornn_sdk/types.py
@@ -21,8 +21,8 @@ SystemFilter = Literal["any", "only", "exclude"]
 SkillsetKind = Literal["generic", "consensus-supported"]
 
 # Access level a grant confers (#1123). `read` allows pull/execute;
-# `read_write` additionally allows publishing new versions / editing.
-SkillPermissionLevel = Literal["read", "read_write"]
+# `write` additionally allows publishing new versions / editing (and implies read).
+SkillPermissionLevel = Literal["read", "write"]
 GrantTarget = Literal["user", "org"]
 
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -733,7 +733,7 @@ class TestPermissionGrants:
                 "data": {
                     "skill": _skill_data(
                         isPrivate=True,
-                        grants=[{"type": "user", "id": "bob", "level": "read_write"}],
+                        grants=[{"type": "user", "id": "bob", "level": "write"}],
                     )
                 },
                 "error": None,
@@ -743,15 +743,15 @@ class TestPermissionGrants:
             result = ornn.set_skill_permissions(
                 "sk-1",
                 is_private=True,
-                grants=[SkillGrant(type="user", id="bob", level="read_write")],
+                grants=[SkillGrant(type="user", id="bob", level="write")],
             )
         # The typed grant rides on the wire in canonical shape.
         sent = _json.loads(route.calls.last.request.content)
         assert sent["isPrivate"] is True
-        assert sent["grants"] == [{"type": "user", "id": "bob", "level": "read_write"}]
+        assert sent["grants"] == [{"type": "user", "id": "bob", "level": "write"}]
         # Response `{ skill }` envelope is unwrapped + grants parse back.
         assert isinstance(result, SkillDetail)
-        assert result.grants == [SkillGrant(type="user", id="bob", level="read_write")]
+        assert result.grants == [SkillGrant(type="user", id="bob", level="write")]
         assert route.called
 
     @respx.mock
@@ -800,7 +800,7 @@ class TestPermissionGrants:
                 "data": _skill_data(
                     grants=[
                         {"type": "user", "id": "u1", "level": "read"},
-                        {"type": "org", "id": "o1", "level": "read_write"},
+                        {"type": "org", "id": "o1", "level": "write"},
                     ]
                 ),
                 "error": None,
@@ -810,7 +810,7 @@ class TestPermissionGrants:
             detail = ornn.get("sk-1")
         assert detail.grants == [
             SkillGrant(type="user", id="u1", level="read"),
-            SkillGrant(type="org", id="o1", level="read_write"),
+            SkillGrant(type="org", id="o1", level="write"),
         ]
 
     @respx.mock

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -274,7 +274,7 @@ export class OrnnClient {
   /**
    * Update a skill's visibility / sharing ACL (#1123). `grants` is the
    * canonical typed ACL — each entry grants a user or org a `read` or
-   * `read_write` level. The legacy `sharedWith*` arrays are still accepted
+   * `write` level. The legacy `sharedWith*` arrays are still accepted
    * (mapped to `read`-level grants) for backward compat. Returns the
    * refreshed skill detail.
    */
@@ -345,7 +345,7 @@ export class OrnnClient {
   /**
    * Update a skillset's visibility / sharing ACL (#1123). `grants` is the
    * canonical typed ACL — each entry grants a user or org a `read` or
-   * `read_write` level. The legacy `sharedWith*` arrays are still accepted
+   * `write` level. The legacy `sharedWith*` arrays are still accepted
    * (mapped to `read`-level grants) for backward compat.
    */
   async setSkillsetPermissions(

--- a/sdk/typescript/src/tests/client.test.ts
+++ b/sdk/typescript/src/tests/client.test.ts
@@ -381,7 +381,7 @@ describe("OrnnClient", () => {
           skill: {
             id: "sk-1",
             isPrivate: false,
-            grants: [{ type: "user", id: "u-2", level: "read_write" }],
+            grants: [{ type: "user", id: "u-2", level: "write" }],
           },
         },
         error: null,
@@ -390,7 +390,7 @@ describe("OrnnClient", () => {
     const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });
     const res = await client.setSkillPermissions("sk-1", {
       isPrivate: false,
-      grants: [{ type: "user", id: "u-2", level: "read_write" }],
+      grants: [{ type: "user", id: "u-2", level: "write" }],
     });
     expect(captured.method).toBe("PUT");
     expect(captured.url).toBe("https://x/api/v1/skills/sk-1/permissions");
@@ -398,10 +398,10 @@ describe("OrnnClient", () => {
     // The typed grant shape (#1123) is sent verbatim on the wire.
     expect(JSON.parse(captured.body)).toEqual({
       isPrivate: false,
-      grants: [{ type: "user", id: "u-2", level: "read_write" }],
+      grants: [{ type: "user", id: "u-2", level: "write" }],
     });
     expect(res.id).toBe("sk-1");
-    expect(res.grants).toEqual([{ type: "user", id: "u-2", level: "read_write" }]);
+    expect(res.grants).toEqual([{ type: "user", id: "u-2", level: "write" }]);
   });
 
   test("setSkillPermissions(): throws OrnnError on validation failure (400)", async () => {
@@ -409,7 +409,7 @@ describe("OrnnClient", () => {
       jsonResponse(400, {
         status: 400,
         code: "validation_error",
-        detail: "grants[0].level must be read|read_write",
+        detail: "grants[0].level must be read|write",
       }),
     );
     const client = new OrnnClient({ baseUrl: "https://x", fetch: fetchMock });

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -13,9 +13,9 @@ export type SearchScope = "public" | "private" | "mine" | "mixed" | "shared-with
 
 /**
  * Access level a grant confers (#1123). `read` allows pull/execute;
- * `read_write` additionally allows publishing new versions / editing.
+ * `write` additionally allows publishing new versions / editing.
  */
-export type SkillPermissionLevel = "read" | "read_write";
+export type SkillPermissionLevel = "read" | "write";
 
 /**
  * One typed ACL entry (#1123) — the canonical sharing primitive for


### PR DESCRIPTION
## Summary

Separates **read** and **write** access — the combined `read_write` level is gone — and fixes the bug where a user with write access saw **no edit UI**.

Closes #1127

## What changed

**Model: `read_write` → `write`** (API + both SDKs + web + docs). Each grant is `read` or `write`; a `write` grant implies read, but there's no combined label and a principal holds at most one level. Gate behaviour is unchanged from #1123 — only the value renamed.

**Migration (non-disruptive, rollback-safe):** a boot step rewrites any stored `read_write` grant → `write` on skills + skillsets (idempotent; read grants + legacy lists + privacy untouched). `coerceStoredGrants` also maps a stored `read_write` → `write` at read time, so an un-migrated doc (or one written by an older pod mid-deploy) never loses access.

**The bug fix — write-grantees can now edit:** a shared `useSkillAccess(skill)` hook computes the frontend tiers (`canWrite` = owner / platform admin / a `write` grant matching the user directly or via a granted org). The Edit button, inline file editor, and Save are re-pointed at `canWrite`; admin actions (permissions, transfer, delete, visibility, refresh, version mgmt) stay owner/admin. EditSkillPage gates its package update on `canWrite` and its visibility toggle on `canManage`, with a read-only notice for non-writers.

## Verification

- API **1923** tests, web **566**, TS SDK **38**, Python SDK **45** — all pass. typecheck (api/web/sdk) clean; lint 0 errors.
- Migration test pins read_write→write + non-disruption + idempotency; new web tests cover write-grantee-sees-edit and reader-sees-read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
