### PR TITLE
docs: release notes for v0.13.0

### DIFF
--- a/.changeset/release-prep-v0-13-0.md
+++ b/.changeset/release-prep-v0-13-0.md
@@ -1,0 +1,4 @@
+---
+---
+
+Release prep: adds the dated release-notes file for v0.13.0. No package bump.

--- a/.github/release-notes-20260616.md
+++ b/.github/release-notes-20260616.md
@@ -1,0 +1,15 @@
+## Fixed
+
+- Few technical bugs fixed
+
+## New Feature
+
+- Share skills and skillsets at read or write access level
+- Transfer skill or skillset ownership to another Ornn user
+- Users with write access can now edit shared skills, not just owners
+- TypeScript and Python SDKs gain ownership transfer and permission management
+
+## Changed
+
+- Manage Permissions split into separate Read and Write tabs (public read + org write now possible)
+- Technical enhancement


### PR DESCRIPTION
Curated release notes for the v0.13.0 permissions release (#1123 / #1125 / #1127). Lands on develop ahead of the develop → main promotion. Empty changeset for the gate.