### PR TITLE
fix(web): stop signed-out landing nav from overlapping actions

### DIFF
--- a/.changeset/navbar-signedout-overlap.md
+++ b/.changeset/navbar-signedout-overlap.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Fix the signed-out landing top nav overlapping its right-hand actions: the centered links no longer collide with the GitHub / language / theme buttons or the "Sign in" / "Get started" CTAs. The centered nav is now laid out in flow instead of absolutely positioned, and the desktop bar activates at the `lg` (1024px) breakpoint — below that it collapses to the hamburger menu, matching the design system.

--- a/ornn-web/src/components/layout/Navbar.test.tsx
+++ b/ornn-web/src/components/layout/Navbar.test.tsx
@@ -93,7 +93,7 @@ function Nav({ to }: { to: string }) {
 }
 
 function mobileToggle(): HTMLButtonElement {
-  // The hamburger toggle is the button carrying aria-expanded (md:hidden).
+  // The hamburger toggle is the button carrying aria-expanded (lg:hidden).
   return screen
     .getAllByRole("button")
     .find((b) => b.hasAttribute("aria-expanded")) as HTMLButtonElement;

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -265,7 +265,7 @@ export function Navbar({ className = "", showGetStartedCta = false }: NavbarProp
           <Logo className="block h-[26px] w-auto" />
         </Link>
 
-        <div className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 gap-7 md:flex">
+        <div className="hidden flex-1 items-center justify-center gap-6 lg:flex xl:gap-7">
           {NAV_ITEMS.map((item) => (
             <NavLink
               key={item.i18nKey}
@@ -290,7 +290,7 @@ export function Navbar({ className = "", showGetStartedCta = false }: NavbarProp
           ))}
         </div>
 
-        <div className="hidden items-center gap-3.5 md:flex">
+        <div className="hidden items-center gap-3.5 lg:flex">
           <a
             href="https://github.com/ChronoAIProject/Ornn"
             target="_blank"
@@ -406,7 +406,7 @@ export function Navbar({ className = "", showGetStartedCta = false }: NavbarProp
           aria-expanded={menuOpen}
           aria-controls="app-mobile-nav-panel"
           data-open={menuOpen}
-          className="group inline-flex h-9 w-9 items-center justify-center rounded-sm border border-strong-edge bg-transparent text-strong transition-colors duration-200 hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent md:hidden"
+          className="group inline-flex h-9 w-9 items-center justify-center rounded-sm border border-strong-edge bg-transparent text-strong transition-colors duration-200 hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent lg:hidden"
         >
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
             <line x1="3" y1="6" x2="21" y2="6" className="origin-center [transform-box:fill-box] transition-[translate,rotate] duration-300 ease-out group-data-[open=true]:translate-y-[6px] group-data-[open=true]:rotate-45" />
@@ -420,7 +420,7 @@ export function Navbar({ className = "", showGetStartedCta = false }: NavbarProp
         id="app-mobile-nav-panel"
         data-open={menuOpen}
         aria-hidden={!menuOpen}
-        className="absolute left-0 right-0 top-full grid grid-rows-[0fr] bg-page transition-[grid-template-rows,border-color] duration-300 ease-out border-t border-transparent data-[open=true]:grid-rows-[1fr] data-[open=true]:border-subtle data-[open=true]:card-impression md:hidden"
+        className="absolute left-0 right-0 top-full grid grid-rows-[0fr] bg-page transition-[grid-template-rows,border-color] duration-300 ease-out border-t border-transparent data-[open=true]:grid-rows-[1fr] data-[open=true]:border-subtle data-[open=true]:card-impression lg:hidden"
       >
         <div className="overflow-hidden">
           <div className="mx-auto flex max-w-[1280px] flex-col px-6 py-3 sm:px-8">


### PR DESCRIPTION
## Summary

The landing top nav centered its links with absolute positioning, so the centered block ignored the width of the right-hand actions cluster. Signed out, that cluster carries both "Sign in" and "Get started", so it slid under the centered links and "Contact" collided with the GitHub icon at every width. This replaces the absolute centering with an in-flow `flex-1` center region and moves the desktop layout from the `md` to the `lg` breakpoint so the dense bar only renders when it fits.

## Linked issue

Closes #1145

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`) — no behaviour change
- [ ] Docs (`docs:`)
- [ ] CI / build / infra
- [ ] Breaking change

## Commit decomposition

- [x] Each commit is self-contained.
- [x] Each commit is small (one logical change).
- [x] Refactors are separated from behaviour changes.
- [x] No `Co-Authored-By` trailers.

Commits:
1. `fix(web): stop signed-out landing nav from overlapping actions` — the layout fix + test comment.
2. `docs: changeset for navbar signed-out overlap fix`.

## Changeset

- [x] Added a changeset (`ornn-web`: patch).

## Verification

Built `ornn-web` from this branch and deployed to the local cluster. Measured Contact→GitHub spacing (signed out) across viewports:

| width | before (overlap) | after |
|------:|----:|----:|
| 768px | 271px overlap | hamburger (desktop nav hidden) |
| 1024px | 143px overlap | 26px gap |
| 1280px | 15px overlap | 144px gap |
| 1440px | 15px overlap | 144px gap |

Hamburger below 1024px opens with all items (News, Build, Registry, Skillsets, Docs, Contact, GitHub, Sign in, Get started). `typecheck:web`, `eslint`, and the Navbar vitest suite (5 tests) all pass.