### PR TITLE
fix(web): center the top nav on the bar, drop redundant desktop sign-in

### DIFF
--- a/.changeset/navbar-true-center.md
+++ b/.changeset/navbar-true-center.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+Center the landing top nav links dead-center on the bar (3-column grid) instead of between the logo and the actions, and drop the redundant standalone "Sign in" link from the desktop bar — it and "Get started" both open /login, so nothing is lost (the mobile menu keeps both). The nav no longer sits left-of-center or crowds the actions, and "Get started" never wraps.

--- a/ornn-web/src/components/layout/Navbar.tsx
+++ b/ornn-web/src/components/layout/Navbar.tsx
@@ -260,12 +260,12 @@ export function Navbar({ className = "", showGetStartedCta = false }: NavbarProp
     <nav
       className={`sticky top-0 z-50 shrink-0 border-b border-subtle bg-page/95 backdrop-blur-md ${className}`}
     >
-      <div className="relative mx-auto flex h-[60px] max-w-[1280px] items-center justify-between gap-3 px-6 sm:px-8">
-        <Link to="/" className="flex items-center gap-2 text-strong" aria-label={t("aria.brandHome", { brand: "Ornn" })}>
+      <div className="relative mx-auto flex h-[60px] max-w-[1280px] items-center justify-between gap-3 px-6 sm:px-8 lg:grid lg:grid-cols-[1fr_auto_1fr]">
+        <Link to="/" className="flex items-center gap-2 text-strong lg:justify-self-start" aria-label={t("aria.brandHome", { brand: "Ornn" })}>
           <Logo className="block h-[26px] w-auto" />
         </Link>
 
-        <div className="hidden flex-1 items-center justify-center gap-6 lg:flex xl:gap-7">
+        <div className="hidden items-center justify-center gap-3 lg:flex lg:justify-self-center xl:gap-7">
           {NAV_ITEMS.map((item) => (
             <NavLink
               key={item.i18nKey}
@@ -290,7 +290,7 @@ export function Navbar({ className = "", showGetStartedCta = false }: NavbarProp
           ))}
         </div>
 
-        <div className="hidden items-center gap-3.5 lg:flex">
+        <div className="hidden items-center gap-3.5 lg:flex lg:justify-self-end">
           <a
             href="https://github.com/ChronoAIProject/Ornn"
             target="_blank"
@@ -381,14 +381,9 @@ export function Navbar({ className = "", showGetStartedCta = false }: NavbarProp
               </AnimatePresence>
             </div>
           ) : showGetStartedCta ? (
-            <>
-              <EmberLink to="/login" variant="ghost">
-                {t("nav.signIn")}
-              </EmberLink>
-              <EmberLink to="/login" variant="primary">
-                {t("landing.getStarted")}
-              </EmberLink>
-            </>
+            <EmberLink to="/login" variant="primary" className="whitespace-nowrap">
+              {t("landing.getStarted")}
+            </EmberLink>
           ) : (
             <Link
               to="/login"


### PR DESCRIPTION
## Summary

Lay the desktop nav out as a 3-column grid (`1fr / auto / 1fr`) so the links sit **dead-center on the bar** instead of centered in the gap between the logo and the (wider) actions cluster. To fit true-centering within the 1280px max content width, drop the redundant standalone "Sign in" from the desktop landing CTA — both it and "Get started" route to `/login`. The mobile menu keeps both.

## Linked issue

Closes #1147

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Docs (`docs:`)
- [ ] CI / build / infra
- [ ] Breaking change

## Commit decomposition

- [x] Each commit is self-contained and small.
- [x] No `Co-Authored-By` trailers.

Commits:
1. `fix(web): center the top nav on the bar, drop redundant desktop sign-in`
2. `docs: changeset ...`

## Changeset

- [x] Added (`ornn-web`: patch).

## Verification (local cluster, signed out)

| width | nav off-center | nav↔actions | "Get started" |
|------:|----:|----:|----|
| 1024 | 0px | 17px | one line |
| 1100 | 0px | 55px | one line |
| 1280 | 0px | 105px | one line |
| 1440 | 0px | 105px | one line |

No horizontal overflow at any width; hamburger below 1024px; mobile menu unchanged (still lists Sign in + Get started). `typecheck`, `eslint`, and the 5 Navbar tests pass.

## Note

Only the **desktop** standalone "Sign in" is removed (it caused the bar to be too wide to dead-center). The mobile hamburger menu keeps "Sign in →" + "Get started" since it has the vertical room and preserves the returning-user affordance.