### PR TITLE
docs: add v0.14.0 release notes

### DIFF
--- a/.changeset/release-prep-20260629.md
+++ b/.changeset/release-prep-20260629.md
@@ -1,0 +1,4 @@
+---
+---
+
+Release prep: add the v0.14.0 dated release-notes file. Docs/CI only — no package change.

--- a/.github/release-notes-20260629.md
+++ b/.github/release-notes-20260629.md
@@ -1,0 +1,14 @@
+## Fixed
+
+- Signed-out top navigation no longer overlaps and is now centered
+- Landing announcement popups now size to their content
+
+## New Feature
+
+- Skillset detail shows a read-only Public/Restricted/Broken visibility badge
+- Owners are notified when a member skill reduces a skillset's reach
+
+## Changed
+
+- Skillset visibility is now derived from its member skills, not owner-set
+- Technical enhancement


### PR DESCRIPTION
## Summary

Adds the dated release-notes file `.github/release-notes-20260629.md` required before promoting develop → main for the **v0.14.0** release (gated by `check-release-notes.yml`).

Notes cover the user-facing changes accumulated since v0.13.0:
- Skillset visibility now derived from member skills (+ read-only badge, member-unreadable notification)
- Signed-out top nav overlap fixed and re-centered
- Landing announcement popups size to content
- Dep bumps + undici security override + internal migration removal → bucketed as technical

Carries an empty changeset (docs/CI-only PR). No package or code change.

## Type of change

- [x] Docs / release prep

## Changeset

- [x] Empty changeset added (docs/CI-only).