### PR TITLE
feat(api): serve a Claude Code marketplace from the public skill mirror

### DIFF
--- a/.changeset/claude-code-marketplace.md
+++ b/.changeset/claude-code-marketplace.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+The public skill mirror repo now doubles as a Claude Code plugin marketplace. Each sync publishes a root `.claude-plugin/marketplace.json` catalogue plus a per-skill `.claude-plugin/plugin.json`, kept in lockstep with every public skill — add, remove, privatise, or version-bump a skill and the marketplace follows. Claude Code users can now `/plugin marketplace add <owner>/<repo>` and install Ornn skills directly, with no change to Ornn's model-agnostic registry, API, or permissions.

--- a/ornn-api/src/domains/skills/mirror/marketplaceManifest.test.ts
+++ b/ornn-api/src/domains/skills/mirror/marketplaceManifest.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the Claude Code marketplace manifest generators (#1153).
+ *
+ * Pure functions — no GitHub, no DB. The load-bearing properties:
+ *   1. Output is valid JSON matching the Claude Code marketplace /
+ *      plugin schema (name/owner/plugins, source "./<name>").
+ *   2. Output is DETERMINISTIC — plugins sorted by name, stable key
+ *      order — so the mirror's blob-SHA no-op check never sees churn.
+ *   3. `keywords` is present only when the skill has tags.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  buildMarketplaceJson,
+  buildPluginJson,
+  MARKETPLACE_MANIFEST_PATH,
+  PLUGIN_MANIFEST_RELPATH,
+  type MarketplaceConfig,
+  type MarketplaceSkillInput,
+} from "./marketplaceManifest";
+
+const CFG: MarketplaceConfig = {
+  name: "ornn-skills",
+  owner: { name: "ChronoAIProject" },
+};
+
+function skill(overrides: Partial<MarketplaceSkillInput> = {}): MarketplaceSkillInput {
+  return {
+    name: "demo-skill",
+    description: "A test skill.",
+    version: "1.0",
+    keywords: [],
+    ...overrides,
+  };
+}
+
+describe("constants", () => {
+  it("uses the Claude Code well-known paths", () => {
+    expect(MARKETPLACE_MANIFEST_PATH).toBe(".claude-plugin/marketplace.json");
+    expect(PLUGIN_MANIFEST_RELPATH).toBe(".claude-plugin/plugin.json");
+  });
+});
+
+describe("buildMarketplaceJson", () => {
+  it("renders a valid marketplace catalogue for one skill", () => {
+    const out = buildMarketplaceJson([skill({ name: "pdf-extract", keywords: ["pdf"] })], CFG);
+    const parsed = JSON.parse(out);
+    expect(parsed.name).toBe("ornn-skills");
+    expect(parsed.owner).toEqual({ name: "ChronoAIProject" });
+    expect(parsed.plugins).toHaveLength(1);
+    expect(parsed.plugins[0]).toEqual({
+      name: "pdf-extract",
+      source: "./pdf-extract",
+      description: "A test skill.",
+      version: "1.0",
+      keywords: ["pdf"],
+    });
+  });
+
+  it("sorts plugins by name regardless of input order (determinism)", () => {
+    const a = buildMarketplaceJson(
+      [skill({ name: "zebra" }), skill({ name: "alpha" }), skill({ name: "mike" })],
+      CFG,
+    );
+    const b = buildMarketplaceJson(
+      [skill({ name: "mike" }), skill({ name: "zebra" }), skill({ name: "alpha" })],
+      CFG,
+    );
+    expect(a).toBe(b); // same set, any order -> identical bytes
+    const names = JSON.parse(a).plugins.map((p: { name: string }) => p.name);
+    expect(names).toEqual(["alpha", "mike", "zebra"]);
+  });
+
+  it("omits keywords for a tag-less skill but includes them when present", () => {
+    const without = JSON.parse(buildMarketplaceJson([skill({ keywords: [] })], CFG));
+    expect(without.plugins[0]).not.toHaveProperty("keywords");
+
+    const withTags = JSON.parse(
+      buildMarketplaceJson([skill({ keywords: ["a", "b"] })], CFG),
+    );
+    expect(withTags.plugins[0].keywords).toEqual(["a", "b"]);
+  });
+
+  it("handles an empty catalogue", () => {
+    const parsed = JSON.parse(buildMarketplaceJson([], CFG));
+    expect(parsed.plugins).toEqual([]);
+    expect(parsed.name).toBe("ornn-skills");
+  });
+
+  it("escapes special characters in description without corrupting JSON", () => {
+    const weird = 'Quote " backslash \\ newline \n tab \t end';
+    const parsed = JSON.parse(
+      buildMarketplaceJson([skill({ description: weird })], CFG),
+    );
+    expect(parsed.plugins[0].description).toBe(weird);
+  });
+
+  it("ends with a trailing newline (git-friendly)", () => {
+    expect(buildMarketplaceJson([skill()], CFG).endsWith("}\n")).toBe(true);
+  });
+
+  it("does not mutate the caller's keywords array", () => {
+    const tags = ["x"];
+    const s = skill({ keywords: tags });
+    buildMarketplaceJson([s], CFG);
+    expect(tags).toEqual(["x"]);
+  });
+});
+
+describe("buildPluginJson", () => {
+  it("renders a one-skill plugin manifest pinned to the skill version", () => {
+    const parsed = JSON.parse(
+      buildPluginJson(skill({ name: "pdf-extract", version: "2.3" })),
+    );
+    expect(parsed).toEqual({
+      name: "pdf-extract",
+      version: "2.3",
+      description: "A test skill.",
+    });
+  });
+
+  it("is deterministic and trailing-newline terminated", () => {
+    const a = buildPluginJson(skill());
+    const b = buildPluginJson(skill());
+    expect(a).toBe(b);
+    expect(a.endsWith("}\n")).toBe(true);
+  });
+
+  it("escapes special characters in name/description", () => {
+    const parsed = JSON.parse(
+      buildPluginJson(skill({ description: 'has "quotes" and \\ slashes' })),
+    );
+    expect(parsed.description).toBe('has "quotes" and \\ slashes');
+  });
+});

--- a/ornn-api/src/domains/skills/mirror/marketplaceManifest.ts
+++ b/ornn-api/src/domains/skills/mirror/marketplaceManifest.ts
@@ -1,0 +1,134 @@
+/**
+ * Claude Code marketplace manifest generators (#1153).
+ *
+ * The GitHub mirror repo (`ChronoAIProject/ornn-skills`) already holds
+ * one `<skill-name>/` folder per public skill. Adding a root
+ * `.claude-plugin/marketplace.json` plus a per-folder
+ * `.claude-plugin/plugin.json` turns that same repo into a valid
+ * Claude Code plugin marketplace — users run
+ * `/plugin marketplace add <owner>/<repo>` then
+ * `/plugin install <skill>@<marketplace>`.
+ *
+ * Ornn stays the model-agnostic registry of record; this is purely an
+ * export adapter on top of the existing mirror. No browse/ranking, no
+ * consuming external marketplaces.
+ *
+ * These functions are intentionally **pure and deterministic**: same
+ * input -> byte-identical output. The mirror skips no-op commits by
+ * comparing git blob SHAs, so any non-determinism here (unstable key
+ * order, unsorted plugins) would manufacture churn commits on every
+ * sync. Plugins are sorted by name and JSON is serialized with a
+ * stable key order + trailing newline.
+ *
+ * @module domains/skills/mirror/marketplaceManifest
+ */
+
+/** Repo-root path of the marketplace catalogue file. */
+export const MARKETPLACE_MANIFEST_PATH = ".claude-plugin/marketplace.json";
+
+/** Per-skill plugin manifest path, relative to the skill's `<name>/` folder. */
+export const PLUGIN_MANIFEST_RELPATH = ".claude-plugin/plugin.json";
+
+/**
+ * The slice of a skill the manifests need. Decoupled from
+ * `SkillDocument` so this module stays free of DB/runtime types and is
+ * trivially unit-testable.
+ */
+export interface MarketplaceSkillInput {
+  /** Canonical skill name — also the folder name and plugin source path. */
+  name: string;
+  description: string;
+  /** Ornn `<major>.<minor>` latest version, used as the plugin version. */
+  version: string;
+  /** Skill tags -> Claude Code plugin `keywords`. Empty array => omitted. */
+  keywords: string[];
+}
+
+/** Claude Code marketplace `owner` object (only `name` is required). */
+export interface MarketplaceOwner {
+  name: string;
+}
+
+export interface MarketplaceConfig {
+  /** Marketplace `name` field — the mirror repo name, e.g. `ornn-skills`. */
+  name: string;
+  owner: MarketplaceOwner;
+}
+
+interface MarketplacePluginEntry {
+  name: string;
+  source: string;
+  description: string;
+  version: string;
+  keywords?: string[];
+}
+
+interface MarketplaceManifest {
+  name: string;
+  owner: MarketplaceOwner;
+  plugins: MarketplacePluginEntry[];
+}
+
+interface PluginManifest {
+  name: string;
+  version: string;
+  description: string;
+}
+
+/** Stable, locale-independent ascending compare by skill name. */
+function byName(a: MarketplaceSkillInput, b: MarketplaceSkillInput): number {
+  if (a.name < b.name) return -1;
+  if (a.name > b.name) return 1;
+  return 0;
+}
+
+/** Pretty-print with a trailing newline so the file is git-friendly. */
+function serialize(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+/**
+ * Build the root `.claude-plugin/marketplace.json` cataloguing every
+ * supplied (already public + safely-named) skill as a single-skill
+ * plugin sourced from its sibling folder.
+ */
+export function buildMarketplaceJson(
+  skills: MarketplaceSkillInput[],
+  cfg: MarketplaceConfig,
+): string {
+  const plugins: MarketplacePluginEntry[] = [...skills].sort(byName).map((skill) => {
+    const entry: MarketplacePluginEntry = {
+      name: skill.name,
+      source: `./${skill.name}`,
+      description: skill.description,
+      version: skill.version,
+    };
+    // Omit `keywords` entirely when empty — keeps the manifest clean and
+    // avoids an unnecessary `[]` diff for tag-less skills.
+    if (skill.keywords.length > 0) {
+      entry.keywords = [...skill.keywords];
+    }
+    return entry;
+  });
+
+  const manifest: MarketplaceManifest = {
+    name: cfg.name,
+    owner: cfg.owner,
+    plugins,
+  };
+  return serialize(manifest);
+}
+
+/**
+ * Build a single skill folder's `.claude-plugin/plugin.json`, making
+ * that folder a valid one-skill Claude Code plugin and pinning the
+ * plugin version to the skill's latest Ornn version.
+ */
+export function buildPluginJson(skill: MarketplaceSkillInput): string {
+  const manifest: PluginManifest = {
+    name: skill.name,
+    version: skill.version,
+    description: skill.description,
+  };
+  return serialize(manifest);
+}

--- a/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
@@ -400,3 +400,127 @@ describe("MirrorService path-traversal guard (#807, CWE-22)", () => {
     expect(result.added).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe("MirrorService Claude Code marketplace (#1153)", () => {
+  // Parse every blob the service uploaded and return the first one that
+  // is valid JSON exposing a `plugins` array — i.e. the marketplace.json.
+  function findMarketplaceBlob(calls: CallLog): { plugins: Array<{ name: string; source: string }> } | null {
+    for (const b of calls.blobs) {
+      try {
+        const parsed = JSON.parse(b.content);
+        if (parsed && Array.isArray(parsed.plugins)) return parsed;
+      } catch {
+        // not JSON — a SKILL.md / README, skip.
+      }
+    }
+    return null;
+  }
+
+  function allTreePaths(calls: CallLog): string[] {
+    return calls.trees.flatMap((t) => t.entries.map((e) => e.path));
+  }
+
+  it("reconcileAll emits a root marketplace.json + per-skill plugin.json", async () => {
+    const skill = makeSkill({ guid: "g1", name: "demo-skill", isPrivate: false });
+    const { github, calls } = makeFakeGithub();
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([skill]),
+      skillService: makeFakeSkillService({ g1: { "SKILL.md": "# demo" } }),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+    await svc.reconcileAll();
+
+    const paths = allTreePaths(calls);
+    expect(paths).toContain(".claude-plugin/marketplace.json");
+    expect(paths).toContain("demo-skill/.claude-plugin/plugin.json");
+
+    const manifest = findMarketplaceBlob(calls);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.plugins).toHaveLength(1);
+    expect(manifest!.plugins[0]).toMatchObject({
+      name: "demo-skill",
+      source: "./demo-skill",
+    });
+  });
+
+  it("reconcileAll keeps private skills out of the marketplace catalogue", async () => {
+    const pub = makeSkill({ guid: "g-pub", name: "pub", isPrivate: false });
+    const priv = makeSkill({ guid: "g-priv", name: "priv", isPrivate: true });
+    const { github, calls } = makeFakeGithub();
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([pub, priv]),
+      skillService: makeFakeSkillService({ "g-pub": { "SKILL.md": "# pub" } }),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+    await svc.reconcileAll();
+
+    const manifest = findMarketplaceBlob(calls);
+    expect(manifest).not.toBeNull();
+    const names = manifest!.plugins.map((p) => p.name);
+    expect(names).toContain("pub");
+    expect(names).not.toContain("priv");
+  });
+
+  it("publishSkill refreshes the root marketplace.json in the same commit", async () => {
+    const skill = makeSkill({ guid: "g1", name: "demo-skill", isPrivate: false });
+    // Existing head with the folder present but NO manifest yet.
+    const currentTree: TreeEntry[] = [
+      { path: "demo-skill/SKILL.md", mode: "100644", type: "blob", sha: "old-sha" },
+    ];
+    const { github, calls } = makeFakeGithub({ currentTree });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([skill]),
+      skillService: makeFakeSkillService({ g1: { "SKILL.md": "# demo" } }),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+    await svc.publishSkill("g1");
+
+    expect(allTreePaths(calls)).toContain(".claude-plugin/marketplace.json");
+    const manifest = findMarketplaceBlob(calls);
+    expect(manifest!.plugins.map((p) => p.name)).toContain("demo-skill");
+  });
+
+  it("removeSkill drops the skill from the manifest (regenerated from the public set)", async () => {
+    // Mirror currently lists the skill in both the folder and the manifest;
+    // the skill is now ineligible (findAllEligibleForMirror → []).
+    const staleManifest = JSON.stringify({
+      name: "ornn-skills",
+      owner: { name: "ChronoAIProject" },
+      plugins: [{ name: "gone", source: "./gone", description: "x", version: "1.0" }],
+    });
+    const currentTree: TreeEntry[] = [
+      { path: "gone/SKILL.md", mode: "100644", type: "blob", sha: "old-sha" },
+      {
+        path: ".claude-plugin/marketplace.json",
+        mode: "100644",
+        type: "blob",
+        sha: computeGitBlobSha(staleManifest),
+      },
+    ];
+    const { github, calls } = makeFakeGithub({ currentTree });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([]), // nothing eligible
+      skillService: makeFakeSkillService({}),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+    await svc.removeSkill("gone");
+
+    // Folder blob removed AND the manifest rewritten in the same commit.
+    const entries = calls.trees[0]!.entries;
+    const folderRemoval = entries.find((e) => e.path === "gone/SKILL.md");
+    expect(folderRemoval?.sha).toBeNull();
+    expect(entries.some((e) => e.path === ".claude-plugin/marketplace.json")).toBe(true);
+
+    const manifest = findMarketplaceBlob(calls);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.plugins).toEqual([]); // catalogue now empty
+  });
+});

--- a/ornn-api/src/domains/skills/mirror/mirrorService.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.ts
@@ -32,6 +32,13 @@ import { SYSTEM_ACTOR } from "../crud/authorize";
 import type { SkillDocument } from "../../../shared/types/index";
 import type { MirrorSection } from "../../settings/sections/mirror";
 import { SKILL_NAME_REGEX, SKILL_NAME_MAX } from "../../../shared/schemas/skillFrontmatter";
+import {
+  buildMarketplaceJson,
+  buildPluginJson,
+  MARKETPLACE_MANIFEST_PATH,
+  PLUGIN_MANIFEST_RELPATH,
+  type MarketplaceSkillInput,
+} from "./marketplaceManifest";
 
 const logger = createLogger("mirrorService");
 
@@ -260,6 +267,9 @@ export class MirrorService {
     // so we can stamp `mirrorSync` on the skills that get touched.
     const desired = new Map<string, string>(); // path → content
     const skillByName = new Map<string, { guid: string; version: string }>();
+    // Collected in lockstep with the folders we publish so the root
+    // marketplace.json (#1153) lists exactly the skills we mirror.
+    const manifestInputs: MarketplaceSkillInput[] = [];
     for (const skill of eligible) {
       // #807 (CWE-22): skip — do NOT abort — a row whose name would
       // escape its `<name>/` subtree. One poisoned row must not stop the
@@ -272,12 +282,25 @@ export class MirrorService {
         continue;
       }
       skillByName.set(skill.name, { guid: skill.guid, version: skill.latestVersion });
+      manifestInputs.push(toMarketplaceInput(skill));
       const folder = await this.buildSkillFolder(skill);
       for (const [relPath, content] of folder) {
         desired.set(`${skill.name}/${relPath}`, content);
       }
     }
     desired.set("README.md", await this.repoReadme());
+    const mirrorCfg = await this.deps.settingsService.getMirror();
+    desired.set(
+      MARKETPLACE_MANIFEST_PATH,
+      buildMarketplaceJson(manifestInputs, {
+        name: mirrorCfg.repo,
+        owner: { name: mirrorCfg.owner },
+      }),
+    );
+    logger.debug(
+      { count: manifestInputs.length },
+      "reconcileAll: regenerated Claude Code marketplace.json",
+    );
 
     // Read current state of the mirror.
     const headCommit = await client.getDefaultBranchHead();
@@ -378,6 +401,9 @@ export class MirrorService {
       out.set(path, content);
     }
     out.set("README.md", await this.skillReadme(skill));
+    // Per-skill plugin manifest so this folder is a valid one-skill
+    // Claude Code plugin (#1153). Rides every publish + reconcile path.
+    out.set(PLUGIN_MANIFEST_RELPATH, buildPluginJson(toMarketplaceInput(skill)));
     return out;
   }
 
@@ -550,14 +576,18 @@ export class MirrorService {
         }
       }
     } else {
-      if (currentInFolder.length === 0) {
-        logger.info({ skillName }, "removeSkill: folder absent, no-op");
-        return null;
-      }
+      // Remove: drop every blob currently under `<name>/`. An absent
+      // folder leaves `changes` empty here; a stale root manifest entry
+      // is still healed by the manifest refresh below.
       for (const e of currentInFolder) {
         changes.push({ path: e.path, mode: "100644", type: "blob", sha: null as unknown as string });
       }
     }
+
+    // The root marketplace.json (#1153) is a function of the WHOLE public
+    // set, so a single-skill publish/remove must refresh it in the same
+    // commit or the catalogue drifts until the next full reconcile.
+    await this.appendMarketplaceManifestChange(client, currentTree, changes);
 
     if (changes.length === 0) {
       logger.info({ skillName, op }, "commitSkillFolderChange: no diff, skipping commit");
@@ -574,6 +604,30 @@ export class MirrorService {
     });
     logger.info({ skillName, op, changes: changes.length }, "commitSkillFolderChange: committed");
     return commit;
+  }
+
+  /**
+   * Regenerate the root marketplace.json from the current public set
+   * and stage a blob change when it differs from the mirror. Shared by
+   * the incremental publish/remove paths (#1153).
+   */
+  private async appendMarketplaceManifestChange(
+    client: GitHubMirrorClient,
+    currentTree: TreeEntry[],
+    changes: TreeEntry[],
+  ): Promise<void> {
+    const eligible = await this.deps.skillRepo.findAllEligibleForMirror();
+    const cfg = await this.deps.settingsService.getMirror();
+    const content = buildMarketplaceJson(toManifestInputs(eligible), {
+      name: cfg.repo,
+      owner: { name: cfg.owner },
+    });
+    const existing = currentTree.find(
+      (e) => e.type === "blob" && e.path === MARKETPLACE_MANIFEST_PATH,
+    );
+    if (existing?.sha === computeGitBlobSha(content)) return;
+    const sha = await client.createBlob(content);
+    changes.push({ path: MARKETPLACE_MANIFEST_PATH, mode: "100644", type: "blob", sha });
   }
 
   private async writeCommitAndTag(
@@ -608,6 +662,33 @@ export class MirrorService {
     });
     return { sha: commitSha, committedAt };
   }
+}
+
+/**
+ * Map a skill doc to the minimal shape the marketplace generators need
+ * (#1153).
+ */
+function toMarketplaceInput(skill: SkillDocument): MarketplaceSkillInput {
+  return {
+    name: skill.name,
+    description: skill.description,
+    version: skill.latestVersion,
+    keywords: skill.metadata.tags ?? [],
+  };
+}
+
+/** Mirror folder-name safety (#807) — also gates manifest membership. */
+function isSafeSkillFolderName(name: string): boolean {
+  return SKILL_NAME_REGEX.test(name) && name.length <= SKILL_NAME_MAX;
+}
+
+/**
+ * Filter to safely-named skills and map to manifest inputs. Keeps a
+ * poisoned `../escape` name out of the public marketplace.json source
+ * paths, mirroring the reconcile sweep's per-folder guard.
+ */
+function toManifestInputs(skills: SkillDocument[]): MarketplaceSkillInput[] {
+  return skills.filter((s) => isSafeSkillFolderName(s.name)).map(toMarketplaceInput);
 }
 
 /**


### PR DESCRIPTION
## Summary

Makes the existing public-skill GitHub mirror (`ChronoAIProject/ornn-skills`) double as a **Claude Code plugin marketplace** by emitting a root `.claude-plugin/marketplace.json` catalogue plus a per-skill `.claude-plugin/plugin.json` on every sync. Claude Code users can then `/plugin marketplace add <owner>/<repo>` and `/plugin install <skill>@<marketplace>`. Export-only and additive — Ornn stays the model-agnostic registry of record; the marketplace is one downstream distribution adapter on top of the mirror (no browse/ranking UI, no consuming external marketplaces).

## Linked issue

Closes #1153

## Type of change

- [x] New feature (`feat:`)

## Commit decomposition

- [x] Each commit is self-contained (a reviewer can understand it from the diff + message alone).
- [x] Each commit is small (one logical change).
- [x] Refactors are separated from behaviour changes.
- [x] No `Co-Authored-By` trailers.

Three commits:
1. `feat(api): add Claude Code marketplace manifest generators` — new pure, deterministic `marketplaceManifest.ts` + unit tests.
2. `feat(api): publish marketplace manifests from the skill mirror` — wire the generators into `MirrorService` (reconcile + incremental publish/remove) + integration tests.
3. `docs: changeset for #1153`.

## Changeset

- [x] Added a changeset (`.changeset/claude-code-marketplace.md`, `ornn-api` minor → fixed-mode bumps the pair).

## Testing

- Generator unit tests: 11/11 (valid JSON, plugin sort/determinism, keyword omission, empty catalogue, special-char escaping, no-mutation, trailing newline).
- Mirror integration tests: marketplace.json + per-folder plugin.json emitted on `reconcileAll`; private skills excluded from the catalogue; incremental `publishSkill`/`removeSkill` refresh the root manifest in the same commit.
- Full backend suite: **1964 pass / 0 fail**. `bunx tsc --noEmit` clean. `eslint` clean on changed files.
- Not yet done: live `/plugin marketplace add ChronoAIProject/ornn-skills` smoke test against the real mirror repo (needs the mirror enabled in an environment).

## Notes for the reviewer

- **Sync is the contract.** The root `marketplace.json` is a function of the *whole* public set, so the incremental publish/remove paths regenerate it (not just `reconcileAll`) — otherwise the catalogue would drift until the next full reconcile. Determinism (sorted plugins, stable key order, trailing newline) is load-bearing: the mirror skips no-op commits via blob-SHA compare, so unstable output would churn a commit every sync.
- **Safety reuse.** Unsafe-named skills (#807, CWE-22) are filtered out of the manifest, mirroring the existing per-folder traversal guard, so a poisoned name can never reach a `source: "./.."` entry.
- **Deferred follow-up (not in scope):** `mirrorService.ts` is now 738 lines and `mirrorService.test.ts` 526 — both over the 500-line guideline (the service was already 656). Worth a later decomposition; kept out of this PR to keep the diff focused.
