### PR TITLE
feat(api): immediately re-export skillsets on member-skill changes

### DIFF
--- a/.changeset/skillset-mirror-immediacy.md
+++ b/.changeset/skillset-mirror-immediacy.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+Exported skillsets now reflect member-skill changes on the mirror immediately instead of waiting up to 24h for the nightly reconcile. When a member skill publishes a new version, refreshes from GitHub, or moves a dist-tag, the mirror re-exports only the skillsets that reference that skill — rebuilding their bundled member files and bumping the plugin version fingerprint in a single commit. The same applies to a moving `@latest`/`@tag` member: Claude Code picks up the update right away. The re-export is targeted (only affected skillsets, never a full sweep) and deterministic (no commit when nothing actually changed), and a content change can never leak a non-public skillset to the mirror. Skillset transfer-ownership now also triggers a mirror reconcile, matching the skill path. The nightly cron stays as the safety net.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -801,6 +801,17 @@ export async function bootstrap(
     resolveUser: async (userId) =>
       (await userDirectoryRepo.findByUserIds([userId]))[0] ?? null,
     fireSkillsetRecompute: (changedSkill) => skillsetRecomputeHook.fire?.(changedSkill),
+    // #1159 — targeted skillset re-export on a member-skill content/dist-tag
+    // change. Fire-and-forget; the targeted method already no-ops cleanly when
+    // the mirror is disabled or nothing is affected, and the cron is the
+    // backstop for any swallowed failure.
+    fireSkillsetMirrorForMember: (skillGuid, skillName) => {
+      mirrorService
+        .syncSkillsetsForMember(skillGuid, skillName)
+        .catch((err) =>
+          logger.warn({ err, skillGuid, skillName }, "mirror syncSkillsetsForMember failed"),
+        );
+    },
   });
 
   // ---- Domain: Skill Search ----

--- a/ornn-api/src/domains/skills/crud/routes.test.ts
+++ b/ornn-api/src/domains/skills/crud/routes.test.ts
@@ -123,6 +123,8 @@ interface BuildOpts {
   ) => Promise<{ userId: string; email: string; displayName: string } | null>;
   /** #1136 — capture reactive skillset-recompute hook invocations. */
   onSkillsetRecompute?: (changedSkill: { guid: string; name: string }) => void;
+  /** #1159 — capture targeted skillset mirror re-export hook invocations. */
+  onSkillsetMirrorForMember?: (skillGuid: string, skillName: string) => void;
 }
 
 function buildApp(opts: BuildOpts = {}) {
@@ -137,6 +139,7 @@ function buildApp(opts: BuildOpts = {}) {
     extraNyxidServices = [],
     resolveUser,
     onSkillsetRecompute,
+    onSkillsetMirrorForMember,
   } = opts;
 
   const skillRepo = {
@@ -154,6 +157,7 @@ function buildApp(opts: BuildOpts = {}) {
     extraNyxidServicesResolver: async () => extraNyxidServices,
     ...(resolveUser ? { resolveUser } : {}),
     ...(onSkillsetRecompute ? { fireSkillsetRecompute: onSkillsetRecompute } : {}),
+    ...(onSkillsetMirrorForMember ? { fireSkillsetMirrorForMember: onSkillsetMirrorForMember } : {}),
   };
 
   const app = new Hono();
@@ -374,6 +378,46 @@ describe("POST /skills/:id/refresh", () => {
     });
     expect(res.status).toBe(200);
     expect(calls).toContain("refreshSkillFromSource");
+  });
+
+  test("fires the targeted skillset mirror re-export on a real refresh (#1159)", async () => {
+    const fired: Array<[string, string]> = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      service: {
+        getSkill: async () => detail({ createdBy: OWNER }),
+        refreshSkillFromSource: async () => detail({ createdBy: OWNER, name: "demo-skill" }),
+      },
+      onSkillsetMirrorForMember: (guid, name) => fired.push([guid, name]),
+    });
+    const res = await app.request("/api/v1/skills/guid-1/refresh", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    expect(fired).toEqual([["guid-1", "demo-skill"]]);
+  });
+
+  test("does NOT fire the re-export on a dry-run refresh (#1159)", async () => {
+    const fired: Array<[string, string]> = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      service: {
+        getSkill: async () => detail({ createdBy: OWNER }),
+        previewRefreshFromSource: async () => ({ skill: { guid: "guid-1" }, hasChanges: false }),
+      },
+      onSkillsetMirrorForMember: (guid, name) => fired.push([guid, name]),
+    });
+    const res = await app.request("/api/v1/skills/guid-1/refresh", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ dryRun: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(fired).toEqual([]);
   });
 
   test("dryRun delegates to previewRefreshFromSource", async () => {
@@ -830,6 +874,38 @@ describe("dist-tags routes", () => {
     expect(res.status).toBe(200);
     expect(calls).toEqual(["deleteDistTag"]);
   });
+
+  test("PUT dist-tag fires the targeted skillset mirror re-export (#1159)", async () => {
+    const fired: Array<[string, string]> = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER, name: "demo-skill" }) },
+      service: { setDistTag: async () => ({ latest: "1.0", beta: "1.0" }) },
+      onSkillsetMirrorForMember: (guid, name) => fired.push([guid, name]),
+    });
+    const res = await app.request("/api/v1/skills/guid-1/dist-tags/beta", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ version: "1.0" }),
+    });
+    expect(res.status).toBe(200);
+    expect(fired).toEqual([["guid-1", "demo-skill"]]);
+  });
+
+  test("DELETE dist-tag fires the targeted skillset mirror re-export (#1159)", async () => {
+    const fired: Array<[string, string]> = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER, name: "demo-skill" }) },
+      service: { deleteDistTag: async () => ({ latest: "1.0" }) },
+      onSkillsetMirrorForMember: (guid, name) => fired.push([guid, name]),
+    });
+    const res = await app.request("/api/v1/skills/guid-1/dist-tags/beta", { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(fired).toEqual([["guid-1", "demo-skill"]]);
+  });
 });
 
 // ======================================================================
@@ -918,6 +994,44 @@ describe("PUT /skills/:id", () => {
     });
     expect(res.status).toBe(200);
     expect(calls).toEqual(["updateSkill"]);
+  });
+
+  test("ZIP republish fires the targeted skillset mirror re-export (#1159)", async () => {
+    const fired: Array<[string, string]> = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: { updateSkill: async () => detail({ createdBy: OWNER, name: "demo-skill" }) },
+      onSkillsetMirrorForMember: (guid, name) => fired.push([guid, name]),
+    });
+    const res = await app.request("/api/v1/skills/guid-1", {
+      method: "PUT",
+      headers: { "content-type": "application/zip" },
+      body: await skillZipBytes(),
+    });
+    expect(res.status).toBe(200);
+    expect(fired).toEqual([["guid-1", "demo-skill"]]);
+  });
+
+  test("JSON-only visibility update does NOT fire the targeted re-export (#1159)", async () => {
+    // A privacy flip changes readability, not content — it must NOT trigger
+    // the content-path re-export (the visibility-recompute hook handles it).
+    const fired: Array<[string, string]> = [];
+    const app = buildApp({
+      userId: OWNER,
+      permissions: [UPDATE],
+      repo: { findByGuid: async () => skillDoc({ createdBy: OWNER }) },
+      service: { updateSkill: async () => detail({ createdBy: OWNER, name: "demo-skill" }) },
+      onSkillsetMirrorForMember: (guid, name) => fired.push([guid, name]),
+    });
+    const res = await app.request("/api/v1/skills/guid-1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ isPrivate: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(fired).toEqual([]);
   });
 
   test("200 ZIP republish for a write grantee — content edit is the write tier (#1123)", async () => {

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -185,6 +185,15 @@ export interface SkillRoutesConfig {
    * visibility and owners are notified on access loss. No-op when unset.
    */
   fireSkillsetRecompute?: (changedSkill: { guid: string; name: string }) => void;
+  /**
+   * #1159 — fire-and-forget targeted skillset re-export. Called after a skill
+   * CONTENT change (new-version publish, GitHub refresh, dist-tag move) so any
+   * export-eligible skillset referencing the skill via `@latest`/`@tag` is
+   * rebuilt on the mirror immediately, not on the next cron. Distinct from
+   * `fireSkillsetRecompute` (visibility): a content change can't alter skillset
+   * eligibility, so there is no visibility-recompute race here. No-op when unset.
+   */
+  fireSkillsetMirrorForMember?: (skillGuid: string, skillName: string) => void;
 }
 
 /** Marker prefix for synthetic NyxID-service ids. See `extraNyxidServices`. */
@@ -202,6 +211,7 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
     mirrorService,
     resolveUser,
     fireSkillsetRecompute,
+    fireSkillsetMirrorForMember,
   } = config;
   const app = new Hono<{ Variables: AuthVariables }>();
 
@@ -507,6 +517,8 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
         // Refresh bumps version + replaces files → mirror needs to
         // re-extract.
         fireMirrorSync(guid);
+        // New version content → re-export skillsets referencing it (#1159).
+        fireSkillsetMirrorForMember?.(guid, refreshed.name);
 
         return c.json({ data: refreshed, error: null });
       } catch (err) {
@@ -952,6 +964,9 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
 
       const body = getValidatedBody<z.infer<typeof distTagSetSchema>>(c);
       const tags = await skillService.setDistTag(id, tag, body.version);
+      // A dist-tag move can re-resolve a `@tag`-pinned skillset member →
+      // targeted re-export of the skillsets referencing this skill (#1159).
+      fireSkillsetMirrorForMember?.(id, existing.name);
       return c.json({ data: { tags }, error: null });
     },
   );
@@ -984,6 +999,9 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       }
 
       const tags = await skillService.deleteDistTag(id, tag);
+      // Removing a dist-tag can re-resolve a `@tag`-pinned skillset member →
+      // targeted re-export of the skillsets referencing this skill (#1159).
+      fireSkillsetMirrorForMember?.(id, existing.name);
       return c.json({ data: { tags }, error: null });
     },
   );
@@ -1117,6 +1135,13 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
       // umbrella decides between publish vs remove based on the new
       // `isPrivate` state.
       fireMirrorSync(guid);
+      // A new-version publish (ZIP) changes the skill's content but not its
+      // readability → targeted re-export of skillsets referencing it (#1159),
+      // NOT a visibility recompute. A pure privacy flip (no ZIP) does the
+      // reverse below.
+      if (zipBuffer !== undefined) {
+        fireSkillsetMirrorForMember?.(guid, result.name);
+      }
       // Only a privacy flip changes who can read the skill, so recompute
       // dependent skillsets only then (#1136) — a content-only update
       // leaves readability untouched.

--- a/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
@@ -24,6 +24,7 @@ import {
   type MirrorSkillsetRepo,
   type MirrorSkillsetSource,
 } from "./mirrorService";
+import { fingerprintVersion } from "./skillsetPlugin";
 import type { GitHubMirrorClient, TreeEntry } from "./githubMirrorClient";
 import type { SkillRepository } from "../crud/repository";
 import type { SkillService } from "../crud/service";
@@ -146,6 +147,58 @@ function makeFakeGithub(opts: {
   return { github: github as GitHubMirrorClient, calls };
 }
 
+/**
+ * Stateful github stub (#1159): an in-memory tree with DETERMINISTIC blob SHAs
+ * (`computeGitBlobSha`), so committed writes are visible to a subsequent read.
+ * Lets a test commit once and prove a second identical sync produces NO commit
+ * (the no-churn guarantee). Seeded paths give the branch an initial head.
+ */
+function makeStatefulGithub(seed: Record<string, string> = {}): { github: GitHubMirrorClient; calls: CallLog } {
+  const calls: CallLog = { blobs: [], trees: [], commits: [], branchUpdates: [], branchCreates: [], tags: [] };
+  const tree = new Map<string, string>(); // path -> sha
+  for (const [path, content] of Object.entries(seed)) tree.set(path, computeGitBlobSha(content));
+  let head: string | null = Object.keys(seed).length > 0 ? "commit-0" : null;
+  let commitN = 0;
+  let treeN = 0;
+  const github: Partial<GitHubMirrorClient> = {
+    getDefaultBranchHead: mock(async () => head),
+    getCommitTreeSha: mock(async () => `tree-for-${head}`),
+    getRecursiveTree: mock(async () =>
+      [...tree.entries()].map(
+        ([path, sha]) => ({ path, mode: "100644", type: "blob", sha }) as TreeEntry,
+      ),
+    ),
+    createBlob: mock(async (content: string) => {
+      calls.blobs.push({ content });
+      return computeGitBlobSha(content);
+    }),
+    createTree: mock(async (entries: TreeEntry[], baseTree: string | null = null) => {
+      calls.trees.push({ entries, baseTree });
+      // Apply the deltas so a later getRecursiveTree reflects the new state.
+      for (const e of entries) {
+        if (e.sha == null) tree.delete(e.path);
+        else tree.set(e.path, e.sha);
+      }
+      return `new-tree-${++treeN}`;
+    }),
+    createCommit: mock(async (o) => {
+      calls.commits.push(o);
+      head = `commit-${++commitN}`;
+      return head;
+    }),
+    updateDefaultBranch: mock(async (sha: string) => {
+      calls.branchUpdates.push(sha);
+    }),
+    createBranchRef: mock(async (sha: string) => {
+      calls.branchCreates.push(sha);
+    }),
+    createAnnotatedTag: mock(async (o) => {
+      calls.tags.push({ tagName: o.tagName, objectSha: o.objectSha });
+    }),
+  };
+  return { github: github as GitHubMirrorClient, calls };
+}
+
 function makeFakeRepo(skills: SkillDocument[] = []): SkillRepository {
   const byGuid = new Map(skills.map((s) => [s.guid, s]));
   return {
@@ -205,32 +258,42 @@ interface FakeSkillset {
  * (`memberVisibilityState === "all-public"` AND `exportAsPlugin`) so the
  * exclusion tests exercise the contract the mirror depends on.
  */
-function makeFakeSkillsetRepo(skillsets: FakeSkillset[]): MirrorSkillsetRepo {
+function toSkillsetDoc(s: FakeSkillset): SkillsetDocument {
   return {
-    findAllEligibleForMirror: mock(async () =>
-      skillsets
-        .filter((s) => s.memberVisibilityState === "all-public" && s.exportAsPlugin)
-        .map(
-          (s) =>
-            ({
-              guid: s.guid,
-              name: s.name,
-              description: s.description,
-              kind: "generic",
-              tags: s.tags,
-              createdBy: "u1",
-              createdOn: new Date(),
-              updatedBy: "u1",
-              updatedOn: new Date(),
-              isPrivate: false,
-              sharedWithUsers: [],
-              sharedWithOrgs: [],
-              memberVisibilityState: s.memberVisibilityState,
-              exportAsPlugin: s.exportAsPlugin,
-              ...(s.pluginConfig ? { pluginConfig: s.pluginConfig } : {}),
-              latestVersion: s.latestVersion,
-            }) as unknown as SkillsetDocument,
-        ),
+    guid: s.guid,
+    name: s.name,
+    description: s.description,
+    kind: "generic",
+    tags: s.tags,
+    createdBy: "u1",
+    createdOn: new Date(),
+    updatedBy: "u1",
+    updatedOn: new Date(),
+    isPrivate: false,
+    sharedWithUsers: [],
+    sharedWithOrgs: [],
+    memberVisibilityState: s.memberVisibilityState,
+    exportAsPlugin: s.exportAsPlugin,
+    ...(s.pluginConfig ? { pluginConfig: s.pluginConfig } : {}),
+    latestVersion: s.latestVersion,
+  } as unknown as SkillsetDocument;
+}
+
+function makeFakeSkillsetRepo(skillsets: FakeSkillset[]): MirrorSkillsetRepo {
+  const eligible = (): FakeSkillset[] =>
+    skillsets.filter((s) => s.memberVisibilityState === "all-public" && s.exportAsPlugin);
+  return {
+    findAllEligibleForMirror: mock(async () => eligible().map(toSkillsetDoc)),
+    // Replicates the real repo (#1159): only opted-in, all-public skillsets
+    // whose members reference the skill (by name OR guid) come back.
+    findEligibleSkillsetsByMember: mock(async (skillName: string, skillGuid: string) =>
+      eligible()
+        .filter((s) =>
+          s.members.some(
+            (ref) => ref.startsWith(`${skillName}@`) || ref.startsWith(`${skillGuid}@`),
+          ),
+        )
+        .map(toSkillsetDoc),
     ),
   };
 }
@@ -790,5 +853,210 @@ describe("MirrorService skillset plugin export (#1155)", () => {
     });
     await svc.reconcileAll();
     expect(allTreePaths(calls).some((p) => p.startsWith("skillsets/"))).toBe(false);
+  });
+});
+
+describe("MirrorService.syncSkillsetsForMember (#1159)", () => {
+  function allTreePaths(calls: CallLog): string[] {
+    return calls.trees.flatMap((t) => t.entries.map((e) => e.path));
+  }
+  function parsedBlobs(calls: CallLog): Array<Record<string, unknown>> {
+    return calls.blobs
+      .map((b) => {
+        try {
+          return JSON.parse(b.content) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .filter((p): p is Record<string, unknown> => p !== null);
+  }
+
+  const researchBundle: FakeSkillset = {
+    guid: "ss-research",
+    name: "research-bundle",
+    description: "A curated research set.",
+    latestVersion: "2.0",
+    tags: ["research"],
+    memberVisibilityState: "all-public",
+    exportAsPlugin: true,
+    members: ["pdf@1.1", "ocr@1.0"],
+    instructions: "Run pdf, then ocr.",
+  };
+
+  it("rebuilds the affected subtree + bumps the plugin.json fingerprint on a member change", async () => {
+    // The mirror already holds an OLD subtree; the member set now resolves
+    // pdf to 1.1, so the rebuilt plugin.json must carry a NEW fingerprint and
+    // the member SKILL.md must be re-uploaded.
+    const currentTree: TreeEntry[] = [
+      { path: "skillsets/research-bundle/.claude-plugin/plugin.json", mode: "100644", type: "blob", sha: "old-plugin-sha" },
+      { path: "skillsets/research-bundle/skills/pdf/SKILL.md", mode: "100644", type: "blob", sha: "old-pdf-sha" },
+      { path: "skillsets/research-bundle/skills/ocr/SKILL.md", mode: "100644", type: "blob", sha: "old-ocr-sha" },
+      { path: "skillsets/research-bundle/README.md", mode: "100644", type: "blob", sha: "old-readme-sha" },
+    ];
+    const { github, calls } = makeFakeGithub({ currentTree });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([makeSkill({ guid: "pdf-guid", name: "pdf", isPrivate: false })]),
+      skillService: makeFakeSkillService({
+        pdf: { "SKILL.md": "# pdf member v2" },
+        ocr: { "SKILL.md": "# ocr member" },
+      }),
+      skillsetRepo: makeFakeSkillsetRepo([researchBundle]),
+      skillsetService: makeFakeSkillsetService([researchBundle]),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+
+    await svc.syncSkillsetsForMember("pdf-guid", "pdf");
+
+    // The member file got rebuilt under the skillset subtree.
+    expect(allTreePaths(calls)).toContain("skillsets/research-bundle/skills/pdf/SKILL.md");
+    expect(calls.blobs.some((b) => b.content === "# pdf member v2")).toBe(true);
+
+    // plugin.json carries the fingerprint of the NEW resolved member set,
+    // which differs from the old one (pdf 1.0 → 1.1).
+    const pluginJson = parsedBlobs(calls).find((p) => p.name === "research-bundle");
+    expect(pluginJson).toBeTruthy();
+    const newFp = fingerprintVersion("2.0", [
+      { name: "ocr", version: "1.0", description: "", files: {} },
+      { name: "pdf", version: "1.1", description: "", files: {} },
+    ]);
+    const oldFp = fingerprintVersion("2.0", [
+      { name: "ocr", version: "1.0", description: "", files: {} },
+      { name: "pdf", version: "1.0", description: "", files: {} },
+    ]);
+    expect(newFp).not.toBe(oldFp);
+    expect(pluginJson!.version).toBe(newFp);
+    expect(calls.commits.length).toBe(1);
+  });
+
+  it("no-ops when no eligible skillset references the changed skill", async () => {
+    const { github, calls } = makeFakeGithub({
+      currentTree: [
+        { path: "skillsets/research-bundle/README.md", mode: "100644", type: "blob", sha: "x" },
+      ],
+    });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([]),
+      skillService: makeFakeSkillService({ pdf: { "SKILL.md": "# pdf" }, ocr: { "SKILL.md": "# ocr" } }),
+      skillsetRepo: makeFakeSkillsetRepo([researchBundle]),
+      skillsetService: makeFakeSkillsetService([researchBundle]),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+    // `unrelated` is not a member of any eligible skillset.
+    await svc.syncSkillsetsForMember("unrelated-guid", "unrelated");
+    expect(calls.blobs.length).toBe(0);
+    expect(calls.trees.length).toBe(0);
+    expect(calls.commits.length).toBe(0);
+  });
+
+  it("skips ineligible skillsets (opted-out / not all-public) that reference the skill", async () => {
+    const optedOut: FakeSkillset = { ...researchBundle, guid: "ss-out", name: "out-set", exportAsPlugin: false };
+    const restricted: FakeSkillset = {
+      ...researchBundle,
+      guid: "ss-restr",
+      name: "restr-set",
+      memberVisibilityState: "restricted",
+    };
+    const { github, calls } = makeFakeGithub({
+      currentTree: [{ path: "skillsets/out-set/README.md", mode: "100644", type: "blob", sha: "x" }],
+    });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([]),
+      skillService: makeFakeSkillService({ pdf: { "SKILL.md": "# pdf" }, ocr: { "SKILL.md": "# ocr" } }),
+      skillsetRepo: makeFakeSkillsetRepo([optedOut, restricted]),
+      skillsetService: makeFakeSkillsetService([optedOut, restricted]),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+    await svc.syncSkillsetsForMember("pdf-guid", "pdf");
+    // Neither skillset is export-eligible, so nothing is rebuilt/committed.
+    expect(calls.commits.length).toBe(0);
+    expect(calls.blobs.length).toBe(0);
+  });
+
+  it("rebuilds multiple affected skillsets in a SINGLE commit", async () => {
+    const dataBundle: FakeSkillset = {
+      guid: "ss-data",
+      name: "data-bundle",
+      description: "A data set.",
+      latestVersion: "1.0",
+      tags: ["data"],
+      memberVisibilityState: "all-public",
+      exportAsPlugin: true,
+      members: ["pdf@1.1", "csv@1.0"],
+      instructions: "Run pdf, then csv.",
+    };
+    const currentTree: TreeEntry[] = [
+      { path: "skillsets/research-bundle/README.md", mode: "100644", type: "blob", sha: "r-old" },
+      { path: "skillsets/data-bundle/README.md", mode: "100644", type: "blob", sha: "d-old" },
+    ];
+    const { github, calls } = makeFakeGithub({ currentTree });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([]),
+      skillService: makeFakeSkillService({
+        pdf: { "SKILL.md": "# pdf" },
+        ocr: { "SKILL.md": "# ocr" },
+        csv: { "SKILL.md": "# csv" },
+      }),
+      skillsetRepo: makeFakeSkillsetRepo([researchBundle, dataBundle]),
+      skillsetService: makeFakeSkillsetService([researchBundle, dataBundle]),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+
+    await svc.syncSkillsetsForMember("pdf-guid", "pdf");
+
+    // One commit; both subtrees rebuilt.
+    expect(calls.commits.length).toBe(1);
+    const paths = allTreePaths(calls);
+    expect(paths).toContain("skillsets/research-bundle/.claude-plugin/plugin.json");
+    expect(paths).toContain("skillsets/data-bundle/.claude-plugin/plugin.json");
+    expect(paths).toContain("skillsets/data-bundle/skills/csv/SKILL.md");
+  });
+
+  it("produces NO commit when the subtree already matches (no churn)", async () => {
+    // A stateful github with a pre-existing head: first sync writes the
+    // subtree, the second identical sync must be a clean no-op.
+    const { github, calls } = makeStatefulGithub({ "README.md": "root" });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([]),
+      skillService: makeFakeSkillService({
+        pdf: { "SKILL.md": "# pdf" },
+        ocr: { "SKILL.md": "# ocr" },
+      }),
+      skillsetRepo: makeFakeSkillsetRepo([researchBundle]),
+      skillsetService: makeFakeSkillsetService([researchBundle]),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+
+    await svc.syncSkillsetsForMember("pdf-guid", "pdf");
+    expect(calls.commits.length).toBe(1);
+    // Second run sees a byte-identical desired tree → zero new commits.
+    await svc.syncSkillsetsForMember("pdf-guid", "pdf");
+    expect(calls.commits.length).toBe(1);
+  });
+
+  it("is a no-op when the mirror is disabled", async () => {
+    const { github, calls } = makeFakeGithub();
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([]),
+      skillService: makeFakeSkillService({ pdf: { "SKILL.md": "# pdf" }, ocr: { "SKILL.md": "# ocr" } }),
+      skillsetRepo: makeFakeSkillsetRepo([researchBundle]),
+      skillsetService: makeFakeSkillsetService([researchBundle]),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings({ enabled: false }),
+    });
+    await svc.syncSkillsetsForMember("pdf-guid", "pdf");
+    expect(calls.blobs.length).toBe(0);
+    expect(calls.commits.length).toBe(0);
   });
 });

--- a/ornn-api/src/domains/skills/mirror/mirrorService.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.ts
@@ -65,6 +65,15 @@ export interface MirrorSettingsReader {
  */
 export interface MirrorSkillsetRepo {
   findAllEligibleForMirror(): Promise<SkillsetDocument[]>;
+  /**
+   * Export-eligible skillsets referencing the given member skill (#1159).
+   * Drives the targeted re-export so a member content / dist-tag change
+   * rebuilds only the affected `skillsets/<name>/` subtrees, not a full sweep.
+   */
+  findEligibleSkillsetsByMember(
+    skillName: string,
+    skillGuid: string,
+  ): Promise<SkillsetDocument[]>;
 }
 
 /**
@@ -278,6 +287,81 @@ export class MirrorService {
     const client = await this.getActiveClient();
     if (!client) return;
     await this.commitSkillFolderChange(client, name, null, "remove");
+  }
+
+  /**
+   * Targeted re-export (#1159): rebuild ONLY the `skillsets/<name>/` subtrees
+   * of the export-eligible skillsets that reference the given member skill, in
+   * a SINGLE commit. Fired fire-and-forget from the skill content-change paths
+   * (new-version publish, GitHub refresh, dist-tag move) so an exported
+   * skillset referencing the skill via `@latest`/`@tag` reflects the change
+   * immediately instead of waiting up to 24h for the cron reconcile.
+   *
+   * No-ops cleanly when the mirror is disabled, skillset deps are unwired, no
+   * eligible skillset references the skill, or every affected skillset is
+   * unresolvable. Deterministic: an unchanged subtree (e.g. a member ref pinned
+   * to a fixed version, so the resolved-member fingerprint is unmoved) produces
+   * no diff and therefore no commit.
+   *
+   * reconcileInFlight handling: when a full reconcile is already running it
+   * rebuilds EVERY eligible skillset subtree anyway, so we defer to it rather
+   * than racing a second commit against the same branch head. The cron remains
+   * the backstop if that reconcile somehow misses this skill.
+   */
+  async syncSkillsetsForMember(skillGuid: string, skillName: string): Promise<void> {
+    const client = await this.getActiveClient();
+    if (!client) return;
+    if (!this.deps.skillsetRepo || !this.deps.skillsetService) return;
+
+    if (this.reconcileInFlight) {
+      logger.info(
+        { skillGuid, skillName },
+        "syncSkillsetsForMember: reconcile in flight — deferring the targeted re-export to it",
+      );
+      return;
+    }
+
+    const affected = await this.deps.skillsetRepo.findEligibleSkillsetsByMember(
+      skillName,
+      skillGuid,
+    );
+    if (affected.length === 0) {
+      logger.debug(
+        { skillGuid, skillName },
+        "syncSkillsetsForMember: no eligible skillset references this skill",
+      );
+      return;
+    }
+
+    // Build every affected subtree, then commit them all in one shot.
+    const desired = new Map<string, string>();
+    const folderPrefixes: string[] = [];
+    const rebuilt: string[] = [];
+    for (const ss of affected) {
+      const subtree = await this.buildOneSkillsetSubtree(ss);
+      if (!subtree) continue;
+      for (const [path, content] of subtree.files) desired.set(path, content);
+      folderPrefixes.push(`${SKILLSET_FOLDER}/${ss.name}/`);
+      rebuilt.push(ss.name);
+    }
+    if (folderPrefixes.length === 0) {
+      logger.debug(
+        { skillGuid, skillName, affected: affected.length },
+        "syncSkillsetsForMember: affected skillsets unresolvable — nothing to rebuild",
+      );
+      return;
+    }
+
+    const commit = await this.commitFolderSubtrees(client, {
+      folderPrefixes,
+      desired,
+      op: "skillset-sync",
+      message: `mirror: re-export skillsets for ${skillName}`,
+    });
+    logger.info(
+      { skillGuid, skillName, skillsets: rebuilt, committed: !!commit },
+      "syncSkillsetsForMember: targeted re-export complete",
+    );
   }
 
   /**
@@ -596,74 +680,100 @@ export class MirrorService {
     // call is scoped to a single skill (publishSkill / removeSkill), so a
     // bad name fails just that operation, never a batch.
     this.assertSafeSkillFolder(skillName);
+    const folderPrefix = `${skillName}/`;
+    // Re-key the per-skill RELATIVE paths to full mirror paths so the shared
+    // subtree-commit core can diff them against the current tree.
+    const desiredFull = desired
+      ? new Map<string, string>(
+          [...desired].map(([rel, content]) => [`${folderPrefix}${rel}`, content]),
+        )
+      : null;
+    return this.commitFolderSubtrees(client, {
+      folderPrefixes: [folderPrefix],
+      desired: desiredFull,
+      op,
+      message: op === "publish" ? `mirror: publish ${skillName}` : `mirror: remove ${skillName}`,
+    });
+  }
+
+  /**
+   * Shared incremental-commit core (#1153/#1159). Diffs a combined
+   * `fullPath → content` desired map against the current mirror tree,
+   * RESTRICTED to `folderPrefixes`, and writes ONE commit with the add /
+   * update / delete deltas. Generalizes the original per-skill `<name>/` commit
+   * to an arbitrary set of subtrees, so a single member change can re-export
+   * every affected `skillsets/<name>/` subtree in one commit.
+   *
+   *   - `desired === null` removes every blob under the prefixes (the per-skill
+   *     remove case). Otherwise each prefix is fully reconciled to `desired`: a
+   *     current blob under a prefix that isn't in `desired` is deleted.
+   *   - The root marketplace.json (#1153) is refreshed in the SAME commit, but
+   *     stages a blob ONLY when its content actually changed — a content-only
+   *     member bump leaves the plain catalogue entry unmoved → no manifest
+   *     churn.
+   *   - No diff (and no manifest change) ⇒ no commit (deterministic).
+   *   - First-ever push (no branch head) defers to `reconcileAll` so the
+   *     bootstrap commit reflects the whole catalogue; returns null so the
+   *     caller doesn't double-stamp.
+   */
+  private async commitFolderSubtrees(
+    client: GitHubMirrorClient,
+    opts: {
+      folderPrefixes: string[];
+      desired: Map<string, string> | null;
+      op: string;
+      message: string;
+    },
+  ): Promise<{ sha: string; committedAt: Date } | null> {
+    const { folderPrefixes, desired, op, message } = opts;
     const headCommit = await client.getDefaultBranchHead();
     if (!headCommit) {
-      // First-ever push — bootstrap requires an initial commit. Defer
-      // to reconcile so the bootstrap commit reflects the entire
-      // current Ornn catalogue, not just one skill in isolation.
-      // Reconcile stamps everything itself; we return null here so
-      // the caller doesn't double-stamp.
-      logger.warn(
-        { skillName, op },
-        "commitSkillFolderChange: mirror branch missing — running reconcileAll instead",
-      );
+      logger.warn({ op }, "commitFolderSubtrees: mirror branch missing — running reconcileAll instead");
       await this.reconcileAll();
       return null;
     }
-    const currentTreeSha = await client.getCommitTreeSha(headCommit);
-    const currentTree = await client.getRecursiveTree(currentTreeSha);
-    const folderPrefix = `${skillName}/`;
-    const currentInFolder = currentTree
-      .filter((e) => e.type === "blob" && e.path.startsWith(folderPrefix))
+    const currentTree = await client.getRecursiveTree(await client.getCommitTreeSha(headCommit));
+    const currentInFolders = currentTree
+      .filter((e) => e.type === "blob" && folderPrefixes.some((p) => e.path.startsWith(p)))
       .map((e) => ({ path: e.path, sha: e.sha }));
 
     const changes: TreeEntry[] = [];
     if (desired) {
-      // Build add/update entries for every desired path; mark deletes
-      // for any current path that isn't in the desired set.
       const desiredPaths = new Set<string>();
-      for (const [relPath, content] of desired) {
-        const fullPath = `${folderPrefix}${relPath}`;
+      for (const [fullPath, content] of desired) {
         desiredPaths.add(fullPath);
-        const existing = currentInFolder.find((e) => e.path === fullPath);
+        const existing = currentInFolders.find((e) => e.path === fullPath);
         const desiredSha = computeGitBlobSha(content);
         if (existing?.sha === desiredSha) continue;
         const newSha = await client.createBlob(content);
         changes.push({ path: fullPath, mode: "100644", type: "blob", sha: newSha });
       }
-      for (const e of currentInFolder) {
+      for (const e of currentInFolders) {
         if (!desiredPaths.has(e.path)) {
           changes.push({ path: e.path, mode: "100644", type: "blob", sha: null as unknown as string });
         }
       }
     } else {
-      // Remove: drop every blob currently under `<name>/`. An absent
-      // folder leaves `changes` empty here; a stale root manifest entry
-      // is still healed by the manifest refresh below.
-      for (const e of currentInFolder) {
+      for (const e of currentInFolders) {
         changes.push({ path: e.path, mode: "100644", type: "blob", sha: null as unknown as string });
       }
     }
 
-    // The root marketplace.json (#1153) is a function of the WHOLE public
-    // set, so a single-skill publish/remove must refresh it in the same
-    // commit or the catalogue drifts until the next full reconcile.
+    // The root marketplace.json is a function of the WHOLE public set, so a
+    // targeted commit refreshes it too — but only when its content changed.
     await this.appendMarketplaceManifestChange(client, currentTree, changes);
 
     if (changes.length === 0) {
-      logger.info({ skillName, op }, "commitSkillFolderChange: no diff, skipping commit");
+      logger.info({ op, prefixes: folderPrefixes.length }, "commitFolderSubtrees: no diff, skipping commit");
       return null;
     }
 
     const commit = await this.writeCommitAndTag(client, {
       changes,
       parentCommit: headCommit,
-      message:
-        op === "publish"
-          ? `mirror: publish ${skillName}`
-          : `mirror: remove ${skillName}`,
+      message,
     });
-    logger.info({ skillName, op, changes: changes.length }, "commitSkillFolderChange: committed");
+    logger.info({ op, changes: changes.length }, "commitFolderSubtrees: committed");
     return commit;
   }
 
@@ -736,6 +846,40 @@ export class MirrorService {
     const eligible = await this.deps.skillsetRepo.findAllEligibleForMirror();
     logger.info({ count: eligible.length }, "reconcileAll: found plugin-export-eligible skillsets");
 
+    const marketplaceInputs: MarketplacePluginInput[] = [];
+    for (const ss of eligible) {
+      const subtree = await this.buildOneSkillsetSubtree(ss);
+      if (!subtree) continue;
+      for (const [path, content] of subtree.files) desired.set(path, content);
+      marketplaceInputs.push(subtree.marketplace);
+    }
+    return marketplaceInputs;
+  }
+
+  /**
+   * Assemble ONE skillset's `skillsets/<name>/…` subtree (#1155/#1159):
+   * resolve its latest-version members to concrete packages, build the
+   * multi-skill plugin via {@link buildSkillsetPlugin}, and return the file map
+   * already prefixed under `skillsets/<name>/` plus the marketplace catalogue
+   * row. Returns `null` when the skillset can't be exported (unsafe name, no
+   * published version, or skillset deps unwired) so a caller skips it without
+   * aborting a batch. Shared by the full reconcile sweep and the targeted
+   * per-member re-export.
+   */
+  private async buildOneSkillsetSubtree(
+    ss: SkillsetDocument,
+  ): Promise<{ files: Map<string, string>; marketplace: MarketplacePluginInput } | null> {
+    if (!this.deps.skillsetService) return null;
+    // #807 — skip (don't abort) a skillset whose name would escape its subtree.
+    if (!isSafeSkillFolderName(ss.name)) {
+      logger.error({ guid: ss.guid, name: ss.name }, "mirror: skipping unsafe skillset name");
+      return null;
+    }
+    const latest = await this.deps.skillsetService.getLatestForMirror(ss.guid);
+    if (!latest) {
+      logger.warn({ guid: ss.guid, name: ss.name }, "mirror: skillset has no version; skipping");
+      return null;
+    }
     const cfg = await this.deps.settingsService.getMirror();
     const pluginCfg = {
       ornnPublicOrigin: this.deps.ornnPublicOrigin,
@@ -743,44 +887,30 @@ export class MirrorService {
       repoName: cfg.repo,
     };
     const loadMember = this.makeMemberLoader();
-
-    const marketplaceInputs: MarketplacePluginInput[] = [];
-    for (const ss of eligible) {
-      // #807 — skip (don't abort) a skillset whose name would escape its subtree.
-      if (!isSafeSkillFolderName(ss.name)) {
-        logger.error({ guid: ss.guid, name: ss.name }, "reconcileAll: skipping unsafe skillset name");
-        continue;
-      }
-      const latest = await this.deps.skillsetService.getLatestForMirror(ss.guid);
-      if (!latest) {
-        logger.warn({ guid: ss.guid, name: ss.name }, "reconcileAll: skillset has no version; skipping");
-        continue;
-      }
-      const members: SkillsetPluginMember[] = [];
-      for (const ref of latest.members) {
-        const m = await loadMember(ref);
-        if (m) members.push(m);
-        else logger.warn({ skillset: ss.name, ref }, "reconcileAll: skillset member unresolvable; skipping");
-      }
-      const { files, marketplace } = buildSkillsetPlugin(
-        {
-          name: ss.name,
-          description: ss.description,
-          version: ss.latestVersion,
-          tags: ss.tags,
-          instructions: latest.instructions,
-          members,
-          // #1157 — owner listing overrides; the builder resolves the fallbacks.
-          pluginConfig: ss.pluginConfig,
-        },
-        pluginCfg,
-      );
-      for (const [relPath, content] of files) {
-        desired.set(`${SKILLSET_FOLDER}/${ss.name}/${relPath}`, content);
-      }
-      marketplaceInputs.push(marketplace);
+    const members: SkillsetPluginMember[] = [];
+    for (const ref of latest.members) {
+      const m = await loadMember(ref);
+      if (m) members.push(m);
+      else logger.warn({ skillset: ss.name, ref }, "mirror: skillset member unresolvable; skipping");
     }
-    return marketplaceInputs;
+    const { files, marketplace } = buildSkillsetPlugin(
+      {
+        name: ss.name,
+        description: ss.description,
+        version: ss.latestVersion,
+        tags: ss.tags,
+        instructions: latest.instructions,
+        members,
+        // #1157 — owner listing overrides; the builder resolves the fallbacks.
+        pluginConfig: ss.pluginConfig,
+      },
+      pluginCfg,
+    );
+    const prefixed = new Map<string, string>();
+    for (const [relPath, content] of files) {
+      prefixed.set(`${SKILLSET_FOLDER}/${ss.name}/${relPath}`, content);
+    }
+    return { files: prefixed, marketplace };
   }
 
   /**

--- a/ornn-api/src/domains/skillsets/bootstrap.ts
+++ b/ornn-api/src/domains/skillsets/bootstrap.ts
@@ -66,8 +66,10 @@ export function wireSkillsets(deps: {
    */
   fireMirrorReconcile?: () => void;
 }): SkillsetWiring {
-  const skillsetRepo = new SkillsetRepository(deps.db);
+  // Version repo first: the identity repo takes it so the targeted mirror
+  // re-export (#1159) can resolve "which skillsets reference this member?".
   const skillsetVersionRepo = new SkillsetVersionRepository(deps.db);
+  const skillsetRepo = new SkillsetRepository(deps.db, skillsetVersionRepo);
 
   const service = new SkillsetService({
     skillsetRepo,

--- a/ornn-api/src/domains/skillsets/repository.test.ts
+++ b/ornn-api/src/domains/skillsets/repository.test.ts
@@ -28,8 +28,8 @@ beforeAll(async () => {
   client = new MongoClient(mongo.getUri());
   await client.connect();
   db = client.db("skillsets_test");
-  repo = new SkillsetRepository(db);
   versionRepo = new SkillsetVersionRepository(db);
+  repo = new SkillsetRepository(db, versionRepo);
   await repo.ensureIndexes();
   await versionRepo.ensureIndexes();
 });
@@ -243,6 +243,56 @@ describe("SkillsetRepository — findAllEligibleForMirror (#1155)", () => {
   test("returns an empty list when nothing is eligible", async () => {
     await seed({ _id: "x", name: "x-set", memberVisibilityState: "all-public", exportAsPlugin: false });
     expect(await repo.findAllEligibleForMirror()).toEqual([]);
+  });
+});
+
+describe("SkillsetRepository — findEligibleSkillsetsByMember (#1159)", () => {
+  async function seedVersion(skillsetGuid: string, members: string[]): Promise<void> {
+    await versionRepo.create({
+      skillsetGuid,
+      version: "1.0",
+      majorVersion: 1,
+      minorVersion: 0,
+      kind: "generic",
+      description: "d",
+      instructions: "p",
+      tags: [],
+      members,
+      createdBy: "owner-1",
+    });
+  }
+
+  test("returns only opted-in + all-public skillsets that reference the skill", async () => {
+    await seed(
+      // eligible: opted in, all-public, references `review` by name.
+      { _id: "ss-ok", name: "ok-set", memberVisibilityState: "all-public", exportAsPlugin: true },
+      // references the skill but NOT opted in → excluded.
+      { _id: "ss-noopt", name: "noopt-set", memberVisibilityState: "all-public", exportAsPlugin: false },
+      // references the skill, opted in, but NOT all-public → excluded (unsafe to publish).
+      { _id: "ss-restr", name: "restr-set", memberVisibilityState: "restricted", exportAsPlugin: true },
+      // eligible but does NOT reference the skill → excluded.
+      { _id: "ss-unrel", name: "unrel-set", memberVisibilityState: "all-public", exportAsPlugin: true },
+    );
+    await seedVersion("ss-ok", ["review@1.0", "other@1.0"]);
+    await seedVersion("ss-noopt", ["review@latest"]);
+    await seedVersion("ss-restr", ["review@1.0"]);
+    await seedVersion("ss-unrel", ["unrelated@1.0"]);
+
+    const eligible = await repo.findEligibleSkillsetsByMember("review", "skl-review-guid");
+    expect(eligible.map((s) => s.guid)).toEqual(["ss-ok"]);
+  });
+
+  test("matches a skillset that references the skill by guid (#1159)", async () => {
+    await seed({ _id: "ss-g", name: "g-set", memberVisibilityState: "all-public", exportAsPlugin: true });
+    await seedVersion("ss-g", ["skl-review-guid@2.1"]);
+    const eligible = await repo.findEligibleSkillsetsByMember("review", "skl-review-guid");
+    expect(eligible.map((s) => s.guid)).toEqual(["ss-g"]);
+  });
+
+  test("returns an empty list when no skillset references the skill", async () => {
+    await seed({ _id: "ss-z", name: "z-set", memberVisibilityState: "all-public", exportAsPlugin: true });
+    await seedVersion("ss-z", ["other@1.0"]);
+    expect(await repo.findEligibleSkillsetsByMember("review", "skl-review-guid")).toEqual([]);
   });
 });
 

--- a/ornn-api/src/domains/skillsets/repository.ts
+++ b/ornn-api/src/domains/skillsets/repository.ts
@@ -18,6 +18,7 @@ import { AppError } from "../../shared/types/index";
 import { createLogger } from "../../shared/logger";
 import { coerceStoredGrants, legacyListsFromGrants } from "../skills/crud/grants";
 import type { SkillGrant } from "../../shared/types/index";
+import { SkillsetVersionRepository } from "./skillsetVersionRepository";
 import type {
   SkillsetDocument,
   SkillsetKind,
@@ -103,9 +104,17 @@ export class SkillsetRepository {
   private readonly collection: Collection;
   /** Server-side cap on paginated reads (mirrors SkillRepository). */
   private static readonly MAX_QUERY_MS = 5_000;
+  /**
+   * Append-only version repo (#1159). Injected so the targeted mirror
+   * re-export can ask "which skillsets reference this member skill?" via the
+   * version collection's multikey `members` index, then narrow to the
+   * export-eligible identity docs here.
+   */
+  private readonly versionRepo: SkillsetVersionRepository;
 
-  constructor(db: Db) {
+  constructor(db: Db, versionRepo: SkillsetVersionRepository) {
     this.collection = db.collection("skillsets");
+    this.versionRepo = versionRepo;
   }
 
   /**
@@ -147,6 +156,41 @@ export class SkillsetRepository {
       .find({ memberVisibilityState: "all-public", exportAsPlugin: true })
       .maxTimeMS(SkillsetRepository.MAX_QUERY_MS)
       .toArray();
+    return docs.map((d) => mapDoc(d)!);
+  }
+
+  /**
+   * Export-eligible skillsets that reference the given skill as a member of
+   * ANY version (#1159). Powers the targeted mirror re-export: when a member
+   * skill publishes a new version or moves a dist-tag, ONLY the skillsets that
+   * actually reference it are rebuilt — not a full sweep.
+   *
+   * Backed by the version repo's multikey `members` index
+   * (`findSkillsetGuidsByMember`, which matches by name OR guid across every
+   * ref grammar), then narrowed to the SAME eligibility predicate as
+   * {@link findAllEligibleForMirror} (`memberVisibilityState: "all-public"`
+   * AND `exportAsPlugin: true`). The all-public narrowing is load-bearing: a
+   * content change must never leak a non-public skillset's member subtree into
+   * the public mirror.
+   */
+  async findEligibleSkillsetsByMember(
+    skillName: string,
+    skillGuid: string,
+  ): Promise<SkillsetDocument[]> {
+    const guids = await this.versionRepo.findSkillsetGuidsByMember(skillName, skillGuid);
+    if (guids.length === 0) return [];
+    const docs = await this.collection
+      .find({
+        _id: { $in: guids } as never,
+        memberVisibilityState: "all-public",
+        exportAsPlugin: true,
+      })
+      .maxTimeMS(SkillsetRepository.MAX_QUERY_MS)
+      .toArray();
+    logger.debug(
+      { skillName, candidates: guids.length, eligible: docs.length },
+      "findEligibleSkillsetsByMember resolved",
+    );
     return docs.map((d) => mapDoc(d)!);
   }
 

--- a/ornn-api/src/domains/skillsets/routes.test.ts
+++ b/ornn-api/src/domains/skillsets/routes.test.ts
@@ -434,8 +434,9 @@ describe("PUT/DELETE /skillsets/:id — scope gating", () => {
     expect(res.status).toBe(403);
   });
 
-  test("transfer-ownership 200 delegating to the service", async () => {
+  test("transfer-ownership 200 delegating to the service + firing the mirror reconcile (#1159)", async () => {
     const calls: string[] = [];
+    let fired = 0;
     const app = buildApp({
       permissions: [UPDATE],
       service: {
@@ -443,6 +444,9 @@ describe("PUT/DELETE /skillsets/:id — scope gating", () => {
           calls.push("transferOwnership");
           return { guid: "ss-1", createdBy: "alice" };
         },
+      },
+      fireMirrorReconcile: () => {
+        fired += 1;
       },
     });
     const res = await app.request("/api/v1/skillsets/ss-1/transfer-ownership", {
@@ -452,6 +456,30 @@ describe("PUT/DELETE /skillsets/:id — scope gating", () => {
     });
     expect(res.status).toBe(200);
     expect(calls).toEqual(["transferOwnership"]);
+    // #1159 — the transfer now reconciles the mirror, matching the skill path.
+    expect(fired).toBe(1);
+  });
+
+  test("transfer-ownership does NOT fire the mirror reconcile when rejected (#1159)", async () => {
+    let fired = 0;
+    const app = buildApp({
+      permissions: [UPDATE],
+      service: {
+        transferOwnership: async () => {
+          throw AppError.forbidden("forbidden", "only the owner may transfer");
+        },
+      },
+      fireMirrorReconcile: () => {
+        fired += 1;
+      },
+    });
+    const res = await app.request("/api/v1/skillsets/ss-1/transfer-ownership", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ newOwnerUserId: "alice" }),
+    });
+    expect(res.status).toBe(403);
+    expect(fired).toBe(0);
   });
 
   test("transfer-ownership 400 on a missing newOwnerUserId", async () => {

--- a/ornn-api/src/domains/skillsets/routes.ts
+++ b/ornn-api/src/domains/skillsets/routes.ts
@@ -244,6 +244,9 @@ export function createSkillsetRoutes(
       // mutation) so a non-owner can't enumerate users via the response.
       const updated = await skillsetService.transferOwnership(id, body.newOwnerUserId, actor);
       logger.info({ guid: id, newOwnerId: body.newOwnerUserId }, "Skillset ownership transferred via API");
+      // #1159 — symmetry with the skill transfer path: a re-owned skillset must
+      // refresh the mirror (its plugin README provenance/links can change).
+      fireMirrorReconcile?.();
       return c.json({ data: { skillset: updated }, error: null });
     },
   );


### PR DESCRIPTION
## Summary

Make the GitHub mirror reflect ANY public-registry change immediately. An audit found that direct mutations already fire immediate mirror hooks, but three indirect cases were cron-only (≤24h stale). Closes them via **targeted re-export** — rebuild only the skillsets that reference the changed skill, never a full sweep per publish — keeping the cron as the backstop.

## Linked issue

Closes #1159

## Type of change

- [x] New feature (`feat:`)

## Commit decomposition

- [x] Self-contained, small, dependency-ordered. No `Co-Authored-By`.

5 commits: eligible-skillsets-by-member query → targeted `syncSkillsetsForMember` → fire from skill content paths → skillset transfer-ownership reconcile → changeset.

## Changeset

- [x] `.changeset/skillset-mirror-immediacy.md` (`ornn-api` minor).

## Testing

Independently verified locally:
- `ornn-api` tsc 0 errors; `bun test` **2033 pass / 0 fail**; `bun run lint` 0 errors.
- A stateful in-memory GitHub fake proves no-churn (a second identical sync = 0 new commits).

## Notes for the reviewer

- **Gaps closed:** (1) a member skill's new version / refresh now immediately re-exports any exported skillset referencing it via `@latest` (bundled files + fingerprint); (2) dist-tag moves re-resolve `@tag`-pinned skillset members; (3) skillset transfer-ownership now reconciles.
- **Targeted, not full-sweep:** `findEligibleSkillsetsByMember` (multikey `members` index → `all-public` + `exportAsPlugin` filter) → `syncSkillsetsForMember` rebuilds only those `skillsets/<name>/` subtrees in one commit. `commitSkillFolderChange` was generalized into `commitFolderSubtrees` (per-skill path is now a thin, behavior-preserving wrapper).
- **Safety:** the content hook fires only on genuine content/dist-tag changes (republish/refresh/dist-tag), NOT on privacy flips (those keep routing through `fireSkillsetRecompute` → reconcile), and the query filters to `all-public` — so a now-private member can't leak into the public mirror, and there's no visibility-recompute race for the new path.
- **reconcileInFlight:** `syncSkillsetsForMember` early-returns when a full reconcile is already running (it rebuilds every subtree anyway) — best-effort, same model as the existing per-skill path; cron is the backstop.
