### PR TITLE
fix: bump skillset revision when a member is excluded (goes private)

### DIFF
--- a/.changeset/skillset-revision-on-member-exclusion.md
+++ b/.changeset/skillset-revision-on-member-exclusion.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Exported skillsets now bump their revision when a member skill is excluded or re-included via a visibility change, so Claude Code picks up the update. Previously a member going private was correctly dropped from the bundle and noted in the README, but the skillset revision stayed the same — and since Claude Code detects plugin updates only by the version string, installed clients kept the stale copy (including the now-private member's files). The reactive revision bump now compares the PUBLIC-resolvable member subset (exactly what gets exported), so a member's visibility flip moves the snapshot and bumps the minor — in addition to the existing member-version-increment trigger. The re-exported plugin.json and marketplace entry carry the new revision. No spurious churn: an unchanged public subset still produces no bump, and a skillset still carrying a pre-fix all-members snapshot self-corrects with a single one-time bump on its first member event.

--- a/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.test.ts
@@ -1115,6 +1115,78 @@ describe("MirrorService.syncSkillsetsForMember (#1159)", () => {
     expect(calls.commits.length).toBe(1);
   });
 
+  it("member private on a 3-member set: re-export drops its files + carries the bumped revision (#1165)", async () => {
+    // The live bug: a member of an EXPORTED skillset goes private. The service
+    // bumps the revision (proven in skillsets/service.test.ts) BEFORE this
+    // export runs (bootstrap sequencing), so the doc here already carries the
+    // bumped `latestVersion`. The re-export must (a) carry that new version in
+    // plugin.json — the ONLY signal Claude Code uses to detect an update — and
+    // (b) drop the now-private member's files while keeping the 2 public ones.
+    const tripleBundle: FakeSkillset = {
+      guid: "ss-triple",
+      name: "triple-bundle",
+      description: "A three-member set.",
+      // Post-bump latestVersion (was 1.0 at create; the member-private bump
+      // advanced it to 1.1 before this export reads it).
+      latestVersion: "1.1",
+      tags: ["triple"],
+      memberVisibilityState: "restricted",
+      exportAsPlugin: true,
+      members: ["pdf@1.0", "ocr@1.0", "img@1.0"],
+      instructions: "Run pdf, then ocr.",
+    };
+    const currentTree: TreeEntry[] = [
+      { path: "skillsets/triple-bundle/.claude-plugin/plugin.json", mode: "100644", type: "blob", sha: "old-plugin" },
+      { path: "skillsets/triple-bundle/skills/pdf/SKILL.md", mode: "100644", type: "blob", sha: "old-pdf" },
+      { path: "skillsets/triple-bundle/skills/ocr/SKILL.md", mode: "100644", type: "blob", sha: "old-ocr" },
+      { path: "skillsets/triple-bundle/skills/img/SKILL.md", mode: "100644", type: "blob", sha: "old-img" },
+      { path: "skillsets/triple-bundle/README.md", mode: "100644", type: "blob", sha: "old-readme" },
+    ];
+    const { github, calls } = makeFakeGithub({ currentTree });
+    const svc = new MirrorService({
+      githubClientForTest: github,
+      skillRepo: makeFakeRepo([]),
+      // `img` is now private → the public-subset filter drops it; pdf + ocr stay.
+      skillService: makeFakeSkillService(
+        {
+          pdf: { "SKILL.md": "# pdf member" },
+          ocr: { "SKILL.md": "# ocr member" },
+          img: { "SKILL.md": "# secret img member" },
+        },
+        ["img"],
+      ),
+      skillsetRepo: makeFakeSkillsetRepo([tripleBundle]),
+      skillsetService: makeFakeSkillsetService([tripleBundle]),
+      ornnPublicOrigin: "https://example",
+      settingsService: makeFakeSettings(),
+    });
+
+    await svc.syncSkillsetsForMember("img-guid", "img");
+
+    // plugin.json carries the bumped revision — the update signal.
+    const pluginJson = parsedBlobs(calls).find((p) => p.name === "triple-bundle");
+    expect(pluginJson).toBeTruthy();
+    expect(pluginJson!.version).toBe("1.1");
+
+    // The two public members are bundled; the private member's blob never is.
+    const blobContents = calls.blobs.map((b) => b.content);
+    expect(blobContents.some((c) => c === "# pdf member")).toBe(true);
+    expect(blobContents.some((c) => c === "# ocr member")).toBe(true);
+    expect(blobContents.some((c) => c.includes("secret img member"))).toBe(false);
+
+    // The private member's stale file in the mirror is deleted; the subtree as a
+    // whole survives (2 public members ≥ the export floor).
+    const entries = calls.trees.flatMap((t) => t.entries);
+    const imgDeletion = entries.find(
+      (e) => e.path === "skillsets/triple-bundle/skills/img/SKILL.md" && e.sha === null,
+    );
+    expect(imgDeletion).toBeDefined();
+    expect(
+      entries.some((e) => e.path === "skillsets/triple-bundle/.claude-plugin/plugin.json" && e.sha !== null),
+    ).toBe(true);
+    expect(calls.commits.length).toBe(1);
+  });
+
   it("rebuilds multiple affected skillsets in a SINGLE commit", async () => {
     const dataBundle: FakeSkillset = {
       guid: "ss-data",

--- a/ornn-api/src/domains/skillsets/recompute.test.ts
+++ b/ornn-api/src/domains/skillsets/recompute.test.ts
@@ -16,6 +16,7 @@ import type { SkillsetMemberVisibilityState } from "./types";
 import {
   backfillDerivedVisibility,
   computeDerivedVisibility,
+  computePublicResolvedMembers,
   recomputeForSkill,
   recomputeSkillsetVisibility,
   type MemberVisibilityResolver,
@@ -69,6 +70,36 @@ describe("computeDerivedVisibility", () => {
     const resolver = makeResolver({});
     const result = await computeDerivedVisibility([], resolver);
     expect(result).toEqual({ membersAllPublic: true, memberVisibilityState: "all-public" });
+  });
+});
+
+describe("computePublicResolvedMembers (#1165 — public-only snapshot)", () => {
+  test("includes only public, resolvable members, sorted + de-duped", async () => {
+    const resolver = makeResolver({ "b@1.0": "public", "a@2.1": "public" });
+    const snapshot = await computePublicResolvedMembers(["b@1.0", "a@2.1"], resolver);
+    // Sorted by the canonical `name@version` string, so `a@2.1` precedes `b@1.0`.
+    expect(snapshot).toEqual(["a@2.1", "b@1.0"]);
+  });
+
+  test("excludes a PRIVATE member — the export-subset signal (#1165)", async () => {
+    // m3 is private: it still RESOLVES under SYSTEM but is not in the exported
+    // set, so it must not appear in the snapshot. This is what makes a privacy
+    // flip move the snapshot (and bump the revision) even though no version did.
+    const resolver = makeResolver({ "m1@1.0": "public", "m2@1.0": "public", "m3@1.0": "private" });
+    const snapshot = await computePublicResolvedMembers(["m1@1.0", "m2@1.0", "m3@1.0"], resolver);
+    expect(snapshot).toEqual(["m1@1.0", "m2@1.0"]);
+  });
+
+  test("excludes an unresolvable member ref", async () => {
+    const resolver = makeResolver({ "m1@1.0": "public" });
+    const snapshot = await computePublicResolvedMembers(["m1@1.0", "gone@1.0"], resolver);
+    expect(snapshot).toEqual(["m1@1.0"]);
+  });
+
+  test("empty when no member is public-resolvable", async () => {
+    const resolver = makeResolver({ "m1@1.0": "private" });
+    const snapshot = await computePublicResolvedMembers(["m1@1.0", "gone@1.0"], resolver);
+    expect(snapshot).toEqual([]);
   });
 });
 

--- a/ornn-api/src/domains/skillsets/recompute.ts
+++ b/ornn-api/src/domains/skillsets/recompute.ts
@@ -87,14 +87,25 @@ export async function computeDerivedVisibility(
 }
 
 /**
- * Resolve a member-ref list to its lockfile-like snapshot (#1162): the
- * concrete `name@<major.minor>` of every member that resolves under SYSTEM,
- * sorted + de-duped so the snapshot is order-independent and stable. An
- * unresolvable member contributes nothing (its disappearance shows up as a
- * snapshot change → a bump). Single-sourced with the visibility classifier so
- * both walk member refs through the exact same loader grammar.
+ * Resolve a member-ref list to its EXPORTED snapshot (#1162/#1165): the concrete
+ * `name@<major.minor>` of every member that resolves under SYSTEM AND is public
+ * (`isPrivate === false`), sorted + de-duped so the snapshot is order-independent
+ * and stable.
+ *
+ * Public-only by design (#1165): the snapshot is the baseline the reactive
+ * revision bump diffs against, and a skillset's EXPORTED content is exactly its
+ * public-resolvable member subset (#1161). A member going PRIVATE is a
+ * visibility change — its resolved VERSION is unchanged, so an all-members
+ * snapshot wouldn't move and the revision would never bump — but it DROPS from
+ * the exported set, so Claude Code (which detects plugin updates only by the
+ * version string) would keep serving the stale bundle. Counting only public
+ * members makes a visibility flip move the snapshot → bump the revision →
+ * re-export carries the new version. A private or unresolvable member therefore
+ * contributes nothing; its appearance / disappearance shows up as a snapshot
+ * change → a bump. Single-sourced with the visibility classifier + the mirror's
+ * export filter so all three agree on what "in the exported set" means.
  */
-export async function computeResolvedMembers(
+export async function computePublicResolvedMembers(
   members: string[],
   skillService: MemberVisibilityResolver,
 ): Promise<string[]> {
@@ -102,7 +113,9 @@ export async function computeResolvedMembers(
   const snapshot = new Set<string>();
   for (const ref of members) {
     const node = await load(ref);
-    if (node) snapshot.add(`${node.name}@${node.version}`);
+    // SYSTEM resolves everything, so `node.isPrivate` faithfully reports the
+    // member skill's OWN privacy — the public-export gate, not a read denial.
+    if (node && node.isPrivate === false) snapshot.add(`${node.name}@${node.version}`);
   }
   return [...snapshot].sort();
 }
@@ -110,11 +123,19 @@ export async function computeResolvedMembers(
 /**
  * One-shot boot backfill (#1162): for every existing skillset, populate the
  * resolved-member snapshot on its LATEST version doc when it lacks one (a
- * pre-feature doc). Existing skillsets keep their current `latestVersion` as
- * the starting revision — only the snapshot is added, so a later member-version
- * change has a baseline to compare against. Idempotent (skips docs that already
- * carry a snapshot) and failure-isolated per skillset, so one bad member set
- * never aborts boot.
+ * pre-feature doc). The snapshot is the PUBLIC-resolvable member set (#1165),
+ * single-sourced with the reactive bump so create / publish / backfill / bump
+ * all compare apples to apples. Existing skillsets keep their current
+ * `latestVersion` as the starting revision — only the snapshot is added, so a
+ * later member change has a baseline to compare against. Idempotent (skips docs
+ * that already carry a snapshot) and failure-isolated per skillset, so one bad
+ * member set never aborts boot.
+ *
+ * Docs that already carry a (pre-#1165, all-members) snapshot are intentionally
+ * NOT rewritten here: silently swapping the baseline to the public set would
+ * desync the stored revision from the export content with no version bump — the
+ * exact bug #1165 fixes. The first reactive event corrects such a doc with a
+ * legitimate one-time bump (and is idempotent thereafter).
  */
 export async function backfillResolvedMembers(deps: SkillsetRecomputeDeps): Promise<void> {
   const guids = await deps.skillsetRepo.listAllGuids();
@@ -123,7 +144,7 @@ export async function backfillResolvedMembers(deps: SkillsetRecomputeDeps): Prom
     try {
       const latest = await deps.skillsetVersionRepo.findLatestBySkillset(guid);
       if (!latest || latest.resolvedMembers !== undefined) continue;
-      const snapshot = await computeResolvedMembers(latest.members, deps.skillService);
+      const snapshot = await computePublicResolvedMembers(latest.members, deps.skillService);
       await deps.skillsetVersionRepo.setResolvedMembers(guid, latest.version, snapshot);
       backfilled += 1;
     } catch (err) {

--- a/ornn-api/src/domains/skillsets/service.test.ts
+++ b/ornn-api/src/domains/skillsets/service.test.ts
@@ -848,6 +848,112 @@ describe("SkillsetService — reactive revision bump on member-version change (#
   });
 });
 
+describe("SkillsetService — reactive revision bump on member VISIBILITY change (#1165)", () => {
+  /**
+   * Three public member skills. The exported subset is all three at create, so
+   * dropping one to private still leaves a meaningful set — mirroring the live
+   * 3→2 bug report.
+   */
+  function threeMemberSkills(): { skills: SkillDocument[]; versions: SkillVersionDocument[] } {
+    const a = skillDoc({ guid: "g-a", name: "pdf-tools", latestVersion: "1.0" });
+    const b = skillDoc({ guid: "g-b", name: "csv-tools", latestVersion: "1.0" });
+    const c = skillDoc({ guid: "g-c", name: "img-tools", latestVersion: "1.0" });
+    return {
+      skills: [a, b, c],
+      versions: [
+        skillVersion({ _id: "g-a@1.0", skillGuid: "g-a", version: "1.0" }),
+        skillVersion({ _id: "g-b@1.0", skillGuid: "g-b", version: "1.0" }),
+        skillVersion({ _id: "g-c@1.0", skillGuid: "g-c", version: "1.0" }),
+      ],
+    };
+  }
+
+  async function seed3() {
+    const { skills, versions } = threeMemberSkills();
+    const skillService = makeSkillService(skills, versions);
+    const { deps, state } = makeSkillsetDeps(skillService);
+    const service = new SkillsetService(deps);
+    const created = await service.createSkillset(
+      {
+        name: "vis-set",
+        description: "d",
+        instructions: "p",
+        kind: "generic",
+        tags: [],
+        members: ["pdf-tools@1.0", "csv-tools@1.0", "img-tools@1.0"],
+      },
+      { userId: "owner-1" },
+    );
+    return { service, state, skills, guid: created.guid };
+  }
+
+  it("a member going private bumps the minor; the new snapshot is the public subset", async () => {
+    const { service, state, skills, guid } = await seed3();
+    // 1.0 snapshot is all three (every member public at create).
+    const v10 = state.versions.find((v) => v._id === `${guid}@1.0`)!;
+    expect(v10.resolvedMembers).toEqual(["csv-tools@1.0", "img-tools@1.0", "pdf-tools@1.0"]);
+
+    // img-tools goes private — same resolved VERSION, but it drops from the
+    // exported set, so the public snapshot moves → a revision bump (the #1165 fix:
+    // without it the snapshot was unchanged and Claude Code kept the stale bundle).
+    skills.find((s) => s.name === "img-tools")!.isPrivate = true;
+    await service.bumpRevisionsForChangedMember({ guid: "g-c", name: "img-tools" });
+
+    expect((await service.getSkillset(guid)).latestVersion).toBe("1.1");
+    const v11 = state.versions.find((v) => v._id === `${guid}@1.1`)!;
+    expect(v11.resolvedMembers).toEqual(["csv-tools@1.0", "pdf-tools@1.0"]);
+    // Authored member refs are carried forward verbatim — img-tools stays a
+    // member of the set; only its EXPORTED contribution dropped.
+    expect(v11.members).toEqual(["pdf-tools@1.0", "csv-tools@1.0", "img-tools@1.0"]);
+  });
+
+  it("a member going public again bumps + re-includes it in the snapshot", async () => {
+    const { service, state, skills, guid } = await seed3();
+    const img = skills.find((s) => s.name === "img-tools")!;
+
+    img.isPrivate = true;
+    await service.bumpRevisionsForChangedMember({ guid: "g-c", name: "img-tools" });
+    expect((await service.getSkillset(guid)).latestVersion).toBe("1.1");
+
+    // Back to public → re-enters the exported subset → another bump.
+    img.isPrivate = false;
+    await service.bumpRevisionsForChangedMember({ guid: "g-c", name: "img-tools" });
+    expect((await service.getSkillset(guid)).latestVersion).toBe("1.2");
+    const v12 = state.versions.find((v) => v._id === `${guid}@1.2`)!;
+    expect(v12.resolvedMembers).toEqual(["csv-tools@1.0", "img-tools@1.0", "pdf-tools@1.0"]);
+  });
+
+  it("a no-op visibility event (public subset unchanged) does NOT bump", async () => {
+    const { service, state, guid } = await seed3();
+    // Nothing actually flipped — the public subset is identical → no churn,
+    // preserving the mirror's deterministic no-op-commit skip.
+    await service.bumpRevisionsForChangedMember({ guid: "g-c", name: "img-tools" });
+    expect(state.versions.filter((v) => v.skillsetGuid === guid)).toHaveLength(1);
+    expect((await service.getSkillset(guid)).latestVersion).toBe("1.0");
+  });
+
+  it("a pre-#1165 all-members snapshot self-corrects with ONE bump, then is idempotent", async () => {
+    const { service, state, skills, guid } = await seed3();
+    // Simulate a doc cut before #1165: img-tools is now private, but the stored
+    // snapshot still lists it (the old all-members logic the backfill leaves
+    // untouched). The FIRST reactive event must correct it — exactly once.
+    skills.find((s) => s.name === "img-tools")!.isPrivate = true;
+    const v10 = state.versions.find((v) => v._id === `${guid}@1.0`)!;
+    v10.resolvedMembers = ["csv-tools@1.0", "img-tools@1.0", "pdf-tools@1.0"];
+
+    // First event: public subset (2) differs from the stored 3 → one legit bump.
+    await service.bumpRevisionsForChangedMember({ guid: "g-c", name: "img-tools" });
+    expect((await service.getSkillset(guid)).latestVersion).toBe("1.1");
+    const v11 = state.versions.find((v) => v._id === `${guid}@1.1`)!;
+    expect(v11.resolvedMembers).toEqual(["csv-tools@1.0", "pdf-tools@1.0"]);
+
+    // Second event with nothing further changed → snapshot matches → no churn.
+    await service.bumpRevisionsForChangedMember({ guid: "g-c", name: "img-tools" });
+    expect(state.versions.filter((v) => v.skillsetGuid === guid)).toHaveLength(2);
+    expect((await service.getSkillset(guid)).latestVersion).toBe("1.1");
+  });
+});
+
 describe("SkillsetService — plugin-export opt-in (#1155)", () => {
   function service() {
     const { skills, versions } = twoMemberSkills();

--- a/ornn-api/src/domains/skillsets/service.ts
+++ b/ornn-api/src/domains/skillsets/service.ts
@@ -36,7 +36,7 @@ import type { SkillService } from "../skills/crud/service";
 import { parseVersion } from "../skills/crud/version";
 import { effectiveGrants, normalizeGrants } from "../skills/crud/grants";
 import {
-  computeResolvedMembers,
+  computePublicResolvedMembers,
   recomputeForSkill,
   recomputeSkillsetVisibility,
 } from "./recompute";
@@ -649,13 +649,14 @@ export class SkillsetService {
   }
 
   /**
-   * Reactive revision bump (#1162) for a member skill whose resolved version
-   * may have moved (new-version publish, GitHub refresh, dist-tag set/delete, a
-   * privacy flip that changes the resolved set). Finds EVERY skillset that
-   * references the changed skill — exported or not, since the revision is the
-   * skillset's OWN version — and, for each, re-cuts a new revision ONLY when the
-   * resolved-member snapshot actually changed from the latest revision's
-   * baseline.
+   * Reactive revision bump (#1162/#1165) for a member skill whose EXPORTED
+   * contribution may have moved — either its resolved version (new-version
+   * publish, GitHub refresh, dist-tag set/delete) OR its visibility (a privacy
+   * flip that adds/removes it from the public-resolvable set, #1165). Finds
+   * EVERY skillset that references the changed skill — exported or not, since the
+   * revision is the skillset's OWN version — and, for each, re-cuts a new
+   * revision ONLY when the public-resolved-member snapshot actually changed from
+   * the latest revision's baseline.
    *
    * Ordering (#1162): bootstrap invokes this BEFORE the mirror's targeted
    * re-export (`syncSkillsetsForMember`) inside one fire-and-forget handler, so
@@ -691,10 +692,10 @@ export class SkillsetService {
   }
 
   /**
-   * Re-cut a skillset's revision iff its resolved-member snapshot changed
-   * (#1162). Returns `true` when a new revision was written. Compares the
-   * current resolved members (under SYSTEM) against the latest revision's
-   * stored snapshot:
+   * Re-cut a skillset's revision iff its public-resolved-member snapshot changed
+   * (#1162/#1165). Returns `true` when a new revision was written. Compares the
+   * current public-resolvable members (under SYSTEM) against the latest
+   * revision's stored snapshot:
    *   - snapshot identical → no-op (idempotency guard, no churn).
    *   - snapshot missing (pre-feature doc the backfill hasn't reached) →
    *     populate it in place, no bump (no baseline to diff against).
@@ -702,6 +703,13 @@ export class SkillsetService {
    *     same authored members/metadata + the new snapshot, then advance the
    *     pointer WITHOUT touching the audit timestamps (a member-driven change,
    *     not an owner edit).
+   *
+   * A member going private/public is a snapshot move (#1165), so this is what
+   * makes an exported plugin's version bump when its public member subset
+   * changes — the bootstrap sequences this BEFORE the targeted re-export, so the
+   * re-exported plugin.json carries the freshly-bumped revision. A doc still
+   * carrying a pre-#1165 all-members snapshot self-corrects with one legitimate
+   * bump on its first reactive event, then is idempotent.
    */
   private async maybeBumpRevisionForMemberChange(guid: string): Promise<boolean> {
     const latest = await this.skillsetVersionRepo.findLatestBySkillset(guid);
@@ -741,13 +749,15 @@ export class SkillsetService {
   }
 
   /**
-   * Resolve member refs to the lockfile-like snapshot (#1162). Thin instance
-   * wrapper over the shared {@link computeResolvedMembers} so create / publish /
-   * reactive-bump all snapshot members the same way (SYSTEM loader, sorted,
-   * de-duped concrete `name@<major.minor>`).
+   * Resolve member refs to the EXPORTED snapshot (#1162/#1165). Thin instance
+   * wrapper over the shared {@link computePublicResolvedMembers} so create /
+   * publish / reactive-bump all snapshot members the same way: the SYSTEM loader,
+   * sorted + de-duped concrete `name@<major.minor>` of the PUBLIC-resolvable
+   * subset only. Public-only means a member's visibility flip (private⇄public)
+   * moves the snapshot and bumps the revision, in addition to a version move.
    */
   private async resolveMemberSnapshot(members: string[]): Promise<string[]> {
-    return computeResolvedMembers(members, this.skillService);
+    return computePublicResolvedMembers(members, this.skillService);
   }
 
   /** Load a skillset's requested (or latest) version doc, or 404. */
@@ -886,9 +896,9 @@ function nextRevision(current: string): { version: string; major: number; minor:
 
 /**
  * Order-independent equality of two resolved-member snapshots (#1162). Both are
- * produced sorted by {@link computeResolvedMembers}, so a positional compare is
- * sufficient and cheap — this is the idempotency guard that stops a no-op member
- * sync from churning a new revision.
+ * produced sorted by {@link computePublicResolvedMembers}, so a positional
+ * compare is sufficient and cheap — this is the idempotency guard that stops a
+ * no-op member sync from churning a new revision.
  */
 function snapshotsEqual(a: string[], b: string[]): boolean {
   if (a.length !== b.length) return false;

--- a/ornn-api/src/domains/skillsets/types.ts
+++ b/ornn-api/src/domains/skillsets/types.ts
@@ -326,13 +326,17 @@ export interface SkillsetVersionDocument {
   /** Member skill refs (`<name-or-guid>@<major.minor>` or `<name>@<dist-tag>`). */
   members: string[];
   /**
-   * Lockfile-like snapshot of the members RESOLVED to concrete versions at the
-   * time this revision was cut (#1162) — sorted, de-duped `name@<major.minor>`
-   * strings. Makes a revision reproducible even when its authored `members`
-   * pin `@latest`/dist-tags, and is the baseline the reactive bump compares
-   * against to decide whether a member-version change warrants a new revision.
-   * Optional for back-compat: pre-#1162 version docs lack it until the boot
-   * backfill populates the latest one.
+   * Lockfile-like snapshot of the PUBLIC-resolvable members RESOLVED to concrete
+   * versions at the time this revision was cut (#1162/#1165) — sorted, de-duped
+   * `name@<major.minor>` strings, private/unresolvable members excluded. This is
+   * exactly the EXPORTED member subset (#1161), so it captures the revision's
+   * delivered content reproducibly even when authored `members` pin
+   * `@latest`/dist-tags, and is the baseline the reactive bump compares against:
+   * a member-version move OR a member visibility flip (private⇄public, #1165)
+   * both shift this set → warranting a new revision so Claude Code picks up the
+   * change. Optional for back-compat: pre-#1162 version docs lack it until the
+   * boot backfill populates the latest one; a pre-#1165 doc may still carry an
+   * all-members snapshot until its first reactive bump self-corrects it.
    */
   resolvedMembers?: string[] | undefined;
   createdBy: string;


### PR DESCRIPTION
## Summary

Fix a correctness bug found by live E2E test: when a member skill of an exported skillset goes **private**, it's dropped from the bundle (#1161) but the skillset **revision didn't bump** — so the exported plugin's content changed (e.g. 3 members → 2) while its version string stayed the same. Claude Code detects plugin updates only by the version string, so installed clients never received the update and kept the stale bundle (including the now-private member's files).

## Linked issue
Closes #1165

## Type of change
- [x] Bug fix (`fix:`)

## Root cause + fix
The #1162 reactive bump compared a snapshot of **all** resolved member versions; a visibility flip doesn't change any member's version, so no bump fired. Renamed `computeResolvedMembers` → `computePublicResolvedMembers`, filtered to `isPrivate === false`, so the snapshot is exactly the **public-resolvable subset** the mirror exports. Now a private⇄public flip moves the snapshot → bumps the minor → the plugin version moves → CC picks up the change. Version-increment + own-metadata triggers and the no-churn guard are preserved; bump still runs before the re-export.

## Testing
Independently verified: `ornn-api` tsc 0; `bun test` **2056 pass / 0 fail**; `bun run lint` 0 errors. New tests cover private→drop→bump, public→re-include→bump, no-op→no-bump, and a mirror regression that the re-export carries the bumped revision for the 3→2 scenario.

## Notes
- Backfill deliberately doesn't rewrite pre-fix all-members snapshots in place; a pre-fix doc self-corrects with exactly one legitimate bump on its first reactive event, then is idempotent.
- (Separately tracked, not here: skillset-export-enable reconcile can be dropped by the in-flight coalescing guard — a smaller immediacy-robustness gap.)
