### PR TITLE
fix(web): center the skill plugin install tab like the npx tab

### DIFF
--- a/.changeset/skill-plugin-tab-centered.md
+++ b/.changeset/skill-plugin-tab-centered.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": patch
+---
+
+The skill install card's "via plugin (Claude Code Marketplace)" tab now matches the "via npx" layout — the install commands are centered within the box and the auto-update reminder is folded into the helper text (no per-tab footer), keeping all install tabs the same height.

--- a/ornn-web/src/components/skill/SkillInstallCard.test.tsx
+++ b/ornn-web/src/components/skill/SkillInstallCard.test.tsx
@@ -78,8 +78,9 @@ describe("SkillInstallCard — plugin tab", () => {
     expect(code?.textContent).toContain("/plugin marketplace add acme/skills-mirror");
     expect(code?.textContent).toContain("/plugin install pdf-tools@skills-mirror");
 
-    // The shared auto-update note rides below the commands.
-    expect(screen.getByText(/default to auto-update off/i)).toBeInTheDocument();
+    // The auto-update reminder is folded into the helper above the box
+    // (no per-tab footer) so the panel matches the "via npx" layout.
+    expect(screen.getByText(/auto-update off/i)).toBeInTheDocument();
   });
 
   it("shows the 'available once public' hint for a private skill, no command", () => {

--- a/ornn-web/src/components/skill/SkillInstallCard.tsx
+++ b/ornn-web/src/components/skill/SkillInstallCard.tsx
@@ -119,10 +119,12 @@ function CopyBlock({
   content,
   copyAriaLabel,
   multiline,
+  centered = false,
 }: {
   content: string;
   copyAriaLabel: string;
   multiline: boolean;
+  centered?: boolean;
 }) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
@@ -154,15 +156,21 @@ function CopyBlock({
     <div className="relative h-32 overflow-hidden rounded border border-strong-edge bg-elevated/40">
       <code
         className={
-          multiline
-            // pr-20 reserves a clear gutter so prompt text never slides
-            // under the floating COPY button.
-            ? "block h-full overflow-y-auto whitespace-pre-wrap break-words px-3 py-2 pr-20 font-mono text-xs leading-relaxed text-strong"
-            // Single-line command centred both axes inside the h-32
-            // box. Symmetric `px-20` mirrors the COPY-button gutter on
-            // the left so the centred text is visually centred, not
-            // offset by the right-only padding.
-            : "h-full flex items-center justify-center overflow-x-auto px-20 font-mono text-sm text-strong"
+          centered
+            // Multi-line command(s) centred both axes inside the box —
+            // the same centred treatment as the single-line npx variant,
+            // but `whitespace-pre` keeps the line breaks. Used by the
+            // plugin tab so its layout matches "via npx".
+            ? "h-full flex items-center justify-center overflow-auto px-12 text-center font-mono text-sm leading-relaxed text-strong whitespace-pre"
+            : multiline
+              // pr-20 reserves a clear gutter so prompt text never slides
+              // under the floating COPY button.
+              ? "block h-full overflow-y-auto whitespace-pre-wrap break-words px-3 py-2 pr-20 font-mono text-xs leading-relaxed text-strong"
+              // Single-line command centred both axes inside the h-32
+              // box. Symmetric `px-20` mirrors the COPY-button gutter on
+              // the left so the centred text is visually centred, not
+              // offset by the right-only padding.
+              : "h-full flex items-center justify-center overflow-x-auto px-20 font-mono text-sm text-strong"
         }
       >
         {content}
@@ -345,25 +353,21 @@ export function SkillInstallCard({ skill, className }: SkillInstallCardProps) {
         <div role="tabpanel" className="mt-3 space-y-3">
           {npxAvailable ? (
             <>
+              {/* Auto-update reminder folded into the helper (above the box)
+                  so the panel matches the "via npx" layout — helper + a
+                  centred CopyBlock, no per-tab footer (#418 symmetry). */}
               <p className="font-text text-xs text-meta">
                 {t(
                   "skillInstallCard.pluginHelper",
-                  "Published to the Claude Code marketplace as a single-skill plugin. Install it in Claude Code:",
+                  "Published to the Claude Code marketplace as a single-skill plugin. Third-party marketplaces ship auto-update OFF — enable it in /plugin → Marketplaces.",
                 )}
               </p>
               <CopyBlock
                 content={pluginCommands}
                 copyAriaLabel={t("skillInstallCard.copyPluginAria", "Copy plugin install commands")}
-                multiline
+                multiline={false}
+                centered
               />
-              {/* Shared wording with the skillset export card — third-party
-                  marketplaces ship auto-update OFF (#1167). */}
-              <p className="font-text text-xs text-meta">
-                {t(
-                  "skillsetPluginExport.installAutoUpdate",
-                  "Third-party marketplaces default to auto-update OFF — enable it in /plugin → Marketplaces to receive updates.",
-                )}
-              </p>
             </>
           ) : (
             <p className="font-text text-xs text-meta">

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -175,7 +175,7 @@
     "npxHelper": "Mirrored to GitHub for one-line installation in any agent harness.",
     "npxNotAvailablePrivate": "Not available — private skills are never mirrored to GitHub. Use the prompt flow instead.",
     "npxNotAvailableMirrorOff": "Not available — this deployment doesn't have the GitHub mirror configured. Use the prompt flow instead.",
-    "pluginHelper": "Published to the Claude Code marketplace as a single-skill plugin. Install it in Claude Code:",
+    "pluginHelper": "Published to the Claude Code marketplace as a single-skill plugin. Third-party marketplaces ship auto-update OFF — enable it in /plugin → Marketplaces.",
     "pluginNotAvailablePrivate": "Available once this skill is public — public skills are published to the Claude Code marketplace as a plugin.",
     "copy": "Copy",
     "copied": "Copied",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -175,7 +175,7 @@
     "npxHelper": "已镜像到 GitHub，可在任何 agent 环境中一行命令安装。",
     "npxNotAvailablePrivate": "不可用 —— 私有技能不会镜像到 GitHub。请改用 Via prompt。",
     "npxNotAvailableMirrorOff": "不可用 —— 当前部署未配置 GitHub 镜像。请改用 Via prompt。",
-    "pluginHelper": "已作为单技能插件发布到 Claude Code 市场。在 Claude Code 中安装：",
+    "pluginHelper": "已作为单技能插件发布到 Claude Code 市场。第三方市场默认关闭自动更新 —— 在 /plugin → Marketplaces 中启用。",
     "pluginNotAvailablePrivate": "在该技能公开后可用 —— 公开技能会作为插件发布到 Claude Code 市场。",
     "copy": "复制",
     "copied": "已复制",


### PR DESCRIPTION
## Summary
The 'via plugin (Claude Code Marketplace)' tab (#1167) used a left-aligned multiline command block + a below-box auto-update footer, making it taller/asymmetric vs 'via npx'. This matches the npx layout: a new `centered` `CopyBlock` variant centers the two commands within the fixed-height box (`whitespace-pre` keeps both lines), and the auto-update reminder is folded into the helper above the box (no per-tab footer, per the #418 symmetry).

Closes #1169

## Testing
`ornn-web` tsc 0; SkillInstallCard + i18n parity tests pass; eslint 0 on changed files. Frontend-only, isolated to `SkillInstallCard`.

## Type
- [x] Chore / UI polish