### PR TITLE
[Feature] Authenticated + conditional GitHub source reads and drift-detection model (#1175)

### DIFF
--- a/.changeset/gh-source-auth-drift-foundation.md
+++ b/.changeset/gh-source-auth-drift-foundation.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": minor
+---
+
+Add the efficient-read foundation for automatic GitHub source sync (#1175): GitHub source reads can now authenticate with a service-account token (settings section `sourceSync` or `ORNN_SOURCE_SYNC_GITHUB_TOKEN`) and use ETag-conditional requests, a cheap `git/ref` HEAD-SHA drift probe, and a read-only `checkSourceDrift` that records drift state on the skill. No behavior change to existing flows — the manual refresh path simply sends an `Authorization` header when a token is configured.

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -487,6 +487,10 @@ export async function bootstrap(
     maxEntryUncompressedBytes: config.maxEntryUncompressedBytes,
     maxPackageFileCount: config.maxPackageFileCount,
     maxCompressionRatio: config.maxCompressionRatio,
+    // Source-sync (#1175): authenticate GitHub source reads. The settings
+    // token wins; the env token is the fallback.
+    sourceSyncSettings: settingsService,
+    sourceSyncGithubTokenFallback: config.sourceSyncGithubToken,
   });
 
   // ---- Domain: Notifications + Broadcasts ----

--- a/ornn-api/src/domains/settings/exportImport/exporter.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/exporter.test.ts
@@ -92,6 +92,7 @@ function fakeSettingsService(): SettingsService {
     listLlmProviders: async () => providers,
     getLlmProvider: async (id: string) => providers.find((p) => p._id === id) ?? null,
     getLaunchPromo: () => make("launchPromo"),
+    getSourceSync: () => make("sourceSync"),
     invalidateCache: () => {},
   };
 }

--- a/ornn-api/src/domains/settings/exportImport/importer.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/importer.test.ts
@@ -49,6 +49,7 @@ function fakeSettingsService(initial?: Partial<Record<string, Record<string, unk
     listLlmProviders: async () => [],
     getLlmProvider: async () => null,
     getLaunchPromo: async () => store.get("launchPromo") as never,
+    getSourceSync: async () => store.get("sourceSync") as never,
     invalidateCache: () => {},
   };
   return Object.assign(svc, {

--- a/ornn-api/src/domains/settings/exportImport/routes.test.ts
+++ b/ornn-api/src/domains/settings/exportImport/routes.test.ts
@@ -43,6 +43,7 @@ function fakeSettingsService(): SettingsService {
     listLlmProviders: async () => [],
     getLlmProvider: async () => null,
     getLaunchPromo: async () => store.get("launchPromo") as never,
+    getSourceSync: async () => store.get("sourceSync") as never,
     invalidateCache: () => {},
   };
 }

--- a/ornn-api/src/domains/settings/sections/cronSchedule.ts
+++ b/ornn-api/src/domains/settings/sections/cronSchedule.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared cron-expression Zod validator for settings sections.
+ *
+ * Extracted from `sections/mirror.ts` so multiple scheduled-work sections
+ * (mirror reconcile, source-sync poll, …) validate their cron field the
+ * same way instead of copy-pasting the refine.
+ *
+ * An empty string means "disabled" and is always accepted. A non-empty
+ * value must parse under `cron-parser` (which accepts both 5-field UNIX
+ * and 6-field with-seconds forms — either is fine for our schedulers).
+ *
+ * @module domains/settings/sections/cronSchedule
+ */
+import { z } from "zod";
+import { CronExpressionParser } from "cron-parser";
+
+export const cronSchedule = z
+  .string()
+  .refine(
+    (s) => {
+      if (s.length === 0) return true;
+      try {
+        CronExpressionParser.parse(s);
+        return true;
+      } catch {
+        // Intentional silent (#579): the false return becomes a Zod
+        // validation error with the message below — that's the
+        // user-facing signal. Logging the cron-parser exception would
+        // be noisy on every form-validation typo.
+        return false;
+      }
+    },
+    { message: "must be a valid cron expression or empty (disabled)" },
+  );

--- a/ornn-api/src/domains/settings/sections/index.ts
+++ b/ornn-api/src/domains/settings/sections/index.ts
@@ -18,6 +18,7 @@ import { skillGenSection, type SkillGenSection } from "./skillGen";
 import { telemetrySection, type TelemetrySection } from "./telemetry";
 import { extrasSection, type ExtrasSection } from "./extras";
 import { launchPromoSection, type LaunchPromoSection } from "./launchPromo";
+import { sourceSyncSection, type SourceSyncSection } from "./sourceSync";
 
 export {
   assistantSection,
@@ -29,6 +30,7 @@ export {
   telemetrySection,
   extrasSection,
   launchPromoSection,
+  sourceSyncSection,
 };
 
 export type {
@@ -41,6 +43,7 @@ export type {
   TelemetrySection,
   ExtrasSection,
   LaunchPromoSection,
+  SourceSyncSection,
 };
 
 export type SectionId =
@@ -52,7 +55,8 @@ export type SectionId =
   | "skillAudit"
   | "telemetry"
   | "extras"
-  | "launchPromo";
+  | "launchPromo"
+  | "sourceSync";
 
 export interface SectionMeta<T> {
   /** Stable section id, also the Mongo `_id` of the section row. */
@@ -77,4 +81,5 @@ export const sections = {
   telemetry: telemetrySection,
   extras: extrasSection,
   launchPromo: launchPromoSection,
+  sourceSync: sourceSyncSection,
 } as const;

--- a/ornn-api/src/domains/settings/sections/mirror.ts
+++ b/ornn-api/src/domains/settings/sections/mirror.ts
@@ -14,34 +14,9 @@
  * @module domains/settings/sections/mirror
  */
 import { z } from "zod";
-import { CronExpressionParser } from "cron-parser";
 import { OWNER_RE, REPO_RE } from "../../../shared/githubNaming";
+import { cronSchedule } from "./cronSchedule";
 import type { SectionMeta } from "./index";
-
-/**
- * Validates that the input is either an empty string (disabled) or a
- * cron expression accepted by `cron-parser`. We do NOT require a
- * 5-field UNIX cron specifically — `cron-parser` also accepts 6-field
- * forms with seconds; either is fine for our purposes.
- */
-const cronSchedule = z
-  .string()
-  .refine(
-    (s) => {
-      if (s.length === 0) return true;
-      try {
-        CronExpressionParser.parse(s);
-        return true;
-      } catch {
-        // Intentional silent (#579): the false return becomes a Zod
-        // validation error with the message below — that's the
-        // user-facing signal. Logging the cron-parser exception would
-        // be noisy on every form-validation typo.
-        return false;
-      }
-    },
-    { message: "must be a valid cron expression or empty (disabled)" },
-  );
 
 export const mirrorSchema = z.object({
   enabled: z.boolean(),

--- a/ornn-api/src/domains/settings/sections/sourceSync.test.ts
+++ b/ornn-api/src/domains/settings/sections/sourceSync.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  sourceSyncSchema,
+  sourceSyncDefaults,
+  sourceSyncSection,
+} from "./sourceSync";
+
+describe("sourceSync section", () => {
+  test("defaults parse and ship inert (disabled, no token, no auto-publish)", () => {
+    const parsed = sourceSyncSchema.parse(sourceSyncDefaults);
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.githubToken).toBe("");
+    expect(parsed.autoPublish).toBe(false);
+    expect(parsed.minCheckIntervalMinutes).toBe(60);
+  });
+
+  test("githubToken is a secret field (encrypted at rest + masked on GET)", () => {
+    expect(sourceSyncSection.secretFields).toContain("githubToken");
+  });
+
+  test("empty pollSchedule (disabled) is accepted", () => {
+    const parsed = sourceSyncSchema.parse({ ...sourceSyncDefaults, pollSchedule: "" });
+    expect(parsed.pollSchedule).toBe("");
+  });
+
+  test("a valid cron is accepted", () => {
+    const parsed = sourceSyncSchema.parse({
+      ...sourceSyncDefaults,
+      pollSchedule: "0 * * * *",
+    });
+    expect(parsed.pollSchedule).toBe("0 * * * *");
+  });
+
+  test("an invalid cron is rejected", () => {
+    expect(() =>
+      sourceSyncSchema.parse({ ...sourceSyncDefaults, pollSchedule: "not a cron" }),
+    ).toThrow();
+  });
+
+  test("minCheckIntervalMinutes must be a positive integer", () => {
+    expect(() =>
+      sourceSyncSchema.parse({ ...sourceSyncDefaults, minCheckIntervalMinutes: 0 }),
+    ).toThrow();
+    expect(() =>
+      sourceSyncSchema.parse({ ...sourceSyncDefaults, minCheckIntervalMinutes: 1.5 }),
+    ).toThrow();
+  });
+
+  test("section id + publicPath are stable", () => {
+    expect(sourceSyncSection.id).toBe("sourceSync");
+    expect(sourceSyncSection.publicPath).toBe("sourceSync");
+  });
+});

--- a/ornn-api/src/domains/settings/sections/sourceSync.ts
+++ b/ornn-api/src/domains/settings/sections/sourceSync.ts
@@ -1,0 +1,66 @@
+/**
+ * GitHub source-sync section schema.
+ *
+ * Controls the automatic sync of GitHub-sourced skills — the poller that
+ * detects when a linked upstream repo has moved and (later phases) re-pulls
+ * it. This section (#1175) only carries the config; the scheduler (#1176)
+ * and auto-publish (#1177) consume it.
+ *
+ * `githubToken` is a service-account GitHub token used ONLY to authenticate
+ * reads of **public** repos so drift checks escape the unauthenticated
+ * 60-req/hr-per-IP ceiling (authenticated is 5,000/hr with free `304`s). It
+ * grants no access the public web doesn't already have — it exists purely to
+ * lift the rate limit. It is encrypted at rest by the SettingsService (like
+ * `mirror.appPrivateKey`), mid-masked on GET, and redacted on export. When
+ * empty here, the runtime falls back to the `ORNN_SOURCE_SYNC_GITHUB_TOKEN`
+ * env var; when both are empty the poller runs unauthenticated (rate-limited).
+ *
+ * `pollSchedule` is a cron expression interpreted in `Asia/Singapore`
+ * (matching the mirror scheduler). Empty string disables the schedule.
+ *
+ * @module domains/settings/sections/sourceSync
+ */
+import { z } from "zod";
+import { cronSchedule } from "./cronSchedule";
+import type { SectionMeta } from "./index";
+
+export const sourceSyncSchema = z.object({
+  /** Master switch — when false the poller (#1176) does nothing. */
+  enabled: z.boolean(),
+  /**
+   * Service-account GitHub token (fine-grained/classic, public-read).
+   * Encrypted at rest + masked. Empty ⇒ fall back to env, then to
+   * unauthenticated reads.
+   */
+  githubToken: z.string(),
+  /** Cron for the drift poll; "" disables. Interpreted Asia/Singapore. */
+  pollSchedule: cronSchedule,
+  /** A skill is not re-checked more often than this many minutes. */
+  minCheckIntervalMinutes: z.number().int().min(1),
+  /**
+   * Full unattended auto-publish switch. Consumed by #1177 — when true,
+   * detected drift auto-publishes a new version. Default false so the
+   * foundation ships inert.
+   */
+  autoPublish: z.boolean(),
+});
+
+export type SourceSyncSection = z.infer<typeof sourceSyncSchema>;
+
+export const sourceSyncDefaults: SourceSyncSection = {
+  enabled: false,
+  githubToken: "",
+  // Every 15 minutes. Applied by the (future) source-sync scheduler with
+  // `timezone: "Asia/Singapore"`, matching the mirror scheduler.
+  pollSchedule: "*/15 * * * *",
+  minCheckIntervalMinutes: 60,
+  autoPublish: false,
+};
+
+export const sourceSyncSection: SectionMeta<SourceSyncSection> = {
+  id: "sourceSync",
+  publicPath: "sourceSync",
+  schema: sourceSyncSchema,
+  secretFields: ["githubToken"],
+  defaults: sourceSyncDefaults,
+};

--- a/ornn-api/src/domains/settings/service.ts
+++ b/ornn-api/src/domains/settings/service.ts
@@ -4,7 +4,8 @@
  *
  * Responsibilities:
  *   • Decrypt secret fields on read (apiKey / clientSecret / password /
- *     appPrivateKey / postHogApiKey) so internal callers see plaintext.
+ *     appPrivateKey / postHogApiKey / githubToken) so internal callers see
+ *     plaintext.
  *   • Encrypt secret fields on write before they hit Mongo.
  *   • Run the section's Zod schema before persisting (caller may also
  *     validate, but the service is the last line of defence).
@@ -40,6 +41,7 @@ import {
   type SectionId,
   type SkillAuditSection,
   type SkillGenSection,
+  type SourceSyncSection,
   type TelemetrySection,
 } from "./sections";
 import type {
@@ -120,6 +122,10 @@ export class SettingsServiceImpl implements SettingsService {
   }
   async getLaunchPromo(): Promise<LaunchPromoSection> {
     return this.getSection<LaunchPromoSection>("launchPromo");
+  }
+
+  async getSourceSync(): Promise<SourceSyncSection> {
+    return this.getSection<SourceSyncSection>("sourceSync");
   }
 
   async getSection<T>(id: SectionId): Promise<T> {

--- a/ornn-api/src/domains/settings/types.ts
+++ b/ornn-api/src/domains/settings/types.ts
@@ -22,6 +22,7 @@ import type {
   SectionId,
   SkillAuditSection,
   SkillGenSection,
+  SourceSyncSection,
   TelemetrySection,
 } from "./sections";
 import type { LlmProvider } from "./llmProviders/types";
@@ -60,6 +61,7 @@ export interface SettingsService {
   getTelemetry(): Promise<TelemetrySection>;
   getExtras(): Promise<ExtrasSection>;
   getLaunchPromo(): Promise<LaunchPromoSection>;
+  getSourceSync(): Promise<SourceSyncSection>;
 
   /**
    * Read a section by id. Returns the typed payload, applying defaults

--- a/ornn-api/src/domains/skills/crud/repository.ts
+++ b/ornn-api/src/domains/skills/crud/repository.ts
@@ -4,7 +4,12 @@
  */
 
 import type { Collection, Db, Document } from "mongodb";
-import type { SkillDocument, SkillGrant, SkillMetadata } from "../../../shared/types/index";
+import type {
+  SkillDocument,
+  SkillGrant,
+  SkillMetadata,
+  SkillSourceDriftState,
+} from "../../../shared/types/index";
 import { AppError } from "../../../shared/types/index";
 import { createLogger } from "../../../shared/logger";
 import { coerceStoredGrants, legacyListsFromGrants } from "./grants";
@@ -347,6 +352,41 @@ export class SkillRepository {
       },
     );
     return this.findByGuid(guid);
+  }
+
+  /**
+   * Persist the drift-detection fields on a skill's `source` (#1175). Only
+   * touches `source.*` drift keys via dot-paths — it never rewrites the
+   * whole `source` object (so it can't race with a concurrent refresh that
+   * updated `lastSyncedCommit`) and never touches the package or version
+   * history. A no-op when the skill has no `source`.
+   *
+   * `updatedOn`/`updatedBy` are deliberately NOT bumped: a drift check is a
+   * background read, not a user edit, and must not disturb sort-by-updated
+   * ordering.
+   */
+  async updateSourceDriftState(
+    guid: string,
+    patch: {
+      driftState?: SkillSourceDriftState;
+      upstreamHeadSha?: string;
+      etag?: string;
+      lastCheckedAt?: Date;
+    },
+  ): Promise<void> {
+    const setFields: Record<string, unknown> = {};
+    if (patch.driftState !== undefined) setFields["source.driftState"] = patch.driftState;
+    if (patch.upstreamHeadSha !== undefined)
+      setFields["source.upstreamHeadSha"] = patch.upstreamHeadSha;
+    if (patch.etag !== undefined) setFields["source.etag"] = patch.etag;
+    if (patch.lastCheckedAt !== undefined)
+      setFields["source.lastCheckedAt"] = patch.lastCheckedAt;
+    if (Object.keys(setFields).length === 0) return;
+
+    await this.collection.updateOne(
+      { _id: skillId(guid), source: { $exists: true } },
+      { $set: setFields },
+    );
   }
 
   /**
@@ -936,6 +976,23 @@ function mapDoc(doc: Document | null): SkillDocument | null {
               : {}),
           ...(typeof doc.source.lastSyncedCommit === "string" && doc.source.lastSyncedCommit
             ? { lastSyncedCommit: doc.source.lastSyncedCommit }
+            : {}),
+          // Drift-detection fields (#1175). All optional — absent until the
+          // first drift check runs. Same absent-field care as above so we
+          // never fabricate an Invalid Date.
+          ...(typeof doc.source.upstreamHeadSha === "string" && doc.source.upstreamHeadSha
+            ? { upstreamHeadSha: doc.source.upstreamHeadSha }
+            : {}),
+          ...(typeof doc.source.etag === "string" && doc.source.etag
+            ? { etag: doc.source.etag }
+            : {}),
+          ...(doc.source.lastCheckedAt instanceof Date
+            ? { lastCheckedAt: doc.source.lastCheckedAt }
+            : doc.source.lastCheckedAt != null
+              ? { lastCheckedAt: new Date(doc.source.lastCheckedAt) }
+              : {}),
+          ...(typeof doc.source.driftState === "string"
+            ? { driftState: doc.source.driftState as SkillSourceDriftState }
             : {}),
         }
       : undefined,

--- a/ornn-api/src/domains/skills/crud/service.sourceDrift.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.sourceDrift.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { SkillService, type SkillServiceDeps } from "./service";
+import type { SkillDocument } from "../../../shared/types/index";
+
+/**
+ * End-to-end coverage of `SkillService.checkSourceDrift` — token precedence
+ * (settings > env > anonymous) and the delegation into the real
+ * `resolveRefHeadSha` probe. We patch `globalThis.fetch` so the whole chain
+ * runs without network and without adding test-only surface to prod deps.
+ */
+
+function githubSkillDoc(): SkillDocument {
+  return {
+    source: {
+      type: "github",
+      repo: "acme/x",
+      ref: "main",
+      path: "",
+      lastSyncedCommit: "old",
+    },
+  } as unknown as SkillDocument;
+}
+
+function makeService(opts: {
+  settingsToken?: string;
+  envToken?: string;
+  skill?: SkillDocument | null;
+}): { svc: SkillService; persisted: Array<Record<string, unknown>> } {
+  const persisted: Array<Record<string, unknown>> = [];
+  const deps = {
+    skillRepo: {
+      findByGuid: async () =>
+        opts.skill === undefined ? githubSkillDoc() : opts.skill,
+      updateSourceDriftState: async (
+        _g: string,
+        patch: Record<string, unknown>,
+      ) => {
+        persisted.push(patch);
+      },
+    },
+    ...(opts.settingsToken !== undefined
+      ? {
+          sourceSyncSettings: {
+            getSourceSync: async () =>
+              ({ githubToken: opts.settingsToken }) as never,
+          },
+        }
+      : {}),
+    ...(opts.envToken !== undefined
+      ? { sourceSyncGithubTokenFallback: opts.envToken }
+      : {}),
+  } as unknown as SkillServiceDeps;
+  return { svc: new SkillService(deps), persisted };
+}
+
+function recordingFetch(responder: (url: string) => Response): {
+  impl: typeof fetch;
+  calls: Array<{ url: string; auth: string | undefined }>;
+} {
+  const calls: Array<{ url: string; auth: string | undefined }> = [];
+  const impl = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({
+      url,
+      auth: (init?.headers as Record<string, string> | undefined)?.Authorization,
+    });
+    return responder(url);
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+async function withFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
+  const orig = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = orig;
+  }
+}
+
+describe("SkillService.checkSourceDrift", () => {
+  test("settings token wins over env fallback and authenticates the probe", async () => {
+    const { impl, calls } = recordingFetch(
+      () =>
+        new Response(JSON.stringify({ object: { sha: "new" } }), {
+          status: 200,
+          headers: { etag: 'W/"e"' },
+        }),
+    );
+    await withFetch(impl, async () => {
+      const { svc, persisted } = makeService({
+        settingsToken: "SETTINGS_TOK",
+        envToken: "ENV_TOK",
+      });
+      const res = await svc.checkSourceDrift("g1");
+      expect(res).toEqual({
+        applicable: true,
+        driftState: "drifted",
+        upstreamHeadSha: "new",
+      });
+      expect(calls[0]!.auth).toBe("Bearer SETTINGS_TOK");
+      expect(persisted[0]).toMatchObject({ driftState: "drifted", upstreamHeadSha: "new" });
+    });
+  });
+
+  test("empty settings token falls back to the env token", async () => {
+    const { impl, calls } = recordingFetch(
+      () => new Response(JSON.stringify({ object: { sha: "old" } }), { status: 200 }),
+    );
+    await withFetch(impl, async () => {
+      const { svc } = makeService({ settingsToken: "", envToken: "ENV_TOK" });
+      await svc.checkSourceDrift("g1");
+      expect(calls[0]!.auth).toBe("Bearer ENV_TOK");
+    });
+  });
+
+  test("no token anywhere → anonymous probe (no Authorization header)", async () => {
+    const { impl, calls } = recordingFetch(
+      () => new Response(JSON.stringify({ object: { sha: "old" } }), { status: 200 }),
+    );
+    await withFetch(impl, async () => {
+      const { svc } = makeService({ skill: githubSkillDoc() });
+      await svc.checkSourceDrift("g1");
+      expect(calls[0]!.auth).toBeUndefined();
+    });
+  });
+
+  test("non-github skill → applicable:false with no network call", async () => {
+    const { impl, calls } = recordingFetch(() => new Response("x", { status: 500 }));
+    await withFetch(impl, async () => {
+      const { svc } = makeService({
+        skill: { source: undefined } as unknown as SkillDocument,
+      });
+      const res = await svc.checkSourceDrift("g1");
+      expect(res).toEqual({ applicable: false });
+      expect(calls.length).toBe(0);
+    });
+  });
+});

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -12,6 +12,8 @@ import type { IStorageClient } from "../../../clients/storageClient";
 import type { SkillDocument, SkillMetadata, SkillDetailResponse, SkillVersionDocument, SkillSource } from "../../../shared/types/index";
 import { AppError } from "../../../shared/types/index";
 import { fetchSkillFromGitHub, parseGithubUrl, type GitHubPullInput } from "./utils/githubPull";
+import { runSourceDriftCheck, type SourceDriftResult } from "./sourceDrift";
+import type { SourceSyncSection } from "../../settings/sections/sourceSync";
 import { computeVersionDiff, type VersionDiffResult } from "./utils/versionDiff";
 import { isReservedVerb } from "../../../shared/reservedVerbs";
 import { canReadSkill, isMemberOfOrg, SYSTEM_ACTOR, type ActorContext } from "./authorize";
@@ -115,6 +117,15 @@ export function resolveDistTag(skill: SkillDocument, version: string): string | 
   );
 }
 
+/**
+ * Narrow settings surface the source-drift path needs (#1175). Decoupled
+ * from the full SettingsService so tests stub just this one method — same
+ * pattern as `MirrorSettingsReader`.
+ */
+export interface SourceSyncSettingsReader {
+  getSourceSync(): Promise<SourceSyncSection>;
+}
+
 export interface SkillServiceDeps {
   skillRepo: SkillRepository;
   skillVersionRepo: SkillVersionRepository;
@@ -148,6 +159,19 @@ export interface SkillServiceDeps {
   maxEntryUncompressedBytes?: number;
   maxPackageFileCount?: number;
   maxCompressionRatio?: number;
+
+  /**
+   * Source-sync settings reader (#1175). Optional — when absent the GitHub
+   * source reads/drift checks fall back to the env token (below) or run
+   * anonymously. Production bootstrap passes the SettingsService.
+   */
+  sourceSyncSettings?: SourceSyncSettingsReader;
+  /**
+   * Env-provided GitHub token fallback (`ORNN_SOURCE_SYNC_GITHUB_TOKEN`),
+   * used only when the settings `githubToken` is empty. Lets ops supply the
+   * credential without the admin UI. Never hardcoded, never logged.
+   */
+  sourceSyncGithubTokenFallback?: string;
 }
 
 export class SkillService {
@@ -163,6 +187,8 @@ export class SkillService {
   private readonly maxEntryUncompressedBytes: number | undefined;
   private readonly maxPackageFileCount: number | undefined;
   private readonly maxCompressionRatio: number | undefined;
+  private readonly sourceSyncSettings: SourceSyncSettingsReader | undefined;
+  private readonly sourceSyncGithubTokenFallback: string | undefined;
 
   constructor(deps: SkillServiceDeps) {
     this.skillRepo = deps.skillRepo;
@@ -175,6 +201,32 @@ export class SkillService {
     this.maxEntryUncompressedBytes = deps.maxEntryUncompressedBytes;
     this.maxPackageFileCount = deps.maxPackageFileCount;
     this.maxCompressionRatio = deps.maxCompressionRatio;
+    this.sourceSyncSettings = deps.sourceSyncSettings;
+    this.sourceSyncGithubTokenFallback = deps.sourceSyncGithubTokenFallback;
+  }
+
+  /**
+   * Resolve the GitHub token for authenticated source reads (#1175): the
+   * admin-set settings value wins; the env fallback is next; empty ⇒ run
+   * anonymous (rate-limited). Trimmed so stray whitespace never becomes a
+   * bogus `Authorization` header. NEVER logged.
+   */
+  private async resolveSourceSyncToken(): Promise<string> {
+    const configured = (await this.sourceSyncSettings?.getSourceSync())?.githubToken?.trim();
+    if (configured) return configured;
+    return this.sourceSyncGithubTokenFallback?.trim() ?? "";
+  }
+
+  /**
+   * Read-only drift check for a GitHub-sourced skill (#1175). Probes the
+   * upstream HEAD via the cheap `git/ref` endpoint, compares it to the
+   * last-synced commit, and persists the verdict on `source`. NEVER
+   * re-pulls or publishes — the scheduler (#1176) and auto-publish (#1177)
+   * consume the state this writes.
+   */
+  async checkSourceDrift(guid: string): Promise<SourceDriftResult> {
+    const token = await this.resolveSourceSyncToken();
+    return runSourceDriftCheck({ skillRepo: this.skillRepo }, guid, token);
   }
 
   /**
@@ -849,7 +901,10 @@ export class SkillService {
       skipValidation?: boolean | undefined;
     },
   ): Promise<{ guid: string; source: SkillSource }> {
-    const pulled = await fetchSkillFromGitHub(input);
+    // Authenticate the pull when a token is configured (#1175) — lifts the
+    // 60/hr anonymous ceiling. An explicit input token (tests) wins.
+    const token = await this.resolveSourceSyncToken();
+    const pulled = await fetchSkillFromGitHub({ ...input, token: input.token ?? token });
     const source: SkillSource = {
       type: "github",
       repo: pulled.source.repo,
@@ -897,6 +952,8 @@ export class SkillService {
       repo: existing.source.repo,
       ref: existing.source.ref,
       path: existing.source.path,
+      // Authenticated re-pull when a token is configured (#1175).
+      token: await this.resolveSourceSyncToken(),
     });
 
     const newSource: SkillSource = {

--- a/ornn-api/src/domains/skills/crud/sourceDrift.test.ts
+++ b/ornn-api/src/domains/skills/crud/sourceDrift.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { runSourceDriftCheck, type SourceDriftDeps } from "./sourceDrift";
+import {
+  GitHubSourceNotFoundError,
+  type RefHeadProbeResult,
+} from "./utils/githubPull";
+import type { SkillDocument } from "../../../shared/types/index";
+
+type Probe = NonNullable<SourceDriftDeps["probeRefHead"]>;
+
+function githubSkill(
+  source: Partial<{
+    repo: string;
+    ref: string;
+    path: string;
+    lastSyncedCommit: string;
+    etag: string;
+  }>,
+): SkillDocument {
+  return {
+    source: { type: "github", repo: "acme/x", ref: "main", path: "", ...source },
+  } as unknown as SkillDocument;
+}
+
+function fakeDeps(opts: { skill: SkillDocument | null; probe?: Probe }): {
+  deps: SourceDriftDeps;
+  persisted: Array<Record<string, unknown>>;
+} {
+  const persisted: Array<Record<string, unknown>> = [];
+  const deps: SourceDriftDeps = {
+    skillRepo: {
+      findByGuid: async () => opts.skill,
+      updateSourceDriftState: async (_g, patch) => {
+        persisted.push(patch as Record<string, unknown>);
+      },
+    },
+    ...(opts.probe ? { probeRefHead: opts.probe } : {}),
+  };
+  return { deps, persisted };
+}
+
+describe("runSourceDriftCheck", () => {
+  test("HEAD != lastSyncedCommit → drifted; persists sha + etag + lastCheckedAt", async () => {
+    const { deps, persisted } = fakeDeps({
+      skill: githubSkill({ lastSyncedCommit: "old", etag: 'W/"e0"' }),
+      probe: async (): Promise<RefHeadProbeResult> => ({
+        sha: "new",
+        etag: 'W/"e1"',
+        notModified: false,
+      }),
+    });
+    const res = await runSourceDriftCheck(deps, "g1", "tok");
+    expect(res).toEqual({ applicable: true, driftState: "drifted", upstreamHeadSha: "new" });
+    expect(persisted[0]).toMatchObject({
+      driftState: "drifted",
+      upstreamHeadSha: "new",
+      etag: 'W/"e1"',
+    });
+    expect(persisted[0]!.lastCheckedAt).toBeInstanceOf(Date);
+  });
+
+  test("HEAD == lastSyncedCommit → in_sync", async () => {
+    const { deps, persisted } = fakeDeps({
+      skill: githubSkill({ lastSyncedCommit: "same" }),
+      probe: async () => ({ sha: "same", notModified: false }),
+    });
+    const res = await runSourceDriftCheck(deps, "g1", "tok");
+    expect(res.driftState).toBe("in_sync");
+    expect(persisted[0]).toMatchObject({ driftState: "in_sync", upstreamHeadSha: "same" });
+  });
+
+  test("304 notModified → in_sync; probe receives the stored etag", async () => {
+    let seenEtag: string | undefined;
+    const { deps, persisted } = fakeDeps({
+      skill: githubSkill({ lastSyncedCommit: "x", etag: 'W/"stored"' }),
+      probe: async (_r, _ref, opts) => {
+        seenEtag = opts?.etag;
+        return { notModified: true };
+      },
+    });
+    const res = await runSourceDriftCheck(deps, "g1", "tok");
+    expect(seenEtag).toBe('W/"stored"');
+    expect(res.driftState).toBe("in_sync");
+    expect(persisted[0]).toMatchObject({ driftState: "in_sync" });
+  });
+
+  test("GitHubSourceNotFoundError → broken (persisted, not thrown)", async () => {
+    const { deps, persisted } = fakeDeps({
+      skill: githubSkill({}),
+      probe: async () => {
+        throw new GitHubSourceNotFoundError("acme/x", "main");
+      },
+    });
+    const res = await runSourceDriftCheck(deps, "g1", "tok");
+    expect(res.driftState).toBe("broken");
+    expect(persisted[0]).toMatchObject({ driftState: "broken" });
+  });
+
+  test("transient (non-404) error is re-thrown and nothing is persisted", async () => {
+    const { deps, persisted } = fakeDeps({
+      skill: githubSkill({}),
+      probe: async () => {
+        throw new Error("network boom");
+      },
+    });
+    await expect(runSourceDriftCheck(deps, "g1", "tok")).rejects.toThrow(/network boom/);
+    expect(persisted.length).toBe(0);
+  });
+
+  test("empty token → probe called anonymously (token undefined)", async () => {
+    let seenToken: string | undefined = "unset";
+    const { deps } = fakeDeps({
+      skill: githubSkill({ lastSyncedCommit: "a" }),
+      probe: async (_r, _ref, opts) => {
+        seenToken = opts?.token;
+        return { sha: "a", notModified: false };
+      },
+    });
+    await runSourceDriftCheck(deps, "g1", "");
+    expect(seenToken).toBeUndefined();
+  });
+
+  test("skill without a github source → applicable:false, no persistence", async () => {
+    const { deps, persisted } = fakeDeps({
+      skill: { source: undefined } as unknown as SkillDocument,
+    });
+    const res = await runSourceDriftCheck(deps, "g1", "tok");
+    expect(res).toEqual({ applicable: false });
+    expect(persisted.length).toBe(0);
+  });
+
+  test("missing skill → applicable:false", async () => {
+    const { deps } = fakeDeps({ skill: null });
+    const res = await runSourceDriftCheck(deps, "g1", "tok");
+    expect(res.applicable).toBe(false);
+  });
+});

--- a/ornn-api/src/domains/skills/crud/sourceDrift.ts
+++ b/ornn-api/src/domains/skills/crud/sourceDrift.ts
@@ -1,0 +1,125 @@
+/**
+ * Source-drift check (#1175) — the read-only "did upstream move?" probe for
+ * a GitHub-sourced skill.
+ *
+ * Extracted from `SkillService` (which is already large) so the logic is
+ * unit-testable in isolation and the service exposes only a thin delegating
+ * method. This NEVER re-pulls, publishes, or mutates the skill package — it
+ * only reads the upstream HEAD via the cheap `git/ref` probe and persists
+ * the drift verdict + ETag on `source`. The scheduler (#1176) and
+ * auto-publish (#1177) build on the state this writes.
+ *
+ * @module domains/skills/crud/sourceDrift
+ */
+import { createLogger } from "../../../shared/logger";
+import type { SkillSourceDriftState } from "../../../shared/types/index";
+import type { SkillRepository } from "./repository";
+import {
+  resolveRefHeadSha,
+  GitHubSourceNotFoundError,
+  type RefHeadProbeInput,
+  type RefHeadProbeResult,
+} from "./utils/githubPull";
+
+const logger = createLogger("sourceDrift");
+
+export interface SourceDriftResult {
+  /** False when the skill has no GitHub source — nothing to check. */
+  readonly applicable: boolean;
+  /** The verdict written to `source.driftState`. Absent when not applicable. */
+  readonly driftState?: SkillSourceDriftState;
+  /** The upstream HEAD SHA observed (present on a live probe, not on `broken`). */
+  readonly upstreamHeadSha?: string;
+}
+
+export interface SourceDriftDeps {
+  readonly skillRepo: Pick<
+    SkillRepository,
+    "findByGuid" | "updateSourceDriftState"
+  >;
+  /**
+   * Cheap HEAD-SHA probe. Injectable so tests can drive the 304 / drift /
+   * 404 branches without real network. Defaults to the real
+   * {@link resolveRefHeadSha}.
+   */
+  readonly probeRefHead?: (
+    repo: string,
+    ref: string,
+    opts?: RefHeadProbeInput,
+  ) => Promise<RefHeadProbeResult>;
+}
+
+/**
+ * Check a single skill for upstream drift and persist the verdict.
+ *
+ * @param token Service-account token, or `""` for anonymous (rate-limited)
+ *   reads. Empty logs a warning but still probes.
+ */
+export async function runSourceDriftCheck(
+  deps: SourceDriftDeps,
+  guid: string,
+  token: string,
+): Promise<SourceDriftResult> {
+  const probe = deps.probeRefHead ?? resolveRefHeadSha;
+  const skill = await deps.skillRepo.findByGuid(guid);
+  if (!skill || !skill.source || skill.source.type !== "github") {
+    return { applicable: false };
+  }
+  const source = skill.source;
+  if (token.length === 0) {
+    logger.warn(
+      { guid, repo: source.repo },
+      "source drift check running unauthenticated — GitHub reads are limited to 60/hr per IP",
+    );
+  }
+  const now = new Date();
+
+  try {
+    const result = await probe(source.repo, source.ref, {
+      token: token || undefined,
+      etag: source.etag,
+    });
+
+    // 304 — nothing changed since the stored ETag. Free on authenticated
+    // requests; just record that we looked.
+    if (result.notModified) {
+      await deps.skillRepo.updateSourceDriftState(guid, {
+        driftState: "in_sync",
+        lastCheckedAt: now,
+      });
+      logger.debug({ guid, repo: source.repo }, "source drift check: 304 not modified");
+      return { applicable: true, driftState: "in_sync" };
+    }
+
+    const sha = result.sha!;
+    const drifted = sha !== source.lastSyncedCommit;
+    const driftState: SkillSourceDriftState = drifted ? "drifted" : "in_sync";
+    await deps.skillRepo.updateSourceDriftState(guid, {
+      driftState,
+      upstreamHeadSha: sha,
+      ...(result.etag ? { etag: result.etag } : {}),
+      lastCheckedAt: now,
+    });
+    logger.info(
+      { guid, repo: source.repo, ref: source.ref, driftState, upstreamHeadSha: sha },
+      "source drift check complete",
+    );
+    return { applicable: true, driftState, upstreamHeadSha: sha };
+  } catch (err) {
+    // A genuinely missing repo/ref is a terminal, per-skill state — record
+    // it and return. Transient failures (network, 5xx) are re-thrown so the
+    // caller/scheduler can retry rather than mislabel a blip as broken.
+    if (err instanceof GitHubSourceNotFoundError) {
+      await deps.skillRepo.updateSourceDriftState(guid, {
+        driftState: "broken",
+        lastCheckedAt: now,
+      });
+      logger.warn(
+        { guid, repo: source.repo, ref: source.ref },
+        "source drift check: upstream not found — marked broken",
+      );
+      return { applicable: true, driftState: "broken" };
+    }
+    throw err;
+  }
+}

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.test.ts
@@ -5,7 +5,27 @@ import {
   normalizePath,
   normalizeRepoIdentifier,
   parseGithubUrl,
+  authHeaders,
+  resolveRefHeadSha,
+  GitHubSourceNotFoundError,
 } from "./githubPull";
+
+/** Records each request's URL + Authorization header, returns caller-chosen responses. */
+function recordingFetch(responder: (url: string) => Response): {
+  impl: typeof fetch;
+  calls: Array<{ url: string; headers: Record<string, string> }>;
+} {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  const impl = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, headers: (init?.headers ?? {}) as Record<string, string> });
+    return responder(url);
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
 
 describe("parseGithubUrl", () => {
   test("extracts repo + ref + path from a /tree/ URL", () => {
@@ -290,5 +310,138 @@ Hello world.
     const result = await fetchSkillFromGitHub({ repo: "acme/x" }, fetchMock);
     expect(result.source.ref).toBe("HEAD");
     expect(result.resolvedCommitSha).toBe("headsha");
+  });
+
+  test("token authenticates api.github.com reads but never raw downloads (#1175)", async () => {
+    const authByHost: Record<string, Array<string | undefined>> = {};
+    const impl = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      const u = new URL(url);
+      const auth = (init?.headers as Record<string, string> | undefined)?.Authorization;
+      (authByHost[u.host] ??= []).push(auth);
+      if (u.pathname.includes("/commits/")) {
+        return new Response(JSON.stringify({ sha: "s" }), { status: 200 });
+      }
+      if (u.pathname.includes("/contents")) {
+        return new Response(
+          JSON.stringify([
+            {
+              name: "SKILL.md",
+              path: "SKILL.md",
+              type: "file",
+              size: 12,
+              sha: "x",
+              download_url: "https://raw.example/SKILL.md",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (url.startsWith("https://raw.example/")) {
+        return new Response("---\nname: x\n---\n");
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    await fetchSkillFromGitHub(
+      { repo: "acme/x", ref: "main", token: "ghp_secret" },
+      impl,
+    );
+    // Every api.github.com call carried the bearer; the raw CDN host got none.
+    expect(authByHost["api.github.com"]?.every((a) => a === "Bearer ghp_secret")).toBe(true);
+    expect(authByHost["raw.example"]?.every((a) => a === undefined)).toBe(true);
+  });
+});
+
+describe("authHeaders", () => {
+  test("no token → no Authorization", () => {
+    const h = authHeaders();
+    expect(h.Authorization).toBeUndefined();
+    expect(h.Accept).toBe("application/vnd.github+json");
+    expect(h["User-Agent"]).toBeTruthy();
+  });
+  test("empty token → no Authorization", () => {
+    expect(authHeaders("").Authorization).toBeUndefined();
+  });
+  test("non-empty token → Bearer Authorization", () => {
+    expect(authHeaders("ghp_tok").Authorization).toBe("Bearer ghp_tok");
+  });
+});
+
+describe("resolveRefHeadSha", () => {
+  test("pinned 40-hex SHA short-circuits with ZERO http calls", async () => {
+    const { impl, calls } = recordingFetch(
+      () => new Response("must not be called", { status: 500 }),
+    );
+    const sha = "a1b2c3d4".repeat(5); // 40 hex chars
+    const res = await resolveRefHeadSha("acme/x", sha, {}, impl);
+    expect(res).toEqual({ sha, notModified: false });
+    expect(calls.length).toBe(0);
+  });
+
+  test("branch 200 → object.sha + etag; sends Authorization, no If-None-Match", async () => {
+    const { impl, calls } = recordingFetch(
+      () =>
+        new Response(JSON.stringify({ object: { sha: "newsha" } }), {
+          status: 200,
+          headers: { etag: 'W/"abc"' },
+        }),
+    );
+    const res = await resolveRefHeadSha("acme/x", "main", { token: "ghp_t" }, impl);
+    expect(res).toEqual({ sha: "newsha", etag: 'W/"abc"', notModified: false });
+    expect(calls[0]!.url).toContain("/git/ref/heads/main");
+    expect(calls[0]!.headers.Authorization).toBe("Bearer ghp_t");
+    expect(calls[0]!.headers["If-None-Match"]).toBeUndefined();
+  });
+
+  test("304 with stored etag → notModified, replays If-None-Match", async () => {
+    const { impl, calls } = recordingFetch(() => new Response(null, { status: 304 }));
+    const res = await resolveRefHeadSha(
+      "acme/x",
+      "main",
+      { token: "t", etag: 'W/"prev"' },
+      impl,
+    );
+    expect(res).toEqual({ notModified: true });
+    expect(calls[0]!.headers["If-None-Match"]).toBe('W/"prev"');
+  });
+
+  test("no token → request carries no Authorization", async () => {
+    const { impl, calls } = recordingFetch(
+      () => new Response(JSON.stringify({ object: { sha: "s" } }), { status: 200 }),
+    );
+    await resolveRefHeadSha("acme/x", "main", {}, impl);
+    expect(calls[0]!.headers.Authorization).toBeUndefined();
+  });
+
+  test("404 on heads AND tags → GitHubSourceNotFoundError", async () => {
+    const { impl, calls } = recordingFetch(() => new Response("nf", { status: 404 }));
+    await expect(resolveRefHeadSha("acme/x", "gone", {}, impl)).rejects.toBeInstanceOf(
+      GitHubSourceNotFoundError,
+    );
+    expect(calls.length).toBe(2);
+    expect(calls[0]!.url).toContain("/git/ref/heads/gone");
+    expect(calls[1]!.url).toContain("/git/ref/tags/gone");
+  });
+
+  test("404 heads then 200 tags → resolves via tag fallback", async () => {
+    const { impl } = recordingFetch((url) =>
+      url.includes("/git/ref/heads/")
+        ? new Response("nf", { status: 404 })
+        : new Response(JSON.stringify({ object: { sha: "tagsha" } }), { status: 200 }),
+    );
+    const res = await resolveRefHeadSha("acme/x", "v1.0", {}, impl);
+    expect(res.sha).toBe("tagsha");
+  });
+
+  test("slashed branch name keeps its path segments (not %2F)", async () => {
+    const { impl, calls } = recordingFetch(
+      () => new Response(JSON.stringify({ object: { sha: "s" } }), { status: 200 }),
+    );
+    await resolveRefHeadSha("acme/x", "feature/foo", {}, impl);
+    expect(calls[0]!.url).toContain("/git/ref/heads/feature/foo");
   });
 });

--- a/ornn-api/src/domains/skills/crud/utils/githubPull.ts
+++ b/ornn-api/src/domains/skills/crud/utils/githubPull.ts
@@ -6,10 +6,18 @@
  * the contents API, fetch each file's raw bytes, and build a ZIP in the
  * shape the existing upload pipeline expects (skill-root/SKILL.md, etc.).
  *
- * MVP constraints:
- *   - public repos only (no auth header)
+ * Constraints:
+ *   - public repos only
  *   - single directory, recursive (enumerates via contents API)
  *   - max 200 files / 10 MiB total to keep the pull bounded
+ *
+ * Auth (#1175): every `api.github.com` request may carry an optional
+ * `Authorization: Bearer <token>`. The token is a service-account
+ * credential used ONLY to lift the unauthenticated 60-req/hr-per-IP rate
+ * limit to the authenticated 5,000/hr (with free `304`s) — it grants no
+ * access beyond public content. Raw file downloads (`download_url`, served
+ * from `raw.githubusercontent.com`) stay unauthenticated: they're a
+ * different host with a separate budget and need no credential.
  *
  * @module domains/skills/crud/utils/githubPull
  */
@@ -18,6 +26,40 @@ import JSZip from "jszip";
 import { createLogger } from "../../../../shared/logger";
 import { hasUnsafeSegment } from "../../../../shared/githubNaming";
 const logger = createLogger("githubSkillPull");
+
+const GITHUB_USER_AGENT = "ornn-api/skills-github-pull";
+
+/**
+ * Build headers for an `api.github.com` request. Adds `Authorization` only
+ * when a non-empty token is supplied — so the same code path serves both
+ * authenticated (rate-limit-lifted) and anonymous reads.
+ */
+export function authHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": GITHUB_USER_AGENT,
+  };
+  if (typeof token === "string" && token.length > 0) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+/**
+ * Thrown when a repo/ref genuinely doesn't exist (404 on both the branch
+ * and tag ref lookups). A typed error so the drift checker can map it to a
+ * `broken` state without coupling this low-level util to the HTTP-layer
+ * `AppError`.
+ */
+export class GitHubSourceNotFoundError extends Error {
+  constructor(
+    public readonly repo: string,
+    public readonly ref: string,
+  ) {
+    super(`GitHub ref '${ref}' not found in ${repo}`);
+    this.name = "GitHubSourceNotFoundError";
+  }
+}
 
 export interface GitHubPullInput {
   /** `owner/name`. */
@@ -32,6 +74,30 @@ export interface GitHubPullInput {
   readonly maxFiles?: number | undefined;
   /** Max total bytes. Safety cap. Default 10 MiB. */
   readonly maxTotalBytes?: number | undefined;
+  /**
+   * Service-account token used to authenticate `api.github.com` reads and
+   * lift the rate limit. Absent ⇒ anonymous (rate-limited) reads. Never
+   * sent to raw file downloads.
+   */
+  readonly token?: string | undefined;
+}
+
+/** Options for the cheap HEAD-SHA drift probe. */
+export interface RefHeadProbeInput {
+  /** Auth token — see {@link authHeaders}. */
+  readonly token?: string | undefined;
+  /** Prior ETag for a conditional request; a matching `304` is free. */
+  readonly etag?: string | undefined;
+}
+
+/** Result of {@link resolveRefHeadSha}. */
+export interface RefHeadProbeResult {
+  /** Branch/tag HEAD commit SHA. Absent only when `notModified` is true. */
+  readonly sha?: string | undefined;
+  /** Fresh ETag to persist for the next conditional probe. */
+  readonly etag?: string | undefined;
+  /** True when the server answered `304 Not Modified` (nothing changed). */
+  readonly notModified: boolean;
 }
 
 export interface GitHubPullResult {
@@ -167,11 +233,11 @@ export async function fetchSkillFromGitHub(
   const maxTotalBytes = input.maxTotalBytes ?? DEFAULT_MAX_BYTES;
 
   // Resolve the ref to a concrete commit SHA for audit logging.
-  const resolvedCommitSha = await resolveRefToSha(repo, refInput, fetchImpl);
+  const resolvedCommitSha = await resolveRefToSha(repo, refInput, fetchImpl, input.token);
 
   // Walk the target directory recursively.
   const allFiles: GitHubContentEntry[] = [];
-  await walkContents(repo, resolvedCommitSha, path, fetchImpl, allFiles);
+  await walkContents(repo, resolvedCommitSha, path, fetchImpl, allFiles, input.token);
 
   if (allFiles.length === 0) {
     throw new Error(`No files found under '${path || "/"}' in ${repo}@${refInput}`);
@@ -244,18 +310,84 @@ export async function fetchSkillFromGitHub(
   };
 }
 
+/** Encode a slash-bearing ref (e.g. `feature/x`) segment-by-segment so the
+ * git-ref path stays intact instead of collapsing `/` into `%2F`. */
+function encodeRefPath(ref: string): string {
+  return ref.split("/").map(encodeURIComponent).join("/");
+}
+
+/**
+ * Cheap drift probe: resolve a branch/tag HEAD to its commit SHA using the
+ * lightweight `git/ref` endpoint (~200-byte body vs. the multi-KB commits
+ * API), with optional ETag conditional support.
+ *
+ * - A 40-hex `ref` is a pinned commit — it can never drift, so we return it
+ *   immediately with NO network call.
+ * - Branches resolve via `git/ref/heads/<branch>`. On a `404` we fall back
+ *   to `git/ref/tags/<tag>` before declaring the source missing.
+ * - A stored `etag` yields a `304 Not Modified` when nothing changed, which
+ *   (for authenticated requests) does not count against the rate limit.
+ *
+ * Caveat: for an *annotated* tag, `object.sha` is the tag object SHA, not
+ * the underlying commit — so a tag-sourced skill's drift comparison is
+ * best-effort. Branches and pinned SHAs (the common cases) compare exactly;
+ * the full-pull path (`resolveRefToSha`) remains the source of truth.
+ */
+export async function resolveRefHeadSha(
+  repo: string,
+  ref: string,
+  opts: RefHeadProbeInput = {},
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<RefHeadProbeResult> {
+  const normalizedRepo = normalizeRepoIdentifier(repo);
+  const trimmedRef = ref.trim();
+  if (/^[0-9a-f]{40}$/i.test(trimmedRef)) {
+    // Pinned commit SHA — immutable, no HTTP needed.
+    return { sha: trimmedRef, notModified: false };
+  }
+
+  const headers = authHeaders(opts.token);
+  if (typeof opts.etag === "string" && opts.etag.length > 0) {
+    headers["If-None-Match"] = opts.etag;
+  }
+
+  const probe = async (
+    refType: "heads" | "tags",
+  ): Promise<RefHeadProbeResult | "not-found"> => {
+    const url = `https://api.github.com/repos/${normalizedRepo}/git/ref/${refType}/${encodeRefPath(trimmedRef)}`;
+    const res = await fetchImpl(url, { headers });
+    if (res.status === 304) return { notModified: true };
+    if (res.status === 404) return "not-found";
+    if (!res.ok) {
+      throw new Error(
+        `GitHub git/ref API returned ${res.status} for ${normalizedRepo}@${trimmedRef}`,
+      );
+    }
+    const body = (await res.json()) as { object?: { sha?: string } };
+    const sha = body.object?.sha;
+    if (!sha) {
+      throw new Error(
+        `GitHub git/ref API returned no object SHA for ${normalizedRepo}@${trimmedRef}`,
+      );
+    }
+    return { sha, etag: res.headers.get("etag") ?? undefined, notModified: false };
+  };
+
+  const asBranch = await probe("heads");
+  if (asBranch !== "not-found") return asBranch;
+  const asTag = await probe("tags");
+  if (asTag !== "not-found") return asTag;
+  throw new GitHubSourceNotFoundError(normalizedRepo, trimmedRef);
+}
+
 async function resolveRefToSha(
   repo: string,
   ref: string,
   fetchImpl: typeof fetch,
+  token?: string,
 ): Promise<string> {
   const url = `https://api.github.com/repos/${repo}/commits/${encodeURIComponent(ref)}`;
-  const res = await fetchImpl(url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "User-Agent": "ornn-api/skills-github-pull",
-    },
-  });
+  const res = await fetchImpl(url, { headers: authHeaders(token) });
   if (res.status === 404) {
     throw new Error(`Ref '${ref}' not found in ${repo}`);
   }
@@ -277,15 +409,11 @@ async function walkContents(
   path: string,
   fetchImpl: typeof fetch,
   out: GitHubContentEntry[],
+  token?: string,
 ): Promise<void> {
   const encodedPath = path ? `/${encodeURI(path)}` : "";
   const url = `https://api.github.com/repos/${repo}/contents${encodedPath}?ref=${encodeURIComponent(ref)}`;
-  const res = await fetchImpl(url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "User-Agent": "ornn-api/skills-github-pull",
-    },
-  });
+  const res = await fetchImpl(url, { headers: authHeaders(token) });
   if (res.status === 404) {
     // The target path doesn't exist on this ref. Callers decide whether
     // that's acceptable — for the top-level call it isn't; for an empty
@@ -303,7 +431,7 @@ async function walkContents(
     if (entry.type === "file") {
       out.push(entry);
     } else if (entry.type === "dir") {
-      await walkContents(repo, ref, entry.path, fetchImpl, out);
+      await walkContents(repo, ref, entry.path, fetchImpl, out, token);
     }
     // symlinks, submodules → skip
   }

--- a/ornn-api/src/infra/config.ts
+++ b/ornn-api/src/infra/config.ts
@@ -87,6 +87,15 @@ export interface SkillConfig {
    */
   readonly ornnPublicOrigin: string;
 
+  /**
+   * Service-account GitHub token for authenticated source-repo reads
+   * (#1175). Env fallback used when the `sourceSync` settings section has no
+   * token. Public-read only — it lifts the 60/hr anonymous rate ceiling, it
+   * grants no access beyond public content. Empty ⇒ reads run anonymously
+   * (rate-limited). Never logged.
+   */
+  readonly sourceSyncGithubToken: string;
+
   /** Master passphrase for AES-256-GCM at-rest secret encryption. Required, ≥32 chars; boot fails with ConfigError if missing/short. See ENCRYPTION_KEY in envSchema for full rationale. */
   readonly encryptionKey: string;
 }
@@ -165,6 +174,11 @@ const envSchema = z.object({
     (v) => (v === "" ? undefined : v),
     z.string().url().default("https://ornn.chrono-ai.fun"),
   ),
+
+  // Source-sync GitHub token (#1175). Optional — empty means anonymous,
+  // rate-limited source reads. The `sourceSync` settings section overrides
+  // this at runtime when an admin sets a value there.
+  ORNN_SOURCE_SYNC_GITHUB_TOKEN: z.string().default(""),
 });
 
 /**
@@ -228,5 +242,7 @@ export function loadConfig(): SkillConfig {
     agentsealEnabled: env.AGENTSEAL_ENABLED !== "false",
 
     ornnPublicOrigin: env.ORNN_PUBLIC_ORIGIN.replace(/\/+$/, ""),
+
+    sourceSyncGithubToken: env.ORNN_SOURCE_SYNC_GITHUB_TOKEN.trim(),
   };
 }

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -231,6 +231,21 @@ export interface SkillDocument {
 }
 
 /**
+ * Cached drift verdict from the most recent source-drift check (#1175).
+ * - `in_sync` — upstream HEAD equals `lastSyncedCommit`.
+ * - `drifted` — upstream moved; a re-pull would publish a new version.
+ * - `changed_unversioned` — upstream changed but `SKILL.md` version did not
+ *   advance (reserved for the auto-publish phase #1177).
+ * - `broken` — the source repo/ref could not be resolved (404 / made
+ *   private / deleted).
+ */
+export type SkillSourceDriftState =
+  | "in_sync"
+  | "drifted"
+  | "changed_unversioned"
+  | "broken";
+
+/**
  * Origin metadata for a skill pulled from an external source. The `type`
  * discriminator lets future additions (GitLab, Bitbucket, ...) live
  * alongside `github` without touching callers that only care about one.
@@ -256,6 +271,22 @@ export type SkillSource =
        * detection. Absent in the same "linked but not yet synced" state.
        */
       lastSyncedCommit?: string | undefined;
+      /**
+       * Upstream HEAD commit SHA observed by the most recent drift check
+       * (#1175). When present and different from `lastSyncedCommit`, the
+       * upstream has moved. Written by `checkSourceDrift`; never mutates
+       * the package itself.
+       */
+      upstreamHeadSha?: string | undefined;
+      /**
+       * ETag returned by the last `git/ref` probe, replayed via
+       * `If-None-Match` so an unchanged upstream answers with a free `304`.
+       */
+      etag?: string | undefined;
+      /** Wall-clock time of the most recent drift check. */
+      lastCheckedAt?: Date | undefined;
+      /** Cached drift verdict from the last check. See {@link SkillSourceDriftState}. */
+      driftState?: SkillSourceDriftState | undefined;
     };
 
 /**
@@ -405,6 +436,12 @@ export interface SkillDetailResponse {
         lastSyncedAt?: string | undefined;
         /** Absent in the same "linked but never synced" state. */
         lastSyncedCommit?: string | undefined;
+        /** Upstream HEAD from the last drift check (#1175). */
+        upstreamHeadSha?: string | undefined;
+        /** Wall-clock time of the last drift check (ISO string). */
+        lastCheckedAt?: string | undefined;
+        /** Cached drift verdict. See `SkillSourceDriftState`. */
+        driftState?: SkillSourceDriftState | undefined;
       }
     | undefined;
   /** NyxID service tie (null when untied). See `SkillDocument.nyxidServiceId`. */


### PR DESCRIPTION
## Summary

Foundation (Phase 0 of 5) for **automatic sync of GitHub-sourced skills** — the efficient-read layer, with **no behavior change** to existing flows. Nothing polls or auto-publishes yet; this only makes future automatic sync cheap and adds passive drift state. The scheduler (#1176), auto-publish (#1177), and UI (#1178) build on this.

## What this does

- **Authenticated + ETag-conditional GitHub reads.** Every `api.github.com` request in the pull path can now carry an `Authorization: Bearer <token>`, lifting the anonymous **60-req/hr-per-IP** ceiling to the authenticated **5,000/hr** (where a conditional `304` is free). Raw file downloads (`raw.githubusercontent.com`) stay anonymous — different host, separate budget, no reason to hand a CDN the token.
- **Cheap drift probe** — `resolveRefHeadSha()` resolves a branch/tag HEAD via the lightweight `git/ref` endpoint (~200 bytes vs the multi-KB commits API) with `If-None-Match`. A pinned 40-hex SHA short-circuits with **zero** HTTP calls; a `heads` 404 falls back to `tags` before throwing the typed `GitHubSourceNotFoundError`.
- **`sourceSync` settings section** — `enabled`, a `githubToken` (encrypted at rest + masked, exactly like `mirror.appPrivateKey`), `pollSchedule`, `minCheckIntervalMinutes`, and the `autoPublish` master switch (consumed later). Ships **inert** (all-off). Env fallback: `ORNN_SOURCE_SYNC_GITHUB_TOKEN`.
- **`SkillSource` drift model** — `upstreamHeadSha`, `etag`, `lastCheckedAt`, `driftState` (`in_sync` | `drifted` | `changed_unversioned` | `broken`), coerced in `mapDoc`, written by a targeted `updateSourceDriftState` dot-path setter (never rewrites `source`, never bumps `updatedOn`).
- **`SkillService.checkSourceDrift(guid)`** — read-only: probe → compare vs `lastSyncedCommit` → persist verdict. Never re-pulls or publishes. Token precedence: settings → env → anonymous. Transient (non-404) failures re-throw rather than mislabel a blip as `broken`.

## Why a token at all (public repos)

Public repos are readable anonymously — a token is **not required**. It exists purely to lift the shared-IP rate limit and unlock free `304`s. It can be a maximally locked-down public-read token; it grants nothing beyond public content. See the discussion on #1175. (The mirror GitHub App token is *not* reusable — an installation token 404s on any repo it isn't installed on.)

## Testing

- `bun test src/domains/skills/crud src/domains/settings` → **545 pass, 0 fail**
- New tests cover: auth header present iff token set; `304`/ETag replay; HEAD-SHA mismatch → drifted; 40-hex ref → zero HTTP calls; 404 → broken; token precedence + masking; tag fallback; slashed-branch encoding.
- `tsc --noEmit` clean; `eslint` clean.

## Commits (dependency-ordered, buildable per commit)

1. `refactor(api)` extract shared `cronSchedule` validator
2. `feat(api)` add `sourceSync` settings section
3. `feat(api)` authenticate + ETag-condition GitHub reads
4. `feat(api)` extend `SkillSource` with drift fields
5. `feat(api)` read-only `checkSourceDrift` + authenticated pull wiring
6. `docs` changeset

Closes #1175
