### PR TITLE
[Feature] Surface auto-sync status: drift badges + notifications (#1178)

### DIFF
--- a/.changeset/gh-source-auto-sync-ui.md
+++ b/.changeset/gh-source-auto-sync-ui.md
@@ -1,0 +1,5 @@
+---
+"ornn-web": minor
+---
+
+Surface automatic GitHub source-sync status in the UI (#1178): the skill detail page now shows a passive badge driven by the source's drift state — "Auto-synced", "Update in progress", "Upstream changed — version not bumped" (warning), or "Source unavailable" (error) — next to the existing "Synced from GitHub" chip and in the advanced GitHub-link panel, so owners see what auto-sync did without polling. The `skill.auto_synced` / `skill.auto_sync_failed` / `skill.source_broken` notifications render with proper labels, and opening a skill opportunistically refreshes a stale drift state once (no polling loop). The GET skill response now includes the drift fields that drive this (ornn-api).

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -2204,6 +2204,19 @@ export class SkillService {
             ...(typeof skill.source.lastSyncedCommit === "string" && skill.source.lastSyncedCommit
               ? { lastSyncedCommit: skill.source.lastSyncedCommit }
               : {}),
+            // Drift-detection state (#1176/#1177) — surfaced on GET so the
+            // frontend renders the auto-sync badge (#1178) from the last
+            // scheduled check without a bespoke endpoint. `etag` stays
+            // internal (a conditional-request cache detail, not client-facing).
+            ...(typeof skill.source.upstreamHeadSha === "string" && skill.source.upstreamHeadSha
+              ? { upstreamHeadSha: skill.source.upstreamHeadSha }
+              : {}),
+            ...(skill.source.lastCheckedAt instanceof Date
+              ? { lastCheckedAt: skill.source.lastCheckedAt.toISOString() }
+              : {}),
+            ...(typeof skill.source.driftState === "string"
+              ? { driftState: skill.source.driftState }
+              : {}),
           }
         : undefined,
       agentsealScan: effectiveOverlay?.agentsealScan ?? null,

--- a/ornn-web/src/components/notifications/NotificationDetailModal.tsx
+++ b/ornn-web/src/components/notifications/NotificationDetailModal.tsx
@@ -41,6 +41,9 @@ const CATEGORY_LABEL: Record<NotificationCategory, string> = {
   "quota.credits_granted": "Quota",
   "launchPromo.codeDelivered": "Promo",
   "skillset.member_unreadable": "Skillset",
+  "skill.source_broken": "Source",
+  "skill.auto_synced": "Auto-sync",
+  "skill.auto_sync_failed": "Auto-sync",
 };
 
 export interface NotificationDetailModalProps {

--- a/ornn-web/src/components/skill/AdvancedOptionsModal.tsx
+++ b/ornn-web/src/components/skill/AdvancedOptionsModal.tsx
@@ -26,6 +26,7 @@ import {
 import { useToastStore } from "@/stores/toastStore";
 import type { RefreshPreviewResponse } from "@/services/skillApi";
 import type { SkillDetail } from "@/types/domain";
+import { SourceDriftBadge } from "./SourceDriftBadge";
 import { translateError } from "@/utils/translateError";
 
 type AdvancedSettingId = "nyxid-service-binding" | "github-link";
@@ -571,6 +572,8 @@ function GithubLinkPanel({ skill, onClose }: { skill: SkillDetail; onClose: () =
                   })
                 : t("githubLink.neverSynced", "Linked but never synced.")}
             </p>
+            {/* Auto-sync drift status (#1178) — same passive pill as the chip. */}
+            <SourceDriftBadge source={skill.source} className="mt-2" />
           </div>
         )}
       </div>

--- a/ornn-web/src/components/skill/GitHubOriginChip.test.tsx
+++ b/ornn-web/src/components/skill/GitHubOriginChip.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * GitHubOriginChip tests (#1178) — the auto-sync badge shows next to the
+ * "Synced from GitHub" label, and the manual "Refresh from GitHub" override
+ * button remains available alongside it.
+ *
+ * @module components/skill/GitHubOriginChip.test
+ */
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { GitHubOriginChip } from "./GitHubOriginChip";
+import type { SkillSource } from "@/types/domain";
+
+afterEach(cleanup);
+
+function gh(driftState?: SkillSource["driftState"]): SkillSource {
+  return {
+    type: "github",
+    repo: "o/r",
+    ref: "main",
+    path: "",
+    lastSyncedCommit: "abcdef1234567",
+    ...(driftState ? { driftState } : {}),
+  };
+}
+
+describe("GitHubOriginChip", () => {
+  it("renders the drift badge AND keeps the manual refresh button", () => {
+    render(
+      <GitHubOriginChip
+        source={gh("changed_unversioned")}
+        canRefresh
+        isRefreshing={false}
+        onRefresh={() => {}}
+      />,
+    );
+    // Passive badge from driftState…
+    expect(screen.getByText(/version not bumped/i)).toBeInTheDocument();
+    // …and the manual override is still there.
+    expect(screen.getByText("Refresh from GitHub")).toBeInTheDocument();
+  });
+
+  it("broken source shows the danger badge", () => {
+    render(
+      <GitHubOriginChip source={gh("broken")} canRefresh isRefreshing={false} onRefresh={() => {}} />,
+    );
+    expect(screen.getByText("Source unavailable")).toBeInTheDocument();
+  });
+
+  it("no badge before the first drift check, but the chip still renders", () => {
+    render(
+      <GitHubOriginChip source={gh()} canRefresh isRefreshing={false} onRefresh={() => {}} />,
+    );
+    expect(screen.getByText("Synced from GitHub")).toBeInTheDocument();
+    expect(screen.queryByText("Source unavailable")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Auto-synced/)).not.toBeInTheDocument();
+  });
+
+  it("fires onRefresh when the manual button is clicked", () => {
+    const onRefresh = vi.fn();
+    render(
+      <GitHubOriginChip source={gh("in_sync")} canRefresh isRefreshing={false} onRefresh={onRefresh} />,
+    );
+    screen.getByText("Refresh from GitHub").click();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ornn-web/src/components/skill/GitHubOriginChip.tsx
+++ b/ornn-web/src/components/skill/GitHubOriginChip.tsx
@@ -9,6 +9,7 @@
 
 import { useTranslation } from "react-i18next";
 import type { SkillSource } from "@/types/domain";
+import { SourceDriftBadge } from "./SourceDriftBadge";
 
 interface GitHubOriginChipProps {
   source: SkillSource | undefined;
@@ -79,6 +80,9 @@ export function GitHubOriginChip({
       <span className="font-display text-xs uppercase tracking-wider text-meta">
         {t("githubOrigin.label", "Synced from GitHub")}
       </span>
+      {/* Passive auto-sync status (#1178) — read-only; the refresh button below
+          remains the manual override. */}
+      <SourceDriftBadge source={source} />
       <a
         href={repoUrl}
         target="_blank"

--- a/ornn-web/src/components/skill/SourceDriftBadge.test.tsx
+++ b/ornn-web/src/components/skill/SourceDriftBadge.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * SourceDriftBadge tests (#1178) — each driftState renders the right copy +
+ * DESIGN.md state-token tone, and nothing renders for the no-drift / non-github
+ * cases so legacy skills look unchanged. react-i18next is globally mocked and
+ * resolves keys from en.json (with {{when}} interpolation).
+ *
+ * @module components/skill/SourceDriftBadge.test
+ */
+import { describe, expect, it, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SourceDriftBadge } from "./SourceDriftBadge";
+import type { SkillSource } from "@/types/domain";
+
+afterEach(cleanup);
+
+function gh(
+  driftState?: SkillSource["driftState"],
+  extra: Partial<Extract<SkillSource, { type: "github" }>> = {},
+): SkillSource {
+  return {
+    type: "github",
+    repo: "o/r",
+    ref: "main",
+    path: "",
+    ...(driftState ? { driftState } : {}),
+    ...extra,
+  };
+}
+
+describe("SourceDriftBadge", () => {
+  it("renders nothing before the first drift check (no driftState)", () => {
+    const { container } = render(<SourceDriftBadge source={gh()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for an undefined source", () => {
+    const { container } = render(<SourceDriftBadge source={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("in_sync → 'Auto-synced' with success tone", () => {
+    render(<SourceDriftBadge source={gh("in_sync", { lastSyncedAt: new Date().toISOString() })} />);
+    const el = screen.getByText(/Auto-synced/);
+    expect(el.className).toContain("text-success");
+  });
+
+  it("drifted → 'Update in progress' with info tone", () => {
+    render(<SourceDriftBadge source={gh("drifted")} />);
+    const el = screen.getByText("Update in progress");
+    expect(el.className).toContain("text-info");
+  });
+
+  it("changed_unversioned → warning tone + explanatory copy", () => {
+    render(<SourceDriftBadge source={gh("changed_unversioned")} />);
+    const el = screen.getByText(/version not bumped/i);
+    expect(el.className).toContain("text-warning");
+    expect(el.getAttribute("title")).toMatch(/bump the version/i);
+  });
+
+  it("broken → danger tone", () => {
+    render(<SourceDriftBadge source={gh("broken")} />);
+    const el = screen.getByText("Source unavailable");
+    expect(el.className).toContain("text-danger");
+  });
+});

--- a/ornn-web/src/components/skill/SourceDriftBadge.tsx
+++ b/ornn-web/src/components/skill/SourceDriftBadge.tsx
@@ -1,0 +1,93 @@
+/**
+ * Passive auto-sync status pill (#1178), driven by `source.driftState`.
+ *
+ * Read-only — it reflects what the scheduled drift check / auto-publish
+ * (#1176/#1177) recorded on the skill's GitHub source. It is NOT an action;
+ * the manual "Refresh from GitHub" button remains the override.
+ *
+ * Renders nothing until the first drift check has run (no `driftState`), or
+ * for non-GitHub sources — so legacy skills look unchanged.
+ *
+ * @module components/skill/SourceDriftBadge
+ */
+
+import { useTranslation } from "react-i18next";
+import type { SkillSource } from "@/types/domain";
+
+/** Compact relative-time ("5m ago", "2h ago", "3d ago", "just now"). */
+function relativeTime(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const deltaSec = Math.round((then - Date.now()) / 1000);
+  const abs = Math.abs(deltaSec);
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  if (abs < 60) return rtf.format(Math.round(deltaSec), "second");
+  if (abs < 3600) return rtf.format(Math.round(deltaSec / 60), "minute");
+  if (abs < 86400) return rtf.format(Math.round(deltaSec / 3600), "hour");
+  return rtf.format(Math.round(deltaSec / 86400), "day");
+}
+
+export function SourceDriftBadge({
+  source,
+  className,
+}: {
+  source: SkillSource | undefined;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  if (!source || source.type !== "github" || !source.driftState) return null;
+
+  // Tone classes are DESIGN.md semantic state tokens only (no invented palette).
+  // State color is never the sole signal — each variant pairs copy + border.
+  let tone: string;
+  let label: string;
+  let title: string | undefined;
+
+  switch (source.driftState) {
+    case "in_sync": {
+      const when = relativeTime(source.lastSyncedAt);
+      tone = "text-success bg-success-soft border-success/40";
+      label = when
+        ? t("sourceDrift.inSyncAt", "Auto-synced {{when}}", { when })
+        : t("sourceDrift.inSync", "Auto-synced");
+      title = t("sourceDrift.inSyncTitle", "Automatically kept in sync with the GitHub source.");
+      break;
+    }
+    case "drifted":
+      tone = "text-info bg-info-soft border-info/40";
+      label = t("sourceDrift.drifted", "Update in progress");
+      title = t(
+        "sourceDrift.driftedTitle",
+        "Upstream changed — a new version is being published automatically.",
+      );
+      break;
+    case "changed_unversioned":
+      tone = "text-warning bg-warning-soft border-warning/40";
+      label = t("sourceDrift.changedUnversioned", "Upstream changed — version not bumped");
+      title = t(
+        "sourceDrift.changedUnversionedTitle",
+        "The GitHub source changed but its SKILL.md version was not increased, so no new version was published. Bump the version upstream to resume auto-sync.",
+      );
+      break;
+    case "broken":
+      tone = "text-danger bg-danger-soft border-danger/30";
+      label = t("sourceDrift.broken", "Source unavailable");
+      title = t(
+        "sourceDrift.brokenTitle",
+        "The GitHub source could not be reached (deleted, made private, or the branch/tag was removed). Re-link the skill to resume auto-sync.",
+      );
+      break;
+    default:
+      return null;
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center rounded border px-2 py-0.5 font-text text-xs ${tone} ${className ?? ""}`}
+      title={title}
+    >
+      {label}
+    </span>
+  );
+}

--- a/ornn-web/src/hooks/useSkillDetail.ts
+++ b/ornn-web/src/hooks/useSkillDetail.ts
@@ -42,6 +42,7 @@ import {
   useRefreshSkillFromSource,
 } from "@/hooks/useSkills";
 import { useSkillPackage } from "@/hooks/useSkillPackage";
+import { useSourceDriftProbe } from "@/hooks/useSourceDriftProbe";
 import {
   useStartAudit,
   useAuditSummaryByVersion,
@@ -93,6 +94,10 @@ export function useSkillDetail(idOrName: string | undefined) {
   });
   const refreshMutation = useRefreshSkillFromSource(idOrName ?? "");
   const startAuditMutation = useStartAudit();
+
+  // Lazy on-view drift freshening (#1178) — re-reads the detail once when the
+  // github source's last drift check is stale. See useSourceDriftProbe.
+  useSourceDriftProbe(skill?.source, refetch);
 
   // 7-day pulls totals — feeds the hero "↓ N pulls · 7d" status pill.
   const last7d = useMemo(rangeLast7d, []);

--- a/ornn-web/src/hooks/useSourceDriftProbe.test.ts
+++ b/ornn-web/src/hooks/useSourceDriftProbe.test.ts
@@ -1,0 +1,62 @@
+/**
+ * useSourceDriftProbe tests (#1178) — the lazy on-view drift refetch fires at
+ * most once, only when stale, only for github sources, and never via a timer.
+ *
+ * @module hooks/useSourceDriftProbe.test
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useSourceDriftProbe, SOURCE_DRIFT_STALE_MS } from "./useSourceDriftProbe";
+import type { SkillSource } from "@/types/domain";
+
+function gh(lastCheckedAt?: string): SkillSource {
+  return {
+    type: "github",
+    repo: "o/r",
+    ref: "main",
+    path: "",
+    ...(lastCheckedAt ? { lastCheckedAt } : {}),
+  };
+}
+
+const staleIso = () => new Date(Date.now() - SOURCE_DRIFT_STALE_MS - 60_000).toISOString();
+const freshIso = () => new Date().toISOString();
+
+describe("useSourceDriftProbe", () => {
+  it("refetches once when lastCheckedAt is stale", () => {
+    const refetch = vi.fn();
+    const source = gh(staleIso());
+    renderHook(() => useSourceDriftProbe(source, refetch));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when the source was never checked (no lastCheckedAt)", () => {
+    const refetch = vi.fn();
+    renderHook(() => useSourceDriftProbe(gh(), refetch));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT refetch when the last check is fresh", () => {
+    const refetch = vi.fn();
+    renderHook(() => useSourceDriftProbe(gh(freshIso()), refetch));
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT refetch for a non-github / undefined source", () => {
+    const refetch = vi.fn();
+    renderHook(() => useSourceDriftProbe(undefined, refetch));
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("fires at most once even across re-renders with a new source object", () => {
+    const refetch = vi.fn();
+    const { rerender } = renderHook(({ s }) => useSourceDriftProbe(s, refetch), {
+      initialProps: { s: gh(staleIso()) },
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+    // New (still-stale) object → deps change, but the ref guard prevents a re-fire.
+    rerender({ s: gh(staleIso()) });
+    rerender({ s: gh(staleIso()) });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ornn-web/src/hooks/useSourceDriftProbe.ts
+++ b/ornn-web/src/hooks/useSourceDriftProbe.ts
@@ -1,0 +1,34 @@
+/**
+ * Lazy on-view drift freshening (#1178).
+ *
+ * When a GitHub-sourced skill's last drift check is stale, re-read the skill
+ * detail ONCE on view so the auto-sync badge reflects anything the scheduled
+ * cron (#1176, the primary mechanism) recorded since this query was cached.
+ *
+ * Guarantees: fires at most once per mount (ref-guarded), only when
+ * `lastCheckedAt` is older than {@link SOURCE_DRIFT_STALE_MS}, and never via a
+ * timer/interval — so there is no request storm. The backend surfaces
+ * `driftState` on GET, so a plain refetch is sufficient (no bespoke endpoint).
+ *
+ * @module hooks/useSourceDriftProbe
+ */
+import { useEffect, useRef } from "react";
+import type { SkillSource } from "@/types/domain";
+
+/** Max age of `lastCheckedAt` before an on-view refetch is worthwhile. */
+export const SOURCE_DRIFT_STALE_MS = 5 * 60 * 1000;
+
+export function useSourceDriftProbe(
+  source: SkillSource | undefined,
+  refetch: () => void,
+): void {
+  const probedRef = useRef(false);
+  useEffect(() => {
+    if (probedRef.current) return;
+    if (source?.type !== "github") return;
+    const lastChecked = source.lastCheckedAt ? new Date(source.lastCheckedAt).getTime() : 0;
+    if (Date.now() - lastChecked < SOURCE_DRIFT_STALE_MS) return; // fresh enough
+    probedRef.current = true;
+    refetch();
+  }, [source, refetch]);
+}

--- a/ornn-web/src/i18n/en.json
+++ b/ornn-web/src/i18n/en.json
@@ -1033,6 +1033,17 @@
     "applySync": "Apply sync",
     "urlPlaceholder": "https://github.com/owner/repo/tree/main/path/to/skill"
   },
+  "sourceDrift": {
+    "inSync": "Auto-synced",
+    "inSyncAt": "Auto-synced {{when}}",
+    "inSyncTitle": "Automatically kept in sync with the GitHub source.",
+    "drifted": "Update in progress",
+    "driftedTitle": "Upstream changed — a new version is being published automatically.",
+    "changedUnversioned": "Upstream changed — version not bumped",
+    "changedUnversionedTitle": "The GitHub source changed but its SKILL.md version was not increased, so no new version was published. Bump the version upstream to resume auto-sync.",
+    "broken": "Source unavailable",
+    "brokenTitle": "The GitHub source could not be reached (deleted, made private, or the branch/tag was removed). Re-link the skill to resume auto-sync."
+  },
   "githubImport": {
     "title": "Import from GitHub",
     "subtitle": "Publish a skill from a folder in a public GitHub repo. Subsequent updates can be re-synced from the same link in one click.",

--- a/ornn-web/src/i18n/zh.json
+++ b/ornn-web/src/i18n/zh.json
@@ -1033,6 +1033,17 @@
     "applySync": "应用同步",
     "urlPlaceholder": "https://github.com/owner/repo/tree/main/path/to/skill"
   },
+  "sourceDrift": {
+    "inSync": "已自动同步",
+    "inSyncAt": "已自动同步 · {{when}}",
+    "inSyncTitle": "正在与 GitHub 源自动保持同步。",
+    "drifted": "更新进行中",
+    "driftedTitle": "上游已变更 — 正在自动发布新版本。",
+    "changedUnversioned": "上游已变更 — 版本号未提升",
+    "changedUnversionedTitle": "GitHub 源已变更，但 SKILL.md 的版本号未提升，因此未发布新版本。请在上游提升版本号以恢复自动同步。",
+    "broken": "源不可用",
+    "brokenTitle": "无法访问 GitHub 源（可能已删除、被设为私有，或分支/标签被移除）。请重新关联该技能以恢复自动同步。"
+  },
   "githubImport": {
     "title": "从 GitHub 导入",
     "subtitle": "从公开 GitHub 仓库的某个文件夹发布一个技能。后续更新可通过同一链接一键重新同步。",

--- a/ornn-web/src/pages/NotificationsPage.tsx
+++ b/ornn-web/src/pages/NotificationsPage.tsx
@@ -26,6 +26,9 @@ const CATEGORY_LABEL: Record<NotificationCategory, string> = {
   "quota.credits_granted": "Quota",
   "launchPromo.codeDelivered": "Promo",
   "skillset.member_unreadable": "Skillset",
+  "skill.source_broken": "Source",
+  "skill.auto_synced": "Auto-sync",
+  "skill.auto_sync_failed": "Auto-sync",
 };
 
 function formatTimestamp(iso: string): string {

--- a/ornn-web/src/types/domain.ts
+++ b/ornn-web/src/types/domain.ts
@@ -38,6 +38,20 @@ export type SkillSource =
        * "linked but never synced" state.
        */
       lastSyncedCommit?: string;
+      /**
+       * Automatic-sync drift state (#1176/#1177), surfaced on GET so the UI
+       * renders a passive status badge:
+       *   - `in_sync`             upstream HEAD == last synced commit
+       *   - `drifted`             upstream moved; auto-publish (if on) is imminent
+       *   - `changed_unversioned` upstream changed but SKILL.md version not bumped
+       *   - `broken`              source repo/ref could not be resolved
+       * Absent until the first scheduled drift check runs.
+       */
+      driftState?: "in_sync" | "drifted" | "changed_unversioned" | "broken";
+      /** Upstream HEAD observed by the last drift check. */
+      upstreamHeadSha?: string;
+      /** ISO timestamp of the last drift check. Drives the lazy on-view probe. */
+      lastCheckedAt?: string;
     };
 
 /**

--- a/ornn-web/src/types/notifications.ts
+++ b/ornn-web/src/types/notifications.ts
@@ -12,7 +12,13 @@ export type NotificationCategory =
   | "quota.credits_granted"
   | "launchPromo.codeDelivered"
   /** A member skill became unreadable to the skillset owner (#1136). */
-  | "skillset.member_unreadable";
+  | "skillset.member_unreadable"
+  /** A github-sourced skill's upstream became unreachable (#1176). */
+  | "skill.source_broken"
+  /** A github-sourced skill auto-published a new version from upstream (#1177). */
+  | "skill.auto_synced"
+  /** An automatic re-publish was refused (unversioned / validation) (#1177). */
+  | "skill.auto_sync_failed";
 
 /**
  * Discriminator marking whether this row was lifted out of the


### PR DESCRIPTION
## Summary

Phase 4 of 5 (final feature phase) for **automatic sync of GitHub-sourced skills** (`Depends on #1177`, merged). **Surfaces** the now-automatic behavior in the UI so owners see what auto-sync did — closing the loop on the manual-trigger removal.

## What this does

- **Backend enablement** — the GET skill response now serializes `source.driftState` / `lastCheckedAt` / `upstreamHeadSha` (so the badge reads real state; `etag` stays internal).
- **`SourceDriftBadge`** — a passive, read-only pill driven by `driftState`, rendered next to the "Synced from GitHub" chip **and** in the advanced GitHub-link panel:
  - `in_sync` → "Auto-synced {relative time}" (success tone)
  - `drifted` → "Update in progress" (info)
  - `changed_unversioned` → "Upstream changed — version not bumped" (warning) + tooltip to bump the version upstream
  - `broken` → "Source unavailable" (danger) + tooltip
  - The manual **"Refresh from GitHub"** button is preserved as an override.
- **Notifications** — `skill.auto_synced` / `skill.auto_sync_failed` / `skill.source_broken` render with proper category labels (modal + notifications page); backend-provided title/body already carry the specifics.
- **Lazy on-view refetch** (`useSourceDriftProbe`) — opening a skill whose last drift check is stale re-reads the detail **once** (ref-guarded, staleness-gated, no timer, no storm). The cron (#1176) remains the primary freshness mechanism, so a plain GET refetch suffices — no bespoke endpoint.

## Design

Badge tones use only **DESIGN.md semantic state tokens** (`success` / `info` / `warning` / `danger` + their `-soft` fills and `/40` borders) — no invented palette. Per DESIGN.md, color is never the only signal: each variant pairs a token with copy, a border, and a tooltip. Strings are bilingual (`en.json` + `zh.json`, `sourceDrift.*`).

## Testing

- **Full web suite: 606 pass, 0 fail** (89 files), incl. the i18n en/zh parity test.
- New tests: `SourceDriftBadge.test.tsx` (each driftState → correct tone/copy/tooltip; nothing before first check / non-github), `GitHubOriginChip.test.tsx` (badge + manual button coexist; onRefresh fires), `useSourceDriftProbe.test.ts` (fires once when stale / never-checked; not when fresh / non-github; at-most-once across re-renders).
- `tsc --noEmit` clean; `eslint` clean.

## Commits (dependency-ordered, buildable per commit)

1. `feat(api)` surface driftState on the skill GET response
2. `feat(web)` mirror drift fields + notification categories
3. `feat(web)` passive drift badge on the detail surfaces (+ bilingual strings)
4. `feat(web)` lazy on-view refetch + notification labels
5. `docs` changeset

Closes #1178
