### PR TITLE
feat(api): raise skill description cap to 1536 + richer manual description

### DIFF
--- a/.changeset/raise-skill-description-cap.md
+++ b/.changeset/raise-skill-description-cap.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": patch
+"ornn-web": patch
+---
+
+Raise the skill frontmatter `description` cap from 1024 to 1536 characters, aligned with Claude Code's skill-listing truncation limit (`skillListingMaxDescChars`, default 1536) — so an author can write a description as rich as the runtime actually uses for auto-invocation routing, instead of relying on `skip_validation` to smuggle a longer one past the schema. Skillset descriptions are unchanged (still 1024).

--- a/ornn-api/src/domains/skills/format/routes.ts
+++ b/ornn-api/src/domains/skills/format/routes.ts
@@ -45,7 +45,7 @@ export const SKILL_FORMAT_RULES = `# Ornn Skill Package Format Rules
 ### Required Frontmatter Fields
 
 - **name** (string, required): kebab-case only, must match the skill package folder name. No spaces or capitals.
-- **description** (string, required): must be under 1024 characters. Must not contain XML tags (\`<\` or \`>\`).
+- **description** (string, required): must be under 1536 characters. Must not contain XML tags (\`<\` or \`>\`).
 - **metadata** (object, required): a nested object containing:
   - **category** (string, required): one of \`plain\`, \`tool-based\`, \`runtime-based\`, \`mixed\`.
     - \`plain\`: no programmatic dependency (no tools, no scripts).

--- a/ornn-api/src/shared/schemas/skillFrontmatter.test.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.test.ts
@@ -225,4 +225,15 @@ describe("validateSkillFrontmatter — depends-on grammar (#968)", () => {
     const msg = r.errors.find((e) => e.field === "metadata.depends-on.0")?.message ?? "";
     expect(msg).toContain("depends-on entries must be non-empty");
   });
+
+  test("description at the 1536 cap passes; 1537 fails", () => {
+    // Cap aligned with Claude Code's skill-listing truncation (#1180 follow-up).
+    const ok = validateSkillFrontmatter(base({ description: "x".repeat(1536) }));
+    expect(ok.success).toBe(true);
+
+    const tooLong = validateSkillFrontmatter(base({ description: "x".repeat(1537) }));
+    expect(tooLong.success).toBe(false);
+    if (tooLong.success) return;
+    expect(tooLong.errors.some((e) => e.field === "description")).toBe(true);
+  });
 });

--- a/ornn-api/src/shared/schemas/skillFrontmatter.ts
+++ b/ornn-api/src/shared/schemas/skillFrontmatter.ts
@@ -218,11 +218,17 @@ export const SKILL_VERSION_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
  */
 export const SKILL_NAME_REGEX = /^[a-z0-9][a-z0-9-]*$/;
 export const SKILL_NAME_MAX = 64;
+// Aligned with Claude Code's skill-listing budget: it truncates the combined
+// `description` (+ optional `when_to_use`) at 1536 chars when deciding whether
+// to auto-invoke a skill (the `skillListingMaxDescChars` default). Capping here
+// at the same number lets an author write a description as rich as the runtime
+// will actually use for routing, while still rejecting unbounded input.
+export const SKILL_DESCRIPTION_MAX = 1536;
 
 // Full frontmatter schema (base, before the top-level refinement).
 const baseSkillFrontmatterSchema = z.object({
   name: z.string().min(1).max(SKILL_NAME_MAX).regex(SKILL_NAME_REGEX, "Name must be kebab-case"),
-  description: z.string().min(1).max(1024),
+  description: z.string().min(1).max(SKILL_DESCRIPTION_MAX),
   // YAML parses `version: 0.1` (unquoted) as a float and `1.0` as an
   // integer `1`, which both lose the intended two-digit shape. We require
   // the author to quote it (`version: "0.1"`) so the round-trip is

--- a/ornn-web/src/utils/skillFrontmatterSchema.ts
+++ b/ornn-web/src/utils/skillFrontmatterSchema.ts
@@ -240,7 +240,9 @@ export const skillFrontmatterSchema = z.object({
       /^[a-z0-9][a-z0-9-]*$/,
       issueMessage({ key: "errors.frontmatter.nameFormat" }),
     ),
-  description: z.string().min(1).max(1024),
+  // Aligned with Claude Code's 1536-char skill-listing truncation (kept in
+  // sync with SKILL_DESCRIPTION_MAX in ornn-api's skillFrontmatter.ts).
+  description: z.string().min(1).max(1536),
   // #649 — YAML parses `version: 0.1` (unquoted) as a number, not a
   // string. The default Zod message ("Invalid input") doesn't tell
   // the author to quote the value. Surface an actionable message via

--- a/skills/ornn-agent-manual-cli/SKILL.md
+++ b/skills/ornn-agent-manual-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ornn-agent-manual-cli
-description: The manual an AI agent loads to operate Ornn — the model-agnostic skill-lifecycle API (an npm-style registry + CLI for agent skills) — via the NyxID CLI (`nyxid proxy request ornn-api …`). Load and follow it WHENEVER the user asks to work with Ornn skills or skillsets, e.g. search Ornn or find a skill, pull or install a skill or a specific version, run a skill, build and upload one, publish a new version, make a skill public/private/shared, run or read a security audit, deprecate or delete, bind a skill to a NyxID service, link to GitHub or sync from source, check quota or pick an LLM model; and for skillsets, bundle skills into a set, create or publish a skillset (a curated multi-skill package with a master prompt), resolve its closure in one call, export it as a Claude Code marketplace plugin, transfer ownership, or work out why others can't see a skillset you shared (visibility is derived from members). Authoritative Ornn↔agent contract; pair with references/api-reference.md.
+description: "The manual an AI agent loads to operate Ornn — the model-agnostic skill-lifecycle API (an npm-style registry + CLI for agent skills) — via the NyxID CLI (`nyxid proxy request ornn-api …`). Load and follow this skill WHENEVER the user asks to do anything with Ornn skills or skillsets. Skills: search Ornn or find a skill, pull or install a skill (or a specific version), run a skill, build and upload a skill, publish a new version, make a skill public / private / shared, run or read a security audit, deprecate or delete a version, diff two versions, check usage analytics, bind a skill to a NyxID service, link a skill to GitHub or sync from source, manage npm-style dist-tags, or transfer skill ownership. Skillsets — curated multi-skill bundles with a required master prompt: bundle skills into a set, create or publish a skillset, resolve its closure in one call, export a skillset as a Claude Code marketplace plugin, transfer skillset ownership, or diagnose why a shared skillset isn't visible (visibility derives from its member skills). Also load it to check your quota or pick an LLM model before an SSE call, and on phrases like 'share my skill', 'bundle these skills', or 'export as a Claude Code plugin'. Once loaded, the agent runs the whole search → pull → execute → build → upload → share lifecycle with no further setup — this is the authoritative Ornn↔agent contract, paired with references/api-reference.md (full per-endpoint catalogue + error legend)."
 metadata:
   category: plain
   tag:
@@ -9,7 +9,7 @@ metadata:
     - manual
     - skill-lifecycle
     - cli
-version: "1.4"
+version: "1.5"
 lastUpdated: 2026-07-01
 ---
 


### PR DESCRIPTION
## Summary

Raises the skill frontmatter `description` cap from **1024 → 1536** chars — aligning Ornn with Claude Code's skill-listing truncation limit (`skillListingMaxDescChars`, default 1536) — and uses that budget for a richer, trigger-oriented `ornn-agent-manual-cli` description (v1.5).

### Why
Claude Code routes to a skill by matching its `description`, truncating the combined `description` + `when_to_use` at 1536. Our 1024 cap meant a description rich enough to use that full budget couldn't validate — you had to smuggle it past with `skip_validation`, which also downgrades **all** frontmatter checks to best-effort. Raising the cap lets a rich description validate normally.

### Changes
- `SKILL_DESCRIPTION_MAX = 1536` in the api schema; matched in the ornn-web mirror schema + the format-rules text. **Skillset** description caps stay at 1024 (different field).
- Boundary test: 1536 passes, 1537 fails.
- `ornn-agent-manual-cli` description → rich ~1500-char trigger list (1472 chars), **double-quoted** so an embedded colon can't re-break the YAML (the #1185 regression). Skill bumped 1.4 → 1.5.

### Verification
- ornn-api schema + format tests: 26 pass. ornn-web schema test: 9 pass. Typecheck clean. Lint 0 errors.
- Ran the API's own `yaml.parse` + `validateSkillFrontmatter` on the new SKILL.md: `✓ parse`, `✓ validate (len 1472)`.

Closes #1189. Follow-up to #1180; hardens against #1185.