### PR TITLE
feat: skillset "always keep skills up to date" toggle (#1191)

### DIFF
--- a/.changeset/skillset-auto-update-members.md
+++ b/.changeset/skillset-auto-update-members.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+Add a per-skillset "always keep skills in this skillset up to date" toggle (#1191). When enabled, every member — pinned or not — resolves to its skill's latest version everywhere the set is delivered (closure, plugin export, snapshot, derived visibility), so a member's new version flows into the skillset (and its exported Claude Code plugin) automatically with no per-member ref changes. The override is resolution-time only — the authored member refs are never rewritten, so turning it off restores the pinned behavior. Enabling immediately re-cuts the revision when a member was behind. Exposed API-first as `PUT /api/v1/skillsets/:id/auto-update` and `autoUpdateMembers` on the skillset resource, with an owner-only toggle card on the skillset detail page.

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -1709,12 +1709,16 @@ export class SkillService {
    * stays single-sourced; both surfaces resolve refs (and apply the
    * per-node `canReadSkill` visibility gate) identically.
    */
-  createVersionLoader(actor: ActorContext): LoadVersion {
+  createVersionLoader(actor: ActorContext, forceLatest = false): LoadVersion {
     return async (ref: string): Promise<ResolvedVersion | null> => {
       const at = ref.lastIndexOf("@");
       if (at <= 0 || at === ref.length - 1) return null;
       const idOrName = ref.slice(0, at);
-      const versionOrTag = ref.slice(at + 1);
+      // #1191 — when the caller resolves the members of a skillset with
+      // "always keep skills up to date" ON, every member resolves to its
+      // skill's latest version, overriding the authored pin / dist-tag /
+      // literal version. Non-destructive: the stored ref is untouched.
+      const versionOrTag = forceLatest ? "latest" : ref.slice(at + 1);
 
       const skill =
         (await this.skillRepo.findByGuid(idOrName)) ??

--- a/ornn-api/src/domains/skills/mirror/mirrorService.ts
+++ b/ornn-api/src/domains/skills/mirror/mirrorService.ts
@@ -919,7 +919,11 @@ export class MirrorService {
     // (bundled) vs private/unresolvable (excluded → README note only). Only the
     // public subset's files are ever fetched, so a private member's content can
     // never leak into the public mirror (#1161).
-    const load = this.deps.skillService.createVersionLoader(SYSTEM_ACTOR);
+    // #1191 — an auto-update skillset exports each member at its latest version.
+    const load = this.deps.skillService.createVersionLoader(
+      SYSTEM_ACTOR,
+      ss.autoUpdateMembers ?? false,
+    );
     const members: SkillsetPluginMember[] = [];
     const includedNames = new Set<string>();
     const excludedMembers: string[] = [];
@@ -995,7 +999,11 @@ export class MirrorService {
     if (!this.deps.skillsetService) return 0;
     const latest = await this.deps.skillsetService.getLatestForMirror(ss.guid);
     if (!latest) return 0;
-    const load = this.deps.skillService.createVersionLoader(SYSTEM_ACTOR);
+    // #1191 — count public members at their latest when auto-update is on.
+    const load = this.deps.skillService.createVersionLoader(
+      SYSTEM_ACTOR,
+      ss.autoUpdateMembers ?? false,
+    );
     const publicNames = new Set<string>();
     for (const ref of latest.members) {
       const node = await load(ref);

--- a/ornn-api/src/domains/skillsets/recompute.test.ts
+++ b/ornn-api/src/domains/skillsets/recompute.test.ts
@@ -45,6 +45,62 @@ function makeResolver(refs: Record<string, Verdict>): MemberVisibilityResolver {
   };
 }
 
+/**
+ * Version-aware resolver fake (#1191) — models each skill's version set + a
+ * `latest`, and honors the loader's `forceLatest` flag so a pinned ref resolves
+ * to the skill's latest when the skillset opts into auto-update.
+ */
+function makeVersionedResolver(
+  skills: Record<string, { latest: string; versions: string[]; isPrivate?: boolean }>,
+): MemberVisibilityResolver {
+  return {
+    createVersionLoader(_actor: ActorContext, forceLatest = false): LoadVersion {
+      return async (ref: string): Promise<ResolvedVersion | null> => {
+        const at = ref.lastIndexOf("@");
+        const name = ref.slice(0, at);
+        const skill = skills[name];
+        if (!skill) return null;
+        const version = forceLatest ? skill.latest : ref.slice(at + 1);
+        if (!skill.versions.includes(version)) return null;
+        return { ref: `${name}@${version}`, name, version, isPrivate: skill.isPrivate ?? false, dependsOn: [] };
+      };
+    },
+  };
+}
+
+describe("forceLatest override (#1191)", () => {
+  const skills = { pdf: { latest: "2.0", versions: ["1.0", "2.0"] } };
+
+  test("computePublicResolvedMembers honors the pin when forceLatest is off (default)", async () => {
+    const snap = await computePublicResolvedMembers(["pdf@1.0"], makeVersionedResolver(skills));
+    expect(snap).toEqual(["pdf@1.0"]);
+  });
+
+  test("computePublicResolvedMembers resolves a pin to latest when forceLatest is on", async () => {
+    const snap = await computePublicResolvedMembers(["pdf@1.0"], makeVersionedResolver(skills), true);
+    expect(snap).toEqual(["pdf@2.0"]);
+  });
+
+  test("forceLatest resolves a member whose PINNED version was deleted (unresolvable→resolved)", async () => {
+    // pdf@1.0 is gone; only 2.0 survives. The pin is unresolvable, but
+    // forceLatest jumps to the surviving latest, so the member snapshots.
+    const resolver = makeVersionedResolver({ pdf: { latest: "2.0", versions: ["2.0"] } });
+    expect(await computePublicResolvedMembers(["pdf@1.0"], resolver, false)).toEqual([]);
+    expect(await computePublicResolvedMembers(["pdf@1.0"], resolver, true)).toEqual(["pdf@2.0"]);
+  });
+
+  test("computeDerivedVisibility: a dead pin is unresolvable, but forceLatest recovers it", async () => {
+    const resolver = makeVersionedResolver({
+      pdf: { latest: "2.0", versions: ["2.0"] },
+      csv: { latest: "1.0", versions: ["1.0"] },
+    });
+    const off = await computeDerivedVisibility(["pdf@1.0", "csv@1.0"], resolver, false);
+    expect(off.memberVisibilityState).toBe("unresolvable");
+    const on = await computeDerivedVisibility(["pdf@1.0", "csv@1.0"], resolver, true);
+    expect(on).toEqual({ membersAllPublic: true, memberVisibilityState: "all-public" });
+  });
+});
+
 describe("computeDerivedVisibility", () => {
   test("all members public → all-public / true", async () => {
     const resolver = makeResolver({ "a@1.0": "public", "b@1.0": "public" });
@@ -126,6 +182,10 @@ function makeDeps(opts: {
         writes[guid] = derived;
       },
       listAllGuids: async (): Promise<string[]> => Object.keys(opts.latestMembers),
+      // #1191 — recompute reads the identity doc for the auto-update flag. These
+      // fixtures don't opt in, so resolution uses the authored member refs.
+      findByGuid: async (guid: string) =>
+        guid in opts.latestMembers ? ({ autoUpdateMembers: false } as never) : null,
     },
     skillsetVersionRepo: {
       findLatestBySkillset: async (guid: string) => {

--- a/ornn-api/src/domains/skillsets/recompute.ts
+++ b/ornn-api/src/domains/skillsets/recompute.ts
@@ -37,7 +37,7 @@ const logger = createLogger("skillsetRecompute");
  * resolver without standing up the whole skill service.
  */
 export interface MemberVisibilityResolver {
-  createVersionLoader(actor: ActorContext): LoadVersion;
+  createVersionLoader(actor: ActorContext, forceLatest?: boolean): LoadVersion;
 }
 
 export interface SkillsetRecomputeDeps {
@@ -60,8 +60,9 @@ export interface DerivedVisibility {
 export async function computeDerivedVisibility(
   members: string[],
   skillService: MemberVisibilityResolver,
+  forceLatest = false,
 ): Promise<DerivedVisibility> {
-  const load = skillService.createVersionLoader(SYSTEM_ACTOR);
+  const load = skillService.createVersionLoader(SYSTEM_ACTOR, forceLatest);
   let anyPrivate = false;
   let anyUnresolvable = false;
 
@@ -108,8 +109,9 @@ export async function computeDerivedVisibility(
 export async function computePublicResolvedMembers(
   members: string[],
   skillService: MemberVisibilityResolver,
+  forceLatest = false,
 ): Promise<string[]> {
-  const load = skillService.createVersionLoader(SYSTEM_ACTOR);
+  const load = skillService.createVersionLoader(SYSTEM_ACTOR, forceLatest);
   const snapshot = new Set<string>();
   for (const ref of members) {
     const node = await load(ref);
@@ -172,7 +174,11 @@ export async function recomputeSkillsetVisibility(
     logger.debug({ guid }, "Skillset has no version; skipping visibility recompute");
     return null;
   }
-  const derived = await computeDerivedVisibility(latest.members, deps.skillService);
+  // #1191 — when auto-update is on, classify visibility over the members'
+  // LATEST versions (the delivered set), matching how closure/export resolve.
+  const identity = await deps.skillsetRepo.findByGuid(guid);
+  const forceLatest = identity?.autoUpdateMembers ?? false;
+  const derived = await computeDerivedVisibility(latest.members, deps.skillService, forceLatest);
   await deps.skillsetRepo.setDerivedVisibility(guid, derived);
   return derived;
 }

--- a/ornn-api/src/domains/skillsets/repository.ts
+++ b/ornn-api/src/domains/skillsets/repository.ts
@@ -56,6 +56,8 @@ export interface CreateSkillsetData {
   latestVersion: string;
   /** Owner opt-in (#1155) to export as a multi-skill plugin. Default OFF. */
   exportAsPlugin?: boolean | undefined;
+  /** Owner opt-in (#1191) — always keep members at latest. Default OFF. */
+  autoUpdateMembers?: boolean | undefined;
   /** Owner plugin listing overrides (#1157). Omitted ⇒ no overrides stored. */
   pluginConfig?: SkillsetPluginOverrides | undefined;
 }
@@ -82,6 +84,11 @@ export interface UpdateSkillsetData {
    * doesn't mention the flag must not silently reset it).
    */
   exportAsPlugin?: boolean;
+  /**
+   * Owner opt-in (#1191) — "always keep skills up to date". Set ONLY when an
+   * explicit boolean is provided; omitting it preserves the current setting.
+   */
+  autoUpdateMembers?: boolean;
   /**
    * Owner plugin listing overrides (#1157). Three-state:
    *   - `undefined` — leave the stored overrides untouched (publish path).
@@ -235,6 +242,8 @@ export class SkillsetRepository {
       memberVisibilityState: "all-public",
       // Plugin-export opt-in (#1155) — default OFF.
       exportAsPlugin: data.exportAsPlugin ?? false,
+      // Auto-update-members opt-in (#1191) — default OFF.
+      autoUpdateMembers: data.autoUpdateMembers ?? false,
       latestVersion: data.latestVersion,
     };
     // Plugin listing overrides (#1157) — only written when supplied so a fresh
@@ -276,6 +285,7 @@ export class SkillsetRepository {
     if (data.latestVersion !== undefined) setFields.latestVersion = data.latestVersion;
     // #1155 — only an explicit boolean flips the opt-in; omission preserves it.
     if (data.exportAsPlugin !== undefined) setFields.exportAsPlugin = data.exportAsPlugin;
+    if (data.autoUpdateMembers !== undefined) setFields.autoUpdateMembers = data.autoUpdateMembers;
     // #1157 — three-state plugin overrides: object replaces, null clears
     // ($unset so the mirror falls back to skillset fields), undefined no-ops.
     const unsetFields: Record<string, unknown> = {};
@@ -521,6 +531,8 @@ function mapDoc(doc: Document | null): SkillsetDocument | null {
       (doc.memberVisibilityState as SkillsetMemberVisibilityState | undefined) ?? "all-public",
     // Plugin-export opt-in (#1155) — absent on pre-feature docs ⇒ false.
     exportAsPlugin: doc.exportAsPlugin === true,
+    // Auto-update-members opt-in (#1191) — absent on pre-feature docs ⇒ false.
+    autoUpdateMembers: doc.autoUpdateMembers === true,
     // Plugin listing overrides (#1157) — undefined when unset/legacy.
     pluginConfig: coercePluginConfig(doc.pluginConfig),
     latestVersion: doc.latestVersion ?? "1.0",

--- a/ornn-api/src/domains/skillsets/routes.test.ts
+++ b/ornn-api/src/domains/skillsets/routes.test.ts
@@ -399,6 +399,52 @@ describe("PUT/DELETE /skillsets/:id — scope gating", () => {
     expect(((await res.json()) as { code: string }).code).toBe("skillset_too_few_public_members");
   });
 
+  test("PUT /auto-update 403 without ornn:skill:update (#1191)", async () => {
+    const app = buildApp({ permissions: [CREATE] });
+    const res = await app.request("/api/v1/skillsets/ss-1/auto-update", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("PUT /auto-update 400 on an invalid body (missing enabled) (#1191)", async () => {
+    const app = buildApp({ permissions: [UPDATE] });
+    const res = await app.request("/api/v1/skillsets/ss-1/auto-update", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("PUT /auto-update 200 updates + fires the mirror reconcile (#1191)", async () => {
+    let fired = 0;
+    const captured: unknown[] = [];
+    const app = buildApp({
+      permissions: [UPDATE],
+      service: {
+        setAutoUpdateMembers: async (...args: unknown[]) => {
+          captured.push(args[1]);
+          return detail({ autoUpdateMembers: true });
+        },
+      },
+      fireMirrorReconcile: () => {
+        fired += 1;
+      },
+    });
+    const res = await app.request("/api/v1/skillsets/ss-1/auto-update", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(fired).toBe(1);
+    expect(((await res.json()) as { data: { autoUpdateMembers: boolean } }).data.autoUpdateMembers).toBe(true);
+    expect(captured[0]).toEqual({ enabled: true });
+  });
+
   test("PUT + DELETE fire the mirror reconcile on success (#1155)", async () => {
     let fired = 0;
     const fireMirrorReconcile = () => {

--- a/ornn-api/src/domains/skillsets/routes.ts
+++ b/ornn-api/src/domains/skillsets/routes.ts
@@ -37,7 +37,12 @@ import { validateBody, getValidatedBody } from "../../middleware/validate";
 import { buildActorContext, type ActorContext } from "../skills/crud/authorize";
 import { createLogger } from "../../shared/logger";
 import type { SkillsetService } from "./service";
-import { createSkillsetSchema, publishSkillsetSchema, pluginExportSchema } from "./types";
+import {
+  createSkillsetSchema,
+  publishSkillsetSchema,
+  pluginExportSchema,
+  autoUpdateSchema,
+} from "./types";
 
 const logger = createLogger("skillsetRoutes");
 
@@ -198,6 +203,31 @@ export function createSkillsetRoutes(
       const updated = await skillsetService.setPluginExport(id, body, actor);
       logger.info({ guid: id, enabled: body.enabled }, "Skillset plugin export updated via API");
       // #1157 — flipping the opt-in changes mirror eligibility; reconcile.
+      fireMirrorReconcile?.();
+      return c.json({ data: updated, error: null });
+    },
+  );
+
+  /**
+   * PUT /skillsets/:id/auto-update — enable/disable "always keep skills in this
+   * skillset up to date" (#1191). When ON, every member resolves to its latest
+   * version wherever the set is delivered. Requires: ornn:skill:update +
+   * author/admin. Registered as a literal sub-segment so it never collides with
+   * the `PUT /skillsets/:id` publish.
+   */
+  app.put(
+    "/skillsets/:id/auto-update",
+    auth,
+    requirePermission("ornn:skill:update"),
+    validateBody(autoUpdateSchema, "invalid_auto_update"),
+    async (c) => {
+      const id = c.req.param("id");
+      const body = getValidatedBody<z.infer<typeof autoUpdateSchema>>(c);
+      const actor = await buildActorContext(c);
+      const updated = await skillsetService.setAutoUpdateMembers(id, body, actor);
+      logger.info({ guid: id, enabled: body.enabled }, "Skillset auto-update updated via API");
+      // #1191 — flipping the flag can move the resolved-member set + revision;
+      // reconcile re-exports the plugin at the freshly-bumped revision.
       fireMirrorReconcile?.();
       return c.json({ data: updated, error: null });
     },

--- a/ornn-api/src/domains/skillsets/service.test.ts
+++ b/ornn-api/src/domains/skillsets/service.test.ts
@@ -157,6 +157,8 @@ function makeSkillsetDeps(
         sharedWithOrgs: [],
         // #1155 — persist the plugin-export opt-in (default OFF).
         exportAsPlugin: data.exportAsPlugin ?? false,
+        // #1191 — auto-update-members opt-in (default OFF).
+        autoUpdateMembers: false,
         // #1157 — optional listing overrides.
         ...(data.pluginConfig ? { pluginConfig: data.pluginConfig } : {}),
         latestVersion: data.latestVersion,
@@ -1435,5 +1437,131 @@ describe("SkillsetService — resolveClosure (roots = members)", () => {
 
     const closure = await service.resolveClosure("open-set", ANON);
     expect(closure.items.map((n) => n.name).sort()).toEqual(["csv-tools", "pdf-tools"]);
+  });
+});
+
+describe("SkillsetService — setAutoUpdateMembers (#1191)", () => {
+  const OTHER: ActorContext = {
+    userId: "someone-else",
+    memberships: [],
+    isPlatformAdmin: false,
+    membershipsResolved: true,
+  };
+
+  /** Two public skills, each with versions 1.0 AND 2.0 (latest = 2.0). */
+  function twoMembersV1andV2(): { skills: SkillDocument[]; versions: SkillVersionDocument[] } {
+    const a = skillDoc({ guid: "g-a", name: "pdf-tools", latestVersion: "2.0", isPrivate: false });
+    const b = skillDoc({ guid: "g-b", name: "csv-tools", latestVersion: "2.0", isPrivate: false });
+    return {
+      skills: [a, b],
+      versions: [
+        skillVersion({ _id: "g-a@1.0", skillGuid: "g-a", version: "1.0", majorVersion: 1, minorVersion: 0 }),
+        skillVersion({ _id: "g-a@2.0", skillGuid: "g-a", version: "2.0", majorVersion: 2, minorVersion: 0 }),
+        skillVersion({ _id: "g-b@1.0", skillGuid: "g-b", version: "1.0", majorVersion: 1, minorVersion: 0 }),
+        skillVersion({ _id: "g-b@2.0", skillGuid: "g-b", version: "2.0", majorVersion: 2, minorVersion: 0 }),
+      ],
+    };
+  }
+
+  function makeService() {
+    const { skills, versions } = twoMembersV1andV2();
+    return new SkillsetService(makeSkillsetDeps(makeSkillService(skills, versions)).deps);
+  }
+
+  /** Create a skillset whose members are PINNED to 1.0 (each skill's latest is 2.0). */
+  async function seedPinnedSet(service = makeService(), name = "pinned-set") {
+    const created = await service.createSkillset(
+      {
+        name,
+        description: "d",
+        instructions: "p",
+        kind: "generic",
+        tags: [],
+        members: ["pdf-tools@1.0", "csv-tools@1.0"],
+      },
+      { userId: "owner-1" },
+    );
+    return { service, guid: created.guid };
+  }
+
+  it("OFF (default) resolves members at their PINNED versions", async () => {
+    const { service } = await seedPinnedSet();
+    const detail = await service.getSkillset("pinned-set");
+    expect(detail.autoUpdateMembers).toBe(false);
+    const closure = await service.resolveClosure("pinned-set", SYSTEM_ACTOR);
+    expect(closure.items.map((n) => `${n.name}@${n.version}`).sort()).toEqual([
+      "csv-tools@1.0",
+      "pdf-tools@1.0",
+    ]);
+  });
+
+  it("enabling forces members to latest, bumps the revision, and delivers latest", async () => {
+    const { service, guid } = await seedPinnedSet();
+    expect((await service.getSkillset(guid)).latestVersion).toBe("1.0");
+
+    const updated = await service.setAutoUpdateMembers(guid, { enabled: true }, OWNER);
+    expect(updated.autoUpdateMembers).toBe(true);
+    // Both pinned members' resolved version moved 1.0 → 2.0, so the revision bumps.
+    expect(updated.latestVersion).toBe("1.1");
+
+    const closure = await service.resolveClosure(guid, SYSTEM_ACTOR);
+    expect(closure.items.map((n) => `${n.name}@${n.version}`).sort()).toEqual([
+      "csv-tools@2.0",
+      "pdf-tools@2.0",
+    ]);
+  });
+
+  it("disabling restores the pinned resolution (non-destructive) and bumps again", async () => {
+    const { service, guid } = await seedPinnedSet();
+    await service.setAutoUpdateMembers(guid, { enabled: true }, OWNER); // → 1.1, latest
+    const off = await service.setAutoUpdateMembers(guid, { enabled: false }, OWNER);
+    expect(off.autoUpdateMembers).toBe(false);
+    expect(off.latestVersion).toBe("1.2"); // snapshot moved back 2.0 → 1.0
+    // Authored refs were never rewritten — the override is purely resolution-time.
+    expect(off.members).toEqual(["pdf-tools@1.0", "csv-tools@1.0"]);
+    const closure = await service.resolveClosure(guid, SYSTEM_ACTOR);
+    expect(closure.items.map((n) => `${n.name}@${n.version}`).sort()).toEqual([
+      "csv-tools@1.0",
+      "pdf-tools@1.0",
+    ]);
+  });
+
+  it("enabling is idempotent when members already resolve to latest (no bump)", async () => {
+    const service = makeService();
+    const created = await service.createSkillset(
+      {
+        name: "latest-set",
+        description: "d",
+        instructions: "p",
+        kind: "generic",
+        tags: [],
+        members: ["pdf-tools@2.0", "csv-tools@2.0"],
+      },
+      { userId: "owner-1" },
+    );
+    const updated = await service.setAutoUpdateMembers(created.guid, { enabled: true }, OWNER);
+    expect(updated.autoUpdateMembers).toBe(true);
+    expect(updated.latestVersion).toBe("1.0"); // snapshot unchanged → no bump
+  });
+
+  it("rejects a caller without write access", async () => {
+    const { service, guid } = await seedPinnedSet();
+    let code = "";
+    try {
+      await service.setAutoUpdateMembers(guid, { enabled: true }, OTHER);
+    } catch (err) {
+      code = (err as AppError).code;
+    }
+    expect(code).toBe("forbidden");
+  });
+
+  it("404s an unknown skillset", async () => {
+    let code = "";
+    try {
+      await makeService().setAutoUpdateMembers("nope", { enabled: true }, OWNER);
+    } catch (err) {
+      code = (err as AppError).code;
+    }
+    expect(code).toBe("skillset_not_found");
   });
 });

--- a/ornn-api/src/domains/skillsets/service.ts
+++ b/ornn-api/src/domains/skillsets/service.ts
@@ -45,6 +45,7 @@ import type { SkillsetVersionRepository } from "./skillsetVersionRepository";
 import {
   SKILLSET_INITIAL_REVISION,
   SKILLSET_MIN_PUBLIC_EXPORT_MEMBERS,
+  type AutoUpdateInput,
   type CreateSkillsetInput,
   type PluginExportInput,
   type PublishSkillsetInput,
@@ -236,7 +237,12 @@ export class SkillsetService {
     const next = nextRevision(currentLatest?.version ?? existing.latestVersion);
 
     await this.validateMembers(members, { name: existing.name, version: next.version });
-    const resolvedMembers = await this.resolveMemberSnapshot(members);
+    // #1191 — when auto-update is on, snapshot the members at their latest so
+    // the exported/delivered set matches the "always up to date" promise.
+    const resolvedMembers = await this.resolveMemberSnapshot(
+      members,
+      existing.autoUpdateMembers ?? false,
+    );
 
     // Append-only — a duplicate `guid@version` is rejected by the version
     // repo (skillset_version_exists). Prior versions are never touched.
@@ -311,7 +317,9 @@ export class SkillsetService {
       // leaks — but a plugin under the floor is too thin to be a meaningful set.
       // Count the latest version's public members under SYSTEM and gate on it.
       const latest = await this.skillsetVersionRepo.findLatestBySkillset(guid);
-      const publicCount = latest ? await this.countPublicMembers(latest.members) : 0;
+      const publicCount = latest
+        ? await this.countPublicMembers(latest.members, existing.autoUpdateMembers ?? false)
+        : 0;
       if (publicCount < SKILLSET_MIN_PUBLIC_EXPORT_MEMBERS) {
         throw AppError.conflict(
           "skillset_too_few_public_members",
@@ -332,6 +340,47 @@ export class SkillsetService {
       { guid, enabled: input.enabled, hasOverrides: overrides !== null },
       "Skillset plugin export updated",
     );
+    return this.getSkillset(guid);
+  }
+
+  /**
+   * Enable/disable "always keep skills in this skillset up to date" (#1191).
+   * When ON, every member (pinned or not) resolves to its skill's latest
+   * version wherever the set is delivered — closure, plugin export, snapshot,
+   * visibility. Flipping the flag either way changes the effective resolved
+   * set, so we immediately re-cut the revision when the public snapshot moved
+   * and refresh derived visibility (both idempotent no-ops when nothing
+   * changed); the route then fires the mirror reconcile to re-export the plugin
+   * at the freshly-bumped revision. Requires WRITE (author/admin, #1123).
+   */
+  async setAutoUpdateMembers(
+    guid: string,
+    input: AutoUpdateInput,
+    actor: ActorContext,
+  ): Promise<SkillsetDetailResponse> {
+    const existing = await this.skillsetRepo.findByGuid(guid);
+    if (!existing) {
+      throw AppError.notFound("skillset_not_found", `Skillset '${guid}' not found`);
+    }
+    if (!canWriteSkill(existing, actor)) {
+      throw AppError.forbidden(
+        "forbidden",
+        "You do not have permission to manage auto-update for this skillset",
+      );
+    }
+
+    await this.skillsetRepo.update(guid, {
+      autoUpdateMembers: input.enabled,
+      updatedBy: actor.userId,
+    });
+
+    // Immediate catch-up: the effective resolved-member set just changed (pins
+    // now float to latest, or revert to their pins), so re-cut the revision if
+    // the public snapshot moved and refresh the derived-visibility cache.
+    await this.maybeBumpRevisionForMemberChange(guid);
+    await this.recomputeVisibility(guid);
+
+    logger.info({ guid, enabled: input.enabled }, "Skillset auto-update-members updated");
     return this.getSkillset(guid);
   }
 
@@ -371,7 +420,11 @@ export class SkillsetService {
     const versionDoc = await this.loadVersionOrThrow(skillset, version);
 
     const isOwnerOrAdmin = canManageSkill(skillset, actor);
-    const unreadableMembers = await this.resolveUnreadableMembers(versionDoc.members, actor);
+    const unreadableMembers = await this.resolveUnreadableMembers(
+      versionDoc.members,
+      actor,
+      skillset.autoUpdateMembers ?? false,
+    );
 
     if (!isOwnerOrAdmin && unreadableMembers.length > 0) {
       // No leak: a non-owner who can't read every member sees a flat 404,
@@ -561,9 +614,14 @@ export class SkillsetService {
       );
     }
 
+    // #1191 — deliver each member at its latest when auto-update is on, so a
+    // consumer resolving the skillset gets the up-to-date set, not the pins.
     const roots = versionDoc.members;
     const items = await resolveClosure(roots, {
-      loadVersion: this.skillService.createVersionLoader(actor),
+      loadVersion: this.skillService.createVersionLoader(
+        actor,
+        skillset.autoUpdateMembers ?? false,
+      ),
     });
     logger.info(
       { idOrName, version: resolvedVersion, memberCount: roots.length, nodeCount: items.length },
@@ -627,7 +685,11 @@ export class SkillsetService {
         isPlatformAdmin: false,
         membershipsResolved: false,
       };
-      const unreadable = await this.resolveUnreadableMembers(latest.members, ownerActor);
+      const unreadable = await this.resolveUnreadableMembers(
+        latest.members,
+        ownerActor,
+        skillset.autoUpdateMembers ?? false,
+      );
       if (unreadable.length === 0) continue;
       // Notify only when THIS change is what cost the owner access.
       const changedNowUnreadable = unreadable.some((ref) =>
@@ -715,7 +777,14 @@ export class SkillsetService {
     const latest = await this.skillsetVersionRepo.findLatestBySkillset(guid);
     if (!latest) return false;
 
-    const currentSnapshot = await this.resolveMemberSnapshot(latest.members);
+    // #1191 — resolve the snapshot with the skillset's own auto-update setting
+    // so a pinned member's new version still moves the snapshot (and bumps the
+    // revision) when the owner asked to always track latest.
+    const identity = await this.skillsetRepo.findByGuid(guid);
+    const currentSnapshot = await this.resolveMemberSnapshot(
+      latest.members,
+      identity?.autoUpdateMembers ?? false,
+    );
 
     if (latest.resolvedMembers === undefined) {
       // Defensive backfill: no baseline yet, so record one rather than bump.
@@ -756,8 +825,11 @@ export class SkillsetService {
    * subset only. Public-only means a member's visibility flip (private⇄public)
    * moves the snapshot and bumps the revision, in addition to a version move.
    */
-  private async resolveMemberSnapshot(members: string[]): Promise<string[]> {
-    return computePublicResolvedMembers(members, this.skillService);
+  private async resolveMemberSnapshot(
+    members: string[],
+    autoUpdateMembers = false,
+  ): Promise<string[]> {
+    return computePublicResolvedMembers(members, this.skillService, autoUpdateMembers);
   }
 
   /** Load a skillset's requested (or latest) version doc, or 404. */
@@ -791,8 +863,9 @@ export class SkillsetService {
   private async resolveUnreadableMembers(
     members: string[],
     actor: ActorContext,
+    autoUpdateMembers = false,
   ): Promise<string[]> {
-    const load = this.skillService.createVersionLoader(actor);
+    const load = this.skillService.createVersionLoader(actor, autoUpdateMembers);
     const unreadable: string[] = [];
     for (const ref of members) {
       const node = await load(ref);
@@ -809,8 +882,11 @@ export class SkillsetService {
    * bundled. Resolved as SYSTEM so a member's own privacy — not the caller's
    * read access — decides public-ness.
    */
-  private async countPublicMembers(members: string[]): Promise<number> {
-    const load = this.skillService.createVersionLoader(SYSTEM_ACTOR);
+  private async countPublicMembers(
+    members: string[],
+    autoUpdateMembers = false,
+  ): Promise<number> {
+    const load = this.skillService.createVersionLoader(SYSTEM_ACTOR, autoUpdateMembers);
     const publicNames = new Set<string>();
     for (const ref of members) {
       const node = await load(ref);
@@ -830,7 +906,10 @@ export class SkillsetService {
     versionDoc: SkillsetVersionDocument,
     unreadableMembers: string[],
   ): Promise<SkillsetDetailResponse> {
-    const publicMemberCount = await this.countPublicMembers(versionDoc.members);
+    const publicMemberCount = await this.countPublicMembers(
+      versionDoc.members,
+      skillset.autoUpdateMembers ?? false,
+    );
     return toDetail(skillset, versionDoc, unreadableMembers, publicMemberCount);
   }
 
@@ -954,6 +1033,8 @@ function toDetail(
     memberVisibilityState: skillset.memberVisibilityState ?? "all-public",
     // Plugin-export opt-in (#1155) + owner listing overrides (#1157).
     exportAsPlugin: skillset.exportAsPlugin ?? false,
+    // Auto-update-members opt-in (#1191).
+    autoUpdateMembers: skillset.autoUpdateMembers ?? false,
     pluginConfig: skillset.pluginConfig,
     // Public-member subset size (#1161) — drives the export-card gate.
     publicMemberCount,

--- a/ornn-api/src/domains/skillsets/types.ts
+++ b/ornn-api/src/domains/skillsets/types.ts
@@ -207,9 +207,19 @@ export const pluginExportSchema = z.object({
   keywords: z.array(pluginKeywordSchema).max(20).optional(),
 });
 
+/**
+ * Body for `PUT /skillsets/:id/auto-update` (#1191). A single opt-in toggle —
+ * "always keep skills in this skillset up to date". No overrides: when on, ALL
+ * members always resolve to their latest version.
+ */
+export const autoUpdateSchema = z.object({
+  enabled: z.boolean(),
+});
+
 export type CreateSkillsetInput = z.infer<typeof createSkillsetSchema>;
 export type PublishSkillsetInput = z.infer<typeof publishSkillsetSchema>;
 export type PluginExportInput = z.infer<typeof pluginExportSchema>;
+export type AutoUpdateInput = z.infer<typeof autoUpdateSchema>;
 
 /**
  * Owner-customizable plugin listing fields (#1157). Each is OPTIONAL and, when
@@ -282,6 +292,17 @@ export interface SkillsetDocument {
    * Default OFF.
    */
   exportAsPlugin?: boolean | undefined;
+  /**
+   * Owner opt-in (#1191) — "always keep skills in this skillset up to date".
+   * When `true`, EVERY member (pinned or not) resolves to its skill's latest
+   * version everywhere the set is delivered (closure, plugin export, snapshot,
+   * visibility), so a member's new version auto-updates the skillset with no
+   * per-member ref changes. Non-destructive: the authored `members` refs are
+   * preserved and only overridden at resolution time, so turning it off
+   * restores the pinned behavior. Optional for back-compat (absent ⇒ `false`).
+   * Default OFF.
+   */
+  autoUpdateMembers?: boolean | undefined;
   /**
    * Owner-customizable plugin listing overrides (#1157). Set ONLY when the
    * owner exported with explicit overrides; absent ⇒ the mirror falls back to
@@ -377,6 +398,12 @@ export interface SkillsetDetailResponse {
    * the toggle state + the install snippet. Always present (defaults `false`).
    */
   exportAsPlugin: boolean;
+  /**
+   * Owner opt-in (#1191) — "always keep skills up to date". Surfaced so the web
+   * UI can show the toggle state. Always present (defaults `false`). When on,
+   * every member resolves to its latest version wherever the set is delivered.
+   */
+  autoUpdateMembers: boolean;
   /**
    * Number of THIS version's members whose skill is currently public AND
    * resolvable, counted under SYSTEM (#1161). The export bundles only this

--- a/ornn-web/src/components/skillset/SkillsetAutoUpdateCard.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetAutoUpdateCard.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * SkillsetAutoUpdateCard — owner-only "always keep skills up to date" toggle
+ * (#1191). The mutation + toast are mocked so the test drives state and asserts
+ * the payload / owner gating.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { SkillsetDetail } from "@/types/skillset";
+
+const { mutateAsync } = vi.hoisted(() => ({ mutateAsync: vi.fn() }));
+
+vi.mock("@/hooks/useSkillsets", () => ({
+  useUpdateAutoUpdate: () => ({ mutateAsync, isPending: false }),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: (sel: (s: { addToast: () => void }) => unknown) => sel({ addToast: vi.fn() }),
+}));
+
+import { SkillsetAutoUpdateCard } from "./SkillsetAutoUpdateCard";
+
+const BASE: SkillsetDetail = {
+  guid: "g-1",
+  name: "research-bundle",
+  description: "A curated set",
+  instructions: "Run A, then B.",
+  kind: "generic",
+  tags: ["research"],
+  members: ["a@1.0", "b@1.0"],
+  version: "1.0",
+  latestVersion: "1.0",
+  isPrivate: false,
+  createdBy: "user-1",
+  sharedWithUsers: [],
+  sharedWithOrgs: [],
+  memberVisibilityState: "all-public",
+  exportAsPlugin: false,
+  autoUpdateMembers: false,
+  publicMemberCount: 2,
+  unreadableMembers: [],
+  createdOn: "2026-06-01T00:00:00.000Z",
+  updatedOn: "2026-06-02T00:00:00.000Z",
+};
+
+afterEach(() => {
+  cleanup();
+  mutateAsync.mockReset();
+});
+
+describe("SkillsetAutoUpdateCard", () => {
+  it("renders nothing for a non-owner", () => {
+    const { container } = render(
+      <SkillsetAutoUpdateCard skillset={BASE} isOwner={false} idOrName="research-bundle" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("OFF state: shows the pinned-versions label + a Turn on button", () => {
+    render(<SkillsetAutoUpdateCard skillset={BASE} isOwner idOrName="research-bundle" />);
+    expect(screen.getByText("Off — using pinned versions")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Turn on" })).toBeInTheDocument();
+  });
+
+  it("ON state: shows the tracking-latest label + a Turn off button", () => {
+    render(
+      <SkillsetAutoUpdateCard
+        skillset={{ ...BASE, autoUpdateMembers: true }}
+        isOwner
+        idOrName="research-bundle"
+      />,
+    );
+    expect(screen.getByText("On — tracking latest")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Turn off" })).toBeInTheDocument();
+  });
+
+  it("enabling calls the mutation with { enabled: true }", async () => {
+    mutateAsync.mockResolvedValue({});
+    render(<SkillsetAutoUpdateCard skillset={BASE} isOwner idOrName="research-bundle" />);
+    fireEvent.click(screen.getByRole("button", { name: "Turn on" }));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith({ enabled: true }));
+  });
+
+  it("disabling calls the mutation with { enabled: false }", async () => {
+    mutateAsync.mockResolvedValue({});
+    render(
+      <SkillsetAutoUpdateCard
+        skillset={{ ...BASE, autoUpdateMembers: true }}
+        isOwner
+        idOrName="research-bundle"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Turn off" }));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith({ enabled: false }));
+  });
+});

--- a/ornn-web/src/components/skillset/SkillsetAutoUpdateCard.tsx
+++ b/ornn-web/src/components/skillset/SkillsetAutoUpdateCard.tsx
@@ -1,0 +1,100 @@
+/**
+ * Owner-only "always keep skills in this skillset up to date" toggle (#1191).
+ *
+ * A single opt-in: when ON, every member — pinned or not — resolves to its
+ * skill's latest version wherever the set is delivered (closure, plugin export,
+ * visibility). The flip is reversible and low-risk (the authored member refs are
+ * never rewritten — it's a resolution-time override), so it toggles directly
+ * with no confirm dialog. Enabling immediately re-cuts the revision if any
+ * member was behind, which the returned payload reflects.
+ *
+ * Owner-only: it's a management action. Non-owners see nothing here — the
+ * delivered set is already latest for them when the flag is on, transparently.
+ *
+ * @module components/skillset/SkillsetAutoUpdateCard
+ */
+
+import { useTranslation } from "react-i18next";
+import { RailCard } from "@/components/detail/RailCard";
+import { Button } from "@/components/ui/Button";
+import { useUpdateAutoUpdate } from "@/hooks/useSkillsets";
+import { useToastStore } from "@/stores/toastStore";
+import { translateError } from "@/utils/translateError";
+import type { SkillsetDetail } from "@/types/skillset";
+
+export interface SkillsetAutoUpdateCardProps {
+  skillset: SkillsetDetail;
+  isOwner: boolean;
+  /** URL id (name OR guid) the detail page was opened with — the cache key. */
+  idOrName: string;
+}
+
+export function SkillsetAutoUpdateCard({
+  skillset,
+  isOwner,
+  idOrName,
+}: SkillsetAutoUpdateCardProps) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+  const mutation = useUpdateAutoUpdate(skillset.guid, idOrName);
+
+  // Owner-only management action.
+  if (!isOwner) return null;
+
+  const on = skillset.autoUpdateMembers;
+
+  async function toggle() {
+    try {
+      await mutation.mutateAsync({ enabled: !on });
+      addToast({
+        type: "success",
+        message: on
+          ? t("skillsetAutoUpdate.offSuccess", "Auto-update turned off")
+          : t("skillsetAutoUpdate.onSuccess", "Auto-update turned on"),
+      });
+    } catch (err) {
+      addToast({ type: "error", message: translateError(err) });
+    }
+  }
+
+  return (
+    <RailCard
+      title={t("skillsetAutoUpdate.cardTitle", "Keep skills up to date")}
+      icon={
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <path d="M23 4v6h-6" />
+          <path d="M1 20v-6h6" />
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+        </svg>
+      }
+    >
+      <p className="mb-3 font-mono text-[11px] leading-relaxed text-meta">
+        {t(
+          "skillsetAutoUpdate.explain",
+          "When on, every member always uses its skill's latest version — pinned versions are overridden. New member versions flow into this skillset (and its plugin) automatically.",
+        )}
+      </p>
+      <div className="flex items-center justify-between gap-3">
+        <span
+          className={`font-mono text-[10px] font-semibold uppercase tracking-[0.16em] ${
+            on ? "text-ember" : "text-meta"
+          }`}
+        >
+          {on
+            ? t("skillsetAutoUpdate.stateOn", "On — tracking latest")
+            : t("skillsetAutoUpdate.stateOff", "Off — using pinned versions")}
+        </span>
+        <Button
+          variant={on ? "secondary" : "primary"}
+          size="sm"
+          loading={mutation.isPending}
+          onClick={toggle}
+        >
+          {on
+            ? t("skillsetAutoUpdate.turnOff", "Turn off")
+            : t("skillsetAutoUpdate.turnOn", "Turn on")}
+        </Button>
+      </div>
+    </RailCard>
+  );
+}

--- a/ornn-web/src/hooks/useSkillsets.ts
+++ b/ornn-web/src/hooks/useSkillsets.ts
@@ -22,9 +22,11 @@ import {
   createSkillset,
   publishSkillset,
   updatePluginExport,
+  updateAutoUpdate,
   deleteSkillset,
 } from "@/services/skillsetApi";
 import type {
+  AutoUpdateInput,
   CreateSkillsetInput,
   PluginExportInput,
   PublishSkillsetInput,
@@ -178,6 +180,25 @@ export function useUpdatePluginExport(guid: string, idOrName: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (input: PluginExportInput) => updatePluginExport(guid, input),
+    onSuccess: (updated) => {
+      queryClient.setQueryData([SKILLSETS_KEY, idOrName, "latest"], updated);
+      queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY, idOrName] });
+      queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY] });
+      queryClient.invalidateQueries({ queryKey: [MY_SKILLSETS_KEY] });
+    },
+  });
+}
+
+/**
+ * Toggle "always keep skills in this skillset up to date" (#1191). Same
+ * two-id cache handling as {@link useUpdatePluginExport}: prime the detail
+ * cache with the returned payload (its version/members may have bumped) and
+ * invalidate the list tabs.
+ */
+export function useUpdateAutoUpdate(guid: string, idOrName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: AutoUpdateInput) => updateAutoUpdate(guid, input),
     onSuccess: (updated) => {
       queryClient.setQueryData([SKILLSETS_KEY, idOrName, "latest"], updated);
       queryClient.invalidateQueries({ queryKey: [SKILLSETS_KEY, idOrName] });

--- a/ornn-web/src/pages/SkillsetDetailPage.test.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.test.tsx
@@ -21,6 +21,7 @@ const useSkillsetVersions = vi.fn();
 const useSkillsetClosure = vi.fn();
 const useDeleteSkillset = vi.fn();
 const useUpdatePluginExport = vi.fn();
+const useUpdateAutoUpdate = vi.fn();
 
 vi.mock("@/hooks/useSkillsets", () => ({
   useSkillset: (...a: unknown[]) => useSkillset(...a),
@@ -28,6 +29,7 @@ vi.mock("@/hooks/useSkillsets", () => ({
   useSkillsetClosure: (...a: unknown[]) => useSkillsetClosure(...a),
   useDeleteSkillset: (...a: unknown[]) => useDeleteSkillset(...a),
   useUpdatePluginExport: (...a: unknown[]) => useUpdatePluginExport(...a),
+  useUpdateAutoUpdate: (...a: unknown[]) => useUpdateAutoUpdate(...a),
 }));
 
 vi.mock("@/stores/authStore", () => ({
@@ -108,6 +110,7 @@ beforeEach(() => {
   });
   useDeleteSkillset.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
   useUpdatePluginExport.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+  useUpdateAutoUpdate.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
 });
 
 afterEach(() => {

--- a/ornn-web/src/pages/SkillsetDetailPage.tsx
+++ b/ornn-web/src/pages/SkillsetDetailPage.tsx
@@ -29,6 +29,7 @@ import { SkillsetMemberViewer } from "@/components/skillset/SkillsetMemberViewer
 import { SkillsetDerivedVisibilityCard } from "@/components/skillset/SkillsetDerivedVisibilityCard";
 import { SkillsetMemberWarningBanner } from "@/components/skillset/SkillsetMemberWarningBanner";
 import { SkillsetPluginExportCard } from "@/components/skillset/SkillsetPluginExportCard";
+import { SkillsetAutoUpdateCard } from "@/components/skillset/SkillsetAutoUpdateCard";
 import { parseDeps } from "@/lib/skillsetDeps";
 import { useToastStore } from "@/stores/toastStore";
 import { useCurrentUser } from "@/stores/authStore";
@@ -404,6 +405,14 @@ export function SkillsetDetailPage() {
                   configure + stop) directly ABOVE the visibility card; any viewer
                   sees the install snippet once the skillset is exported. */}
               <SkillsetPluginExportCard
+                skillset={skillset}
+                isOwner={isOwner}
+                idOrName={id}
+              />
+
+              {/* ── Auto-update toggle (#1191) ── owner-only: always keep members
+                  at their latest version. Sits with the other owner actions. */}
+              <SkillsetAutoUpdateCard
                 skillset={skillset}
                 isOwner={isOwner}
                 idOrName={id}

--- a/ornn-web/src/services/skillsetApi.ts
+++ b/ornn-web/src/services/skillsetApi.ts
@@ -22,6 +22,7 @@
 
 import { apiGet, apiPost, apiPut, apiDelete } from "./apiClient";
 import type {
+  AutoUpdateInput,
   CreateSkillsetInput,
   PluginExportInput,
   PublishSkillsetInput,
@@ -133,6 +134,20 @@ export async function updatePluginExport(
 ): Promise<SkillsetDetail> {
   const res = await apiPut<SkillsetDetail>(
     `/api/v1/skillsets/${encodeURIComponent(guid)}/plugin-export`,
+    input,
+  );
+  return res.data!;
+}
+
+/**
+ * Toggle "always keep skills up to date" (#1191). PUT /skillsets/:id/auto-update.
+ */
+export async function updateAutoUpdate(
+  guid: string,
+  input: AutoUpdateInput,
+): Promise<SkillsetDetail> {
+  const res = await apiPut<SkillsetDetail>(
+    `/api/v1/skillsets/${encodeURIComponent(guid)}/auto-update`,
     input,
   );
   return res.data!;

--- a/ornn-web/src/types/skillset.ts
+++ b/ornn-web/src/types/skillset.ts
@@ -79,6 +79,15 @@ export interface PluginExportInput {
   keywords?: string[] | undefined;
 }
 
+/**
+ * Body for `PUT /api/v1/skillsets/:id/auto-update` (#1191) — the single
+ * "always keep skills up to date" toggle. No overrides: when on, all members
+ * always resolve to their latest version.
+ */
+export interface AutoUpdateInput {
+  enabled: boolean;
+}
+
 /** Why a master-prompt body is invalid. `null` = valid. */
 export type MasterPromptRejection = "empty" | "tooLong" | null;
 
@@ -142,6 +151,13 @@ export interface SkillsetDetail {
    * the read-only install snippet on the detail page.
    */
   exportAsPlugin: boolean;
+  /**
+   * Owner opt-in (#1191) — "always keep skills in this skillset up to date".
+   * When on, every member resolves to its skill's latest version wherever the
+   * set is delivered. Drives the auto-update toggle card. Always present from
+   * the API (defaults `false`).
+   */
+  autoUpdateMembers: boolean;
   /**
    * Number of THIS version's members whose skill is currently public AND
    * resolvable (#1161). The export bundles only this public subset; the export


### PR DESCRIPTION
## Summary

Adds a per-skillset owner toggle **"Always keep skills in this skillset up to date"** (`autoUpdateMembers`, default OFF). When ON, every member — pinned or not — resolves to its skill's **latest** version everywhere the set is delivered, so a member's new version automatically flows into the skillset and its exported Claude Code plugin, with no per-member ref edits.

Closes #1191.

## What it does

- **Resolution-time override, non-destructive.** The whole behavior is one flag on the shared version loader (`createVersionLoader(actor, forceLatest)` → `versionOrTag = "latest"`), threaded from each skillset's flag through every resolution seam: the resolved-member snapshot (revision bump), derived visibility, the read gate, the public-member count, closure delivery, and the mirror plugin export. The authored `members` refs are never rewritten, so turning it **off** restores the pinned behavior.
- **Immediate catch-up.** Toggling either way re-cuts the revision when the public snapshot moved and refreshes derived visibility; the route then fires the mirror reconcile so the exported plugin re-publishes at the freshly-bumped revision.
- **API-first.** New `PUT /api/v1/skillsets/:id/auto-update` (mirrors the `plugin-export` toggle) + `autoUpdateMembers` on the skillset resource. The ornn-web toggle card on the detail page is the secondary surface.

Per the product decision on #1191, the toggle **overrides all pins** (a pin is inert while it's on) — the simplest "always keep ALL up to date" model.

## Testing

- **API:** 2146 pass. New unit + route tests cover the toggle (enable → force-latest + revision bump + closure delivers latest; disable → restores pins + bumps again; idempotent when already-latest; auth + 404), plus `forceLatest` resolver threading. The service tests exercise the **real** `SkillService` loader end-to-end, not mocks.
- **Web:** 611 pass. New `SkillsetAutoUpdateCard` tests (owner gating, on/off state, toggle payload).
- `tsc` (api + web + sdk) clean; `eslint` 0 errors; changeset included (minor/minor).

## Not included (follow-ups)

- The agent manual (`skills/ornn-agent-manual-cli/references/api-reference.md`) doesn't yet document the new endpoint — that skill is mirror-published and versioned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQhPzeZKKfFrw6Zc44RGaB
