### PR TITLE
feat: proxy skill package downloads through ornn-api for chrono-bucket (#1196)

### DIFF
--- a/.changeset/chrono-bucket-download-proxy.md
+++ b/.changeset/chrono-bucket-download-proxy.md
@@ -1,0 +1,6 @@
+---
+"ornn-api": minor
+"ornn-web": minor
+---
+
+Migrate skill package downloads to chrono-bucket's streaming endpoint (#1196). chrono-bucket (replacing chrono-storage) removed presigned URLs and the object-copy endpoint and now serves downloads via a streaming `GET /objects/download` behind the NyxID proxy. ornn-api's storage client gains a streaming `downloadObject()` (replacing the removed `getPresignedUrl`/`copy`); package reads for diff/json/audit go through it, and a new `GET /skills/:idOrName/versions/:version/download` route streams the ZIP through ornn-api (the route the TS SDK's `downloadPackage()` already targets). The client-facing `presignedPackageUrl` field is dropped from the skill detail response, and the web viewer now pulls packages through that authenticated ornn-api route instead of fetching chrono-bucket / MinIO directly. Also removes the wasted presigned round-trip and dead code in the audit pipeline (#995).

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -553,9 +553,6 @@ export async function bootstrap(
   const auditService = new AuditService({
     auditRepo,
     skillService,
-    storageClient,
-    storageBucketResolver: async () =>
-      (await settingsService.getNyxid()).chronoStorageBucket,
     llmClient: nyxLlmClient,
     defaultsResolver: async () => resolveAuditDefaults(),
     // Audits are re-run automatically when the cached record ages past

--- a/ornn-api/src/clients/storageClient.test.ts
+++ b/ornn-api/src/clients/storageClient.test.ts
@@ -75,15 +75,10 @@ describe("StorageClient SSRF preflight (#811)", () => {
     expect(fetchCalls).toHaveLength(0);
   });
 
-  it("getPresignedUrl() refuses a rebound host before issuing the request", async () => {
-    await expect(makeClient().getPresignedUrl("b", "k")).rejects.toBeInstanceOf(
+  it("downloadObject() refuses a rebound host before issuing the request", async () => {
+    await expect(makeClient().downloadObject("b", "k")).rejects.toBeInstanceOf(
       SsrfRefusalError,
     );
-    expect(fetchCalls).toHaveLength(0);
-  });
-
-  it("copy() refuses a rebound host before issuing the request", async () => {
-    await expect(makeClient().copy("b", "s", "d")).rejects.toBeInstanceOf(SsrfRefusalError);
     expect(fetchCalls).toHaveLength(0);
   });
 
@@ -93,5 +88,27 @@ describe("StorageClient SSRF preflight (#811)", () => {
     expect(out).toEqual({ url: "x" });
     expect(fetchCalls).toHaveLength(1);
     expect(fetchCalls[0]).toContain("http://rebind.test/api/buckets/b/objects");
+  });
+
+  it("downloadObject() streams raw bytes from the /objects/download endpoint", async () => {
+    process.env[ALLOWLIST_ENV] = "rebind.test";
+    // The default beforeEach stub returns a JSON envelope; downloadObject reads
+    // the body as raw bytes, so this test serves a binary Response instead.
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      fetchCalls.push(url);
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "Content-Type": "application/zip", "Content-Length": "3" },
+      });
+    }) as typeof fetch;
+
+    const out = await makeClient().downloadObject("b", "skills/g/1.0.zip");
+    expect(Array.from(out.bytes)).toEqual([1, 2, 3]);
+    expect(out.contentType).toBe("application/zip");
+    expect(out.contentLength).toBe(3);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]).toContain("/api/buckets/b/objects/download?key=");
   });
 });

--- a/ornn-api/src/clients/storageClient.ts
+++ b/ornn-api/src/clients/storageClient.ts
@@ -11,8 +11,17 @@ const logger = createLogger("storageClient");
 export interface IStorageClient {
   upload(bucket: string, key: string, data: Uint8Array, contentType: string): Promise<{ url: string }>;
   delete(bucket: string, key: string): Promise<void>;
-  getPresignedUrl(bucket: string, key: string, expiresIn?: number): Promise<{ presignedUrl: string; expiresAt: string }>;
-  copy(bucket: string, sourceKey: string, destKey: string): Promise<void>;
+  /**
+   * Stream an object's raw bytes from chrono-bucket's
+   * `GET /api/buckets/:bucket/objects/download?key=` endpoint. Replaces the
+   * removed presigned-URL flow (#1196): chrono-bucket no longer hands out
+   * direct S3 URLs, so every read is proxied through this client instead of a
+   * client fetching MinIO directly.
+   */
+  downloadObject(
+    bucket: string,
+    key: string,
+  ): Promise<{ bytes: Uint8Array; contentType: string; contentLength?: number }>;
 }
 
 /**
@@ -102,48 +111,33 @@ export class StorageClient implements IStorageClient {
     logger.debug({ bucket, key }, "File deleted from storage");
   }
 
-  async getPresignedUrl(
+  async downloadObject(
     bucket: string,
     key: string,
-    expiresIn?: number,
-  ): Promise<{ presignedUrl: string; expiresAt: string }> {
+  ): Promise<{ bytes: Uint8Array; contentType: string; contentLength?: number }> {
     const baseUrl = await this.resolveBaseUrl();
     const params = new URLSearchParams({ key });
-    if (expiresIn !== undefined) {
-      params.set("expiresIn", String(expiresIn));
-    }
-    const url = `${baseUrl}/api/buckets/${bucket}/presigned-url?${params.toString()}`;
+    const url = `${baseUrl}/api/buckets/${bucket}/objects/download?${params.toString()}`;
 
     const auth = await this.authHeaders();
     const res = await safeFetch(url, { method: "GET", headers: auth });
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");
-      logger.error({ status: res.status, bucket, key }, "Storage presigned URL failed");
-      throw new Error(`Storage presigned URL failed (${res.status}): ${text}`);
+      logger.error({ status: res.status, bucket, key }, "Storage download failed");
+      throw new Error(`Storage download failed (${res.status}): ${text}`);
     }
 
-    const json = (await res.json()) as { data: { presignedUrl: string; expiresAt: string } };
-    return json.data;
-  }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    const contentType = res.headers.get("content-type") ?? "application/octet-stream";
+    const lenHeader = res.headers.get("content-length");
+    const contentLength = lenHeader !== null ? Number(lenHeader) : NaN;
+    logger.debug({ bucket, key, bytes: bytes.byteLength }, "File downloaded from storage");
 
-  async copy(bucket: string, sourceKey: string, destKey: string): Promise<void> {
-    const baseUrl = await this.resolveBaseUrl();
-    const url = `${baseUrl}/api/buckets/${bucket}/objects/copy`;
-
-    const auth = await this.authHeaders();
-    const res = await safeFetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...auth },
-      body: JSON.stringify({ sourceKey, destKey }),
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      logger.error({ status: res.status, bucket, sourceKey, destKey }, "Storage copy failed");
-      throw new Error(`Storage copy failed (${res.status}): ${text}`);
-    }
-
-    logger.debug({ bucket, sourceKey, destKey }, "File copied in storage");
+    // exactOptionalPropertyTypes (#657): only attach contentLength when the
+    // header was present and numeric — never assign an explicit `undefined`.
+    return Number.isFinite(contentLength)
+      ? { bytes, contentType, contentLength }
+      : { bytes, contentType };
   }
 }

--- a/ornn-api/src/domains/analytics/routes.test.ts
+++ b/ornn-api/src/domains/analytics/routes.test.ts
@@ -57,7 +57,6 @@ function skill(overrides: Partial<SkillDetailResponse> = {}): SkillDetailRespons
     metadata: {},
     tags: [],
     skillHash: "hash-1",
-    presignedPackageUrl: "https://storage.test/skill.zip",
     isPrivate: false,
     createdBy: OWNER_ID,
     createdOn: "2026-01-01T00:00:00Z",

--- a/ornn-api/src/domains/skills/audit/routes.test.ts
+++ b/ornn-api/src/domains/skills/audit/routes.test.ts
@@ -60,7 +60,6 @@ function skill(overrides: Partial<SkillDetailResponse> = {}): SkillDetailRespons
     metadata: {},
     tags: [],
     skillHash: "hash-1",
-    presignedPackageUrl: "https://storage.test/skill.zip",
     isPrivate: false,
     createdBy: OWNER_ID,
     createdOn: "2026-01-01T00:00:00Z",

--- a/ornn-api/src/domains/skills/audit/service.test.ts
+++ b/ornn-api/src/domains/skills/audit/service.test.ts
@@ -9,8 +9,9 @@
  *   - notification    → LOCAL typed recorder (the shared mock's
  *                       notifyAuditCompleted signature doesn't match the
  *                       real {ownerUserId,...} call site)
- *   - storage/orgs    → minimal fakes
- *   - globalThis.fetch → swapped to a Response wrapping a real JSZip zip
+ *   - orgs            → minimal fake
+ *   - package bytes   → FakeSkillService.getPackageBytes returns a JSZip zip
+ *                       (audit reads bytes through the skill service, #1196)
  *
  * `runAudit` finalizes in a fire-and-forget microtask; tests flush it
  * with `flushFinalize()` before asserting on the recorder.
@@ -19,8 +20,6 @@
  */
 
 import {
-  afterEach,
-  beforeEach,
   describe,
   expect,
   test,
@@ -42,7 +41,6 @@ import type {
 import type { SkillService } from "../crud/service";
 import type { NotificationService } from "../../notifications/service";
 import type { NyxidOrgsClient } from "../../../clients/nyxid/orgs";
-import type { IStorageClient } from "../../../clients/storageClient";
 import type { SkillDetailResponse } from "../../../shared/types/index";
 
 // ---- Local typed notification recorder -------------------------------
@@ -122,7 +120,6 @@ function baseSkill(overrides: Partial<SkillDetailResponse> = {}): SkillDetailRes
     metadata: { category: "devtools", runtimes: [{ runtime: "node" }] },
     tags: ["alpha", "beta"],
     skillHash: "hash-1",
-    presignedPackageUrl: "https://storage.test/skill.zip",
     isPrivate: false,
     createdBy: "owner-1",
     createdOn: "2026-01-01T00:00:00Z",
@@ -136,6 +133,9 @@ function baseSkill(overrides: Partial<SkillDetailResponse> = {}): SkillDetailRes
 
 class FakeSkillService {
   getSkillCalls: Array<{ idOrName: string; version?: string | undefined }> = [];
+  getPackageBytesCalls: Array<{ idOrName: string; version?: string | undefined }> = [];
+  /** When set, getPackageBytes throws this instead of returning bytes. */
+  packageError: Error | null = null;
   constructor(private skill: SkillDetailResponse) {}
   setSkill(s: SkillDetailResponse) {
     this.skill = s;
@@ -143,6 +143,26 @@ class FakeSkillService {
   async getSkill(idOrName: string, version?: string): Promise<SkillDetailResponse> {
     this.getSkillCalls.push({ idOrName, version });
     return this.skill;
+  }
+  // Mirrors SkillService.getPackageBytes (#1196) — audit now reads package
+  // bytes through the skill service. Driven by the module-level `fetchPlan`
+  // (ok/status/bytes/throws) so the existing test bodies still control the
+  // download outcome; `packageError` models a resolve-time failure
+  // (e.g. skill_package_not_found).
+  async getPackageBytes(
+    idOrName: string,
+    _actor: unknown,
+    version?: string,
+  ): Promise<{ bytes: Uint8Array; name: string; version: string }> {
+    this.getPackageBytesCalls.push({ idOrName, version });
+    if (this.packageError) throw this.packageError;
+    if (fetchPlan.throws) throw new Error("network down");
+    if (!fetchPlan.ok) {
+      throw new Error(
+        `Failed to download package for key 'skills/${this.skill.guid}/${this.skill.version}.zip' (HTTP ${fetchPlan.status})`,
+      );
+    }
+    return { bytes: fetchPlan.bytes, name: this.skill.name, version: this.skill.version };
   }
 }
 
@@ -196,13 +216,7 @@ class FakeAuditRepo {
   }
 }
 
-// ---- Fake storage / orgs ---------------------------------------------
-
-class FakeStorageClient {
-  async getPresignedUrl(): Promise<{ presignedUrl: string; expiresAt: string }> {
-    return { presignedUrl: "https://storage.test/skill.zip", expiresAt: "2026-01-01T01:00:00Z" };
-  }
-}
+// ---- Fake orgs -------------------------------------------------------
 
 class FakeOrgsClient {
   membersByOrg = new Map<string, Array<{ userId: string }>>();
@@ -238,8 +252,6 @@ function makeLlmClient(text: string): NyxLlmClient {
 
 // ---- fetch swap ------------------------------------------------------
 
-const originalFetch = globalThis.fetch;
-
 interface FetchPlan {
   ok: boolean;
   status: number;
@@ -247,6 +259,8 @@ interface FetchPlan {
   throws?: boolean;
 }
 
+// Drives FakeSkillService.getPackageBytes — audit reads package bytes through
+// the skill service now (#1196), not a direct global fetch of a presigned URL.
 let fetchPlan: FetchPlan;
 
 async function buildZip(files: Record<string, string>): Promise<Uint8Array> {
@@ -256,21 +270,6 @@ async function buildZip(files: Record<string, string>): Promise<Uint8Array> {
   }
   return zip.generateAsync({ type: "uint8array" });
 }
-
-beforeEach(() => {
-  const fakeFetch = async (): Promise<Response> => {
-    if (fetchPlan.throws) throw new Error("network down");
-    return new Response(fetchPlan.bytes as unknown as BodyInit, {
-      status: fetchPlan.status,
-      statusText: fetchPlan.ok ? "OK" : "Error",
-    });
-  };
-  globalThis.fetch = fakeFetch as unknown as typeof fetch;
-});
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
 
 // ---- helpers ---------------------------------------------------------
 
@@ -310,8 +309,6 @@ function buildService(
   const deps: AuditServiceDeps = {
     auditRepo: repo as unknown as AuditServiceDeps["auditRepo"],
     skillService: skillService as unknown as SkillService,
-    storageClient: new FakeStorageClient() as unknown as IStorageClient,
-    storageBucketResolver: async () => "skills-bucket",
     llmClient: client,
     defaultsResolver: async () => ({
       model: "gpt-test",
@@ -529,15 +526,15 @@ describe("buildAuditContext", () => {
     expect(repo.markCompletedCalls).toHaveLength(1);
   });
 
-  test("missing presignedPackageUrl marks failed with audit_package_unavailable", async () => {
+  test("missing package (no storage key) marks failed", async () => {
     fetchPlan = { ok: true, status: 200, bytes: await buildZip({ "SKILL.md": "# demo" }) };
-    const { service, repo } = buildService({
-      skill: baseSkill({ presignedPackageUrl: "" }),
-    });
+    const { service, repo, skillService } = buildService();
+    // getPackageBytes 404s when the skill has no stored package (#1196).
+    skillService.packageError = new Error("No package stored for skill 'demo-skill'");
     await service.runAudit("demo-skill", { triggeredBy: "owner-1" });
     await flushFinalize();
     expect(repo.markFailedCalls).toHaveLength(1);
-    expect(repo.markFailedCalls[0]!.errorMessage).toContain("No storage URL");
+    expect(repo.markFailedCalls[0]!.errorMessage).toContain("No package stored");
   });
 
   test("non-ok package fetch marks failed with the download-failed message", async () => {

--- a/ornn-api/src/domains/skills/audit/service.ts
+++ b/ornn-api/src/domains/skills/audit/service.ts
@@ -13,11 +13,10 @@
 
 import { createLogger } from "../../../shared/logger";
 import type { NyxLlmClient, ResponsesApiInputMessage } from "../../../clients/nyxid/llm";
-import type { IStorageClient } from "../../../clients/storageClient";
 import type { NyxidOrgsClient } from "../../../clients/nyxid/orgs";
 import type { SkillService } from "../crud/service";
+import { SYSTEM_ACTOR } from "../crud/authorize";
 import type { NotificationService } from "../../notifications/service";
-import { AppError } from "../../../shared/types/index";
 import type { AuditRepository } from "./repository";
 import {
   type AuditFinding,
@@ -54,19 +53,9 @@ export interface AuditLlmDefaults {
 
 export type AuditDefaultsResolver = () => Promise<AuditLlmDefaults>;
 
-/**
- * Per-bucket storage resolver — the audit pipeline reads skill packages
- * from the same bucket the upload path used. Sourced from admin
- * settings (services section) so a bucket rename doesn't redeploy.
- */
-export type AuditStorageBucketResolver = () => Promise<string>;
-
 export interface AuditServiceDeps {
   readonly auditRepo: AuditRepository;
   readonly skillService: SkillService;
-  readonly storageClient: IStorageClient;
-  /** Resolves the active storage bucket from settings. */
-  readonly storageBucketResolver: AuditStorageBucketResolver;
   readonly llmClient: NyxLlmClient;
   /** Resolves audit knobs (LLM toggle/model, AgentSeal toggle/timeout, threshold) from settings. */
   readonly defaultsResolver: AuditDefaultsResolver;
@@ -87,8 +76,6 @@ export interface AuditOptions {
 export class AuditService {
   private readonly auditRepo: AuditRepository;
   private readonly skillService: SkillService;
-  private readonly storageClient: IStorageClient;
-  private readonly storageBucketResolver: AuditStorageBucketResolver;
   private readonly llmClient: NyxLlmClient;
   private readonly defaultsResolver: AuditDefaultsResolver;
   private readonly cacheTtlMs: number;
@@ -99,8 +86,6 @@ export class AuditService {
   constructor(deps: AuditServiceDeps) {
     this.auditRepo = deps.auditRepo;
     this.skillService = deps.skillService;
-    this.storageClient = deps.storageClient;
-    this.storageBucketResolver = deps.storageBucketResolver;
     this.llmClient = deps.llmClient;
     this.defaultsResolver = deps.defaultsResolver;
     this.cacheTtlMs = deps.cacheTtlMs;
@@ -344,28 +329,14 @@ export class AuditService {
   private async buildAuditContext(
     guid: string,
   ): Promise<{ filesBundle: string; metadataSummary: string }> {
-    const storageBucket = await this.storageBucketResolver();
-    const presigned = await this.storageClient.getPresignedUrl(storageBucket, `skills/${guid}.zip`).catch(() => null);
-    // The canonical pointer is `skills/{guid}/{version}.zip`; fall back via
-    // the skill doc's stored `storageKey` for migrated/legacy rows.
+    // Fetch the latest version's package bytes through the skill service, which
+    // proxies chrono-bucket's streaming download (#1196). Audit is a trusted
+    // system pipeline, so it passes SYSTEM_ACTOR to bypass the per-skill
+    // visibility gate. This replaces the old dead presigned-URL round-trip and
+    // the cast-riddled `skillDoc.presignedPackageUrl` read (#995).
+    const { bytes } = await this.skillService.getPackageBytes(guid, SYSTEM_ACTOR);
+    // Metadata/tags for the audit summary come from the skill doc (latest).
     const skillDoc = await this.skillService.getSkill(guid);
-    const storageKey = presigned
-      ? `skills/${guid}.zip`
-      : (skillDoc as unknown as { presignedPackageUrl?: string; storageKey?: string });
-
-    // Prefer the skill doc's presigned URL — `getSkill` already minted one.
-    const url = (skillDoc as unknown as { presignedPackageUrl?: string }).presignedPackageUrl;
-    if (!url) {
-      throw AppError.internalError("audit_package_unavailable", "No storage URL for skill package");
-    }
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw AppError.internalError(
-        "AUDIT_PACKAGE_DOWNLOAD_FAILED",
-        `Failed to download package for audit (HTTP ${res.status})`,
-      );
-    }
-    const bytes = new Uint8Array(await res.arrayBuffer());
     const zip = await JSZip.loadAsync(bytes);
     const allPaths = Object.keys(zip.files);
     resolveZipRoot(zip, allPaths);
@@ -412,7 +383,6 @@ export class AuditService {
       `tags=${(skillDoc.tags ?? []).join(",")}`,
     ].join("; ");
 
-    void storageKey; // used only in legacy fallback; keep reference to satisfy lint
     return { filesBundle: chunks.join("\n\n"), metadataSummary };
   }
 }

--- a/ornn-api/src/domains/skills/crud/routes.test.ts
+++ b/ornn-api/src/domains/skills/crud/routes.test.ts
@@ -52,7 +52,6 @@ function detail(overrides: Partial<SkillDetailResponse> = {}): SkillDetailRespon
     metadata: {},
     tags: [],
     skillHash: "hash-1",
-    presignedPackageUrl: "https://storage.test/skill.zip",
     isPrivate: false,
     createdBy: OWNER,
     createdOn: "2026-01-01T00:00:00Z",
@@ -522,6 +521,60 @@ describe("GET /skills/:idOrName/json", () => {
     const res = await app.request("/api/v1/skills/demo-skill/json");
     expect(res.status).toBe(200);
     expect(calls).toContain("getSkillJson");
+  });
+});
+
+// ======================================================================
+// GET /skills/:idOrName/versions/:version/download  (#1196)
+// ======================================================================
+
+describe("GET /skills/:idOrName/versions/:version/download", () => {
+  const PKG = new Uint8Array([80, 75, 3, 4, 9, 8, 7]); // "PK.." + noise
+
+  test("200 streams the ZIP bytes with attachment headers", async () => {
+    const app = buildApp({
+      permissions: [READ],
+      service: {
+        getPackageBytes: async () => ({ bytes: PKG, name: "demo-skill", version: "1.0" }),
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/versions/1.0/download");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/zip");
+    expect(res.headers.get("content-disposition")).toContain('filename="demo-skill-1.0.zip"');
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(PKG);
+  });
+
+  test("404 (problem+json) when getPackageBytes denies a private/unknown skill", async () => {
+    const app = buildApp({
+      userId: "stranger",
+      permissions: [READ],
+      service: {
+        getPackageBytes: async () => {
+          // The visibility gate lives in getPackageBytes and 404s without
+          // leaking existence — same shape as GET /skills/:idOrName.
+          throw Object.assign(new Error("Skill 'demo-skill' not found"), {
+            code: "skill_not_found",
+            statusCode: 404,
+          });
+        },
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/versions/1.0/download");
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { code: string }).code).toBe("skill_not_found");
+  });
+
+  test("downloads a public skill anonymously (optional auth)", async () => {
+    const app = buildApp({
+      authenticated: false,
+      service: {
+        getPackageBytes: async () => ({ bytes: PKG, name: "demo-skill", version: "1.0" }),
+      },
+    });
+    const res = await app.request("/api/v1/skills/demo-skill/versions/1.0/download");
+    expect(res.status).toBe(200);
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(PKG);
   });
 });
 

--- a/ornn-api/src/domains/skills/crud/routes.ts
+++ b/ornn-api/src/domains/skills/crud/routes.ts
@@ -720,6 +720,61 @@ export function createSkillRoutes(config: SkillRoutesConfig): Hono<{ Variables: 
   );
 
   /**
+   * GET /skills/:idOrName/versions/:version/download — Stream the raw ZIP
+   * package for a specific version, proxied from chrono-bucket (#1196).
+   *
+   * Replaces the removed presigned-URL flow: clients no longer receive a
+   * direct storage URL — the bytes are streamed through ornn-api so the
+   * storage backend (chrono-bucket / MinIO) is never exposed. `version` may
+   * be a literal (e.g. `1.2`) or a dist-tag (e.g. `latest`).
+   *
+   * Visibility rules match GET /skills/:idOrName: anonymous callers may
+   * download public skills only; a private skill the caller cannot read 404s
+   * without leaking existence (the gate lives in `getPackageBytes`, #806).
+   *
+   * Auth: Optional. Returns `application/zip` bytes on success; errors use the
+   * RFC 7807 problem+json envelope (the TS SDK `downloadPackage()` contract).
+   * Deliberately does NOT record an analytics pull — this endpoint also backs
+   * the web file-tree viewer, and counting UI views would inflate the pull
+   * metric (programmatic reads are counted on /json).
+   */
+  app.get(
+    "/skills/:idOrName/versions/:version/download",
+    optionalAuth,
+    async (c) => {
+      const idOrName = c.req.param("idOrName");
+      const version = c.req.param("version");
+      const authCtx = c.get("auth");
+
+      // Authenticated callers get their full org/admin context; anonymous
+      // callers get a read-only actor that can see public skills only.
+      const actor = authCtx
+        ? await buildActorContext(c)
+        : {
+            userId: "",
+            memberships: [],
+            isPlatformAdmin: false,
+            membershipsResolved: true,
+          };
+
+      const pkg = await skillService.getPackageBytes(idOrName, actor, version);
+
+      const safeName = pkg.name.replace(/[^A-Za-z0-9._-]/g, "_");
+      // Raw binary body — NOT the JSON envelope. Returned as a Response so the
+      // Uint8Array streams verbatim (Hono's `c.body` types exclude
+      // ArrayBufferView). Errors thrown above still flow through the RFC 7807
+      // error middleware.
+      return new Response(pkg.bytes as unknown as BodyInit, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/zip",
+          "Content-Disposition": `attachment; filename="${safeName}-${pkg.version}.zip"`,
+        },
+      });
+    },
+  );
+
+  /**
    * GET /skills/:idOrName/closure — Resolve the full transitive
    * dependency closure of a skill version (#968).
    *

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -29,12 +29,12 @@ import { AppError } from "../../../shared/types/index";
 
 const SECRET_BODY = "SECRET_FROM_PACKAGE_b91c";
 
-/** Build a one-file zip and hand it back as a fetchable `data:` URL. */
-async function zipDataUrl(): Promise<string> {
+/** Build a one-file zip and hand it back as raw bytes (what the storage
+ *  client's `downloadObject` returns). */
+async function zipBytes(): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file("SKILL.md", `# demo\n${SECRET_BODY}`);
-  const buf = await zip.generateAsync({ type: "uint8array" });
-  return `data:application/zip;base64,${Buffer.from(buf).toString("base64")}`;
+  return zip.generateAsync({ type: "uint8array" });
 }
 
 /** Minimal SkillDocument carrying just the fields getSkillJson reads. */
@@ -54,14 +54,14 @@ function makeSkillDoc(overrides: Partial<SkillDocument> = {}): SkillDocument {
   } as SkillDocument;
 }
 
-function makeService(skill: SkillDocument, presignedUrl: string): SkillService {
+function makeService(skill: SkillDocument, packageBytes: Uint8Array): SkillService {
   const skillRepo = {
     findByGuid: async (guid: string) => (guid === skill.guid ? skill : null),
     findByName: async (name: string) => (name === skill.name ? skill : null),
   } as unknown as SkillRepository;
   const skillVersionRepo = {} as unknown as SkillVersionRepository;
   const storageClient = {
-    getPresignedUrl: async () => ({ presignedUrl, expiresAt: new Date().toISOString() }),
+    downloadObject: async () => ({ bytes: packageBytes, contentType: "application/zip" }),
   } as unknown as IStorageClient;
   return new SkillService({
     skillRepo,
@@ -79,9 +79,9 @@ describe("SkillService.getSkillJson — object-level authorization (#806)", () =
   it("private skill + stranger actor throws skill_not_found before any download", async () => {
     let downloaded = false;
     const storageClient = {
-      getPresignedUrl: async () => {
+      downloadObject: async () => {
         downloaded = true;
-        return { presignedUrl: "http://unused", expiresAt: "" };
+        return { bytes: new Uint8Array(), contentType: "application/zip" };
       },
     } as unknown as IStorageClient;
     const skill = makeSkillDoc({ isPrivate: true });
@@ -103,30 +103,30 @@ describe("SkillService.getSkillJson — object-level authorization (#806)", () =
     }
     expect(thrown).toBeInstanceOf(AppError);
     expect((thrown as AppError).code).toBe("skill_not_found");
-    // Gate runs before storage — no presigned URL was ever requested.
+    // Gate runs before storage — no package download was ever requested.
     expect(downloaded).toBe(false);
   });
 
   it("private skill succeeds for SYSTEM_ACTOR and returns package contents", async () => {
-    const service = makeService(makeSkillDoc({ isPrivate: true }), await zipDataUrl());
+    const service = makeService(makeSkillDoc({ isPrivate: true }), await zipBytes());
     const result = await service.getSkillJson("guid-1", SYSTEM_ACTOR);
     expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
   });
 
   it("private skill succeeds for the author", async () => {
-    const service = makeService(makeSkillDoc({ isPrivate: true, createdBy: "owner-1" }), await zipDataUrl());
+    const service = makeService(makeSkillDoc({ isPrivate: true, createdBy: "owner-1" }), await zipBytes());
     const result = await service.getSkillJson("guid-1", OWNER);
     expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
   });
 
   it("private skill succeeds for a platform admin", async () => {
-    const service = makeService(makeSkillDoc({ isPrivate: true }), await zipDataUrl());
+    const service = makeService(makeSkillDoc({ isPrivate: true }), await zipBytes());
     const result = await service.getSkillJson("guid-1", ADMIN);
     expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
   });
 
   it("public skill succeeds for any actor (including a stranger)", async () => {
-    const service = makeService(makeSkillDoc({ isPrivate: false }), await zipDataUrl());
+    const service = makeService(makeSkillDoc({ isPrivate: false }), await zipBytes());
     const result = await service.getSkillJson("guid-1", STRANGER);
     expect(result.files["SKILL.md"]).toContain(SECRET_BODY);
   });
@@ -249,9 +249,9 @@ describe("SkillService.setSkillPermissions — org-membership gate (#815)", () =
     const skillVersionRepo = {
       findLatestBySkill: async () => null,
     } as unknown as SkillVersionRepository;
-    const storageClient = {
-      getPresignedUrl: async () => ({ presignedUrl: "http://unused", expiresAt: "" }),
-    } as unknown as IStorageClient;
+    // buildDetailResponse no longer touches storage (#1196), so these flows
+    // need no storage stub.
+    const storageClient = {} as unknown as IStorageClient;
     const service = new SkillService({
       skillRepo,
       skillVersionRepo,
@@ -579,9 +579,9 @@ describe("SkillService.transferSkillOwnership (#1123)", () => {
       },
     } as unknown as SkillRepository;
     const skillVersionRepo = { findLatestBySkill: async () => null } as unknown as SkillVersionRepository;
-    const storageClient = {
-      getPresignedUrl: async () => ({ presignedUrl: "http://unused", expiresAt: "" }),
-    } as unknown as IStorageClient;
+    // buildDetailResponse no longer touches storage (#1196), so these flows
+    // need no storage stub.
+    const storageClient = {} as unknown as IStorageClient;
     const service = new SkillService({
       skillRepo,
       skillVersionRepo,
@@ -847,7 +847,6 @@ function makeFakeDeps(seed?: Partial<FakeState>): { deps: SkillServiceDeps; stat
     delete: async (_bucket: string, key: string) => {
       state.deletes.push(key);
     },
-    getPresignedUrl: async () => ({ presignedUrl: "http://unused", expiresAt: "" }),
   } as unknown as IStorageClient;
 
   return {

--- a/ornn-api/src/domains/skills/crud/service.test.ts
+++ b/ornn-api/src/domains/skills/crud/service.test.ts
@@ -132,6 +132,66 @@ describe("SkillService.getSkillJson — object-level authorization (#806)", () =
   });
 });
 
+// The download route (GET /skills/:idOrName/versions/:version/download, #1196)
+// is optionalAuth and anonymous-reachable, so its object-level gate lives
+// entirely in getPackageBytes. This suite exercises the REAL gate (not a route
+// mock) so deleting the canReadSkill check can never ship green.
+describe("SkillService.getPackageBytes — object-level authorization (#806/#1196)", () => {
+  it("private skill + stranger actor throws skill_not_found before any download", async () => {
+    let downloaded = false;
+    const storageClient = {
+      downloadObject: async () => {
+        downloaded = true;
+        return { bytes: new Uint8Array(), contentType: "application/zip" };
+      },
+    } as unknown as IStorageClient;
+    const skill = makeSkillDoc({ isPrivate: true });
+    const service = new SkillService({
+      skillRepo: {
+        findByGuid: async () => skill,
+        findByName: async () => null,
+      } as unknown as SkillRepository,
+      skillVersionRepo: {} as unknown as SkillVersionRepository,
+      storageClient,
+      storageBucketResolver: async () => "test-bucket",
+    });
+
+    let thrown: unknown;
+    try {
+      await service.getPackageBytes("guid-1", STRANGER);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).code).toBe("skill_not_found");
+    // Gate runs before storage — no package download was ever requested.
+    expect(downloaded).toBe(false);
+  });
+
+  it("public skill returns package bytes + name/version for a stranger", async () => {
+    const bytes = await zipBytes();
+    const service = makeService(makeSkillDoc({ isPrivate: false }), bytes);
+    const result = await service.getPackageBytes("guid-1", STRANGER);
+    expect(result.name).toBe("demo-skill");
+    expect(result.version).toBe("1.0");
+    expect(Array.from(result.bytes)).toEqual(Array.from(bytes));
+  });
+
+  it("private skill succeeds for the author", async () => {
+    const bytes = await zipBytes();
+    const service = makeService(makeSkillDoc({ isPrivate: true, createdBy: "owner-1" }), bytes);
+    const result = await service.getPackageBytes("guid-1", OWNER);
+    expect(Array.from(result.bytes)).toEqual(Array.from(bytes));
+  });
+
+  it("private skill succeeds for SYSTEM_ACTOR (audit pipeline path)", async () => {
+    const bytes = await zipBytes();
+    const service = makeService(makeSkillDoc({ isPrivate: true }), bytes);
+    const result = await service.getPackageBytes("guid-1", SYSTEM_ACTOR);
+    expect(Array.from(result.bytes)).toEqual(Array.from(bytes));
+  });
+});
+
 /**
  * #807 (CWE-22) — `extractSkillInfoLenient` is the `skip_validation=true`
  * import path. It used to accept ANY non-empty `name`, including

--- a/ornn-api/src/domains/skills/crud/service.ts
+++ b/ornn-api/src/domains/skills/crud/service.ts
@@ -1272,18 +1272,21 @@ export class SkillService {
   }
 
   private async downloadPackage(storageKey: string): Promise<Uint8Array> {
-    const presigned = await this.storageClient.getPresignedUrl(
-      (await this.storageBucketResolver()),
-      storageKey,
-    );
-    const res = await fetch(presigned.presignedUrl);
-    if (!res.ok) {
+    // Proxied through chrono-bucket's streaming download (#1196). The storage
+    // client throws on a non-2xx, which we surface as `package_download_failed`
+    // to keep the existing error contract for internal byte-consumers.
+    try {
+      const { bytes } = await this.storageClient.downloadObject(
+        (await this.storageBucketResolver()),
+        storageKey,
+      );
+      return bytes;
+    } catch (err) {
       throw AppError.internalError(
         "package_download_failed",
-        `Failed to download package for key '${storageKey}' (HTTP ${res.status})`,
+        `Failed to download package for key '${storageKey}': ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-    return new Uint8Array(await res.arrayBuffer());
   }
 
   /**
@@ -1509,44 +1512,16 @@ export class SkillService {
       throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
     }
 
-    // 1a. Resolve the requested version (literal or dist-tag, #463).
-    //     When unset OR empty-string, fall through to the skill doc's
-    //     latest storage. `resolveDistTag` returns `undefined` for
-    //     empty input, which we treat as "no pin requested".
-    let resolvedVersion = skill.latestVersion;
-    let storageKey = skill.storageKey;
-    let metadata: SkillMetadata = skill.metadata;
-    if (version !== undefined && version.length > 0) {
-      const literal = resolveDistTag(skill, version);
-      if (!literal) {
-        // Defensive — resolveDistTag's contract returns string for any
-        // non-empty input, but the type system widens to `| undefined`.
-        // Treat as malformed rather than crash.
-        throw AppError.badRequest(
-          "invalid_version",
-          `Could not resolve version '${version}'`,
-        );
-      }
-      parseVersion(literal); // 400 if malformed, before Mongo lookup
-      const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, literal);
-      if (!versionDoc) {
-        throw AppError.notFound(
-          "skill_version_not_found",
-          `Version '${literal}' not found for skill '${skill.name}'`,
-        );
-      }
-      resolvedVersion = versionDoc.version;
-      storageKey = versionDoc.storageKey;
-      metadata = versionDoc.metadata;
-    }
+    // 1a. Resolve the requested version (literal or dist-tag, #463) to its
+    //     concrete version + storage key + metadata. Empty/undefined → latest.
+    const { resolvedVersion, storageKey, metadata } = await this.resolveVersionStorage(
+      skill,
+      version,
+    );
 
-    // 2. Download ZIP from storage
-    const presigned = await this.storageClient.getPresignedUrl((await this.storageBucketResolver()), storageKey);
-    const response = await fetch(presigned.presignedUrl);
-    if (!response.ok) {
-      throw AppError.internalError("package_download_failed", "Failed to download skill package from storage");
-    }
-    const zipBuffer = new Uint8Array(await response.arrayBuffer());
+    // 2. Download the ZIP from storage, proxied through chrono-bucket's
+    //    streaming endpoint (#1196) — no presigned URL / direct MinIO fetch.
+    const zipBuffer = await this.downloadPackage(storageKey);
 
     // 3. Extract all files
     const zip = await JSZip.loadAsync(zipBuffer);
@@ -1596,6 +1571,80 @@ export class SkillService {
       metadata: metadata as unknown as Record<string, unknown>,
       files,
     };
+  }
+
+  /**
+   * Resolve a requested version (literal or dist-tag; empty/undefined →
+   * latest) to its concrete version string, storage key, and metadata.
+   * Shared by the package-content read paths (getSkillJson, getPackageBytes)
+   * so version resolution lives in one place (#463, #1196).
+   */
+  private async resolveVersionStorage(
+    skill: SkillDocument,
+    version?: string,
+  ): Promise<{ resolvedVersion: string; storageKey: string; metadata: SkillMetadata }> {
+    if (version === undefined || version.length === 0) {
+      return {
+        resolvedVersion: skill.latestVersion,
+        storageKey: skill.storageKey,
+        metadata: skill.metadata,
+      };
+    }
+    const literal = resolveDistTag(skill, version);
+    if (!literal) {
+      // Defensive — resolveDistTag returns a string for any non-empty input,
+      // but the type system widens to `| undefined`.
+      throw AppError.badRequest("invalid_version", `Could not resolve version '${version}'`);
+    }
+    parseVersion(literal); // 400 if malformed, before the Mongo lookup
+    const versionDoc = await this.skillVersionRepo.findBySkillAndVersion(skill.guid, literal);
+    if (!versionDoc) {
+      throw AppError.notFound(
+        "skill_version_not_found",
+        `Version '${literal}' not found for skill '${skill.name}'`,
+      );
+    }
+    return {
+      resolvedVersion: versionDoc.version,
+      storageKey: versionDoc.storageKey,
+      metadata: versionDoc.metadata,
+    };
+  }
+
+  /**
+   * Resolve a skill version's package ZIP bytes from storage.
+   *
+   * Enforces the same object-level visibility gate as the metadata / json
+   * paths (#806): a private skill the actor cannot read 404s as
+   * `skill_not_found` before any storage read. `version` may be a literal or
+   * dist-tag; empty/undefined → latest. Bytes are streamed from chrono-bucket
+   * via the storage client — no presigned URL ever leaves the server (#1196).
+   * Backs `GET /skills/:idOrName/versions/:version/download` and the audit
+   * pipeline. Trusted server jobs pass `SYSTEM_ACTOR`.
+   */
+  async getPackageBytes(
+    idOrName: string,
+    actor: ActorContext,
+    version?: string,
+  ): Promise<{ bytes: Uint8Array; name: string; version: string }> {
+    let skill = await this.skillRepo.findByGuid(idOrName);
+    if (!skill) skill = await this.skillRepo.findByName(idOrName);
+    if (!skill) {
+      throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+    }
+    if (!canReadSkill(skill, actor)) {
+      logger.info({ idOrName, actorUserId: actor.userId }, "getPackageBytes visibility denied");
+      throw AppError.notFound("skill_not_found", `Skill '${idOrName}' not found`);
+    }
+    const { resolvedVersion, storageKey } = await this.resolveVersionStorage(skill, version);
+    if (!storageKey) {
+      throw AppError.notFound(
+        "skill_package_not_found",
+        `No package stored for skill '${skill.name}'`,
+      );
+    }
+    const bytes = await this.downloadPackage(storageKey);
+    return { bytes, name: skill.name, version: resolvedVersion };
   }
 
   /**
@@ -2143,7 +2192,10 @@ export class SkillService {
         (await this.skillVersionRepo.findLatestBySkill(skill.guid)) ?? undefined;
     }
 
-    const storageKey = effectiveOverlay?.storageKey ?? skill.storageKey;
+    // Package downloads are proxied through `GET /skills/:idOrName/versions/
+    // :version/download` (#1196); the detail response no longer carries a
+    // presigned URL, so there is no per-read storage round-trip here and no
+    // direct-to-MinIO URL ever reaches a client.
     const metadata = effectiveOverlay?.metadata ?? skill.metadata;
     const skillHash = effectiveOverlay?.skillHash ?? skill.skillHash;
     const license = effectiveOverlay ? effectiveOverlay.license : skill.license;
@@ -2151,16 +2203,6 @@ export class SkillService {
     const version = effectiveOverlay?.version ?? skill.latestVersion;
     const isDeprecated = effectiveOverlay?.isDeprecated === true;
     const deprecationNote = effectiveOverlay?.deprecationNote ?? null;
-
-    let presignedPackageUrl = "";
-    if (storageKey) {
-      try {
-        const result = await this.storageClient.getPresignedUrl((await this.storageBucketResolver()), storageKey);
-        presignedPackageUrl = result.presignedUrl;
-      } catch (err) {
-        logger.warn({ guid: skill.guid, version, err }, "Presigned URL generation failed");
-      }
-    }
 
     const tags: string[] = metadata?.tags ?? [];
 
@@ -2173,7 +2215,6 @@ export class SkillService {
       metadata: metadata as unknown as Record<string, unknown>,
       tags,
       skillHash,
-      presignedPackageUrl,
       isPrivate: skill.isPrivate,
       createdBy: skill.createdBy,
       createdByEmail: skill.createdByEmail,

--- a/ornn-api/src/domains/skills/crud/types/api.ts
+++ b/ornn-api/src/domains/skills/crud/types/api.ts
@@ -14,7 +14,6 @@ export interface SkillDetailResponse {
   metadata: Record<string, unknown>;
   tags: string[];
   skillHash: string;
-  presignedPackageUrl: string;
   isPrivate: boolean;
   createdBy: string;
   createdOn: string;

--- a/ornn-api/src/openapi/schemas.ts
+++ b/ornn-api/src/openapi/schemas.ts
@@ -66,7 +66,6 @@ export const skillDetailResponseSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).describe("Structured skill metadata including category, outputType, runtimes, tools, and tags. See skill format spec for full schema"),
   tags: z.array(z.string()).describe("List of tag names for categorization and search filtering"),
   skillHash: z.string().describe("SHA-256 hash of the skill package contents. Changes when the skill is updated"),
-  presignedPackageUrl: z.string().describe("Temporary pre-signed URL to download the skill package ZIP file. Expires after a short period"),
   isPrivate: z.boolean().describe("If true, only the owner can view and use this skill. If false, the skill is publicly listed in the registry"),
   createdBy: z.string().describe("Email address of the user who created the skill"),
   createdOn: z.string().describe("ISO 8601 timestamp of when the skill was created"),

--- a/ornn-api/src/openapi/specBuilder.ts
+++ b/ornn-api/src/openapi/specBuilder.ts
@@ -126,7 +126,7 @@ function skillReadPath(_prefix: string): PathItem {
   return {
     get: {
       summary: "Get skill by GUID or name",
-      description: "Retrieve full details of a single skill by its UUID or unique name. Returns metadata, tags, package download URL, visibility status, and timestamps. The presignedPackageUrl can be used to download the raw ZIP package. For accessing individual file contents without downloading the ZIP, use the /json endpoint instead.",
+      description: "Retrieve full details of a single skill by its UUID or unique name. Returns metadata, tags, visibility status, and timestamps. To download the raw ZIP package use GET /skills/{idOrName}/versions/{version}/download; for individual file contents without downloading the ZIP, use the /json endpoint instead.",
       operationId: "getSkill",
       tags: ["Skills"],
       security: bearerAuth(),
@@ -146,6 +146,29 @@ function skillJsonPath(_prefix: string): PathItem {
       security: bearerAuth(),
       parameters: [pathParam("idOrName", "Skill UUID (e.g. '550e8400-e29b-41d4-a716-446655440000') or unique skill name (e.g. 'web-summarizer')")],
       responses: { ...jsonResponse(S.skillJsonApiResponse), ...errorResponses(401, 404) },
+    },
+  };
+}
+
+function skillDownloadPath(_prefix: string): PathItem {
+  return {
+    get: {
+      summary: "Download a skill version's package ZIP",
+      description: "Stream the raw ZIP package for a specific skill version. Bytes are proxied from object storage through ornn-api — clients never talk to the storage backend directly. `version` may be a literal (e.g. '1.2') or a dist-tag (e.g. 'latest'). Returns application/zip on success; a private skill the caller cannot read returns 404 (existence is not leaked).",
+      operationId: "downloadSkillPackage",
+      tags: ["Skills"],
+      security: bearerAuth(),
+      parameters: [
+        pathParam("idOrName", "Skill UUID or unique skill name"),
+        pathParam("version", "Version literal (e.g. '1.2') or dist-tag (e.g. 'latest')"),
+      ],
+      responses: {
+        200: {
+          description: "The raw skill package ZIP bytes",
+          content: { "application/zip": { schema: { type: "string", format: "binary" } } },
+        },
+        ...errorResponses(401, 404),
+      },
     },
   };
 }
@@ -453,6 +476,7 @@ export function buildSpec(): OpenApiSpec {
       [`${prefix}/skills`]: skillUploadPath(prefix),
       [`${prefix}/skills/{idOrName}`]: skillReadPath(prefix),
       [`${prefix}/skills/{idOrName}/json`]: skillJsonPath(prefix),
+      [`${prefix}/skills/{idOrName}/versions/{version}/download`]: skillDownloadPath(prefix),
       [`${prefix}/skills/{id}`]: {
         ...skillUpdatePath(prefix),
         ...skillDeletePath(prefix),

--- a/ornn-api/src/shared/types/index.ts
+++ b/ornn-api/src/shared/types/index.ts
@@ -391,7 +391,8 @@ export interface SkillDetailResponse {
   metadata: Record<string, unknown>;
   tags: string[];
   skillHash: string;
-  presignedPackageUrl: string;
+  // Package bytes are fetched via `GET /skills/:idOrName/versions/:version/
+  // download` (#1196) — the response no longer carries a presigned URL.
   isPrivate: boolean;
   createdBy: string;
   // Optionals widen to `T | undefined` for exactOptionalPropertyTypes (#657).

--- a/ornn-web/src/components/skill/AdvancedOptionsModal.test.tsx
+++ b/ornn-web/src/components/skill/AdvancedOptionsModal.test.tsx
@@ -105,7 +105,6 @@ function skill(overrides: Partial<SkillDetail>): SkillDetail {
     isPrivate: false,
     tags: [],
     updatedOn: "2026-05-01T00:00:00.000Z",
-    presignedPackageUrl: "",
     metadata: {},
     version: "1.0.0",
     sharedWithUsers: [],

--- a/ornn-web/src/components/skill/PermissionsModal.test.tsx
+++ b/ornn-web/src/components/skill/PermissionsModal.test.tsx
@@ -69,7 +69,6 @@ function skill(overrides: Partial<SkillDetail> = {}): SkillDetail {
     isPrivate: true,
     tags: [],
     updatedOn: "2026-05-01T00:00:00.000Z",
-    presignedPackageUrl: "",
     metadata: {},
     version: "1.0",
     sharedWithUsers: [],

--- a/ornn-web/src/components/skill/SkillInstallCard.test.tsx
+++ b/ornn-web/src/components/skill/SkillInstallCard.test.tsx
@@ -42,7 +42,6 @@ function makeSkill(overrides: Partial<SkillDetail> = {}): SkillDetail {
     isPrivate: false,
     tags: ["pdf"],
     updatedOn: "2026-06-01T00:00:00.000Z",
-    presignedPackageUrl: "https://example.com/pkg.zip",
     metadata: {},
     version: "1.0.0",
     sharedWithUsers: [],

--- a/ornn-web/src/components/skill/TransferOwnershipModal.test.tsx
+++ b/ornn-web/src/components/skill/TransferOwnershipModal.test.tsx
@@ -68,7 +68,6 @@ function skill(overrides: Partial<SkillDetail> = {}): SkillDetail {
     isPrivate: true,
     tags: [],
     updatedOn: "2026-05-01T00:00:00.000Z",
-    presignedPackageUrl: "",
     metadata: {},
     version: "1.0",
     sharedWithUsers: [],

--- a/ornn-web/src/components/skillset/SkillsetMemberViewer.test.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberViewer.test.tsx
@@ -32,7 +32,7 @@ const MEMBERS = ["alpha@1.0", "beta@2.1"];
 
 beforeEach(() => {
   useSkill.mockReturnValue({
-    data: { presignedPackageUrl: "https://signed/pkg.zip" },
+    data: { guid: "alpha-guid", version: "1.0" },
     isLoading: false,
     error: null,
   });

--- a/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
+++ b/ornn-web/src/components/skillset/SkillsetMemberViewer.tsx
@@ -8,8 +8,9 @@
  *
  * Data path (all read-only — NO skill mutation, NO closure write):
  *   member ref `name@version`
- *     → `useSkill(name, version)`        → SkillDetail (carries presigned URL)
- *     → `useSkillPackage(presignedUrl)`  → FileNode tree + text contents map
+ *     → `useSkill(name, version)`         → SkillDetail (guid + version)
+ *     → `useSkillPackage(guid, version)`  → FileNode tree + text contents map
+ *                                           (proxied ornn-api download, #1196)
  *     → `<SkillPackagePreview>`          → file tree + viewer
  *
  * ACL is enforced upstream: a member the caller can't see (private / removed)
@@ -52,7 +53,7 @@ export function SkillsetMemberViewer({ members, previewRef }: SkillsetMemberView
     fileContents,
     isLoading: pkgLoading,
     error: pkgError,
-  } = useSkillPackage(skill?.presignedPackageUrl);
+  } = useSkillPackage(skill?.guid, skill?.version);
 
   const loading = skillLoading || (!!skill && pkgLoading);
 

--- a/ornn-web/src/hooks/usePlaygroundSession.ts
+++ b/ornn-web/src/hooks/usePlaygroundSession.ts
@@ -49,7 +49,7 @@ export function usePlaygroundSession(skillName: string | null) {
     files: packageFiles,
     fileContents: packageContents,
     isLoading: packageLoading,
-  } = useSkillPackage(skill?.presignedPackageUrl);
+  } = useSkillPackage(skill?.guid, skill?.version);
 
   // ── Env vars ────────────────────────────────────────────────────────
   const envVarKeys = useMemo(

--- a/ornn-web/src/hooks/useSkillDetail.ts
+++ b/ornn-web/src/hooks/useSkillDetail.ts
@@ -118,7 +118,7 @@ export function useSkillDetail(idOrName: string | undefined) {
     rawZip,
     isLoading: packageLoading,
     error: packageError,
-  } = useSkillPackage(skill?.presignedPackageUrl);
+  } = useSkillPackage(skill?.guid, skill?.version);
 
   // Three access tiers (#1127) from the shared hook — `canWrite` is what
   // lets a write-grantee (not just the owner) see the content-edit UI.

--- a/ornn-web/src/hooks/useSkillPackage.test.ts
+++ b/ornn-web/src/hooks/useSkillPackage.test.ts
@@ -1,0 +1,60 @@
+/**
+ * useSkillPackage — guards the proxied download call (#1196).
+ *
+ * The hook fetches a skill version's ZIP through ornn-api's authenticated
+ * download route. The path MUST carry the `/api/v1` prefix like every other
+ * apiClient call — a missing prefix silently 404s at the NyxID proxy (the bug
+ * that shipped in the first cut, invisible because component tests mock this
+ * hook wholesale).
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const apiGetBinary = vi.fn();
+vi.mock("@/services/apiClient", () => ({
+  apiGetBinary: (...a: unknown[]) => apiGetBinary(...a),
+  ApiClientError: class ApiClientError extends Error {
+    statusCode = 0;
+  },
+}));
+
+const loadAsync = vi.fn();
+vi.mock("jszip", () => ({
+  default: { loadAsync: (...a: unknown[]) => loadAsync(...a) },
+}));
+
+import { useSkillPackage } from "./useSkillPackage";
+
+describe("useSkillPackage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGetBinary.mockResolvedValue(new ArrayBuffer(8));
+    // Minimal JSZip stub: an empty archive (forEach yields nothing).
+    loadAsync.mockResolvedValue({ forEach: () => {} });
+  });
+
+  it("downloads via the /api/v1 proxied route using guid + version", async () => {
+    renderHook(() => useSkillPackage("guid-123", "1.2"));
+    await waitFor(() =>
+      expect(apiGetBinary).toHaveBeenCalledWith(
+        "/api/v1/skills/guid-123/versions/1.2/download",
+      ),
+    );
+  });
+
+  it("encodes guid/version and never omits the /api/v1 prefix", async () => {
+    renderHook(() => useSkillPackage("a/b", "latest"));
+    await waitFor(() =>
+      expect(apiGetBinary).toHaveBeenCalledWith(
+        "/api/v1/skills/a%2Fb/versions/latest/download",
+      ),
+    );
+  });
+
+  it("does not fetch until both guid and version are present", () => {
+    renderHook(() => useSkillPackage(undefined, "1.2"));
+    renderHook(() => useSkillPackage("guid-123", undefined));
+    expect(apiGetBinary).not.toHaveBeenCalled();
+  });
+});

--- a/ornn-web/src/hooks/useSkillPackage.ts
+++ b/ornn-web/src/hooks/useSkillPackage.ts
@@ -6,6 +6,7 @@ import {
   type FileTreeEntry,
 } from "@/utils/fileTreeBuilder";
 import { encodeErrorPayload } from "@/utils/translateError";
+import { apiGetBinary, ApiClientError } from "@/services/apiClient";
 
 /** Extensions treated as viewable text files */
 const TEXT_EXTENSIONS = new Set([
@@ -56,11 +57,13 @@ interface UseSkillPackageResult {
 }
 
 /**
- * Fetches a skill ZIP from a presigned URL, extracts it with JSZip,
- * and returns a FileNode tree + text file contents map.
+ * Fetches a skill version's ZIP from the ornn-api proxied download endpoint
+ * (#1196 — no direct chrono-bucket / presigned-URL fetch), extracts it with
+ * JSZip, and returns a FileNode tree + text file contents map.
  */
 export function useSkillPackage(
-  presignedUrl: string | undefined,
+  guid: string | undefined,
+  version: string | undefined,
 ): UseSkillPackageResult {
   const [files, setFiles] = useState<FileNode[]>([]);
   const [fileContents, setFileContents] = useState<Map<string, string>>(
@@ -71,7 +74,7 @@ export function useSkillPackage(
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!presignedUrl) return;
+    if (!guid || !version) return;
 
     let cancelled = false;
 
@@ -80,17 +83,9 @@ export function useSkillPackage(
       setError(null);
 
       try {
-        const response = await fetch(presignedUrl!);
-        if (!response.ok) {
-          throw new Error(
-            encodeErrorPayload({
-              key: "errors.api.skillPackage.downloadFailed",
-              params: { status: response.status },
-            }),
-          );
-        }
-
-        const buffer = await response.arrayBuffer();
+        const buffer = await apiGetBinary(
+          `/skills/${encodeURIComponent(guid!)}/versions/${encodeURIComponent(version!)}/download`,
+        );
         const zip = await JSZip.loadAsync(buffer);
 
         const entries: FileTreeEntry[] = [];
@@ -145,10 +140,18 @@ export function useSkillPackage(
         }
       } catch (err) {
         if (!cancelled) {
+          // A non-2xx from the proxied download surfaces as ApiClientError;
+          // map it to the same translated "download failed" payload the old
+          // direct-fetch path used, preserving the status code.
           setError(
-            err instanceof Error
-              ? err.message
-              : "errors.api.skillPackage.loadFailed",
+            err instanceof ApiClientError
+              ? encodeErrorPayload({
+                  key: "errors.api.skillPackage.downloadFailed",
+                  params: { status: err.statusCode },
+                })
+              : err instanceof Error
+                ? err.message
+                : "errors.api.skillPackage.loadFailed",
           );
         }
       } finally {
@@ -163,7 +166,7 @@ export function useSkillPackage(
     return () => {
       cancelled = true;
     };
-  }, [presignedUrl]);
+  }, [guid, version]);
 
   return { files, fileContents, rawZip, isLoading, error };
 }

--- a/ornn-web/src/hooks/useSkillPackage.ts
+++ b/ornn-web/src/hooks/useSkillPackage.ts
@@ -84,7 +84,7 @@ export function useSkillPackage(
 
       try {
         const buffer = await apiGetBinary(
-          `/skills/${encodeURIComponent(guid!)}/versions/${encodeURIComponent(version!)}/download`,
+          `/api/v1/skills/${encodeURIComponent(guid!)}/versions/${encodeURIComponent(version!)}/download`,
         );
         const zip = await JSZip.loadAsync(buffer);
 

--- a/ornn-web/src/services/apiClient.ts
+++ b/ornn-web/src/services/apiClient.ts
@@ -164,13 +164,16 @@ async function handleResponse<T>(response: Response): Promise<ApiResponse<T>> {
 }
 
 /**
- * Execute fetch with proactive token refresh and automatic retry on 401/403.
+ * Execute fetch with proactive token refresh and automatic retry on 401,
+ * returning the raw Response. Shared by the JSON (`fetchWithRetry`) and binary
+ * (`apiGetBinary`) request paths so the auth / refresh / redirect-to-login
+ * logic lives in exactly one place.
  */
-async function fetchWithRetry<T>(
+async function rawFetchWithRetry(
   url: string,
   options: RequestInit,
   retried: boolean = false,
-): Promise<ApiResponse<T>> {
+): Promise<Response> {
   // Proactively refresh expired tokens before sending the request
   if (!retried && getAccessToken()) {
     await useAuthStore.getState().ensureFreshToken();
@@ -197,7 +200,7 @@ async function fetchWithRetry<T>(
           Authorization: `Bearer ${getAccessToken()}`,
         };
 
-        return fetchWithRetry<T>(url, { ...options, headers: newHeaders }, true);
+        return rawFetchWithRetry(url, { ...options, headers: newHeaders }, true);
       }
 
       // Refresh failed for an authenticated user, redirect to login
@@ -209,7 +212,17 @@ async function fetchWithRetry<T>(
     // Anonymous user got 401 — don't redirect, just let the error propagate
   }
 
-  return handleResponse<T>(response);
+  return response;
+}
+
+/**
+ * Execute fetch with retry and parse the JSON `{ data, error }` envelope.
+ */
+async function fetchWithRetry<T>(
+  url: string,
+  options: RequestInit,
+): Promise<ApiResponse<T>> {
+  return handleResponse<T>(await rawFetchWithRetry(url, options));
 }
 
 /**
@@ -223,6 +236,27 @@ export async function apiGet<T>(
     method: "GET",
     headers: createHeaders(),
   });
+}
+
+/**
+ * GET request returning the raw response bytes (auth + refresh applied), for
+ * binary endpoints such as the skill-package download (#1196). Proxies the
+ * bytes through ornn-api so clients never fetch the storage backend directly.
+ * Throws `ApiClientError` on a non-2xx (parsing the RFC 7807 / envelope body).
+ */
+export async function apiGetBinary(
+  path: string,
+  params?: Record<string, string | number | boolean | undefined>,
+): Promise<ArrayBuffer> {
+  const res = await rawFetchWithRetry(buildUrl(path, params), {
+    method: "GET",
+    headers: createHeaders(),
+  });
+  if (!res.ok) {
+    // handleResponse always throws for a non-2xx — reuse its error parsing.
+    await handleResponse<unknown>(res);
+  }
+  return res.arrayBuffer();
 }
 
 /**

--- a/ornn-web/src/types/domain.ts
+++ b/ornn-web/src/types/domain.ts
@@ -70,7 +70,6 @@ export interface SkillGrant {
 
 export interface SkillDetail extends SkillSummary {
   updatedOn: string;
-  presignedPackageUrl: string;
   metadata: Record<string, unknown>;
   /** Version of the currently-returned payload (latest by default). */
   version: string;


### PR DESCRIPTION
## Summary

Adapts ornn to **chrono-bucket** (the new object-storage backend replacing chrono-storage). chrono-bucket is a NyxID resource server that **removed the presigned-URL and object-copy endpoints** and now streams downloads via `GET /api/buckets/:bucket/objects/download?key=` behind the NyxID proxy. This PR swaps the storage-read primitive, adds a proxied download route through ornn-api, and stops leaking a direct storage URL to clients.

## What changed

**Backend (`ornn-api`)**
- `StorageClient`: add streaming `downloadObject()`; remove the now-dead `getPresignedUrl()` and `copy()` (copy had no callers).
- `SkillService`: internal byte reads (diff / `/json` / rescan) go through `downloadObject`; add a gated `getPackageBytes()` that funnels version→storageKey resolution + the object-level visibility gate (shared with `getSkillJson`); `buildDetailResponse` stops minting a presigned URL and **drops `SkillDetailResponse.presignedPackageUrl`** — no direct-to-storage URL reaches a client, and the hot detail-read path loses a per-read storage round-trip.
- **New route `GET /skills/:idOrName/versions/:version/download`** — streams the ZIP through ornn-api (`application/zip`, attachment; RFC 7807 on error). This is the exact route the TS SDK's `downloadPackage()` already targeted but which was never registered. `optionalAuth`; the visibility gate lives in `getPackageBytes` (private skills 404 without leaking existence; public skills download anonymously). No analytics pull is recorded — the endpoint also backs the web file-tree viewer, so counting UI views would inflate the pull metric.
- `AuditService`: fetch package bytes via `skillService.getPackageBytes(guid, SYSTEM_ACTOR)` instead of the skill doc's presigned URL — removing the wasted presigned round-trip and cast-riddled fallback (**#995**).
- OpenAPI schema + spec updated (field removed, download path documented).

**Frontend (`ornn-web`)**
- `apiClient`: extract `rawFetchWithRetry` (auth + refresh + 401-retry in one place) and add `apiGetBinary()`, an authenticated GET returning raw bytes.
- `useSkillPackage(guid, version)` fetches the proxied route via `apiGetBinary` + JSZip instead of `fetch(presignedUrl)`; callers (`useSkillDetail`, `usePlaygroundSession`, `SkillsetMemberViewer`) repointed at `skill.guid`/`skill.version`; `presignedPackageUrl` dropped from the `SkillDetail` type. Every live download surface (file-tree viewer + hero "Download package") now routes through ornn-api.

## Testing

- `ornn-api` full suite green (incl. new download-route tests + a real-service regression guard on the `getPackageBytes` visibility gate); `ornn-web` (Vitest) and TS SDK suites green; typecheck (api/web/sdk) + ESLint clean.
- A multi-agent adversarial review of the diff surfaced one test-coverage gap on the new anonymous-reachable gate, now closed by the added guard.

## Note

The **runtime cutover is separate**: NyxID's proxy node must be repointed to chrono-bucket and ornn granted `chrono-bucket-user` + `ornn`-bucket ownership before downloads function end-to-end. This PR is the code adaptation only.

Closes #1196
Closes #995
