### PR TITLE
Add FKST-native full-test profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist/
 coverage/
+.testing/
 .env
 .env.*
 !.env.sample.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       # PostHog telemetry off by default in compose.
       POSTHOG_ENABLED: "false"
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3802/livez || exit 1"]
+      test: ["CMD-SHELL", "bun -e \"fetch('http://localhost:3802/livez').then((res) => process.exit(res.ok ? 0 : 1)).catch(() => process.exit(1))\""]
       interval: 10s
       timeout: 5s
       retries: 6

--- a/scripts/ornn-fkst-native-full.sh
+++ b/scripts/ornn-fkst-native-full.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FKST_PACKAGES_TESTING_ROOT="${FKST_PACKAGES_TESTING_ROOT:-/Users/hayleewang/Documents/Projects/fkst-packages-testing}"
+PACKAGE_ROOT="$ROOT/testing/fkst/ornn-native-full"
+ORNN_API_BASE_URL="${ORNN_API_BASE_URL:-http://localhost:3802}"
+ORNN_WEB_BASE_URL="${ORNN_WEB_BASE_URL:-http://localhost:5173}"
+ORNN_CDP_URL="${ORNN_CDP_URL:-http://127.0.0.1:9222}"
+ORNN_FKST_PROFILE="${ORNN_FKST_PROFILE:-public}"
+ORNN_COMPOSE_PROJECT_NAME="${ORNN_COMPOSE_PROJECT_NAME:-ornn}"
+
+export ORNN_API_BASE_URL ORNN_WEB_BASE_URL ORNN_CDP_URL ORNN_FKST_PROFILE ORNN_COMPOSE_PROJECT_NAME
+
+fail() {
+  echo "ornn-fkst: $*" >&2
+  exit 1
+}
+
+require_dir() {
+  [ -d "$1" ] || fail "missing directory: $1"
+}
+
+if [ "$ORNN_FKST_PROFILE" != "public" ]; then
+  fail "only ORNN_FKST_PROFILE=public is enabled; auth/admin require safe host session fixtures"
+fi
+
+require_dir "$FKST_PACKAGES_TESTING_ROOT"
+require_dir "$PACKAGE_ROOT"
+
+wait_url() {
+  local url="$1" label="$2" attempt
+  for attempt in $(seq 1 60); do
+    if curl -fsS --max-time 5 "$url" >/dev/null; then
+      echo "ornn-fkst: ready $label $url"
+      return 0
+    fi
+    sleep 2
+  done
+  fail "timed out waiting for $label at $url"
+}
+
+resolve_bin() {
+  if [ -n "${BIN:-}" ] && [ -x "$BIN" ]; then
+    printf '%s\n' "$BIN"
+    return 0
+  fi
+
+  if [ -f "$FKST_PACKAGES_TESTING_ROOT/.env" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    . "$FKST_PACKAGES_TESTING_ROOT/.env"
+    set +a
+    if [ -n "${BIN:-}" ] && [ -x "$BIN" ]; then
+      printf '%s\n' "$BIN"
+      return 0
+    fi
+  fi
+
+  if command -v fkst-framework >/dev/null 2>&1; then
+    command -v fkst-framework
+    return 0
+  fi
+
+  local sibling="$FKST_PACKAGES_TESTING_ROOT/../fkst-substrate/target/debug/fkst-framework"
+  if [ -x "$sibling" ]; then
+    printf '%s\n' "$sibling"
+    return 0
+  fi
+
+  local bootstrap="$FKST_PACKAGES_TESTING_ROOT/.fkst/run/fkst-packages-conformance/scripts/bin_bootstrap.sh"
+  if [ -f "$bootstrap" ]; then
+    # shellcheck source=/dev/null
+    . "$bootstrap"
+    if resolve_bin_contract "$FKST_PACKAGES_TESTING_ROOT" "bootstrap"; then
+      printf '%s\n' "$RESOLVED_BIN"
+      return 0
+    fi
+  fi
+
+  fail "set BIN to an executable fkst-framework or run $FKST_PACKAGES_TESTING_ROOT/scripts/run.sh test testing-runner once"
+}
+
+copy_tree() {
+  local src="$1" dest="$2" exclude_tests="${3:-0}"
+  mkdir -p "$dest"
+  if [ "$exclude_tests" = "1" ]; then
+    (cd "$src" && LC_ALL=C tar --exclude './tests' --exclude './tests/*' --exclude 'tests' --exclude 'tests/*' -cf - .) | (cd "$dest" && LC_ALL=C tar xf -)
+    rm -rf "$dest/tests"
+  else
+    (cd "$src" && LC_ALL=C tar -cf - .) | (cd "$dest" && LC_ALL=C tar xf -)
+  fi
+}
+
+build_workspace() {
+  local work lib pkg
+  work="$(mktemp -d "${TMPDIR:-/tmp}/ornn-fkst-native.XXXXXX")"
+  mkdir -p "$work/packages" "$work/libraries"
+  cat > "$work/fkst.workspace.toml" <<'TOML'
+[workspace]
+units = ["packages/*", "libraries/*"]
+packages = ["packages/*"]
+libraries = ["libraries/*"]
+
+[registries]
+workspace = "workspace"
+TOML
+
+  for lib in "$FKST_PACKAGES_TESTING_ROOT"/libraries/*/; do
+    [ -d "$lib" ] || continue
+    copy_tree "${lib%/}" "$work/libraries/$(basename "$lib")" 0
+  done
+
+  copy_tree "$PACKAGE_ROOT" "$work/packages/ornn-native-full" 0
+  for pkg in browser-readiness testing-pipeline module-test-loop testing-runner test-artifacts test-publication; do
+    copy_tree "$FKST_PACKAGES_TESTING_ROOT/packages/$pkg" "$work/packages/$pkg" 1
+  done
+  printf '%s\n' "$work"
+}
+
+run_fkst_profile_tests() {
+  local bin="$1" work="$2"
+  "$bin" test \
+    --project-root "$work" \
+    --package-root "$work/packages/ornn-native-full" \
+    --package-root "$work/packages/browser-readiness" \
+    --package-root "$work/packages/testing-pipeline" \
+    --package-root "$work/packages/module-test-loop" \
+    --package-root "$work/packages/testing-runner" \
+    --package-root "$work/packages/test-artifacts" \
+    --package-root "$work/packages/test-publication"
+}
+
+cd "$ROOT"
+
+echo "ornn-fkst: starting Docker Compose services"
+docker compose -p "$ORNN_COMPOSE_PROJECT_NAME" up --build -d mongodb minio ornn-api ornn-web
+
+wait_url "${ORNN_API_BASE_URL%/}/livez" "api livez"
+wait_url "${ORNN_API_BASE_URL%/}/readyz" "api readyz"
+wait_url "${ORNN_WEB_BASE_URL%/}/" "web"
+
+"$PACKAGE_ROOT/bin/ornn-api-public-smoke.sh" "$ORNN_API_BASE_URL"
+
+BIN="$(resolve_bin)"
+WORK="$(build_workspace)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "ornn-fkst: running FKST-native profile tests"
+run_fkst_profile_tests "$BIN" "$WORK"
+
+echo "ornn-fkst: complete; artifacts are under $ROOT/.testing/runs/ornn-*"

--- a/testing/fkst/ornn-native-full/bin/ornn-api-public-smoke.sh
+++ b/testing/fkst/ornn-native-full/bin/ornn-api-public-smoke.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_url="${1:-${ORNN_API_BASE_URL:-http://localhost:3802}}"
+base_url="${base_url%/}"
+
+case "$base_url" in
+  http://localhost:*|http://localhost/*|http://127.0.0.1:*|http://127.0.0.1/*|http://[::1]:*|http://[::1]/*) ;;
+  *)
+    echo "ornn-fkst: API base URL must be local http" >&2
+    exit 2
+    ;;
+esac
+
+for path in /livez /health /readyz /api/v1/openapi.json; do
+  curl -fsS --max-time 10 "$base_url$path" >/dev/null
+done

--- a/testing/fkst/ornn-native-full/fkst.toml
+++ b/testing/fkst/ornn-native-full/fkst.toml
@@ -1,0 +1,12 @@
+kind = "package.composed"
+name = "ornn-native-full"
+persistence_class = "saga"
+
+[code]
+root = "."
+
+[lib_deps]
+libraries = ["workflow", "testkit"]
+
+[event_deps]
+packages = ["browser-readiness", "testing-pipeline", "module-test-loop", "testing-runner", "test-artifacts", "test-publication"]

--- a/testing/fkst/ornn-native-full/ornn_native_full_profile.lua
+++ b/testing/fkst/ornn-native-full/ornn_native_full_profile.lua
@@ -1,0 +1,422 @@
+local M = {}
+
+local max_string = 512
+
+local function env(name)
+  if os == nil or type(os.getenv) ~= "function" then return nil end
+  local value = os.getenv(name)
+  if value == "" then return nil end
+  return value
+end
+
+local function bounded_string(value)
+  return type(value) == "string" and value ~= "" and #value <= max_string
+end
+
+local function dense_list(value)
+  if type(value) ~= "table" then return false end
+  local count = 0
+  for key, _ in pairs(value) do
+    if type(key) ~= "number" or key < 1 or key % 1 ~= 0 then return false end
+    if key > count then count = key end
+  end
+  for index = 1, count do
+    if value[index] == nil then return false end
+  end
+  return true, count
+end
+
+local function safe_artifact_root(value)
+  return bounded_string(value)
+    and value:match("^%.testing/runs/ornn%-[^%z]+$") ~= nil
+    and value:find("..", 1, true) == nil
+end
+
+local function local_url(value)
+  return bounded_string(value)
+    and (value:match("^https?://localhost[:/%?]") ~= nil
+      or value:match("^https?://127%.0%.0%.1[:/%?]") ~= nil
+      or value:match("^https?://%[::1%][:/%?]") ~= nil)
+end
+
+local function origin_from_url(value)
+  if not bounded_string(value) then return nil end
+  local scheme, authority = value:match("^(https?)://([^/%?#]+)")
+  if scheme == nil or authority == nil or authority == "" then return nil end
+  if authority:find("%s") ~= nil or authority:find("\\", 1, true) ~= nil or authority:find("@", 1, true) ~= nil then return nil end
+  return scheme:lower() .. "://" .. authority:lower()
+end
+
+local function normalize_base_url(value)
+  return tostring(value or ""):gsub("/+$", "")
+end
+
+local function join_url(base_url, route)
+  if route == "/" then return normalize_base_url(base_url) .. "/" end
+  return normalize_base_url(base_url) .. route
+end
+
+local function base_scope(value)
+  if origin_from_url(value) == nil then return nil end
+  return tostring(value):gsub("[#?].*$", "")
+end
+
+local function within_base_scope(entry_url, base_url)
+  local scope = base_scope(base_url)
+  if scope == nil or not bounded_string(entry_url) then return false end
+  local clean = entry_url:gsub("[#?].*$", "")
+  if scope:sub(-1) == "/" then return clean:sub(1, #scope) == scope end
+  return clean == scope or clean:sub(1, #scope + 1) == scope .. "/"
+end
+
+local function slug(value)
+  local text = tostring(value or "module")
+  text = text:gsub("^/", "root")
+  text = text:gsub("[^%w%._%-]+", "-")
+  text = text:gsub("%-+", "-")
+  text = text:gsub("^%-", "")
+  text = text:gsub("%-$", "")
+  if text == "" then text = "module" end
+  if #text > 80 then text = text:sub(1, 80) end
+  return text
+end
+
+local function targets_legacy_runner(argv)
+  for _, value in ipairs(argv or {}) do
+    local text = tostring(value)
+    if text:find("agentic_testing", 1, true) ~= nil
+      or text:find("agentic-testing-cli", 1, true) ~= nil
+      or text:find("scripts/fkst-host-module-ui-check", 1, true) ~= nil
+      or text == "fkst-host-module-ui-check"
+      or text:match("/fkst%-host%-module%-ui%-check$") ~= nil then
+      return true
+    end
+  end
+  return false
+end
+
+local function validate_allowed_origins(base_url, origins)
+  local ok, count = dense_list(origins)
+  if not ok or count == 0 or count > 16 then error("ornn-fkst: allowed_origins must be a non-empty bounded dense list") end
+  local base_origin = origin_from_url(base_url)
+  local includes_base = false
+  for _, origin in ipairs(origins) do
+    if not local_url(origin) then error("ornn-fkst: allowed_origins must contain local http origins") end
+    if origin_from_url(origin) == base_origin then includes_base = true end
+  end
+  if not includes_base then error("ornn-fkst: allowed_origins must include base_url origin") end
+end
+
+local function validate_sessions(sessions)
+  local ok, count = dense_list(sessions)
+  if not ok or count == 0 then error("ornn-fkst: sessions must be a non-empty dense list") end
+  for _, session in ipairs(sessions) do
+    if type(session) ~= "table" or not bounded_string(session.role) then error("ornn-fkst: invalid readiness session") end
+    if not bounded_string(session.browser_harness_command)
+      and not bounded_string(session.browser_harness_command_env)
+      and not bounded_string(session.cdp_endpoint_env)
+      and not local_url(session.cdp_url) then
+      error("ornn-fkst: invalid readiness session")
+    end
+  end
+end
+
+local function validate_observations(base_url, observations)
+  local ok, count = dense_list(observations)
+  if not ok or count == 0 or count > 64 then error("ornn-fkst: observations must be a non-empty bounded dense list") end
+  for _, item in ipairs(observations) do
+    if type(item) ~= "table" then error("ornn-fkst: observation must be a table") end
+    if not bounded_string(item.id) or not bounded_string(item.name) then error("ornn-fkst: observation id/name must be bounded strings") end
+    if not within_base_scope(item.entry_url, base_url) then error("ornn-fkst: observation entry_url must stay within base_url scope") end
+    if item.discovery_source ~= "navigation" and item.discovery_source ~= "route" and item.discovery_source ~= "route-manifest" then
+      error("ornn-fkst: observation discovery_source is invalid")
+    end
+    if not bounded_string(item.evidence_pointer) then error("ornn-fkst: observation evidence_pointer must be a bounded string") end
+  end
+end
+
+local function validate_cdp_execution(value)
+  if type(value) ~= "table" then error("ornn-fkst: cdp_execution must be a table") end
+  if value.schema ~= "testing-runner.module-cdp-execution.v1" then error("ornn-fkst: cdp_execution schema is invalid") end
+  if type(value.step_budget) ~= "number" or value.step_budget < 1 or value.step_budget > 32 or value.step_budget % 1 ~= 0 then
+    error("ornn-fkst: cdp_execution.step_budget must be an integer from 1 to 32")
+  end
+  local ok, count = dense_list(value.case_priorities)
+  if not ok or count == 0 or count > 3 then error("ornn-fkst: cdp_execution.case_priorities must be a bounded dense list") end
+  for _, priority in ipairs(value.case_priorities) do
+    if priority ~= "P0" and priority ~= "P1" and priority ~= "P2" then error("ornn-fkst: cdp_execution.case_priorities is invalid") end
+  end
+end
+
+local function validate_native_argv(argv)
+  if argv == nil then return end
+  local ok, count = dense_list(argv)
+  if not ok or count == 0 then error("ornn-fkst: native_argv must be a non-empty dense list") end
+  for _, item in ipairs(argv) do
+    if not bounded_string(item) then error("ornn-fkst: native_argv items must be bounded strings") end
+  end
+  if targets_legacy_runner(argv) then error("ornn-fkst: native_argv must not target the legacy agentic-testing host runner") end
+end
+
+local function validate_profile(profile)
+  if type(profile) ~= "table" then error("ornn-fkst: native module profile must be a table") end
+  if not bounded_string(profile.module) then error("ornn-fkst: module must be a bounded string") end
+  if profile.kind ~= "api" and profile.kind ~= "web" and profile.kind ~= "gated" then error("ornn-fkst: module kind is invalid") end
+  if profile.enabled ~= false then
+    if not local_url(profile.base_url) then error("ornn-fkst: base_url must be a local http URL") end
+    if profile.kind == "web" then
+      validate_allowed_origins(profile.base_url, profile.allowed_origins)
+      validate_sessions(profile.sessions)
+      validate_observations(profile.base_url, profile.observations)
+      validate_cdp_execution(profile.cdp_execution)
+    elseif profile.kind == "api" then
+      validate_sessions(profile.sessions)
+      validate_native_argv(profile.native_argv)
+    end
+    if not safe_artifact_root(profile.artifact_root) then error("ornn-fkst: artifact_root must be under .testing/runs/ornn-*") end
+    if not bounded_string(profile.trace_id) then error("ornn-fkst: trace_id must be a bounded string") end
+    if not bounded_string(profile.dedup_key) then error("ornn-fkst: dedup_key must be a bounded string") end
+  end
+  return profile
+end
+
+local function source_ref(profile)
+  return { kind = "host-module", ref = profile.module }
+end
+
+local function enabled_profiles(profiles)
+  local selected = {}
+  for _, profile in ipairs(profiles) do
+    if profile.enabled ~= false then table.insert(selected, validate_profile(profile)) end
+  end
+  return selected
+end
+
+local function observation(base_url, route, name)
+  local id = "ornn-web-" .. slug(route)
+  return {
+    id = id,
+    name = name,
+    entry_url = join_url(base_url, route),
+    visible_label = name,
+    route = route,
+    discovery_source = "navigation",
+    confidence = "high",
+    evidence_pointer = ".testing/runs/ornn-web-public-navigation/evidence/discovery/" .. id,
+  }
+end
+
+local function api_profiles(config)
+  local base_url = config.api_base_url or "http://localhost:3802"
+  local artifact_root = ".testing/runs/ornn-api-public-smoke"
+  return {
+    validate_profile({
+      kind = "api",
+      module = "ornn-api-public-smoke",
+      module_name = "ORNN API public smoke",
+      base_url = base_url,
+      sessions = {
+        { role = "api", browser_harness_command = "true" },
+      },
+      native_argv = {
+        "testing/fkst/ornn-native-full/bin/ornn-api-public-smoke.sh",
+        base_url,
+      },
+      artifact_root = artifact_root,
+      trace_id = "trace-ornn-api-public-smoke",
+      dedup_key = "ornn-api-public-smoke",
+    }),
+  }
+end
+
+local function web_profiles(config)
+  local base_url = config.web_base_url or "http://localhost:5173"
+  local cdp_url = config.cdp_url or "http://127.0.0.1:9222"
+  local origin = origin_from_url(base_url)
+  return {
+    validate_profile({
+      kind = "web",
+      module = "ornn-web-public-navigation",
+      module_name = "ORNN web public navigation",
+      base_url = base_url,
+      allowed_origins = { origin },
+      sessions = {
+        { role = "base", browser_harness_command = "true" },
+        { role = "cdp", cdp_url = cdp_url },
+      },
+      observations = {
+        observation(base_url, "/", "Landing page"),
+        observation(base_url, "/docs", "Docs"),
+        observation(base_url, "/news", "News"),
+        observation(base_url, "/contact", "Contact"),
+        observation(base_url, "/registry", "Registry"),
+        observation(base_url, "/skillsets", "Skillsets"),
+      },
+      cdp_execution = {
+        schema = "testing-runner.module-cdp-execution.v1",
+        step_budget = 32,
+        case_priorities = { "P0", "P1" },
+        stop_conditions = {
+          "origin-boundary",
+          "module-boundary",
+          "credential-login",
+          "mfa",
+          "captcha",
+          "mutation-policy",
+          "step-budget",
+        },
+      },
+      mutation_policy = "read-only",
+      artifact_root = ".testing/runs/ornn-web-public-navigation",
+      trace_id = "trace-ornn-web-public-navigation",
+      dedup_key = "ornn-web-public-navigation",
+    }),
+  }
+end
+
+M.gated_modules = {
+  validate_profile({
+    kind = "gated",
+    enabled = false,
+    module = "ornn-auth-surface",
+    reason = "requires host-provided NyxID session fixture; credentials never belong in FKST payloads",
+  }),
+  validate_profile({
+    kind = "gated",
+    enabled = false,
+    module = "ornn-admin-surface",
+    reason = "requires seeded admin session and host-approved mutation policy",
+  }),
+}
+
+M.host_config = {
+  project = {
+    id = "ornn",
+    name = "ORNN",
+    artifact_namespace = "ornn",
+  },
+  api_base_url = env("ORNN_API_BASE_URL") or "http://localhost:3802",
+  web_base_url = env("ORNN_WEB_BASE_URL") or "http://localhost:5173",
+  cdp_url = env("ORNN_CDP_URL") or "http://127.0.0.1:9222",
+  platform_test_loop = {
+    platform = "ornn-native-full",
+    artifact_root = ".testing/runs/ornn-native-full-platform",
+    trace_id = "trace-ornn-native-full-platform",
+    dedup_key = "ornn-native-full-platform",
+  },
+}
+
+function M.modules(config)
+  config = config or M.host_config
+  local modules = {}
+  for _, profile in ipairs(api_profiles(config)) do table.insert(modules, profile) end
+  for _, profile in ipairs(web_profiles(config)) do table.insert(modules, profile) end
+  return enabled_profiles(modules)
+end
+
+function M.readiness_check(profile)
+  profile = validate_profile(profile)
+  return {
+    queue = "browser-readiness.browser_readiness_check",
+    payload = {
+      schema = "browser-readiness.check.v1",
+      base_url = profile.base_url,
+      sessions = profile.sessions,
+      request_context = {
+        no_browser = profile.kind == "api",
+        dry_run = false,
+        native_argv = profile.native_argv,
+      },
+      source_ref = source_ref(profile),
+    },
+    source_ref = { kind = "external", reference = profile.module },
+  }
+end
+
+function M.ready_result(profile)
+  profile = validate_profile(profile)
+  local sessions = {
+    { role = "base_url", status = "ready" },
+  }
+  if profile.kind == "api" then
+    table.insert(sessions, { role = "api", status = "ready" })
+  else
+    table.insert(sessions, { role = "base", status = "ready" })
+    table.insert(sessions, { role = "cdp", status = "ready" })
+  end
+  return {
+    schema = "browser-readiness.result.v1",
+    status = "ready",
+    sessions = sessions,
+    source_ref = source_ref(profile),
+    request_context = {
+      no_browser = profile.kind == "api",
+      dry_run = false,
+      native_argv = profile.native_argv,
+    },
+  }
+end
+
+function M.module_start(profile, readiness)
+  profile = validate_profile(profile)
+  local payload = {
+    schema = "testing-pipeline.module-start.v1",
+    module = profile.module,
+    backend = "fkst-native",
+    dry_run = false,
+    preflight_result = readiness,
+    artifact_root = profile.artifact_root,
+    source_ref = source_ref(profile),
+    trace_id = profile.trace_id,
+    dedup_key = profile.dedup_key,
+  }
+  if profile.kind == "api" then
+    payload.no_browser = true
+    payload.native_argv = profile.native_argv
+  else
+    payload.ui_loop = {
+      base_url = profile.base_url,
+      allowed_origins = profile.allowed_origins,
+      browser_readiness_ref = profile.artifact_root .. "/readiness.json",
+      cdp_readiness_ref = "cdp-ready",
+      mutation_policy = profile.mutation_policy or "read-only",
+    }
+    payload.module_discovery = {
+      schema = "testing-runner.module-discovery.v1",
+      observations = profile.observations,
+      limitations = {
+        "Public Docker Compose profile excludes auth-required routes until a safe host session fixture is available.",
+      },
+    }
+    payload.cdp_execution = profile.cdp_execution
+  end
+  return {
+    queue = "testing-pipeline.module_start",
+    payload = payload,
+    source_ref = { kind = "external", reference = profile.module },
+  }
+end
+
+function M.platform_aggregate(module_results, config)
+  local ok = dense_list(module_results)
+  if not ok then error("ornn-fkst: module_results must be a dense list") end
+  config = config or M.host_config
+  local platform = config.platform_test_loop or {}
+  if not bounded_string(platform.platform) then error("ornn-fkst: platform must be a bounded string") end
+  if not safe_artifact_root(platform.artifact_root) then error("ornn-fkst: platform artifact_root must be under .testing/runs/ornn-*") end
+  return {
+    schema = "platform-test-loop.aggregate.v1",
+    platform = platform.platform,
+    module_results = module_results,
+    artifact_root = platform.artifact_root,
+    source_ref = { kind = "host-platform", ref = platform.platform },
+    trace_id = platform.trace_id,
+    dedup_key = platform.dedup_key,
+  }
+end
+
+function M.validate(profile)
+  return validate_profile(profile)
+end
+
+return M

--- a/testing/fkst/ornn-native-full/tests/ornn_native_full_profile_test.lua
+++ b/testing/fkst/ornn-native-full/tests/ornn_native_full_profile_test.lua
@@ -1,0 +1,220 @@
+local graph = require("testkit.graph")
+local profile = require("ornn_native_full_profile")
+local t = fkst.test
+
+local function rendered_argv(argv)
+  local parts = {}
+  for _, value in ipairs(argv or {}) do
+    table.insert(parts, "'" .. value .. "'")
+  end
+  return table.concat(parts, " ")
+end
+
+local function assert_argv(actual, expected)
+  t.eq(#actual, #expected)
+  for index, value in ipairs(expected) do
+    t.eq(actual[index], value)
+  end
+end
+
+local function assert_no_legacy_text(value)
+  local text = tostring(value or "")
+  t.eq(text:find("agentic_testing", 1, true), nil)
+  t.eq(text:find("agentic-testing-cli", 1, true), nil)
+  t.eq(text:find("fkst-host-module-ui-check", 1, true), nil)
+  t.eq(text:find("python -m agentic_testing", 1, true), nil)
+  t.eq(text:find("scripts/fkst-host-module-ui-check", 1, true), nil)
+end
+
+local function inspect_no_legacy(value)
+  local kind = type(value)
+  if kind == "string" then
+    assert_no_legacy_text(value)
+  elseif kind == "table" then
+    for key, item in pairs(value) do
+      inspect_no_legacy(key)
+      inspect_no_legacy(item)
+    end
+  end
+end
+
+local function mock_readiness(module_profile)
+  if module_profile.native_argv ~= nil then
+    t.mock_command(rendered_argv(module_profile.native_argv), {
+      stdout = "",
+      stderr = "",
+      exit_code = 0,
+    })
+  end
+  t.mock_command("'true'", {
+    stdout = "",
+    stderr = "",
+    exit_code = 0,
+  })
+end
+
+local function assert_readiness_request(module_profile)
+  local request = profile.readiness_check(module_profile)
+  t.eq(request.queue, "browser-readiness.browser_readiness_check")
+  t.eq(request.payload.schema, "browser-readiness.check.v1")
+  t.eq(request.payload.base_url, module_profile.base_url)
+  t.eq(request.payload.request_context.dry_run, false)
+  t.eq(request.payload.request_context.no_browser, module_profile.kind == "api")
+  if module_profile.native_argv ~= nil then
+    assert_argv(request.payload.request_context.native_argv, module_profile.native_argv)
+  else
+    t.eq(request.payload.request_context.native_argv, nil)
+  end
+  return request
+end
+
+local function assert_pipeline(module_profile)
+  mock_readiness(module_profile)
+  assert_readiness_request(module_profile)
+  local readiness = profile.ready_result(module_profile)
+  local pipeline_trace = graph.require_quiescent(graph.run(profile.module_start(module_profile, readiness), { max_steps = 12 }))
+  graph.require_delivery(pipeline_trace, {
+    queue = "testing-pipeline.module_start",
+    consumer = "testing-pipeline.start_module",
+  })
+  graph.require_delivery(pipeline_trace, {
+    queue = "module-test-loop.module_loop_request",
+    consumer = "module-test-loop.start",
+  })
+  graph.require_delivery(pipeline_trace, {
+    queue = "testing-runner.module_test_request",
+    consumer = "testing-runner.run_module_loop",
+  })
+  graph.require_delivery(pipeline_trace, {
+    queue = "test-artifacts.testing_result",
+    consumer = "test-artifacts.summarize",
+  })
+  graph.require_delivery(pipeline_trace, {
+    queue = "test-publication.artifact_summary",
+    consumer = "test-publication.prepare_publication",
+  })
+
+  local result = graph.require_raise(pipeline_trace, "testing-runner.testing_result").payload
+  t.eq(result.status, "passed")
+  t.eq(result.adapter.name, "fkst-native")
+  t.eq(result.artifact_root, module_profile.artifact_root)
+  t.eq(result.trace_id, module_profile.trace_id)
+  t.eq(result.dedup_key, module_profile.dedup_key)
+  if module_profile.kind == "api" then
+    t.eq(result.adapter.mode, "module-no-browser")
+    t.eq(result.native_summary.schema, "testing-runner.module-no-browser-summary.v1")
+    t.eq(result.native_summary.module, module_profile.module)
+  else
+    t.eq(result.adapter.mode, "module-cdp-execution")
+    t.eq(result.native_summary.schema, "testing-runner.module-cdp-execution-summary.v1")
+    t.eq(result.native_summary.module, module_profile.module)
+    t.eq(result.native_summary.evidence_bundle_path, module_profile.artifact_root .. "/evidence-bundle.json")
+    t.eq(result.native_summary.stage_report_path, module_profile.artifact_root .. "/stage-report.md")
+    t.eq(result.native_summary.issue_drafts_path, module_profile.artifact_root .. "/issue-drafts.json")
+    t.eq(result.native_summary.gap_backlog_path, module_profile.artifact_root .. "/gap-backlog.json")
+    t.eq(result.native_summary.publication_dry_run, true)
+  end
+
+  local publication = graph.require_raise(pipeline_trace, "test-publication.publication_request").payload
+  t.eq(publication.schema, "test-publication.publication-request.v1")
+  t.eq(publication.status, "passed")
+  t.eq(publication.severity, "success")
+  t.eq(publication.dedup_key, module_profile.dedup_key)
+  t.eq(publication.artifact_root, module_profile.artifact_root)
+  t.eq(publication.metadata_path, module_profile.artifact_root .. "/metadata.json")
+  if module_profile.kind == "web" then
+    t.eq(publication.stage_report_path, result.native_summary.stage_report_path)
+    t.eq(publication.issue_drafts_path, result.native_summary.issue_drafts_path)
+    t.eq(publication.publication_dry_run, true)
+  end
+  return result
+end
+
+return {
+  test_ornn_profile_declares_public_modules_and_gated_future_surfaces = function()
+    local modules = profile.modules()
+    t.eq(#modules, 2)
+    t.eq(modules[1].module, "ornn-api-public-smoke")
+    t.eq(modules[1].kind, "api")
+    t.eq(modules[1].base_url, "http://localhost:3802")
+    t.eq(modules[1].native_argv[1], "testing/fkst/ornn-native-full/bin/ornn-api-public-smoke.sh")
+    t.eq(modules[2].module, "ornn-web-public-navigation")
+    t.eq(modules[2].kind, "web")
+    t.eq(modules[2].base_url, "http://localhost:5173")
+    t.eq(modules[2].allowed_origins[1], "http://localhost:5173")
+    t.eq(#modules[2].observations, 6)
+    t.eq(profile.gated_modules[1].module, "ornn-auth-surface")
+    t.eq(profile.gated_modules[1].enabled, false)
+    t.eq(profile.gated_modules[2].module, "ornn-admin-surface")
+    t.eq(profile.gated_modules[2].enabled, false)
+    inspect_no_legacy(modules)
+  end,
+
+  test_ornn_profile_reaches_publication_handoff_per_enabled_module = function()
+    local seen = {}
+    for _, module_profile in ipairs(profile.modules()) do
+      local result = assert_pipeline(module_profile)
+      t.eq(seen[result.dedup_key], nil)
+      seen[result.dedup_key] = true
+    end
+  end,
+
+  test_ornn_web_module_start_uses_fkst_native_ui_loop_facts = function()
+    local web = profile.modules()[2]
+    local start = profile.module_start(web, profile.ready_result(web))
+    t.eq(start.queue, "testing-pipeline.module_start")
+    t.eq(start.payload.backend, "fkst-native")
+    t.eq(start.payload.native_argv, nil)
+    t.eq(start.payload.no_browser, nil)
+    t.eq(start.payload.ui_loop.base_url, "http://localhost:5173")
+    t.eq(start.payload.ui_loop.mutation_policy, "read-only")
+    t.eq(start.payload.module_discovery.schema, "testing-runner.module-discovery.v1")
+    t.eq(start.payload.module_discovery.observations[1].discovery_source, "navigation")
+    t.eq(start.payload.cdp_execution.schema, "testing-runner.module-cdp-execution.v1")
+    inspect_no_legacy(start)
+  end,
+
+  test_ornn_platform_aggregate_payload_is_pointer_only = function()
+    local module_results = {}
+    for _, module_profile in ipairs(profile.modules()) do
+      table.insert(module_results, {
+        schema = "testing-runner.result.v1",
+        job = "module-test-loop",
+        module = module_profile.module,
+        status = "passed",
+        artifact_root = module_profile.artifact_root,
+        source_ref = { kind = "host-module", ref = module_profile.module },
+        trace_id = module_profile.trace_id,
+        dedup_key = module_profile.dedup_key,
+        adapter = { name = "fkst-native", mode = module_profile.kind == "api" and "module-no-browser" or "module-cdp-execution" },
+        native_summary = {
+          schema = module_profile.kind == "api" and "testing-runner.module-no-browser-summary.v1" or "testing-runner.module-cdp-execution-summary.v1",
+          module = module_profile.module,
+          status = "passed",
+        },
+      })
+    end
+    local aggregate = profile.platform_aggregate(module_results)
+    t.eq(aggregate.schema, "platform-test-loop.aggregate.v1")
+    t.eq(aggregate.platform, "ornn-native-full")
+    t.eq(aggregate.artifact_root, ".testing/runs/ornn-native-full-platform")
+    t.eq(aggregate.source_ref.kind, "host-platform")
+    t.eq(aggregate.source_ref.ref, "ornn-native-full")
+    t.eq(#aggregate.module_results, 2)
+  end,
+
+  test_ornn_profile_blocks_legacy_native_runner_targets = function()
+    t.raises(function()
+      profile.validate({
+        kind = "api",
+        module = "bad-legacy",
+        base_url = "http://localhost:3802",
+        sessions = { { role = "api", browser_harness_command = "true" } },
+        native_argv = { "python3", "-m", "agentic_testing.cli" },
+        artifact_root = ".testing/runs/ornn-bad-legacy",
+        trace_id = "trace-ornn-bad-legacy",
+        dedup_key = "ornn-bad-legacy",
+      })
+    end)
+  end,
+}


### PR DESCRIPTION
## Summary
- Add an ORNN-owned FKST-native full-test profile for public API and web navigation coverage.
- Add a Docker-first runner that starts Compose services and runs the closed-world FKST profile tests.
- Keep auth/admin surfaces gated until safe host session fixtures exist, and keep FKST artifacts under `.testing/runs/ornn-*`.

## Test plan
- [x] Run FKST profile graph tests: `5 passed, 0 failed`
- [x] Run Docker-first smoke with `mongodb`, `minio`, `ornn-api`, and `ornn-web`
- [x] Verify generated artifacts remain ignored under `.testing/runs/ornn-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)