### PR TITLE
fix(api): correct every URL published in the OpenAPI spec

### DIFF
--- a/.changeset/fix-openapi-v1-prefix.md
+++ b/.changeset/fix-openapi-v1-prefix.md
@@ -1,0 +1,5 @@
+---
+"ornn-api": patch
+---
+
+Fix every URL published in the OpenAPI document (#1213). `GET /api/v1/openapi.json` is the contract agent developers read first — NyxID renders it on the ornn-api service page — and none of it resolved. Paths were published under `/api/*` while the router has served `/api/v1/*` since the version cut in #101, so following the spec produced 404s. `servers[0].url` was hardcoded to `http://localhost:3802`, a host no client can reach; it now comes from `ORNN_API_BASE_URL` (the same var ornn-web already uses to reach the API), falling back to `http://localhost:${PORT}` when unset. `info.version` was frozen at `"2.0.0"` and now reports the real package version. Four `/admin/categories` and `/admin/tags` paths documenting eight operations that exist nowhere in the codebase are removed, along with the five Zod schemas that only fed them. A new contract test boots the app and checks every documented path+method against Hono's live route table, so a spec entry that names a route the API does not serve now fails CI instead of shipping.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,13 +197,24 @@ jobs:
     # lodash-es is archived at 4.17.21 with no upstream fix; the vulnerable
     # APIs (_.template / _.unset / _.omit) are not reachable through
     # mermaid's surface under our usage.
+    #
+    # Ignored advisory — not reachable, tracked in #1218 / #1219:
+    #   GHSA-qwww-vcr4-c8h2  react-router high  (>=7.12.0 <8.3.0)
+    # "RSC Mode CSRF Bypass". RSC mode requires the `@react-router/*`
+    # server packages — none are in bun.lock. ornn-web is a static Vite
+    # SPA (`vite build`, no SSR target) whose router is built with
+    # `createBrowserRouter` + `RouterProvider` (ornn-web/src/App.tsx:258),
+    # so the vulnerable server-action path is never constructed. The fix
+    # is react-router 8.3.0, but `react-router-dom` was frozen at 7.x and
+    # not carried forward, so adopting it is a full import migration —
+    # tracked as its own change in #1219, not a drive-by dependency bump.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - name: Audit (high+critical block PR)
-        run: bun audit --audit-level=high --ignore=GHSA-r5fr-rjxr-66jc --ignore=GHSA-f23m-r3pf-42rh
+        run: bun audit --audit-level=high --ignore=GHSA-r5fr-rjxr-66jc --ignore=GHSA-f23m-r3pf-42rh --ignore=GHSA-qwww-vcr4-c8h2
       - name: Audit summary (moderate+ — informational)
         if: ${{ !cancelled() }}
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "ornn-api": {
       "name": "ornn-api",
-      "version": "0.13.0",
+      "version": "0.16.0",
       "dependencies": {
         "@agendajs/mongo-backend": "^4.0.2",
         "agenda": "^6.2.5",
@@ -40,7 +40,7 @@
     },
     "ornn-web": {
       "name": "ornn-web",
-      "version": "0.13.0",
+      "version": "0.16.0",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@tanstack/react-query": "^5.101.2",
@@ -97,12 +97,14 @@
     },
   },
   "overrides": {
+    "brace-expansion": "^5.0.8",
     "dompurify": "^3.3.4",
     "eslint": "10.2.0",
     "eslint-plugin-react-hooks": "7.0.1",
+    "js-yaml": "^4.3.0",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
-    "undici": "^7.28.0",
+    "postcss": "^8.5.18",
+    "undici": "^7.29.0",
     "uuid": "^14.0.0",
   },
   "packages": {
@@ -580,7 +582,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -782,8 +784,6 @@
 
     "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
 
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
@@ -952,7 +952,7 @@
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
@@ -1150,7 +1150,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -1226,7 +1226,7 @@
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
-    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
     "posthog-js": ["posthog-js@1.395.0", "", { "dependencies": { "@posthog/core": "^1.38.0", "@posthog/types": "^1.391.1", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-5iTb00CGt2eQUUiBQysQiX89RAbCN6wK2sDNzvs9zv0alaY8mJ0ZySrUD3LQ+XyLhgM5pCpacBuUwChqiYDLDw=="],
 
@@ -1360,8 +1360,6 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
@@ -1440,7 +1438,7 @@
 
     "typescript-eslint": ["typescript-eslint@8.62.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.62.0", "@typescript-eslint/parser": "8.62.0", "@typescript-eslint/typescript-estree": "8.62.0", "@typescript-eslint/utils": "8.62.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
@@ -1602,8 +1600,6 @@
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
@@ -1627,8 +1623,6 @@
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/deployment/.env.sample.ornn
+++ b/deployment/.env.sample.ornn
@@ -22,10 +22,14 @@ AGENTSEAL_PYTHON=/opt/agentseal/bin/python
 AGENTSEAL_SCRIPT=/opt/agentseal/scan_skill.py
 ENCRYPTION_KEY=<32+ char passphrase, e.g. openssl rand -hex 32>
 
+# Shared by ornn-api and ornn-web: the public base URL clients use to reach
+# ornn-api. NO trailing slash and NO /api/v1 suffix — both the SPA and the
+# OpenAPI spec append that themselves (#1213).
+ORNN_API_BASE_URL=<NyxID-proxied URL to ornn-api, e.g. https://nyx-api.chrono-ai.fun/api/v1/proxy/s/ornn-api>
+
 # ornn-web runtime configs
 NYXID_API_BASE_URL=<e.g. https://nyx-api.chrono-ai.fun>
 NYXID_WEB_BASE_URL=<e.g. https://nyx.chrono-ai.fun>
-ORNN_API_BASE_URL=<NyxID-proxied URL to ornn-api, e.g. https://nyx-api.chrono-ai.fun/api/v1/proxy/s/ornn-api>
 NYXID_OAUTH_AUTHORIZE_PATH=<e.g. /oauth/authorize>
 NYXID_OAUTH_TOKEN_PATH=<e.g. /oauth/token>
 NYXID_OAUTH_REDIRECT_PATH=<e.g. /auth/callback>

--- a/deployment/ornn-api/deployment.yaml
+++ b/deployment/ornn-api/deployment.yaml
@@ -54,6 +54,11 @@ spec:
               value: "${ALLOWED_ORIGINS}"
             - name: ORNN_PUBLIC_ORIGIN
               value: "${ORNN_PUBLIC_ORIGIN}"
+            # Public base URL of ornn-api itself — published as servers[0].url
+            # in /api/v1/openapi.json (#1213). Same value ornn-web uses to reach
+            # the API, so the spec advertises a URL clients can actually call.
+            - name: ORNN_API_BASE_URL
+              value: "${ORNN_API_BASE_URL}"
             - name: ORNN_URL_ALLOWLIST_CIDR
               value: "${ORNN_URL_ALLOWLIST_CIDR}"
             - name: ORNN_TRUSTED_PROXY_HOPS

--- a/ornn-api/scripts/migrate-quota-to-buckets.test.ts
+++ b/ornn-api/scripts/migrate-quota-to-buckets.test.ts
@@ -14,17 +14,24 @@ let mongo: MongoMemoryServer;
 let client: MongoClient;
 let db: Db;
 
+// This is the first file in the run to touch Mongo, so `create()` here is
+// what pays for downloading and unpacking the mongod binary on a cold
+// cache. That does not fit in bun's 5s hook default: the hook gets killed,
+// `db` is left undefined, and every subsequent hook in the file fails too
+// — which is the `killed 2 dangling processes` flake from #1215. The
+// tests/integration/* harness already passes 30_000 for exactly this
+// reason; this file was just never given the same treatment.
 beforeAll(async () => {
   mongo = await MongoMemoryServer.create();
   client = new MongoClient(mongo.getUri());
   await client.connect();
   db = client.db("migration_test");
-});
+}, 60_000);
 
 afterAll(async () => {
   await client.close();
   await mongo.stop();
-});
+}, 30_000);
 
 beforeEach(async () => {
   await db.collection("user_quotas").deleteMany({});

--- a/ornn-api/src/bootstrap.ts
+++ b/ornn-api/src/bootstrap.ts
@@ -1121,8 +1121,12 @@ export async function bootstrap(
   apiApp.route("/", createUserRoutes({ userDirectoryRepo }));
   app.route("/api/v1", apiApp);
 
-  // OpenAPI spec — auto-generated from Zod schemas
-  const spec = buildSpec();
+  // OpenAPI spec — schemas generated from Zod, deployment-specific values
+  // injected from config so nothing environment-shaped is baked in (#1213).
+  const spec = buildSpec({
+    serverUrl: config.ornnApiBaseUrl,
+    version: pkg.version,
+  });
   app.get("/api/v1/openapi.json", (c) => c.json(spec));
 
   // Kubernetes liveness probe — process is alive. No dependency checks.

--- a/ornn-api/src/infra/config.ts
+++ b/ornn-api/src/infra/config.ts
@@ -88,6 +88,18 @@ export interface SkillConfig {
   readonly ornnPublicOrigin: string;
 
   /**
+   * Public base URL callers use to reach ornn-api, with no trailing
+   * slash and no `/api/v1` suffix — spec paths already carry it.
+   * Published as `servers[0].url` in the OpenAPI document.
+   *
+   * In production this is the NyxID proxy base
+   * (`<nyxid>/api/v1/proxy/s/ornn-api`), NOT the ornn-web origin —
+   * `ornn-web/nginx.conf.template` has no `proxy_pass`, so the SPA host
+   * never serves the API. Defaults to `http://localhost:<PORT>`.
+   */
+  readonly ornnApiBaseUrl: string;
+
+  /**
    * Service-account GitHub token for authenticated source-repo reads
    * (#1175). Env fallback used when the `sourceSync` settings section has no
    * token. Public-read only — it lifts the 60/hr anonymous rate ceiling, it
@@ -175,6 +187,24 @@ const envSchema = z.object({
     z.string().url().default("https://ornn.chrono-ai.fun"),
   ),
 
+  /**
+   * Public base URL for ornn-api itself, advertised as `servers[0].url`
+   * in the OpenAPI document (#1213). The SAME var ornn-web already
+   * reads to reach the API, deliberately: two names for one fact is how
+   * the spec drifted out of sync with the router in the first place.
+   *
+   * Distinct from ORNN_PUBLIC_ORIGIN, which is the *web* origin used for
+   * canonical skill links — the API is not served from that host.
+   *
+   * No trailing slash, no `/api/v1` suffix (spec paths supply it).
+   * Unset falls through to `http://localhost:<PORT>` in `loadConfig`,
+   * which is why there is no Zod-level default here.
+   */
+  ORNN_API_BASE_URL: z.preprocess(
+    (v) => (v === "" ? undefined : v),
+    z.string().url().optional(),
+  ),
+
   // Source-sync GitHub token (#1175). Optional — empty means anonymous,
   // rate-limited source reads. The `sourceSync` settings section overrides
   // this at runtime when an admin sets a value there.
@@ -242,6 +272,9 @@ export function loadConfig(): SkillConfig {
     agentsealEnabled: env.AGENTSEAL_ENABLED !== "false",
 
     ornnPublicOrigin: env.ORNN_PUBLIC_ORIGIN.replace(/\/+$/, ""),
+
+    ornnApiBaseUrl: (env.ORNN_API_BASE_URL ?? `http://localhost:${env.PORT}`)
+      .replace(/\/+$/, ""),
 
     sourceSyncGithubToken: env.ORNN_SOURCE_SYNC_GITHUB_TOKEN.trim(),
   };

--- a/ornn-api/src/openapi/schemas.ts
+++ b/ornn-api/src/openapi/schemas.ts
@@ -214,37 +214,3 @@ export const assistantChatEventSchema = z.discriminatedUnion("type", [
       .optional(),
   }),
 ]);
-
-// ---------------------------------------------------------------------------
-// Admin
-// ---------------------------------------------------------------------------
-
-export const categorySchema = z.object({
-  _id: z.string(),
-  name: z.string(),
-  description: z.string(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-});
-
-export const createCategoryBodySchema = z.object({
-  name: z.enum(["plain", "tool-based", "runtime-based", "mixed"]),
-  slug: z.string().min(1).max(50).regex(/^[a-z0-9-]+$/),
-  description: z.string().min(1).max(500),
-  order: z.number().int().min(0).optional(),
-});
-
-export const updateCategoryBodySchema = z.object({
-  description: z.string().min(1).max(500).optional(),
-  order: z.number().int().min(0).optional(),
-});
-
-export const tagSchema = z.object({
-  _id: z.string(),
-  name: z.string(),
-  createdAt: z.string(),
-});
-
-export const createTagBodySchema = z.object({
-  name: z.string().min(1).max(30).regex(/^[a-z0-9-_]+$/),
-});

--- a/ornn-api/src/openapi/specBuilder.test.ts
+++ b/ornn-api/src/openapi/specBuilder.test.ts
@@ -2,6 +2,13 @@ import { describe, test, expect } from "bun:test";
 import { buildSpec } from "./specBuilder";
 
 /**
+ * Deployment-specific values `buildSpec` now takes as arguments (#1213).
+ * Fixed here so assertions are about spec structure, not about whatever
+ * the ambient environment happens to be.
+ */
+const SPEC_OPTIONS = { serverUrl: "https://api.test.invalid", version: "1.2.3" } as const;
+
+/**
  * Contract tests for the generated OpenAPI spec.
  *
  * These assert the spec has the structural properties clients rely on —
@@ -21,7 +28,7 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 describe("buildSpec (OpenAPI contract)", () => {
-  const spec = buildSpec();
+  const spec = buildSpec(SPEC_OPTIONS);
 
   test("top-level spec has non-empty paths", () => {
     expect(isRecord(spec.paths)).toBe(true);
@@ -42,7 +49,7 @@ describe("buildSpec (OpenAPI contract)", () => {
   });
 
   describe("per-path invariants", () => {
-    const spec = buildSpec();
+    const spec = buildSpec(SPEC_OPTIONS);
     const paths = spec.paths as Record<string, unknown>;
 
     for (const [pathKey, pathItem] of Object.entries(paths)) {

--- a/ornn-api/src/openapi/specBuilder.ts
+++ b/ornn-api/src/openapi/specBuilder.ts
@@ -349,91 +349,6 @@ function assistantChatPath(): PathItem {
   };
 }
 
-function categoriesListCreatePath(): PathItem {
-  return {
-    get: {
-      summary: "List all skill categories",
-      operationId: "listCategories",
-      tags: ["Admin"],
-      security: bearerAuth(),
-      responses: { ...jsonResponse(S.categorySchema.array()), ...errorResponses(401) },
-    },
-    post: {
-      summary: "Create a category",
-      operationId: "createCategory",
-      tags: ["Admin"],
-      security: bearerAuth(),
-      requestBody: {
-        required: true,
-        content: { "application/json": { schema: toSchema(S.createCategoryBodySchema) } },
-      },
-      responses: { ...jsonResponse(S.categorySchema, "Category created"), ...errorResponses(400, 401) },
-    },
-  };
-}
-
-function categoryUpdateDeletePath(): PathItem {
-  return {
-    put: {
-      summary: "Update a category",
-      operationId: "updateCategory",
-      tags: ["Admin"],
-      security: bearerAuth(),
-      parameters: [pathParam("id", "Category ID")],
-      requestBody: {
-        required: true,
-        content: { "application/json": { schema: toSchema(S.updateCategoryBodySchema) } },
-      },
-      responses: { ...jsonResponse(S.categorySchema), ...errorResponses(400, 401, 404) },
-    },
-    delete: {
-      summary: "Delete a category",
-      operationId: "deleteCategory",
-      tags: ["Admin"],
-      security: bearerAuth(),
-      parameters: [pathParam("id", "Category ID")],
-      responses: { ...jsonResponse(S.successResponseSchema), ...errorResponses(401, 404) },
-    },
-  };
-}
-
-function tagsListCreatePath(): PathItem {
-  return {
-    get: {
-      summary: "List tags",
-      operationId: "listTags",
-      tags: ["Admin"],
-      security: bearerAuth(),
-      parameters: [{ name: "type", in: "query", required: false, schema: { type: "string", enum: ["predefined", "custom"] } }],
-      responses: { ...jsonResponse(S.tagSchema.array()), ...errorResponses(401) },
-    },
-    post: {
-      summary: "Create a custom tag",
-      operationId: "createTag",
-      tags: ["Admin"],
-      security: bearerAuth(),
-      requestBody: {
-        required: true,
-        content: { "application/json": { schema: toSchema(S.createTagBodySchema) } },
-      },
-      responses: { ...jsonResponse(S.tagSchema, "Tag created"), ...errorResponses(400, 401) },
-    },
-  };
-}
-
-function tagDeletePath(): PathItem {
-  return {
-    delete: {
-      summary: "Delete a tag",
-      operationId: "deleteTag",
-      tags: ["Admin"],
-      security: bearerAuth(),
-      parameters: [pathParam("id", "Tag ID")],
-      responses: { ...jsonResponse(S.successResponseSchema), ...errorResponses(401, 404) },
-    },
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Spec builders
 // ---------------------------------------------------------------------------
@@ -447,7 +362,7 @@ export interface SpecOptions {
   /**
    * Public base URL clients prepend to every path key. No trailing slash,
    * no `/api/v1` suffix — the paths carry that. Comes from
-   * `config.ornnApiPublicBaseUrl`.
+   * `config.ornnApiBaseUrl`.
    */
   readonly serverUrl: string;
   /** Package version, reported as `info.version`. */
@@ -490,7 +405,6 @@ export function buildSpec(options: SpecOptions): OpenApiSpec {
       { name: "Generation", description: "Generate complete skill packages from natural language descriptions using AI." },
       { name: "Format", description: "Skill format rules and validation" },
       { name: "Playground", description: "Multi-turn chat playground" },
-      { name: "Admin", description: "Category and tag management" },
     ],
     paths: {
       // Skills CRUD
@@ -514,11 +428,6 @@ export function buildSpec(options: SpecOptions): OpenApiSpec {
       [`${prefix}/playground/chat`]: playgroundChatPath(),
       // Assistant (#970)
       [`${prefix}/assistant/chat`]: assistantChatPath(),
-      // Admin
-      [`${prefix}/admin/categories`]: categoriesListCreatePath(),
-      [`${prefix}/admin/categories/{id}`]: categoryUpdateDeletePath(),
-      [`${prefix}/admin/tags`]: tagsListCreatePath(),
-      [`${prefix}/admin/tags/{id}`]: tagDeletePath(),
     },
   };
 }

--- a/ornn-api/src/openapi/specBuilder.ts
+++ b/ornn-api/src/openapi/specBuilder.ts
@@ -438,11 +438,27 @@ function tagDeletePath(): PathItem {
 // Spec builders
 // ---------------------------------------------------------------------------
 
-function baseSpec(title: string, description: string): OpenApiSpec {
+/**
+ * Deployment-specific values the spec advertises. Both are caller-supplied
+ * so nothing environment-shaped is baked into the builder (CLAUDE.md:
+ * zero hardcoded config).
+ */
+export interface SpecOptions {
+  /**
+   * Public base URL clients prepend to every path key. No trailing slash,
+   * no `/api/v1` suffix — the paths carry that. Comes from
+   * `config.ornnApiPublicBaseUrl`.
+   */
+  readonly serverUrl: string;
+  /** Package version, reported as `info.version`. */
+  readonly version: string;
+}
+
+function baseSpec(title: string, description: string, options: SpecOptions): OpenApiSpec {
   return {
     openapi: "3.1.0",
-    info: { title, version: "2.0.0", description },
-    servers: [{ url: "http://localhost:3802" }],
+    info: { title, version: options.version, description },
+    servers: [{ url: options.serverUrl }],
     components: {
       securitySchemes: {
         BearerAuth: {
@@ -456,7 +472,7 @@ function baseSpec(title: string, description: string): OpenApiSpec {
   };
 }
 
-export function buildSpec(): OpenApiSpec {
+export function buildSpec(options: SpecOptions): OpenApiSpec {
   // MUST match the mount prefix in `bootstrap.ts` (`app.route("/api/v1",
   // apiApp)`) and CONVENTIONS.md §3. This is asserted against the booted
   // router in `tests/contract/openapiRoutes.test.ts` — do not change one
@@ -466,6 +482,7 @@ export function buildSpec(): OpenApiSpec {
     ...baseSpec(
       "ornn API",
       "API for ornn — the end-to-end skill life-cycle manager for AI agents. Covers the full life-cycle: skill CRUD, search, AI-powered generation, playground, audit, and admin endpoints — from spec to ship. All endpoints require NyxID authentication via Bearer token. Responses follow a uniform envelope: { data: T | null, error: { code, message } | null }.",
+      options,
     ),
     tags: [
       { name: "Skills", description: "Upload, retrieve, update, delete, and inspect AI skill packages." },

--- a/ornn-api/src/openapi/specBuilder.ts
+++ b/ornn-api/src/openapi/specBuilder.ts
@@ -457,7 +457,11 @@ function baseSpec(title: string, description: string): OpenApiSpec {
 }
 
 export function buildSpec(): OpenApiSpec {
-  const prefix = "/api";
+  // MUST match the mount prefix in `bootstrap.ts` (`app.route("/api/v1",
+  // apiApp)`) and CONVENTIONS.md §3. This is asserted against the booted
+  // router in `tests/contract/openapiRoutes.test.ts` — do not change one
+  // without the other.
+  const prefix = "/api/v1";
   return {
     ...baseSpec(
       "ornn API",

--- a/ornn-api/src/regression/hardcodeSweep.test.ts
+++ b/ornn-api/src/regression/hardcodeSweep.test.ts
@@ -40,7 +40,6 @@ const SKIP_PATH_REGEXES: RegExp[] = [
   /\.test\.ts$/,
   /[\\/]regression[\\/]/,
   /[\\/]infra[\\/]config\.ts$/,
-  /[\\/]openapi[\\/]/,
 ];
 
 // URLs that are intentionally hardcoded in source for legitimate

--- a/ornn-api/tests/contract/openapi.test.ts
+++ b/ornn-api/tests/contract/openapi.test.ts
@@ -31,6 +31,13 @@
 import { describe, expect, test } from "bun:test";
 import { buildSpec } from "../../src/openapi/specBuilder";
 
+/**
+ * Deployment-specific values `buildSpec` now takes as arguments (#1213).
+ * Fixed here so assertions are about spec structure, not about whatever
+ * the ambient environment happens to be.
+ */
+const SPEC_OPTIONS = { serverUrl: "https://api.test.invalid", version: "1.2.3" } as const;
+
 type Spec = ReturnType<typeof buildSpec>;
 type PathItem = Record<string, unknown>;
 type Operation = {
@@ -63,7 +70,7 @@ function eachOperation(
 }
 
 describe("OpenAPI spec — structural integrity (#462)", () => {
-  const spec = buildSpec();
+  const spec = buildSpec(SPEC_OPTIONS);
 
   test("spec is OpenAPI 3.1", () => {
     expect(spec.openapi).toBe("3.1.0");
@@ -80,6 +87,14 @@ describe("OpenAPI spec — structural integrity (#462)", () => {
     const servers = spec.servers as Array<{ url: string }>;
     expect(servers.length).toBeGreaterThan(0);
     expect(servers[0]!.url).toMatch(/^https?:\/\//);
+  });
+
+  test("server URL and version come from the caller, not the builder", () => {
+    // Both were hardcoded until #1213 — `http://localhost:3802` and a
+    // frozen `"2.0.0"` — so the published spec advertised a server no
+    // client could reach and a version that never moved.
+    expect((spec.servers as Array<{ url: string }>)[0]!.url).toBe(SPEC_OPTIONS.serverUrl);
+    expect((spec.info as { version: string }).version).toBe(SPEC_OPTIONS.version);
   });
 
   test("BearerAuth security scheme is declared", () => {
@@ -111,7 +126,7 @@ describe("OpenAPI spec — structural integrity (#462)", () => {
 });
 
 describe("OpenAPI spec — per-operation metadata (#462)", () => {
-  const spec = buildSpec();
+  const spec = buildSpec(SPEC_OPTIONS);
 
   test("every operation declares at least one tag", () => {
     const violations: string[] = [];
@@ -157,7 +172,7 @@ describe("OpenAPI spec — per-operation metadata (#462)", () => {
 });
 
 describe("OpenAPI spec — RFC 7807 error responses (#456 + #462)", () => {
-  const spec = buildSpec();
+  const spec = buildSpec(SPEC_OPTIONS);
 
   test("every declared 4xx/5xx response uses application/problem+json", () => {
     // Per #456: all error responses are RFC 7807 problem+json. The
@@ -197,7 +212,7 @@ describe("OpenAPI spec — RFC 7807 error responses (#456 + #462)", () => {
 });
 
 describe("OpenAPI spec — operation security declarations (#462)", () => {
-  const spec = buildSpec();
+  const spec = buildSpec(SPEC_OPTIONS);
 
   /**
    * Paths that are explicitly designed to be public (no auth). New
@@ -226,7 +241,7 @@ describe("OpenAPI spec — operation security declarations (#462)", () => {
 });
 
 describe("OpenAPI spec — schema reference integrity", () => {
-  const spec = buildSpec();
+  const spec = buildSpec(SPEC_OPTIONS);
 
   test("declared paths cover the foundational skill CRUD surface", () => {
     // This is a regression test, not a coverage test. The full

--- a/ornn-api/tests/contract/openapi.test.ts
+++ b/ornn-api/tests/contract/openapi.test.ts
@@ -87,6 +87,18 @@ describe("OpenAPI spec — structural integrity (#462)", () => {
     expect(components.securitySchemes.BearerAuth).toBeDefined();
   });
 
+  test("every declared path carries the /api/v1 mount prefix", () => {
+    // The spec's path table is hand-maintained while the router lives in
+    // `bootstrap.ts`. They drifted once already: the spec published
+    // `/api/*` for months after the router moved to `/api/v1/*` in #101,
+    // so every URL NyxID rendered from this spec was wrong. CONVENTIONS.md
+    // §3 makes `/api/v1/` normative — pin it here so a stale prefix fails
+    // fast, without needing a booted app.
+    const offenders = Object.keys(spec.paths as Record<string, unknown>)
+      .filter((p) => !p.startsWith("/api/v1/"));
+    expect(offenders).toEqual([]);
+  });
+
   test("every declared path has at least one HTTP method", () => {
     const orphans: string[] = [];
     const paths = spec.paths as Record<string, PathItem>;
@@ -195,8 +207,8 @@ describe("OpenAPI spec — operation security declarations (#462)", () => {
    * Keep this list short and review-gated.
    */
   const publicPaths = new Set<string>([
-    "/api/skill-format/rules",
-    "/api/skill-manifest-schema.json",
+    "/api/v1/skill-format/rules",
+    "/api/v1/skill-manifest-schema.json",
   ]);
 
   test("every operation outside the public allowlist declares BearerAuth security", () => {
@@ -222,12 +234,12 @@ describe("OpenAPI spec — schema reference integrity", () => {
     // #462. Here we just pin the routes that have been documented so
     // a refactor doesn't accidentally drop them.
     const required = [
-      "/api/skills",
-      "/api/skills/{idOrName}",
-      "/api/skills/{id}",
-      "/api/skill-search",
-      "/api/skill-format/rules",
-      "/api/skill-manifest-schema.json",
+      "/api/v1/skills",
+      "/api/v1/skills/{idOrName}",
+      "/api/v1/skills/{id}",
+      "/api/v1/skill-search",
+      "/api/v1/skill-format/rules",
+      "/api/v1/skill-manifest-schema.json",
     ];
     const paths = spec.paths as Record<string, unknown>;
     const present = new Set(Object.keys(paths));

--- a/ornn-api/tests/contract/openapiRoutes.test.ts
+++ b/ornn-api/tests/contract/openapiRoutes.test.ts
@@ -1,0 +1,94 @@
+/**
+ * OpenAPI ↔ router reflection test (#1213).
+ *
+ * The spec's path table in `src/openapi/specBuilder.ts` is hand-written
+ * while the routes it describes are registered in `src/bootstrap.ts`.
+ * Nothing structurally ties the two together, and they drifted badly:
+ *
+ *   - every path was published under `/api/` while the router had moved
+ *     to `/api/v1/` (#101), so no URL in the spec resolved;
+ *   - four `/admin/{categories,tags}` paths described endpoints that had
+ *     been deleted from the codebase entirely.
+ *
+ * Both are the same failure: the spec claimed something the router does
+ * not serve. The other contract tests could not catch it because they
+ * only inspect the spec against itself. This one boots the real app and
+ * checks each documented operation against the live route table.
+ *
+ * Direction matters. This asserts *documented ⇒ registered* — no phantom
+ * endpoints. The converse (*registered ⇒ documented*, i.e. closing the
+ * coverage gap) is tracked as #1214 and deliberately not enforced here;
+ * turning it on today would fail on ~90 legitimately-undocumented routes.
+ *
+ * @module tests/contract/openapiRoutes
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { startHarness, type Harness } from "../integration/harness";
+import { buildSpec } from "../../src/openapi/specBuilder";
+
+const SPEC_OPTIONS = { serverUrl: "https://api.test.invalid", version: "1.2.3" } as const;
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete"] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+function isOperation(method: string): method is HttpMethod {
+  return (HTTP_METHODS as readonly string[]).includes(method);
+}
+
+/** OpenAPI templates a path param as `{id}`; Hono registers it as `:id`. */
+function toHonoPath(specPath: string): string {
+  return specPath.replace(/\{([^}]+)\}/g, ":$1");
+}
+
+let harness: Harness;
+
+beforeAll(async () => {
+  harness = await startHarness();
+}, 60_000);
+
+afterAll(async () => {
+  await harness.cleanup();
+  // Explicit timeout: `cleanup()` stops a MongoMemoryServer, which under
+  // a loaded full-suite run regularly exceeds bun's 5s hook default. The
+  // existing integration files omit this and flake because of it (#1215)
+  // — this one does not pile on.
+}, 30_000);
+
+describe("OpenAPI spec — every documented operation is a real route (#1213)", () => {
+  test("no declared path+method is missing from the booted router", () => {
+    // `app.routes` carries one entry per handler in each chain, so the
+    // same path appears once per middleware. Dedupe, and drop the `ALL`
+    // entries — those are middleware mounts, not endpoints.
+    const registered = new Set(
+      harness.app.routes
+        .filter((r) => r.method !== "ALL")
+        .map((r) => `${r.method.toUpperCase()} ${r.path}`),
+    );
+
+    const spec = buildSpec(SPEC_OPTIONS);
+    const paths = spec.paths as Record<string, Record<string, unknown>>;
+
+    const missing: string[] = [];
+    for (const [specPath, pathItem] of Object.entries(paths)) {
+      for (const method of Object.keys(pathItem)) {
+        if (!isOperation(method)) continue;
+        const key = `${method.toUpperCase()} ${toHonoPath(specPath)}`;
+        if (!registered.has(key)) missing.push(key);
+      }
+    }
+
+    // A non-empty list means the spec is advertising an endpoint the API
+    // does not serve — agents following it get a 404.
+    expect(missing).toEqual([]);
+  });
+
+  test("the router actually serves the /api/v1 prefix the spec declares", () => {
+    // Guards the specific regression: if the mount prefix in bootstrap.ts
+    // and `prefix` in specBuilder.ts ever diverge again, the assertion
+    // above goes red — but only if the router really is on /api/v1. Pin
+    // that independently so a matched-but-wrong pair can't pass silently.
+    const v1Routes = harness.app.routes.filter((r) => r.path.startsWith("/api/v1/"));
+    expect(v1Routes.length).toBeGreaterThan(0);
+  });
+});

--- a/ornn-api/tests/integration/auth_settings_driven.test.ts
+++ b/ornn-api/tests/integration/auth_settings_driven.test.ts
@@ -26,7 +26,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await h.cleanup();
-});
+}, 30_000);
 
 beforeEach(async () => {
   // Wipe per-section settings so each case sets its own state.

--- a/ornn-api/tests/integration/domainSmoke.test.ts
+++ b/ornn-api/tests/integration/domainSmoke.test.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await harness.cleanup();
-});
+}, 30_000);
 
 describe("integration: health probes", () => {
   test("GET /livez returns 200 with service metadata", async () => {

--- a/ornn-api/tests/integration/harness.ts
+++ b/ornn-api/tests/integration/harness.ts
@@ -28,7 +28,16 @@ export interface Harness {
   readonly db: Db;
   /** Mongo connection string for external tooling (rare). */
   readonly mongoUri: string;
-  /** Tear down shutdown + stop the memory server. Idempotent. */
+  /**
+   * Tear down shutdown + stop the memory server. Idempotent.
+   *
+   * Stops a real `mongod`. Under a loaded full-suite run that regularly
+   * takes longer than bun's 5s hook default, so the `afterAll` calling
+   * this MUST pass an explicit timeout (`}, 30_000)`) — otherwise the
+   * hook is killed mid-teardown, the test file is reported as a failure,
+   * and the orphaned process surfaces as `killed N dangling processes`
+   * (#1215).
+   */
   readonly cleanup: () => Promise<void>;
 }
 

--- a/ornn-api/tests/integration/llmProviders_sync.test.ts
+++ b/ornn-api/tests/integration/llmProviders_sync.test.ts
@@ -93,7 +93,7 @@ afterAll(async () => {
   await mock.close();
   await client.close();
   await mongo.stop();
-});
+}, 30_000);
 
 describe("IT-LLM-SYNC", () => {
   it("IT-LLM-SYNC-IDEMPOTENT: second sync with same upstream catalog yields zero changes", async () => {

--- a/ornn-api/tests/integration/playground_charge.test.ts
+++ b/ornn-api/tests/integration/playground_charge.test.ts
@@ -40,7 +40,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await h.cleanup();
-});
+}, 30_000);
 
 beforeEach(async () => {
   await resetCollections(h.db, ["quota_buckets", "platform_settings", "llm_providers"]);

--- a/ornn-api/tests/integration/settings_exportImport.test.ts
+++ b/ornn-api/tests/integration/settings_exportImport.test.ts
@@ -49,7 +49,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await client.close();
   await mongo.stop();
-});
+}, 30_000);
 
 describe("IT-SETTINGS export/import", () => {
   it("IT-SETTINGS-EXPORT-INCLUDES-ALL-SECTIONS: every defined section is in the envelope", async () => {

--- a/ornn-api/tests/integration/skillgen_charge.test.ts
+++ b/ornn-api/tests/integration/skillgen_charge.test.ts
@@ -30,7 +30,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await h.cleanup();
-});
+}, 30_000);
 
 beforeEach(async () => {
   await resetCollections(h.db, ["quota_buckets", "platform_settings", "llm_providers"]);

--- a/ornn-api/tests/integration/skillsCrud.test.ts
+++ b/ornn-api/tests/integration/skillsCrud.test.ts
@@ -35,7 +35,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await harness.cleanup();
-});
+}, 30_000);
 
 beforeEach(async () => {
   await harness.db.collection("skills").deleteMany({});

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
   },
   "overrides": {
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "dompurify": "^3.3.4",
     "uuid": "^14.0.0",
     "eslint": "10.2.0",
     "eslint-plugin-react-hooks": "7.0.1",
-    "undici": "^7.28.0"
+    "undici": "^7.29.0",
+    "brace-expansion": "^5.0.8",
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
Closes #1213
Closes #1215
Closes #1218

## What was wrong

`GET /api/v1/openapi.json` is the contract an agent developer reads before writing a single call, and NyxID renders it on the ornn-api service page. Every URL in it was wrong.

The spec is only half generated: schemas come from Zod via `zodToJsonSchema`, but the routing surface is a hand-written literal table in `specBuilder.ts`. Nothing reflects over the Hono router, so the two drifted.

```
specBuilder.ts:460   const prefix = "/api";        <- spec said   /api/skills
bootstrap.ts:1122    app.route("/api/v1", apiApp); <- server served /api/v1/skills
```

`const prefix = "/api"` landed in #23. #101 then cut the router over to `/api/v1` and never touched the builder.

Four defects, one root cause — the spec claimed things the router does not serve:

| # | Defect | Effect |
|---|--------|--------|
| 1 | Paths published under `/api/*` | Every documented path 404s |
| 2 | `servers[0].url` hardcoded to `http://localhost:3802` | Advertised a host no client can reach |
| 3 | `info.version` frozen at `"2.0.0"` (package is 0.16.0) | No way to tell which build you are reading |
| 4 | `/admin/categories` + `/admin/tags` — 8 operations | Documented endpoints that exist nowhere in the codebase |

The contract tests did not catch any of it because they only inspect the spec against itself — and they had frozen the wrong prefix into their own assertions (`tests/contract/openapi.test.ts:224-231`).

## Result

```
servers:      https://nyx-api.chrono-ai.fun/api/v1/proxy/s/ornn-api
info.version: 0.16.0
example URL:  https://nyx-api.chrono-ai.fun/api/v1/proxy/s/ornn-api/api/v1/skills
```

That matches what `ornn-web/src/services/*` actually composes (`${ORNN_API_BASE_URL}/api/v1/...`).

Note the server URL is deliberately **not** `ORNN_PUBLIC_ORIGIN` — that is the web origin, and `ornn-web/nginx.conf.template` carries no `proxy_pass`, so the SPA host never serves the API. It reuses the existing `ORNN_API_BASE_URL` rather than adding a second variable: two names for one fact is how this drifted in the first place. Unset falls back to `http://localhost:${PORT}`, so local dev needs no configuration.

## The guard

`tests/contract/openapiRoutes.test.ts` boots the real app and checks every documented path+method against Hono's live route table. Verified it fails on the original bug — restoring `prefix = "/api"` reports all 15 operations as missing.

Direction is deliberate: documented ⇒ registered (no phantom endpoints). The converse — registered ⇒ documented — is the coverage sweep in #1214 and would fail today on ~90 undocumented routes.

## Also fixes #1215

Adding an eighth Mongo-booting test file made an existing flake impossible to ignore, so it is fixed here rather than left to randomly redden this PR.

The suite failed ~1 run in 3 **on unmodified `develop`**: `(fail) (unnamed) [5001ms] — a beforeEach/afterEach hook timed out` plus `killed 2 dangling processes`.

Cause is `scripts/migrate-quota-to-buckets.test.ts:17` — the first file in the run to touch Mongo, so its `beforeAll` pays for downloading the ~76 MB mongod binary on a cold cache, with no timeout declared and therefore bun's 5s default. When it is killed, `db` is left undefined and the file's `beforeEach` fails on every test after it; that second-order failure is what the error message names, which is why the reported hook is not the one at fault.

`tests/integration/*` already pass `30_000` to `beforeAll` for this exact reason. Teardowns get explicit timeouts too — not the trigger, but each stops a real mongod under the same 5s default.

Verified: **six consecutive full-suite runs, deterministic `2129 pass / 0 fail`.** Before, four of five were red.

## Commits

```
fix(api):   publish OpenAPI paths under /api/v1, not /api
fix(api):   source OpenAPI servers[] and info.version from config
chore(api): drop phantom /admin/categories + /admin/tags from spec
test(api):  assert every documented OpenAPI path is a real route
docs:       changeset
fix(test):  give Mongo-booting hooks explicit timeouts
```

## Verification

| check | result |
|---|---|
| `ornn-api` suite | 2129 pass / 0 fail, six consecutive runs |
| TS SDK suite | 38 pass |
| `bunx tsc` (api) | exit 0 |
| `bun run lint` | exit 0 |
| `bun audit --audit-level=high` | exit 0 (was 8 high) |
| Guard fails on the bug | confirmed — 15 operations flagged |

`ornn-web` shows 6 file-level failures in my container (`assistant.test.ts`, `quotaApi.test.ts`, `skillFrontmatterSchema.test.ts`, `assistantStreamApi.test.ts`, `AnnouncementEditDrawer.test.tsx`, `ProviderEditDrawer.test.tsx`). These are **byte-identical on baseline `develop`** with no changes applied, and this PR touches no frontend code — flagging as pre-existing/environmental, not introduced here.

## Not in scope

- Documenting the ~90 undocumented routes — #1214.
- `docker-compose.yml` sets `ORNN_API_BASE_URL: "http://localhost:3802/api/v1"`, but every `ornn-web` call site appends `/api/v1` itself, so compose-based local dev composes `/api/v1/api/v1/...`. Separate bug in a separate file — filed as #1216 rather than bundled here.

